### PR TITLE
Make clearer that overview filters on logbook rather than locations

### DIFF
--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Име на сателита';
 $lang['gen_hamradio_satellite_mode'] = 'Режим на сателита';
 
 $lang['gen_hamradio_logbook'] = 'Дневник';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Режим на сателита';
 
 $lang['gen_hamradio_logbook'] = 'Дневник';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = '卫星模式';
 
 $lang['gen_hamradio_logbook'] = '日志簿';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "奖项";
 
 $lang['gen_hamradio_zones'] = '分区';

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = '卫星名称';
 $lang['gen_hamradio_satellite_mode'] = '卫星模式';
 
 $lang['gen_hamradio_logbook'] = '日志簿';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "奖项";
 
 $lang['gen_hamradio_zones'] = '分区';

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Režim satelitu';
 
 $lang['gen_hamradio_logbook'] = 'Logbook';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Název satelitu';
 $lang['gen_hamradio_satellite_mode'] = 'Režim satelitu';
 
 $lang['gen_hamradio_logbook'] = 'Logbook';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Satelliet Naam';
 $lang['gen_hamradio_satellite_mode'] = 'Satelliet Mode';
 
 $lang['gen_hamradio_logbook'] = 'Logboek';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Satelliet Mode';
 
 $lang['gen_hamradio_logbook'] = 'Logboek';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Satellite Name';
 $lang['gen_hamradio_satellite_mode'] = 'Satellite Mode';
 
 $lang['gen_hamradio_logbook'] = 'Logbook';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Satellite Mode';
 
 $lang['gen_hamradio_logbook'] = 'Logbook';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Satelliitin Mode';
 
 $lang['gen_hamradio_logbook'] = 'Lokikirja';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Satelliitti';
 $lang['gen_hamradio_satellite_mode'] = 'Satelliitin Mode';
 
 $lang['gen_hamradio_logbook'] = 'Lokikirja';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = "Mode du Satellite";
 
 $lang['gen_hamradio_logbook'] = "Journal de trafic";
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = "Zones";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = "Nom du Satellite";
 $lang['gen_hamradio_satellite_mode'] = "Mode du Satellite";
 
 $lang['gen_hamradio_logbook'] = "Journal de trafic";
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = "Zones";

--- a/application/language/german/general_words_lang.php
+++ b/application/language/german/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Satellit';
 $lang['gen_hamradio_satellite_mode'] = 'Satellitenmodus';
 
 $lang['gen_hamradio_logbook'] = 'Logbuch';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Zeigt QSOs der Standorte deines aktiven Stationslogbuchs';
 $lang['gen_hamradio_award'] = "Diplom";
 
 $lang['gen_hamradio_zones'] = 'Zonen';

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Λειτουργία δορυφόρου'
 
 $lang['gen_hamradio_logbook'] = 'Αρχείο επαφών';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Όνομα δορυφόρου';
 $lang['gen_hamradio_satellite_mode'] = 'Λειτουργία δορυφόρου';
 
 $lang['gen_hamradio_logbook'] = 'Αρχείο επαφών';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Nome Satellite';
 $lang['gen_hamradio_satellite_mode'] = 'Modo Satellite';
 
 $lang['gen_hamradio_logbook'] = 'Logbook';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Modo Satellite';
 
 $lang['gen_hamradio_logbook'] = 'Logbook';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'modulacja satelity';
 
 $lang['gen_hamradio_logbook'] = 'Log';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Nazwa satelity';
 $lang['gen_hamradio_satellite_mode'] = 'modulacja satelity';
 
 $lang['gen_hamradio_logbook'] = 'Log';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -157,6 +157,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Режим работы спутника
 
 $lang['gen_hamradio_award'] = "Диплом";
 $lang['gen_hamradio_logbook'] = 'Журнал';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_zones'] = 'Зоны';
 
 $lang['gen_hamradio_itu_zone'] = 'Зона ITU';

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_name'] = 'Название спутника';
 $lang['gen_hamradio_satellite_mode'] = 'Режим работы спутника';
 
 $lang['gen_hamradio_award'] = "Диплом";
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_logbook'] = 'Журнал';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
 $lang['gen_hamradio_zones'] = 'Зоны';

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_name'] = 'Nombre del Satélite';
 $lang['gen_hamradio_satellite_mode'] = 'Modo del Satélite';
 
 $lang['gen_hamradio_logbook'] = 'Libro de Guardia';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
 $lang['gen_hamradio_award'] = "Premio";
 

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -156,6 +156,7 @@ $lang['gen_hamradio_satellite_name'] = 'Nombre del Satélite';
 $lang['gen_hamradio_satellite_mode'] = 'Modo del Satélite';
 
 $lang['gen_hamradio_logbook'] = 'Libro de Guardia';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Premio";
 
 $lang['gen_hamradio_zones'] = 'Zonas';

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_name'] = 'Satellitnamn';
 $lang['gen_hamradio_satellite_mode'] = 'Satellite-mode';
 
 $lang['gen_hamradio_award'] = "Award";
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_logbook'] = 'Loggbok';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
 

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -157,6 +157,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Satellite-mode';
 
 $lang['gen_hamradio_award'] = "Award";
 $lang['gen_hamradio_logbook'] = 'Loggbok';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 
 $lang['gen_hamradio_zones'] = 'Zones';
 $lang['gen_hamradio_cq_zone'] = 'CQ Zone';

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -155,6 +155,7 @@ $lang['gen_hamradio_satellite_name'] = 'Uydu Adı';
 $lang['gen_hamradio_satellite_mode'] = 'Uydu Modu';
 
 $lang['gen_hamradio_logbook'] = 'Kayıt defteri';
+$lang['gen_hamradio_show_active_station_logbook'] = 'Showing QSOs from locations in your active station logbook';
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -156,7 +156,7 @@ $lang['gen_hamradio_satellite_mode'] = 'Uydu Modu';
 
 $lang['gen_hamradio_logbook'] = 'Kayıt defteri';
 $lang['gen_hamradio_active_logbook'] = 'Active Logbook';
-$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs from station locations which are linked with this logbook";
+$lang['gen_hamradio_active_logbook_hint'] = "Displaying all QSOs of station locations which are linked to this logbook";
 $lang['gen_hamradio_award'] = "Award";
 
 $lang['gen_hamradio_zones'] = 'Zones';

--- a/application/views/view_log/index.php
+++ b/application/views/view_log/index.php
@@ -1,7 +1,7 @@
 <div class="alert alert-secondary" role="alert" style="margin-bottom: 0px !important;">
 <div class="container">
 	<?php if ($results) { ?>
-		<p style="margin-bottom: 0px !important;"><?php echo lang('gen_hamradio_logbook'); ?>: <span class="badge text-bg-info"><?php echo $this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></span> <?php echo lang('general_word_location'); ?>: <span class="badge text-bg-info"><?php echo $this->stations->find_name(); ?></span></p>
+		<p style="margin-bottom: 0px !important;"><?php echo lang('gen_hamradio_show_active_station_logbook'); ?>: <span class="badge text-bg-info"><?php echo $this->logbooks_model->find_name($this->session->userdata('active_station_logbook')); ?></span> </p>
 	<?php } ?>
 </div>
 </div>


### PR DESCRIPTION
Addresses: https://github.com/wavelog/wavelog/issues/105 to make clear(er) that logbook overview only filters on station logbooks rather than station locations.