### PR TITLE
show flashdata if no station has eqsl nick

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -129,8 +129,7 @@ class eqsl extends CI_Controller {
 		// Check if eQSL Nicknames have been defined
 			$this->load->model('stations');
 			if($this->stations->are_eqsl_nicks_defined() == 0) {
-				show_error('eQSL Nicknames in Station Profiles arent defined');
-				exit;
+				$this->session->set_flashdata('error', 'eQSL Nicknames in Station Profiles aren\'t defined!');
 			}
 
 		ini_set('memory_limit', '-1');


### PR DESCRIPTION
#74 was not complete. this adds the same error message to the Upload section.

<img width="545" alt="eqsl" src="https://github.com/wavelog/wavelog/assets/80885850/284d5232-e10e-40ee-aa83-dfc2e0669dbd">
