### PR TITLE
[eQSL] add stations_id to eqsl functions

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -74,10 +74,11 @@ class eqsl extends CI_Controller {
 				$this->eqslimporter->from_callsign_and_QTH(
 					$eqsl_location['station_callsign'],
 					$eqsl_location['eqslqthnickname'],
-					$config['upload_path']
+					$config['upload_path'],
+					$eqsl_location['station_id']
 				);
 
-				$eqsl_results[] = $this->eqslimporter->fetch($eqsl_password,$eqsl_force_from_date);
+				$eqsl_results[] = $this->eqslimporter->fetch($eqsl_password, $eqsl_force_from_date);
 			}
 		} elseif ($this->input->post('eqslimport') == 'upload') {
 			$station_id4upload=$this->input->post('station_profile');
@@ -97,7 +98,7 @@ class eqsl extends CI_Controller {
 					$data = array('upload_data' => $this->upload->data());
 
 					$this->load->library('EqslImporter');
-					$this->eqslimporter->from_file('./uploads/'.$data['upload_data']['file_name'],$station_callsign);
+					$this->eqslimporter->from_file('./uploads/'.$data['upload_data']['file_name'], $station_callsign, $station_id4upload);
 
 					$eqsl_results[] = $this->eqslimporter->import();
 				}
@@ -728,7 +729,8 @@ class eqsl extends CI_Controller {
 			$this->eqslimporter->from_callsign_and_QTH(
 				$eqsl_location['station_callsign'],
 				$eqsl_location['eqslqthnickname'],
-				$config['upload_path']
+				$config['upload_path'],
+				$eqsl_location['station_id']
 			);
 
 			$eqsl_results[] = $this->eqslimporter->fetch($password);

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -122,7 +122,7 @@ class Eqslmethods_model extends CI_Model {
 		$this->db->where('eqslqthnickname IS NOT NULL');
 		$this->db->where('eqslqthnickname !=', '');
 		$this->db->from('station_profile');
-		$this->db->select('station_callsign, eqslqthnickname');
+		$this->db->select('station_callsign, eqslqthnickname, station_id');
 		$this->db->distinct(TRUE);
 
 		return $this->db->get();
@@ -156,9 +156,10 @@ class Eqslmethods_model extends CI_Model {
     }
 
     // Update a QSO with eQSL QSL info
-    // We could also probably use this use this: https://eqsl.cc/qslcard/VerifyQSO.txt
+    // We could also probably use this:
+    // https://eqsl.cc/qslcard/VerifyQSO.txt
     // https://www.eqsl.cc/qslcard/ImportADIF.txt
-    function eqsl_update($datetime, $callsign, $band, $mode, $qsl_status,$station_callsign) {
+    function eqsl_update($datetime, $callsign, $band, $mode, $qsl_status, $station_callsign, $station_id) {
         $data = array(
             'COL_EQSL_QSLRDATE' => date('Y-m-d H:i:s'), // eQSL doesn't give us a date, so let's use current
             'COL_EQSL_QSL_RCVD' => $qsl_status
@@ -170,6 +171,7 @@ class Eqslmethods_model extends CI_Model {
 	$this->db->where('COL_STATION_CALLSIGN', $station_callsign);
         $this->db->where('COL_BAND', $band);
         $this->db->where('COL_MODE', $mode);
+        $this->db->where('station_id', $station_id);
 
         $this->db->update($this->config->item('table_name'), $data);
 
@@ -177,7 +179,7 @@ class Eqslmethods_model extends CI_Model {
     }
 
     // Determine if we've already received an eQSL for this QSO
-    function eqsl_dupe_check($datetime, $callsign, $band, $mode, $qsl_status,$station_callsign) {
+    function eqsl_dupe_check($datetime, $callsign, $band, $mode, $qsl_status, $station_callsign, $station_id) {
         $this->db->select('COL_EQSL_QSLRDATE');
         $this->db->where('COL_TIME_ON >= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL -15 MINUTE )');
         $this->db->where('COL_TIME_ON <= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL 15 MINUTE )');
@@ -186,6 +188,7 @@ class Eqslmethods_model extends CI_Model {
         $this->db->where('COL_MODE', $mode);
 	$this->db->where('COL_STATION_CALLSIGN', $station_callsign);
         $this->db->where('COL_EQSL_QSL_RCVD', $qsl_status);
+        $this->db->where('station_id', $station_id);
         $this->db->limit(1);
     
         $query = $this->db->get($this->config->item('table_name'));

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2981,7 +2981,7 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
   }
 
   /* Used to check if the qso is already in the database */
-    function import_check($datetime, $callsign, $band, $mode, $station_callsign) {
+    function import_check($datetime, $callsign, $band, $mode, $station_callsign, $station_id = null) {
 	    $mode=$this->get_main_mode_from_mode($mode);
 
 	    $this->db->select('COL_PRIMARY_KEY, COL_TIME_ON, COL_CALL, COL_BAND');
@@ -2991,6 +2991,10 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
 	    $this->db->where('COL_BAND', $band);
 	    $this->db->where('COL_MODE', $mode);
+
+	    if(isset($station_id) && $station_id > 0) {
+		    $this->db->where('station_id', $station_id);
+	    }
 
 	    $query = $this->db->get($this->config->item('table_name'));
 


### PR DESCRIPTION
It seems that all eQSL functions are not aware of the station ID and therefore check all QSOs regardless of their
accounts and locations.

In a multi-user environment, if the label is the same, QSOs may be updated out of scope (club stations).
