### PR TITLE
Regard for order and also output time for VUCC timeline

### DIFF
--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -280,7 +280,7 @@ class Timeline_model extends CI_Model
 
     public function get_gridsquare($band, $mode, $location_list, $qsl, $lotw, $eqsl) {
         // $sql = "select min(date(COL_TIME_ON)) date, col_gridsquare from "
-        $sql = "select min(date(COL_TIME_ON)) date, upper(substring(col_gridsquare, 1, 4)) gridsquare from "
+        $sql = "select min(COL_TIME_ON) date, upper(substring(col_gridsquare, 1, 4)) gridsquare from "
             .$this->config->item('table_name'). " thcv
             where station_id in (" . $location_list . ")";
 
@@ -310,7 +310,7 @@ class Timeline_model extends CI_Model
 
     public function get_vucc_grids($band, $mode, $location_list, $qsl, $lotw, $eqsl) {
         // $sql = "select min(date(COL_TIME_ON)) date, col_gridsquare from "
-        $sql = "select date(COL_TIME_ON) date, upper(col_vucc_grids) gridsquare from "
+        $sql = "select COL_TIME_ON as date, upper(col_vucc_grids) gridsquare from "
             .$this->config->item('table_name'). " thcv
             where station_id in (" . $location_list . ")";
 

--- a/application/views/timeline/index.php
+++ b/application/views/timeline/index.php
@@ -229,6 +229,7 @@ function write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, 
                     <tr>
                         <td>#</td>
                         <td>'.$ci->lang->line('general_word_date').'</td>
+                        <td>'.$ci->lang->line('general_word_time').'</td>
                         <td>'.$ci->lang->line('gen_hamradio_gridsquare').'</td>
                         <td>'.$ci->lang->line('gridsquares_show_qsos').'</td>
                     </tr>
@@ -240,6 +241,7 @@ function write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, 
         echo '<tr>
                 <td>' . $i-- . '</td>
                 <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
+                <td>' . date('H:i', $date_as_timestamp) . '</td>
                 <td>' . $line['gridsquare'] . '</td>
                 <td><a href=javascript:displayTimelineContacts("' . $line['gridsquare'] . '","'. $bandselect . '","'. $modeselect . '","' . $award .'")>'.$ci->lang->line('filter_options_show').'</a></td>
                </tr>';


### PR DESCRIPTION
Currently VUCC grids are only sorted by date and within the same date randomly. This patch also takes time into account for sorting and also shows it in the result table.