### PR TITLE
Throw detailled Error at CAT-API, if radio-value isn't set

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -425,6 +425,12 @@ class API extends CI_Controller {
 			die();
 		}
 
+		if(!isset($obj['radio'])) {
+			http_response_code(404);
+			echo json_encode(['status' => 'failed', 'reason' => "missing radio element in payload"]);
+			die();
+		}
+
 		$this->api_model->update_last_used($obj['key']);
 
 		$user_id = $this->api_model->key_userid($obj['key']);


### PR DESCRIPTION
Without that patch there'll be a mysql-exception throwing a 500 to the API-User