### PR TITLE
catch exception from RecursiveDirectory-Checker 

### DIFF
--- a/application/libraries/Permissions.php
+++ b/application/libraries/Permissions.php
@@ -3,8 +3,8 @@
 class Permissions {
 
 	/*
-	*	Class Description: Provide functions for checking file and folder permissions
-  	*/
+	 *	Class Description: Provide functions for checking file and folder permissions
+	 */
 
 	function is_really_writable($folder) {
 		// Get the absolute path to the folder
@@ -16,18 +16,22 @@ class Permissions {
 		}
 
 		// Check if the folder is writable
-		if (is_writable($path)) {
-			// Check if the subdirectories are writable (recursive check)
-			$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
-			foreach ($iterator as $item) {
-				if ($item->isDir() && basename($item->getPathName()) != '..') {
-					if (!is_writable($item->getRealPath())) {
-						return false;
+		try {
+			if (is_writable($path)) {
+				// Check if the subdirectories are writable (recursive check)
+				$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
+				foreach ($iterator as $item) {
+					if ($item->isDir() && basename($item->getPathName()) != '..') {
+						if (!is_writable($item->getRealPath())) {
+							return false;
+						}
 					}
 				}
-			}
 
-			return true;
+				return true;
+			}
+		} catch(Exception $e) { 
+			return false;
 		}
 
 		return false;


### PR DESCRIPTION
if directory isn't readable on Top (of not writeable), the Recursive-Class throws an exception which isn't handled.
This one fixes that.