### PR TITLE
Revert "Re-add POTA menu item to awards"

### DIFF
--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -163,8 +163,6 @@
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item" href="<?php echo site_url('awards/rac'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_rac'); ?></a>
 								<div class="dropdown-divider"></div>
-								<a class="dropdown-item" href="<?php echo site_url('awards/pota'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_pota'); ?></a>
-								<div class="dropdown-divider"></div>
 								<a class="dropdown-item" href="<?php echo site_url('awards/sig'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_sig'); ?></a>
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item" href="<?php echo site_url('awards/sota'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_sota'); ?></a>


### PR DESCRIPTION
POTA award link was apparently added twice. So removing the obsolet one again.

This reverts commit fb6a43d21f9c4b1c146745feb921ab22b28c685d.