### PR TITLE
[QSO View/Edit] States from Database

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -132,7 +132,7 @@ class Lookup extends CI_Controller {
 	public function get_state_list() {
 		$this->load->library('subdivisions');
 
-		$dxcc = $this->input->post('dxcc');
+		$dxcc = xss_clean($this->input->post('dxcc'));
 		$states_result = $this->subdivisions->get_state_list($dxcc);
 		$subdivision_name = $this->subdivisions->get_primary_subdivision_name($dxcc);
 

--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -129,4 +129,26 @@ class Lookup extends CI_Controller {
 		}
 	}
 
+	public function get_state_list() {
+		$this->load->library('subdivisions');
+
+		$dxcc = $this->input->post('dxcc');
+		$states_result = $this->subdivisions->get_state_list($dxcc);
+		$subdivision_name = $this->subdivisions->get_primary_subdivision_name($dxcc);
+
+		if ($states_result->num_rows() > 0) {
+			$states_array = $states_result->result_array();
+			$result = array(
+				'status' => 'ok',
+				'subdivision_name' => $subdivision_name,
+				'data' => $states_array
+			);
+			header('Content-Type: application/json');
+        	echo json_encode($result);
+		} else {
+			header('Content-Type: application/json');
+			echo json_encode(array('status' => 'No States for this DXCC in Database'));
+		}
+	}
+
 }

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -1,12 +1,5 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
-/*
-TODO
-	- Update Edit
-	- Store Radio Information
-	- Upload to clublog (request api key)
-*/
-
 class QSO extends CI_Controller {
 
 	function __construct()

--- a/application/libraries/Subdivisions.php
+++ b/application/libraries/Subdivisions.php
@@ -93,4 +93,13 @@ class Subdivisions {
 		}
 		return 'County';
 	}
+
+	public function get_state_list($dxcc) {
+		$CI =& get_instance();
+		$CI->load->model('logbook_model');
+
+		$states = $CI->logbook_model->get_states_by_dxcc($dxcc);
+
+		return $states;
+	}
 }

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -145,8 +145,8 @@ class Logbook_model extends CI_Model {
         $submode = $this->input->post('mode');
     }
 
-    if($this->input->post('county') && $this->input->post('usa_state')) {
-      $clean_county_input = trim($this->input->post('usa_state')) . "," . trim($this->input->post('county'));
+    if($this->input->post('county') && $this->input->post('input_state_edit')) {
+      $clean_county_input = trim($this->input->post('input_state_edit')) . "," . trim($this->input->post('county'));
     } else {
       $clean_county_input = null;
     }
@@ -234,7 +234,7 @@ class Logbook_model extends CI_Model {
             'COL_LON' => null,
             'COL_DXCC' => $dxcc_id,
             'COL_CQZ' => $cqz,
-            'COL_STATE' => $this->input->post('usa_state') == null ? '' : trim($this->input->post('usa_state')),
+            'COL_STATE' => $this->input->post('input_state_edit') == null ? '' : trim($this->input->post('input_state_edit')),
             'COL_CNTY' => $clean_county_input,
             'COL_SOTA_REF' => $this->input->post('sota_ref') == null ? '' : trim($this->input->post('sota_ref')),
             'COL_WWFF_REF' => $this->input->post('wwff_ref') == null ? '' : trim($this->input->post('wwff_ref')),
@@ -1079,8 +1079,8 @@ class Logbook_model extends CI_Model {
 
 	  if (stristr($this->input->post('usa_county') ?? '', ',')) {	// Already comma-seperated Conuty?
 		  $uscounty = $this->input->post('usa_county');
-	  } elseif ($this->input->post('usa_county') && $this->input->post('usa_state')) {	// Both filled (and no comma - because that fits one above)
-		  $uscounty = trim($this->input->post('usa_state') . "," . $this->input->post('usa_county'));
+	  } elseif ($this->input->post('usa_county') && $this->input->post('input_state_edit')) {	// Both filled (and no comma - because that fits one above)
+		  $uscounty = trim($this->input->post('input_state_edit') . "," . $this->input->post('usa_county'));
 	  } else {	// nothing from above?
 		  $uscounty = null;
 	  }
@@ -1227,7 +1227,7 @@ class Logbook_model extends CI_Model {
 		  'station_id' => $stationId,
 		  'COL_STATION_CALLSIGN' => $stationCallsign,
 		  'COL_OPERATOR' => $this->input->post('operator_callsign'),
-		  'COL_STATE' =>$this->input->post('usa_state'),
+		  'COL_STATE' =>$this->input->post('input_state_edit'),
 		  'COL_CNTY' => $uscounty,
 		  'COL_MY_IOTA' => $iotaRef,
 		  'COL_MY_SOTA_REF' => $sotaRef,
@@ -4665,7 +4665,7 @@ function lotw_last_qsl_date($user_id) {
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
-		$this->db->join('lotw_users', 'lotw_users.callsign = '.$this->config->item('table_name').'.col_call', 'left outer');
+		    $this->db->join('lotw_users', 'lotw_users.callsign = '.$this->config->item('table_name').'.col_call', 'left outer');
         $this->db->where_in($this->config->item('table_name').'.station_id', $logbooks_locations_array);
         $this->db->where('COL_STATE', $state);
         $this->db->where('COL_CNTY', $county);
@@ -4746,6 +4746,11 @@ function lotw_last_qsl_date($user_id) {
         $json["markers"][] = $plot;
       }
       return $json;
+    }
+
+    public function get_states_by_dxcc($dxcc) {
+        $this->db->where('adif', $dxcc);
+        return $this->db->get('primary_subdivisions');
     }
 }
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -596,9 +596,9 @@ $(function () {
 
 <script>
 $(document).ready(function() {
-	$('#create_station_profile #country').val($("#dxcc_select option:selected").text());
-	$("#create_station_profile #dxcc_select" ).change(function() {
-	$('#country').val($("#dxcc_select option:selected").text());
+	$('#create_station_profile #country').val($("#dxcc_id option:selected").text());
+	$("#create_station_profile #dxcc_id" ).change(function() {
+	$('#country').val($("#dxcc_id option:selected").text());
 
 	});
 });
@@ -606,20 +606,20 @@ $(document).ready(function() {
 
 <script>
 function printWarning() {
-    if ($("#dxcc_select option:selected").text().includes("<?php echo lang('gen_hamradio_deleted_dxcc'); ?>")) {
+    if ($("#dxcc_id option:selected").text().includes("<?php echo lang('gen_hamradio_deleted_dxcc'); ?>")) {
         $('#warningMessageDXCC').show();
-        $('#dxcc_select').css('border', '2px solid rgb(217, 83, 79)');
+        $('#dxcc_id').css('border', '2px solid rgb(217, 83, 79)');
         $('#warningMessageDXCC').text("<?php echo lang('station_location_dxcc_warning'); ?>");
     } else {
-        $('#dxcc_select').css('border', '');
+        $('#dxcc_id').css('border', '');
         $('#warningMessageDXCC').hide();
     }
 }
-$('#dxcc_select').ready(function() {
+$('#dxcc_id').ready(function() {
     printWarning();
 });
 
-$('#dxcc_select').on('change', function() {
+$('#dxcc_id').on('change', function() {
     printWarning();
 });
 </script>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2091,63 +2091,64 @@ $(document).ready(function(){
 
 <script>
 
-        function selectize_usa_county() {
-            var baseURL= "<?php echo base_url();?>";
-            $('#stationCntyInputEdit').selectize({
-                delimiter: ';',
-                maxItems: 1,
-                closeAfterSelect: true,
-                loadThrottle: 250,
-                valueField: 'name',
-                labelField: 'name',
-                searchField: 'name',
-                options: [],
-                create: false,
-                load: function(query, callback) {
-                    var state = $("#input_state_edit option:selected").text();
+function selectize_usa_county() {
+    console.log('selectize_usa_county');
+    var baseURL= "<?php echo base_url();?>";
+    $('#stationCntyInputEdit').selectize({
+        delimiter: ';',
+        maxItems: 1,
+        closeAfterSelect: true,
+        loadThrottle: 250,
+        valueField: 'name',
+        labelField: 'name',
+        searchField: 'name',
+        options: [],
+        create: false,
+        load: function(query, callback) {
+            var state = $("#stateDropdown option:selected").text();
 
-                    if (!query || state == "") return callback();
-                    $.ajax({
-                        url: baseURL+'index.php/qso/get_county',
-                        type: 'GET',
-                        dataType: 'json',
-                        data: {
-                            query: query,
-                            state: state,
-                        },
-                        error: function() {
-                            callback();
-                        },
-                        success: function(res) {
-                            callback(res);
-                        }
-                    });
-                }
-            });
-        }
-
-        function qso_save() {
-            var baseURL= "<?php echo base_url();?>";
-            var myform = document.getElementById("qsoform");
-            var fd = new FormData(myform);
+            if (!query || state == "") return callback();
             $.ajax({
-                url: baseURL + 'index.php/qso/qso_save_ajax',
-                data: fd,
-                cache: false,
-                processData: false,
-                contentType: false,
-                type: 'POST',
-                success: function (dataofconfirm) {
-                    $(".edit-dialog").modal('hide');
-                    $(".qso-dialog").modal('hide');
-                    <?php if ($this->uri->segment(1) != "search" && $this->uri->segment(2) != "filter" && $this->uri->segment(1) != "qso" && $this->uri->segment(1) != "logbookadvanced") { ?>location.reload();<?php } ?>
+                url: baseURL+'index.php/qso/get_county',
+                type: 'GET',
+                dataType: 'json',
+                data: {
+                    query: query,
+                    state: state,
                 },
-                error: function(xhr, status, error) {
-                    console.log(xhr.responseText);
+                error: function() {
+                    callback();
+                },
+                success: function(res) {
+                    callback(res);
                 }
             });
         }
-        </script>
+    });
+}
+
+function qso_save() {
+    var baseURL= "<?php echo base_url();?>";
+    var myform = document.getElementById("qsoform");
+    var fd = new FormData(myform);
+    $.ajax({
+        url: baseURL + 'index.php/qso/qso_save_ajax',
+        data: fd,
+        cache: false,
+        processData: false,
+        contentType: false,
+        type: 'POST',
+        success: function (dataofconfirm) {
+            $(".edit-dialog").modal('hide');
+            $(".qso-dialog").modal('hide');
+            <?php if ($this->uri->segment(1) != "search" && $this->uri->segment(2) != "filter" && $this->uri->segment(1) != "qso" && $this->uri->segment(1) != "logbookadvanced") { ?>location.reload();<?php } ?>
+        },
+        error: function(xhr, status, error) {
+            console.log(xhr.responseText);
+        }
+    });
+}
+</script>
     <?php if ($this->uri->segment(1) == "timeline") { ?>
         <script>
             $('.timelinetable').DataTable({

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2104,7 +2104,8 @@ $(document).ready(function(){
                 options: [],
                 create: false,
                 load: function(query, callback) {
-                    var state = $("#input_state_edit").val();
+                    var state = $("#input_state_edit option:selected").text();
+                    console.log = (state);
 
                     if (!query || state == "") return callback();
                     $.ajax({

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2094,7 +2094,7 @@ $(document).ready(function(){
         function selectize_usa_county() {
             var baseURL= "<?php echo base_url();?>";
             $('#stationCntyInputEdit').selectize({
-				delimiter: ';',
+                delimiter: ';',
                 maxItems: 1,
                 closeAfterSelect: true,
                 loadThrottle: 250,
@@ -2104,7 +2104,7 @@ $(document).ready(function(){
                 options: [],
                 create: false,
                 load: function(query, callback) {
-                    var state = $("#input_usa_state_edit option:selected").text();
+                    var state = $("#input_state_edit").val();
 
                     if (!query || state == "") return callback();
                     $.ajax({

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2105,7 +2105,6 @@ $(document).ready(function(){
                 create: false,
                 load: function(query, callback) {
                     var state = $("#input_state_edit option:selected").text();
-                    console.log = (state);
 
                     if (!query || state == "") return callback();
                     $.ajax({

--- a/application/views/lookup/index.php
+++ b/application/views/lookup/index.php
@@ -19,7 +19,7 @@
 			}
 			?>
 		</select>
-		
+
 		<!-- DXCC -->
 		<select style="display:none" class="form-select w-auto" id="quicklookupdxcc" name="dxcc" required>
 
@@ -36,57 +36,18 @@
 		</select>
 
 		<select style="display:none" class="form-select w-auto" id="quicklookupwas" name="was">
-			<option value="AL">Alabama (AL)</option>
-			<option value="AK">Alaska (AK)</option>
-			<option value="AZ">Arizona (AZ)</option>
-			<option value="AR">Arkansas (AR)</option>
-			<option value="CA">California (CA)</option>
-			<option value="CO">Colorado (CO)</option>
-			<option value="CT">Connecticut (CT)</option>
-			<option value="DE">Delaware (DE)</option>
-			<option value="DC">District Of Columbia (DC)</option>
-			<option value="FL">Florida (FL)</option>
-			<option value="GA">Georgia (GA)</option>
-			<option value="HI">Hawaii (HI)</option>
-			<option value="ID">Idaho (ID)</option>
-			<option value="IL">Illinois (IL)</option>
-			<option value="IN">Indiana (IN)</option>
-			<option value="IA">Iowa (IA)</option>
-			<option value="KS">Kansas (KS)</option>
-			<option value="KY">Kentucky (KY)</option>
-			<option value="LA">Louisiana (LA)</option>
-			<option value="ME">Maine (ME)</option>
-			<option value="MD">Maryland (MD)</option>
-			<option value="MA">Massachusetts (MA)</option>
-			<option value="MI">Michigan (MI)</option>
-			<option value="MN">Minnesota (MN)</option>
-			<option value="MS">Mississippi (MS)</option>
-			<option value="MO">Missouri (MO)</option>
-			<option value="MT">Montana (MT)</option>
-			<option value="NE">Nebraska (NE)</option>
-			<option value="NV">Nevada (NV)</option>
-			<option value="NH">New Hampshire (NH)</option>
-			<option value="NJ">New Jersey (NJ)</option>
-			<option value="NM">New Mexico (NM)</option>
-			<option value="NY">New York (NY)</option>
-			<option value="NC">North Carolina (NC)</option>
-			<option value="ND">North Dakota (ND)</option>
-			<option value="OH">Ohio (OH)</option>
-			<option value="OK">Oklahoma (OK)</option>
-			<option value="OR">Oregon (OR)</option>
-			<option value="PA">Pennsylvania (PA)</option>
-			<option value="RI">Rhode Island (RI)</option>
-			<option value="SC">South Carolina (SC)</option>
-			<option value="SD">South Dakota (SD)</option>
-			<option value="TN">Tennessee (TN)</option>
-			<option value="TX">Texas (TX)</option>
-			<option value="UT">Utah (UT)</option>
-			<option value="VT">Vermont (VT)</option>
-			<option value="VA">Virginia (VA)</option>
-			<option value="WA">Washington (WA)</option>
-			<option value="WV">West Virginia (WV)</option>
-			<option value="WI">Wisconsin (WI)</option>
-			<option value="WY">Wyoming (WY)</option>
+			<?php
+			$CI = &get_instance();
+			$CI->load->library('subdivisions');
+
+			$state_list = $CI->subdivisions->get_state_list('291');                                 // USA hardcoded
+			?>
+			<option value="">Choose a State</option>
+			<?php foreach ($state_list->result() as $state) {?>
+				<option value="<?php echo $state->state; ?>">
+					<?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
+				</option>
+			<?php } ?>
 		</select>
 
 		<select style="display:none" class="form-select w-auto" id="quicklookupiota" name="iota_ref">

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -300,7 +300,7 @@
                                         <?php foreach ($state_list->result() as $state) {
                                             $selected = ($qso->COL_STATE == $state->state) ? 'selected="selected"' : '';
                                         ?>
-                                            <option value="<?php echo $state->subdivision . ' (' . $state->state . ')'; ?>" <?php echo $selected; ?>>
+                                            <option value="<?php echo $state->state; ?>" <?php echo $selected; ?>>
                                                 <?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
                                             </option>
                                         <?php } ?>

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -286,15 +286,14 @@
                                 <div class="mb-3">
                                     <?php 
                                         $CI =& get_instance();
-
                                         $CI->load->library('subdivisions');
 
                                         $subdivision_name = $CI->subdivisions->get_primary_subdivision_name($qso->COL_DXCC);
                                         $state_list = $CI->subdivisions->get_state_list($qso->COL_DXCC);
                                     ?>
-
-                                    <label for="input_state_edit"><?php echo $subdivision_name; ?></label>
-                                    <select class="form-select" id="input_state_edit" name="input_state_edit">
+                                    
+                                    <label for="stateDropdown" id="stateInputLabel"><?php echo $subdivision_name; ?></label>
+                                    <select class="form-select" id="stateDropdown" name="input_state_edit">
                                         <option value=""></option>
 
                                         <?php foreach ($state_list->result() as $state) {
@@ -308,7 +307,7 @@
                                 </div>
                                 
                                 <?php if ($qso->COL_DXCC == '291' || $qso->COL_DXCC == '110'  || $qso->COL_DXCC == '006') { ?>
-                                <div class="mb-3">
+                                <div class="mb-3" id="location_us_county">
                                     <label for="stationCntyInput">USA County</label>
                                     <input class="form-control" id="stationCntyInputEdit" type="text" name="usa_county" value="<?php echo $qso->COL_CNTY; ?>" />
                                 </div>

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -284,67 +284,35 @@
 
 
                                 <div class="mb-3">
-                                    <label for="usa_state">USA State</label>
-                                    <select class="form-select" id="input_usa_state_edit" name="usa_state">
+                                    <?php 
+                                        $CI =& get_instance();
+
+                                        $CI->load->library('subdivisions');
+
+                                        $subdivision_name = $CI->subdivisions->get_primary_subdivision_name($qso->COL_DXCC);
+                                        $state_list = $CI->subdivisions->get_state_list($qso->COL_DXCC);
+                                    ?>
+
+                                    <label for="input_state_edit"><?php echo $subdivision_name; ?></label>
+                                    <select class="form-select" id="input_state_edit" name="input_state_edit">
                                         <option value=""></option>
-                                        <option value="AL" <?php if($qso->COL_STATE == "AL") { echo "selected=\"selected\""; } ?>>Alabama (AL)</option>
-                                        <option value="AK" <?php if($qso->COL_STATE == "AK") { echo "selected=\"selected\""; } ?>>Alaska (AK)</option>
-                                        <option value="AZ" <?php if($qso->COL_STATE == "AZ") { echo "selected=\"selected\""; } ?>>Arizona (AZ)</option>
-                                        <option value="AR" <?php if($qso->COL_STATE == "AR") { echo "selected=\"selected\""; } ?>>Arkansas (AR)</option>
-                                        <option value="CA" <?php if($qso->COL_STATE == "CA") { echo "selected=\"selected\""; } ?>>California (CA)</option>
-                                        <option value="CO" <?php if($qso->COL_STATE == "CO") { echo "selected=\"selected\""; } ?>>Colorado (CO)</option>
-                                        <option value="CT" <?php if($qso->COL_STATE == "CT") { echo "selected=\"selected\""; } ?>>Connecticut (CT)</option>
-                                        <option value="DE" <?php if($qso->COL_STATE == "DE") { echo "selected=\"selected\""; } ?>>Delaware (DE)</option>
-                                        <option value="DC" <?php if($qso->COL_STATE == "DC") { echo "selected=\"selected\""; } ?>>District Of Columbia (DC)</option>
-                                        <option value="FL" <?php if($qso->COL_STATE == "FL") { echo "selected=\"selected\""; } ?>>Florida (FL)</option>
-                                        <option value="GA" <?php if($qso->COL_STATE == "GA") { echo "selected=\"selected\""; } ?>>Georgia (GA)</option>
-                                        <option value="HI" <?php if($qso->COL_STATE == "HI") { echo "selected=\"selected\""; } ?>>Hawaii (HI)</option>
-                                        <option value="ID" <?php if($qso->COL_STATE == "ID") { echo "selected=\"selected\""; } ?>>Idaho (ID)</option>
-                                        <option value="IL" <?php if($qso->COL_STATE == "IL") { echo "selected=\"selected\""; } ?>>Illinois (IL)</option>
-                                        <option value="IN" <?php if($qso->COL_STATE == "IN") { echo "selected=\"selected\""; } ?>>Indiana (IN)</option>
-                                        <option value="IA" <?php if($qso->COL_STATE == "IA") { echo "selected=\"selected\""; } ?>>Iowa (IA)</option>
-                                        <option value="KS" <?php if($qso->COL_STATE == "KS") { echo "selected=\"selected\""; } ?>>Kansas (KS)</option>
-                                        <option value="KY" <?php if($qso->COL_STATE == "KY") { echo "selected=\"selected\""; } ?>>Kentucky (KY)</option>
-                                        <option value="LA" <?php if($qso->COL_STATE == "LA") { echo "selected=\"selected\""; } ?>>Louisiana (LA)</option>
-                                        <option value="ME" <?php if($qso->COL_STATE == "ME") { echo "selected=\"selected\""; } ?>>Maine (ME)</option>
-                                        <option value="MD" <?php if($qso->COL_STATE == "MD") { echo "selected=\"selected\""; } ?>>Maryland (MD)</option>
-                                        <option value="MA" <?php if($qso->COL_STATE == "MA") { echo "selected=\"selected\""; } ?>>Massachusetts (MA)</option>
-                                        <option value="MI" <?php if($qso->COL_STATE == "MI") { echo "selected=\"selected\""; } ?>>Michigan (MI)</option>
-                                        <option value="MN" <?php if($qso->COL_STATE == "MN") { echo "selected=\"selected\""; } ?>>Minnesota (MN)</option>
-                                        <option value="MS" <?php if($qso->COL_STATE == "MS") { echo "selected=\"selected\""; } ?>>Mississippi (MS)</option>
-                                        <option value="MO" <?php if($qso->COL_STATE == "MO") { echo "selected=\"selected\""; } ?>>Missouri (MO)</option>
-                                        <option value="MT" <?php if($qso->COL_STATE == "MT") { echo "selected=\"selected\""; } ?>>Montana (MT)</option>
-                                        <option value="NE" <?php if($qso->COL_STATE == "NE") { echo "selected=\"selected\""; } ?>>Nebraska (NE)</option>
-                                        <option value="NV" <?php if($qso->COL_STATE == "NV") { echo "selected=\"selected\""; } ?>>Nevada (NV)</option>
-                                        <option value="NH" <?php if($qso->COL_STATE == "NH") { echo "selected=\"selected\""; } ?>>New Hampshire (NH)</option>
-                                        <option value="NJ" <?php if($qso->COL_STATE == "NJ") { echo "selected=\"selected\""; } ?>>New Jersey (NJ)</option>
-                                        <option value="NM" <?php if($qso->COL_STATE == "NM") { echo "selected=\"selected\""; } ?>>New Mexico (NM)</option>
-                                        <option value="NY" <?php if($qso->COL_STATE == "NY") { echo "selected=\"selected\""; } ?>>New York (NY)</option>
-                                        <option value="NC" <?php if($qso->COL_STATE == "NC") { echo "selected=\"selected\""; } ?>>North Carolina (NC)</option>
-                                        <option value="ND" <?php if($qso->COL_STATE == "ND") { echo "selected=\"selected\""; } ?>>North Dakota (ND)</option>
-                                        <option value="OH" <?php if($qso->COL_STATE == "OH") { echo "selected=\"selected\""; } ?>>Ohio (OH)</option>
-                                        <option value="OK" <?php if($qso->COL_STATE == "OK") { echo "selected=\"selected\""; } ?>>Oklahoma (OK)</option>
-                                        <option value="OR" <?php if($qso->COL_STATE == "OR") { echo "selected=\"selected\""; } ?>>Oregon (OR)</option>
-                                        <option value="PA" <?php if($qso->COL_STATE == "PA") { echo "selected=\"selected\""; } ?>>Pennsylvania (PA)</option>
-                                        <option value="RI" <?php if($qso->COL_STATE == "RI") { echo "selected=\"selected\""; } ?>>Rhode Island (RI)</option>
-                                        <option value="SC" <?php if($qso->COL_STATE == "SC") { echo "selected=\"selected\""; } ?>>South Carolina (SC)</option>
-                                        <option value="SD" <?php if($qso->COL_STATE == "SD") { echo "selected=\"selected\""; } ?>>South Dakota (SD)</option>
-                                        <option value="TN" <?php if($qso->COL_STATE == "TN") { echo "selected=\"selected\""; } ?>>Tennessee (TN)</option>
-                                        <option value="TX" <?php if($qso->COL_STATE == "TX") { echo "selected=\"selected\""; } ?>>Texas (TX)</option>
-                                        <option value="UT" <?php if($qso->COL_STATE == "UT") { echo "selected=\"selected\""; } ?>>Utah (UT)</option>
-                                        <option value="VT" <?php if($qso->COL_STATE == "VT") { echo "selected=\"selected\""; } ?>>Vermont (VT)</option>
-                                        <option value="VA" <?php if($qso->COL_STATE == "VA") { echo "selected=\"selected\""; } ?>>Virginia (VA)</option>
-                                        <option value="WA" <?php if($qso->COL_STATE == "WA") { echo "selected=\"selected\""; } ?>>Washington (WA)</option>
-                                        <option value="WV" <?php if($qso->COL_STATE == "WV") { echo "selected=\"selected\""; } ?>>West Virginia (WV)</option>
-                                        <option value="WI" <?php if($qso->COL_STATE == "WI") { echo "selected=\"selected\""; } ?>>Wisconsin (WI)</option>
-                                        <option value="WY" <?php if($qso->COL_STATE == "WY") { echo "selected=\"selected\""; } ?>>Wyoming (WY)</option>
+
+                                        <?php foreach ($state_list->result() as $state) {
+                                            $selected = ($qso->COL_STATE == $state->state) ? 'selected="selected"' : '';
+                                        ?>
+                                            <option value="<?php echo $state->subdivision . ' (' . $state->state . ')'; ?>" <?php echo $selected; ?>>
+                                                <?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
+                                            </option>
+                                        <?php } ?>
                                     </select>
                                 </div>
-
+                                
+                                <?php if ($qso->COL_DXCC == '291' || $qso->COL_DXCC == '110'  || $qso->COL_DXCC == '006') { ?>
                                 <div class="mb-3">
                                     <label for="stationCntyInput">USA County</label>
-                                    <input disabled="disabled" class="form-control" id="stationCntyInputEdit" type="text" name="usa_county" value="<?php echo $qso->COL_CNTY; ?>" />
+                                    <input class="form-control" id="stationCntyInputEdit" type="text" name="usa_county" value="<?php echo $qso->COL_CNTY; ?>" />
                                 </div>
+                                <?php } ?> 
 
                                 <div class="mb-3">
                                     <label for="iota_ref">IOTA</label>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -353,7 +353,7 @@
 
             <div class="mb-3" id="location_us_county">
                 <label for="stationCntyInput"><?php echo lang('gen_hamradio_county_reference'); ?></label>
-                <input disabled="disabled" class="form-control" id="stationCntyInput" type="text" name="county" value="" />
+                <input class="form-control" id="stationCntyInput" type="text" name="county" value="" />
             </div>
 
             <div class="mb-3">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -352,8 +352,8 @@
             </div>
 
             <div class="mb-3" id="location_us_county">
-                <label for="stationCntyInput"><?php echo lang('gen_hamradio_county_reference'); ?></label>
-                <input class="form-control" id="stationCntyInput" type="text" name="county" value="" />
+                <label for="stationCntyInputEdit"><?php echo lang('gen_hamradio_county_reference'); ?></label>
+                <input class="form-control" id="stationCntyInputEdit" type="text" name="county" value="" />
             </div>
 
             <div class="mb-3">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -345,27 +345,13 @@
             </div>
 
             <div class="mb-3">
-              <?php
-              $CI = &get_instance();
-              $CI->load->library('subdivisions');
-
-              //$subdivision_name = $CI->subdivisions->get_primary_subdivision_name($qso->COL_DXCC);  // TODO Show different subdivision name based on callsign dxcc
-              $state_list = $CI->subdivisions->get_state_list('291');                                 // USA hardcoded at the moment
-              ?>
-              <label for="stateDropdown"><?php echo lang('gen_hamradio_usa_state'); ?></label>
-              <select class="form-select" id="stateDropdown" name="input_state_edit">
-                <option value=""></option>
-                <?php foreach ($state_list->result() as $state) {
-                  $selected = ($qso->COL_STATE == $state->state) ? 'selected="selected"' : '';
-                ?>
-                  <option value="<?php echo $state->state; ?>" <?php echo $selected; ?>>
-                    <?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
-                  </option>
-                <?php } ?>
-              </select>
+              <label for="stateInput" id="stateInputLabel"></label>
+                <select class="form-select" name="input_state_edit" id="stateDropdown">
+                  <option value=""></option>
+                </select>
             </div>
 
-            <div class="mb-3">
+            <div class="mb-3" id="location_us_county">
                 <label for="stationCntyInput"><?php echo lang('gen_hamradio_county_reference'); ?></label>
                 <input disabled="disabled" class="form-control" id="stationCntyInput" type="text" name="county" value="" />
             </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -346,7 +346,7 @@
 
             <div class="mb-3">
               <label for="input_usa_state"><?php echo lang('gen_hamradio_usa_state'); ?></label>
-              <select class="form-select" id="input_usa_state" name="usa_state">
+              <select class="form-select" id="input_usa_state" name="input_state_edit">
                 <option value=""></option>
                 <option value="AL">Alabama (AL)</option>
                 <option value="AK">Alaska (AK)</option>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -345,67 +345,30 @@
             </div>
 
             <div class="mb-3">
+              <?php
+              $CI = &get_instance();
+              $CI->load->library('subdivisions');
+
+              //$subdivision_name = $CI->subdivisions->get_primary_subdivision_name($qso->COL_DXCC);  // TODO Show different subdivision name based on callsign dxcc
+              $state_list = $CI->subdivisions->get_state_list('291');                                 // USA hardcoded at the moment
+              ?>
               <label for="input_usa_state"><?php echo lang('gen_hamradio_usa_state'); ?></label>
               <select class="form-select" id="input_usa_state" name="input_state_edit">
                 <option value=""></option>
-                <option value="AL">Alabama (AL)</option>
-                <option value="AK">Alaska (AK)</option>
-                <option value="AZ">Arizona (AZ)</option>
-                <option value="AR">Arkansas (AR)</option>
-                <option value="CA">California (CA)</option>
-                <option value="CO">Colorado (CO)</option>
-                <option value="CT">Connecticut (CT)</option>
-                <option value="DE">Delaware (DE)</option>
-                <option value="DC">District Of Columbia (DC)</option>
-                <option value="FL">Florida (FL)</option>
-                <option value="GA">Georgia (GA)</option>
-                <option value="HI">Hawaii (HI)</option>
-                <option value="ID">Idaho (ID)</option>
-                <option value="IL">Illinois (IL)</option>
-                <option value="IN">Indiana (IN)</option>
-                <option value="IA">Iowa (IA)</option>
-                <option value="KS">Kansas (KS)</option>
-                <option value="KY">Kentucky (KY)</option>
-                <option value="LA">Louisiana (LA)</option>
-                <option value="ME">Maine (ME)</option>
-                <option value="MD">Maryland (MD)</option>
-                <option value="MA">Massachusetts (MA)</option>
-                <option value="MI">Michigan (MI)</option>
-                <option value="MN">Minnesota (MN)</option>
-                <option value="MS">Mississippi (MS)</option>
-                <option value="MO">Missouri (MO)</option>
-                <option value="MT">Montana (MT)</option>
-                <option value="NE">Nebraska (NE)</option>
-                <option value="NV">Nevada (NV)</option>
-                <option value="NH">New Hampshire (NH)</option>
-                <option value="NJ">New Jersey (NJ)</option>
-                <option value="NM">New Mexico (NM)</option>
-                <option value="NY">New York (NY)</option>
-                <option value="NC">North Carolina (NC)</option>
-                <option value="ND">North Dakota (ND)</option>
-                <option value="OH">Ohio (OH)</option>
-                <option value="OK">Oklahoma (OK)</option>
-                <option value="OR">Oregon (OR)</option>
-                <option value="PA">Pennsylvania (PA)</option>
-                <option value="RI">Rhode Island (RI)</option>
-                <option value="SC">South Carolina (SC)</option>
-                <option value="SD">South Dakota (SD)</option>
-                <option value="TN">Tennessee (TN)</option>
-                <option value="TX">Texas (TX)</option>
-                <option value="UT">Utah (UT)</option>
-                <option value="VT">Vermont (VT)</option>
-                <option value="VA">Virginia (VA)</option>
-                <option value="WA">Washington (WA)</option>
-                <option value="WV">West Virginia (WV)</option>
-                <option value="WI">Wisconsin (WI)</option>
-                <option value="WY">Wyoming (WY)</option>
+                <?php foreach ($state_list->result() as $state) {
+                  $selected = ($qso->COL_STATE == $state->state) ? 'selected="selected"' : '';
+                ?>
+                  <option value="<?php echo $state->state; ?>" <?php echo $selected; ?>>
+                    <?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
+                  </option>
+                <?php } ?>
               </select>
             </div>
 
-              <div class="mb-3">
-                  <label for="stationCntyInput"><?php echo lang('gen_hamradio_county_reference'); ?></label>
-                  <input disabled="disabled" class="form-control" id="stationCntyInput" type="text" name="county" value="" />
-              </div>
+            <div class="mb-3">
+                <label for="stationCntyInput"><?php echo lang('gen_hamradio_county_reference'); ?></label>
+                <input disabled="disabled" class="form-control" id="stationCntyInput" type="text" name="county" value="" />
+            </div>
 
             <div class="mb-3">
               <label for="iota_ref"><?php echo lang('gen_hamradio_iota_reference'); ?></label>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -352,8 +352,8 @@
               //$subdivision_name = $CI->subdivisions->get_primary_subdivision_name($qso->COL_DXCC);  // TODO Show different subdivision name based on callsign dxcc
               $state_list = $CI->subdivisions->get_state_list('291');                                 // USA hardcoded at the moment
               ?>
-              <label for="input_usa_state"><?php echo lang('gen_hamradio_usa_state'); ?></label>
-              <select class="form-select" id="input_usa_state" name="input_state_edit">
+              <label for="stateDropdown"><?php echo lang('gen_hamradio_usa_state'); ?></label>
+              <select class="form-select" id="stateDropdown" name="input_state_edit">
                 <option value=""></option>
                 <?php foreach ($state_list->result() as $state) {
                   $selected = ($qso->COL_STATE == $state->state) ? 'selected="selected"' : '';

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -48,7 +48,7 @@
 		  <div class="mb-3">
 		    <label for="stationDXCCInput"><?php echo lang("station_location_dxcc"); ?></label>
 				<?php if ($dxcc_list->num_rows() > 0) { ?>
-				<select class="form-select" id="dxcc_select" name="dxcc" aria-describedby="stationCallsignInputHelp">
+				<select class="form-select" id="dxcc_id" name="dxcc" aria-describedby="stationCallsignInputHelp">
 				<option value="0" selected><?php echo "- " . lang('general_word_none') . " -"; ?></option>
 				<?php foreach ($dxcc_list->result() as $dxcc) { ?>
 				<option value="<?php echo $dxcc->adif; ?>"><?php echo ucwords(strtolower($dxcc->name)) . ' - ' . $dxcc->prefix; if ($dxcc->end != NULL) echo ' ('.lang('gen_hamradio_deleted_dxcc').')';?>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -66,122 +66,51 @@
 		    <small id="stationCityInputHelp" class="form-text text-muted"><?php echo lang("station_location_city_hint"); ?></small>
 		  </div>
 
-        <div class="row">
-            <div class="mb-3 col-sm-6" id="us_state">
-		    <label for="stateInput"><?php echo lang("station_location_state"); ?></label>
-		    <select class="form-select" name="station_state" id="StateHelp" aria-describedby="stationCntyInputHelp">
-		    	<option value="" selected></option>
-				<option value="AK">Alaska</option>
-				<option value="AL">Alabama</option>
-				<option value="AR">Arkansas</option>
-				<option value="AZ">Arizona</option>
-				<option value="CA">California</option>
-				<option value="CO">Colorado</option>
-				<option value="CT">Connecticut</option>
-				<option value="DE">Delaware</option>
-				<option value="FL">Florida</option>
-				<option value="GA">Georgia</option>
-				<option value="HI">Hawaii</option>
-				<option value="IA">Iowa</option>
-				<option value="ID">Idaho</option>
-				<option value="IL">Illinois</option>
-				<option value="IN">Indiana</option>
-				<option value="KS">Kansas</option>
-				<option value="KY">Kentucky</option>
-				<option value="LA">Louisiana</option>
-				<option value="MA">Massachusetts</option>
-				<option value="MD">Maryland</option>
-				<option value="ME">Maine</option>
-				<option value="MI">Michigan</option>
-				<option value="MN">Minnesota</option>
-				<option value="MO">Missouri</option>
-				<option value="MS">Mississippi</option>
-				<option value="MT">Montana</option>
-				<option value="NC">North Carolina</option>
-				<option value="ND">North Dakota</option>
-				<option value="NE">Nebraska</option>
-				<option value="NH">New Hampshire</option>
-				<option value="NJ">New Jersey</option>
-				<option value="NM">New Mexico</option>
-				<option value="NV">Nevada</option>
-				<option value="NY">New York</option>
-				<option value="OH">Ohio</option>
-				<option value="OK">Oklahoma</option>
-				<option value="OR">Oregon</option>
-				<option value="PA">Pennsylvania</option>
-				<option value="RI">Rhode Island</option>
-				<option value="SC">South Carolina</option>
-				<option value="SD">South Dakota</option>
-				<option value="TN">Tennessee</option>
-				<option value="TX">Texas</option>
-				<option value="UT">Utah</option>
-				<option value="VA">Virginia</option>
-				<option value="VT">Vermont</option>
-				<option value="WA">Washington</option>
-				<option value="WI">Wisconsin</option>
-				<option value="WV">West Virginia</option>
-				<option value="WY">Wyoming</option>
+        <!-- State -->
+		<div class="mb-3" id="location_state">
+			<label for="stateInput" id="stateInputLabel"></label>
+			<select class="form-select" name="station_state" id="stateDropdown">
+				<option value=""></option>
 			</select>
-		    <small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
-		  </div>
+			<small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
+		</div>
 
-		  <div class="mb-3 col-sm-6" id="canada_state">
-		    <label for="stateInput"><?php echo lang("station_location_state"); ?></label>
-		    <select class="form-select" name="station_ca_state" id="StateHelp" aria-describedby="stationCntyInputHelp">
-		    	<option value="" selected></option>
-				<option value="AB">Alberta</option>
-				<option value="BC">British Columbia</option>
-				<option value="MB">Manitoba</option>
-				<option value="NB">New Brunswick</option>
-				<option value="NL">Newfoundland & Labrador</option>
-				<option value="NS">Nova Scotia</option>
-				<option value="NT">Northwest Territories</option>
-				<option value="NU">Nunavut</option>
-				<option value="ON">Ontario</option>
-				<option value="PE">Prince Edward Island</option>
-				<option value="QC">Quebec</option>
-				<option value="SK">Saskatchewan</option>
-				<option value="YT">Yukon</option>
-			</select>
-		    <small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
-		  </div>
+		<!-- US County -->
+		<div class="mb-3" id="location_us_county">
+			<label for="stationCntyInput"><?php echo lang("station_location_county"); ?></label>
+			<input disabled="disabled" type="text" class="form-control" name="station_cnty" id="stationCntyInput" aria-describedby="stationCntyInputHelp">
+			<small id="stationCntyInputHelp" class="form-text text-muted"><?php echo lang("station_location_county_hint"); ?></small>
+		</div>
 
-		  <div class="mb-3 col-sm-6">
-		    <label for="stationCntyInput"><?php echo lang("station_location_county"); ?></label>
-		    <input disabled="disabled" type="text" class="form-control" name="station_cnty" id="stationCntyInput" aria-describedby="stationCntyInputHelp">
-		    <small id="stationCntyInputHelp" class="form-text text-muted"><?php echo lang("station_location_county_hint"); ?></small>
-		  </div>
-        </div>
+		<div class="row">
+			<div class="mb-3 col-sm-6">
+				<label for="stationCQZoneInput"><?php echo lang("gen_hamradio_cq_zone"); ?></label>
+				<select class="form-select" id="stationCQZoneInput" name="station_cq" required>
+					<?php
+					for ($i = 1; $i<=40; $i++) {
+						echo '<option value='. $i;
 
-            <div class="row">
-                <div class="mb-3 col-sm-6">
-                    <label for="stationCQZoneInput"><?php echo lang("gen_hamradio_cq_zone"); ?></label>
-                    <select class="form-select" id="stationCQZoneInput" name="station_cq" required>
-                        <?php
-                        for ($i = 1; $i<=40; $i++) {
-                            echo '<option value='. $i;
+						echo '>'. $i .'</option>';
+					}
+					?>
+				</select>
+				<small id="stationCQInputHelp" class="form-text text-muted"><?php echo lang("gen_find_zone_cq_part1")." <a href='https://zone-check.eu/?m=cq' target='_blank'>".lang("gen_find_zone_part2")."</a> ".lang("gen_find_zone_part3"); ?></small>
+			</div>
 
-                            echo '>'. $i .'</option>';
-                        }
-                        ?>
-                    </select>
-                    <small id="stationCQInputHelp" class="form-text text-muted"><?php echo lang("gen_find_zone_cq_part1")." <a href='https://zone-check.eu/?m=cq' target='_blank'>".lang("gen_find_zone_part2")."</a> ".lang("gen_find_zone_part3"); ?></small>
-                </div>
+			<div class="mb-3 col-sm-6">
+				<label for="stationITUZoneInput"><?php echo lang("gen_hamradio_itu_zone"); ?></label>
+				<select class="form-select" id="stationITUZoneInput" name="station_itu" required>
+					<?php
+					for ($i = 1; $i<=90; $i++) {
+						echo '<option value='. $i;
 
-                <div class="mb-3 col-sm-6">
-                    <label for="stationITUZoneInput"><?php echo lang("gen_hamradio_itu_zone"); ?></label>
-                    <select class="form-select" id="stationITUZoneInput" name="station_itu" required>
-                        <?php
-                        for ($i = 1; $i<=90; $i++) {
-                            echo '<option value='. $i;
-
-                            echo '>'. $i .'</option>';
-                        }
-                        ?>
-                    </select>
-                    <small id="stationITUInputHelp" class="form-text text-muted"><?php echo lang("gen_find_zone_itu_part1")." <a href='https://zone-check.eu/?m=itu' target='_blank'>".lang("gen_find_zone_part2")."</a> ".lang("gen_find_zone_part3"); ?></small>
-                </div>
-            </div>
+						echo '>'. $i .'</option>';
+					}
+					?>
+				</select>
+				<small id="stationITUInputHelp" class="form-text text-muted"><?php echo lang("gen_find_zone_itu_part1")." <a href='https://zone-check.eu/?m=itu' target='_blank'>".lang("gen_find_zone_part2")."</a> ".lang("gen_find_zone_part3"); ?></small>
+			</div>
+		</div>
 
 		  <div class="mb-3">
 		    <label for="stationGridsquareInput"><?php echo lang("station_location_gridsquare"); ?></label>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -78,7 +78,7 @@
 		<!-- US County -->
 		<div class="mb-3" id="location_us_county">
 			<label for="stationCntyInput"><?php echo lang("station_location_county"); ?></label>
-			<input disabled="disabled" type="text" class="form-control" name="station_cnty" id="stationCntyInput" aria-describedby="stationCntyInputHelp">
+			<input type="text" class="form-control" name="station_cnty" id="stationCntyInputEdit" aria-describedby="stationCntyInputHelp">
 			<small id="stationCntyInputHelp" class="form-text text-muted"><?php echo lang("station_location_county_hint"); ?></small>
 		</div>
 

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -97,58 +97,20 @@
 					<div class="mb-3" id="us_state">
 		    			<label for="stateInput"><?php echo lang("station_location_state"); ?></label>
 		    				<select class="form-select" name="station_state" id="StateHelp" aria-describedby="stationCntyInputHelp">
+							<?php
+							$CI = &get_instance();
+							$CI->load->library('subdivisions');
+
+							$state_list = $CI->subdivisions->get_state_list($my_station_profile->station_dxcc);
+							?>
 								<option value=""></option>
-								<option value="AK" <?php if($my_station_profile->state == "AK") { echo "selected"; } ?>>Alaska</option>
-								<option value="AL" <?php if($my_station_profile->state == "AL") { echo "selected"; } ?>>Alabama</option>
-								<option value="AR" <?php if($my_station_profile->state == "AR") { echo "selected"; } ?>>Arkansas</option>
-								<option value="AZ" <?php if($my_station_profile->state == "AZ") { echo "selected"; } ?>>Arizona</option>
-								<option value="CA" <?php if($my_station_profile->state == "CA") { echo "selected"; } ?>>California</option>
-								<option value="CO" <?php if($my_station_profile->state == "CO") { echo "selected"; } ?>>Colorado</option>
-								<option value="CT" <?php if($my_station_profile->state == "CT") { echo "selected"; } ?>>Connecticut</option>
-								<option value="DE" <?php if($my_station_profile->state == "DE") { echo "selected"; } ?>>Delaware</option>
-								<option value="DC" <?php if($my_station_profile->state == "DC") { echo "selected"; } ?>>District of Columbia</option>
-								<option value="FL" <?php if($my_station_profile->state == "FL") { echo "selected"; } ?>>Florida</option>
-								<option value="GA" <?php if($my_station_profile->state == "GA") { echo "selected"; } ?>>Georgia</option>
-								<option value="HI" <?php if($my_station_profile->state == "HI") { echo "selected"; } ?>>Hawaii</option>
-								<option value="IA" <?php if($my_station_profile->state == "IA") { echo "selected"; } ?>>Iowa</option>
-								<option value="ID" <?php if($my_station_profile->state == "ID") { echo "selected"; } ?>>Idaho</option>
-								<option value="IL" <?php if($my_station_profile->state == "IL") { echo "selected"; } ?>>Illinois</option>
-								<option value="IN" <?php if($my_station_profile->state == "IN") { echo "selected"; } ?>>Indiana</option>
-								<option value="KS" <?php if($my_station_profile->state == "KS") { echo "selected"; } ?>>Kansas</option>
-								<option value="KY" <?php if($my_station_profile->state == "KY") { echo "selected"; } ?>>Kentucky</option>
-								<option value="LA" <?php if($my_station_profile->state == "LA") { echo "selected"; } ?>>Louisiana</option>
-								<option value="MA" <?php if($my_station_profile->state == "MA") { echo "selected"; } ?>>Massachusetts</option>
-								<option value="MD" <?php if($my_station_profile->state == "MD") { echo "selected"; } ?>>Maryland</option>
-								<option value="ME" <?php if($my_station_profile->state == "ME") { echo "selected"; } ?>>Maine</option>
-								<option value="MI" <?php if($my_station_profile->state == "MI") { echo "selected"; } ?>>Michigan</option>
-								<option value="MN" <?php if($my_station_profile->state == "MN") { echo "selected"; } ?>>Minnesota</option>
-								<option value="MO" <?php if($my_station_profile->state == "MO") { echo "selected"; } ?>>Missouri</option>
-								<option value="MS" <?php if($my_station_profile->state == "MS") { echo "selected"; } ?>>Mississippi</option>
-								<option value="MT" <?php if($my_station_profile->state == "MT") { echo "selected"; } ?>>Montana</option>
-								<option value="NC" <?php if($my_station_profile->state == "NC") { echo "selected"; } ?>>North Carolina</option>
-								<option value="ND" <?php if($my_station_profile->state == "ND") { echo "selected"; } ?>>North Dakota</option>
-								<option value="NE" <?php if($my_station_profile->state == "NE") { echo "selected"; } ?>>Nebraska</option>
-								<option value="NH" <?php if($my_station_profile->state == "NH") { echo "selected"; } ?>>New Hampshire</option>
-								<option value="NJ" <?php if($my_station_profile->state == "NJ") { echo "selected"; } ?>>New Jersey</option>
-								<option value="NM" <?php if($my_station_profile->state == "NM") { echo "selected"; } ?>>New Mexico</option>
-								<option value="NV" <?php if($my_station_profile->state == "NV") { echo "selected"; } ?>>Nevada</option>
-								<option value="NY" <?php if($my_station_profile->state == "NY") { echo "selected"; } ?>>New York</option>
-								<option value="OH" <?php if($my_station_profile->state == "OH") { echo "selected"; } ?>>Ohio</option>
-								<option value="OK" <?php if($my_station_profile->state == "OK") { echo "selected"; } ?>>Oklahoma</option>
-								<option value="OR" <?php if($my_station_profile->state == "OR") { echo "selected"; } ?>>Oregon</option>
-								<option value="PA" <?php if($my_station_profile->state == "PA") { echo "selected"; } ?>>Pennsylvania</option>
-								<option value="RI" <?php if($my_station_profile->state == "RI") { echo "selected"; } ?>>Rhode Island</option>
-								<option value="SC" <?php if($my_station_profile->state == "SC") { echo "selected"; } ?>>South Carolina</option>
-								<option value="SD" <?php if($my_station_profile->state == "SD") { echo "selected"; } ?>>South Dakota</option>
-								<option value="TN" <?php if($my_station_profile->state == "TN") { echo "selected"; } ?>>Tennessee</option>
-								<option value="TX" <?php if($my_station_profile->state == "TX") { echo "selected"; } ?>>Texas</option>
-								<option value="UT" <?php if($my_station_profile->state == "UT") { echo "selected"; } ?>>Utah</option>
-								<option value="VA" <?php if($my_station_profile->state == "VA") { echo "selected"; } ?>>Virginia</option>
-								<option value="VT" <?php if($my_station_profile->state == "VT") { echo "selected"; } ?>>Vermont</option>
-								<option value="WA" <?php if($my_station_profile->state == "WA") { echo "selected"; } ?>>Washington</option>
-								<option value="WI" <?php if($my_station_profile->state == "WI") { echo "selected"; } ?>>Wisconsin</option>
-								<option value="WV" <?php if($my_station_profile->state == "WV") { echo "selected"; } ?>>West Virginia</option>
-								<option value="WY" <?php if($my_station_profile->state == "WY") { echo "selected"; } ?>>Wyoming</option>
+							<?php foreach ($state_list->result() as $state) {
+								$selected = ($my_station_profile->state == $state->state) ? 'selected="selected"' : '';
+							?>
+								<option value="<?php echo $state->state; ?>" <?php echo $selected; ?>>
+									<?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
+								</option>
+							<?php } ?>
 							</select>
 		    				<small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
 		 				</div>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -68,7 +68,7 @@
 					<div class="mb-3">
 					    <label for="stationDXCCInput"><?php echo lang("station_location_dxcc"); ?></label>
 					    <?php if ($dxcc_list->num_rows() > 0) { ?>
-					        <select class="form-select" id="dxcc_select" name="dxcc" aria-describedby="stationCallsignInputHelp">
+					        <select class="form-select" id="dxcc_id" name="dxcc" aria-describedby="stationCallsignInputHelp">
 					            <option value="0" <?php if($my_station_profile->station_dxcc == "0") { ?>selected<?php } ?>><?php echo "- " . lang('general_word_none') . " -"; ?></option>
 					            <?php foreach ($dxcc_list->result() as $dxcc) { ?>
 					                <?php $isDeleted = $dxcc->end !== NULL; ?>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -108,7 +108,7 @@
 					<!-- US County -->
 					<div class="mb-3" id="location_us_county">
 						<label for="stationCntyInput"><?php echo lang("station_location_county"); ?></label>
-						<input disabled="disabled" type="text" class="form-control" name="station_cnty" id="stationCntyInput" aria-describedby="stationCntyInputHelp" value="<?php if(set_value('station_cnty') != "") { echo set_value('station_cnty'); } else { echo $my_station_profile->station_cnty; } ?>">
+						<input type="text" class="form-control" name="station_cnty" id="stationCntyInputEdit" aria-describedby="stationCntyInputHelp" value="<?php if(set_value('station_cnty') != "") { echo set_value('station_cnty'); } else { echo $my_station_profile->station_cnty; } ?>">
 						<small id="stationCntyInputHelp" class="form-text text-muted"><?php echo lang("station_location_county_hint"); ?></small>
 					</div>
 				</div>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -93,56 +93,24 @@
 		    			<small id="stationCityInputHelp" class="form-text text-muted"><?php echo lang("station_location_city_hint"); ?></small>
 		  			</div>
 
-					<!-- US State -->
-					<div class="mb-3" id="us_state">
-		    			<label for="stateInput"><?php echo lang("station_location_state"); ?></label>
-		    				<select class="form-select" name="station_state" id="StateHelp" aria-describedby="stationCntyInputHelp">
-							<?php
-							$CI = &get_instance();
-							$CI->load->library('subdivisions');
+					<!-- State -->
+					<script>
+						var set_state = '<?php echo $my_station_profile->state; ?>';
+					</script>
+					<div class="mb-3" id="location_state">
+		    			<label for="stateInput" id="stateInputLabel"></label>
+						<select class="form-select" name="station_state" id="stateDropdown">
+							<option value=""></option>
+						</select>
+						<small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
+					</div>
 
-							$state_list = $CI->subdivisions->get_state_list($my_station_profile->station_dxcc);
-							?>
-								<option value=""></option>
-							<?php foreach ($state_list->result() as $state) {
-								$selected = ($my_station_profile->state == $state->state) ? 'selected="selected"' : '';
-							?>
-								<option value="<?php echo $state->state; ?>" <?php echo $selected; ?>>
-									<?php echo $state->subdivision . ' (' . $state->state . ')'; ?>
-								</option>
-							<?php } ?>
-							</select>
-		    				<small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
-		 				</div>
-
-					<!-- Canada State -->
-					<div class="mb-3" id="canada_state">
-		    			<label for="stateInput"><?php echo lang("station_location_state"); ?></label>
-		    				<select class="form-select" name="station_ca_state" id="StateHelp" aria-describedby="stationCntyInputHelp">
-								<option value=""></option>
-								<option value="AB" <?php if($my_station_profile->state == "AB") { echo "selected"; } ?>>Alberta</option>
-								<option value="BC" <?php if($my_station_profile->state == "BC") { echo "selected"; } ?>>British Columbia</option>
-								<option value="MB" <?php if($my_station_profile->state == "MB") { echo "selected"; } ?>>Manitoba</option>
-								<option value="NB" <?php if($my_station_profile->state == "NB") { echo "selected"; } ?>>New Brunswick</option>
-								<option value="NL" <?php if($my_station_profile->state == "NL") { echo "selected"; } ?>>Newfoundland & Labrador</option>
-								<option value="NS" <?php if($my_station_profile->state == "NS") { echo "selected"; } ?>>Nova Scotia</option>
-								<option value="NT" <?php if($my_station_profile->state == "NT") { echo "selected"; } ?>>Northwest Territories</option>
-								<option value="NU" <?php if($my_station_profile->state == "NU") { echo "selected"; } ?>>Nunavut</option>
-								<option value="ON" <?php if($my_station_profile->state == "ON") { echo "selected"; } ?>>Ontario</option>
-								<option value="PE" <?php if($my_station_profile->state == "PE") { echo "selected"; } ?>>Prince Edward Island</option>
-								<option value="QC" <?php if($my_station_profile->state == "QC") { echo "selected"; } ?>>Quebec</option>
-								<option value="SK" <?php if($my_station_profile->state == "SK") { echo "selected"; } ?>>Saskatchewan</option>
-								<option value="YT" <?php if($my_station_profile->state == "YT") { echo "selected"; } ?>>Yukon</option>
-							</select>
-		    				<small id="StateHelp" class="form-text text-muted"><?php echo lang("station_location_state_hint"); ?></small>
-						</div>
-
-						<!-- US County -->
-						<div class="mb-3">
-							<label for="stationCntyInput"><?php echo lang("station_location_county"); ?></label>
-							<input disabled="disabled" type="text" class="form-control" name="station_cnty" id="stationCntyInput" aria-describedby="stationCntyInputHelp" value="<?php if(set_value('station_cnty') != "") { echo set_value('station_cnty'); } else { echo $my_station_profile->station_cnty; } ?>">
-							<small id="stationCntyInputHelp" class="form-text text-muted"><?php echo lang("station_location_county_hint"); ?></small>
-		  				</div>
+					<!-- US County -->
+					<div class="mb-3" id="location_us_county">
+						<label for="stationCntyInput"><?php echo lang("station_location_county"); ?></label>
+						<input disabled="disabled" type="text" class="form-control" name="station_cnty" id="stationCntyInput" aria-describedby="stationCntyInputHelp" value="<?php if(set_value('station_cnty') != "") { echo set_value('station_cnty'); } else { echo $my_station_profile->station_cnty; } ?>">
+						<small id="stationCntyInputHelp" class="form-text text-muted"><?php echo lang("station_location_county_hint"); ?></small>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -20,7 +20,13 @@
 .border-top {
 	--bs-border-color: #282828;
 }
-/*
+
+.form-select:disabled {
+	color: #7f7f7f;
+	background-color: #151515;
+}
+
+/* 
 *	Dark Maps
 */
 

--- a/assets/css/cyborg_wide/overrides.css
+++ b/assets/css/cyborg_wide/overrides.css
@@ -20,6 +20,12 @@
 .border-top {
 	--bs-border-color: #282828;
 }
+
+.form-select:disabled {
+	color: #7f7f7f;
+	background-color: #151515;
+}
+
 /*
 *	Dark Maps
 */

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -39,6 +39,10 @@
 	color: white;
 }
 
+.form-select:disabled {
+	background-color: #222222;
+}
+
 /*
 *	Dark Maps
 */

--- a/assets/css/darkly_wide/overrides.css
+++ b/assets/css/darkly_wide/overrides.css
@@ -39,6 +39,10 @@
 	color: white;
 }
 
+.form-select:disabled {
+	background-color: #222222;
+}
+
 /*
 *	Dark Maps
 */

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -28,6 +28,11 @@ body {
 	--bs-border-color: #253544;
 }
 
+.form-select:disabled {
+	color: #7f7f7f;
+	background-color: #2b3e50;
+}
+
 /*
 *	 Maps
 */

--- a/assets/css/superhero_wide/overrides.css
+++ b/assets/css/superhero_wide/overrides.css
@@ -39,6 +39,11 @@ body {
 	overflow-y: auto;
 }
 
+.form-select:disabled {
+	color: #7f7f7f;
+	background-color: #2b3e50;
+}
+
 /*
 *	 Maps
 */

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -133,14 +133,14 @@ function qso_edit(id) {
                 nl2br: false,
                 message: html,
                 onshown: function(dialog) {
-                    var state = $("#input_usa_state_edit option:selected").text();
+                    var state = $("#input_state_edit option:selected").text();
                     if (state != "") {
                         $("#stationCntyInputEdit").prop('disabled', false);
                         selectize_usa_county();
                     }
 
-                    $('#input_usa_state_edit').change(function(){
-                        var state = $("#input_usa_state_edit option:selected").text();
+                    $('#input_state_edit').change(function(){
+                        var state = $("#input_state_edit option:selected").text();
                         if (state != "") {
                             $("#stationCntyInputEdit").prop('disabled', false);
 

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -627,6 +627,7 @@ function showQsoActionsMenu(_this) {
         }
     });
 }
+
 if ($('.table-responsive .dropdown-toggle').length>0) {
     $('.table-responsive .dropdown-toggle').off('mouseenter').on('mouseenter', function () {
         showQsoActionsMenu($(this).closest('.dropdown'));
@@ -635,6 +636,33 @@ if ($('.table-responsive .dropdown-toggle').length>0) {
 
 function getDataTablesLanguageUrl() {
     return "../assets/json/datatables_languages/" + lang_datatables_language + ".json";
+}
+
+function statesDropdown(states, set_state = null) {
+    var dropdown = $('#stateDropdown');
+    dropdown.empty();
+    dropdown.append($('<option>', {
+        value: '',
+    }));
+    if (states.status == 'ok') {
+        dropdown.prop('disabled', false);
+        $.each(states.data, function(index, state) {
+            var option = $('<option>', {
+                value: state.state,
+                text: state.subdivision + ' (' + state.state + ')'
+            });
+            dropdown.append(option);
+        });
+        $(dropdown).val(set_state);
+    } else {
+        dropdown.empty();
+        var option = $('<option>', {
+            value: '',
+            text: 'No states for this DXCC in database'
+        });
+        dropdown.append(option);
+        dropdown.prop('disabled', true);
+    }
 }
 
 console.log("Ready to unleash your coding prowess and join the fun?\n\n" +

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -308,7 +308,7 @@ function qso_edit(id) {
                     $('.modal-content #qslmsg').keyup(function(event) {
                         calcRemainingChars(event, '.modal-content');
                     });
-                    console.log('script is running');
+                    
                     $("#dxcc_id").change(function () {
                         updateStateDropdown();
                     });

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -312,42 +312,42 @@ function qso_edit(id) {
                     $("#dxcc_id").change(function () {
                         updateStateDropdown();
                     });
-                    // updateStateDropdown();
-                    function updateStateDropdown() {
-                        console.log('dropdown triggered');
-                        var selectedDxcc = $("#dxcc_id");
-
-                        if (selectedDxcc.val() !== "") {
-                            $.ajax({
-                                url: base_url + "index.php/lookup/get_state_list",
-                                type: "POST",
-                                data: { dxcc: selectedDxcc.val() },
-                                success: function (response) {
-                                    if (response.status === "ok") {
-                                        statesDropdown(response, set_state);
-                                        $('#stateInputLabel').html(response.subdivision_name);
-                                    } else {
-                                        statesDropdown(response);
-                                        $('#stateInputLabel').html('State');
-                                    }
-                                },
-                                error: function () {
-                                    console.log('ERROR', response.status);
-                                },
-                            });
-                        } 
-
-                        if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
-                            $("#location_us_county").show();
-                        } else {
-                            $("#location_us_county").hide();
-                            $("#stationCntyInputEdit").val();
-                        }
-                    }
                 },
             });
         }
     });
+}
+
+function updateStateDropdown() {
+    console.log('dropdown triggered');
+    var selectedDxcc = $("#dxcc_id");
+
+    if (selectedDxcc.val() !== "") {
+        $.ajax({
+            url: base_url + "index.php/lookup/get_state_list",
+            type: "POST",
+            data: { dxcc: selectedDxcc.val() },
+            success: function (response) {
+                if (response.status === "ok") {
+                    statesDropdown(response, set_state);
+                    $('#stateInputLabel').html(response.subdivision_name);
+                } else {
+                    statesDropdown(response);
+                    $('#stateInputLabel').html('State');
+                }
+            },
+            error: function () {
+                console.log('ERROR', response.status);
+            },
+        });
+    } 
+
+    if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
+        $("#location_us_county").show();
+    } else {
+        $("#location_us_county").hide();
+        $("#stationCntyInputEdit").val();
+    }
 }
 
 function spawnQrbCalculator(locator1, locator2) {

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -638,11 +638,12 @@ function getDataTablesLanguageUrl() {
     return "../assets/json/datatables_languages/" + lang_datatables_language + ".json";
 }
 
+var set_state;
 function statesDropdown(states, set_state = null) {
     var dropdown = $('#stateDropdown');
     dropdown.empty();
     dropdown.append($('<option>', {
-        value: '',
+        value: ''
     }));
     if (states.status == 'ok') {
         dropdown.prop('disabled', false);
@@ -658,7 +659,7 @@ function statesDropdown(states, set_state = null) {
         dropdown.empty();
         var option = $('<option>', {
             value: '',
-            text: 'No states for this DXCC in database'
+            text: 'No states for this DXCC available'
         });
         dropdown.append(option);
         dropdown.prop('disabled', true);

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -133,14 +133,14 @@ function qso_edit(id) {
                 nl2br: false,
                 message: html,
                 onshown: function(dialog) {
-                    var state = $("#input_state_edit option:selected").text();
+                    var state = $("#stateDropdown option:selected").text();
                     if (state != "") {
                         $("#stationCntyInputEdit").prop('disabled', false);
                         selectize_usa_county();
                     }
 
-                    $('#input_state_edit').change(function(){
-                        var state = $("#input_state_edit option:selected").text();
+                    $('#stateDropdown').change(function(){
+                        var state = $("#stateDropdown option:selected").text();
                         if (state != "") {
                             $("#stationCntyInputEdit").prop('disabled', false);
 
@@ -308,6 +308,42 @@ function qso_edit(id) {
                     $('.modal-content #qslmsg').keyup(function(event) {
                         calcRemainingChars(event, '.modal-content');
                     });
+                    console.log('script is running');
+                    $("#dxcc_id").change(function () {
+                        updateStateDropdown();
+                    });
+                    // updateStateDropdown();
+                    function updateStateDropdown() {
+                        console.log('dropdown triggered');
+                        var selectedDxcc = $("#dxcc_id");
+
+                        if (selectedDxcc.val() !== "") {
+                            $.ajax({
+                                url: base_url + "index.php/lookup/get_state_list",
+                                type: "POST",
+                                data: { dxcc: selectedDxcc.val() },
+                                success: function (response) {
+                                    if (response.status === "ok") {
+                                        statesDropdown(response, set_state);
+                                        $('#stateInputLabel').html(response.subdivision_name);
+                                    } else {
+                                        statesDropdown(response);
+                                        $('#stateInputLabel').html('State');
+                                    }
+                                },
+                                error: function () {
+                                    console.log('ERROR', response.status);
+                                },
+                            });
+                        } 
+
+                        if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
+                            $("#location_us_county").show();
+                        } else {
+                            $("#location_us_county").hide();
+                            $("#stationCntyInputEdit").val();
+                        }
+                    }
                 },
             });
         }

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -577,7 +577,7 @@ function reset_fields() {
 	var $select = $('#darc_dok').selectize();
 	var selectize = $select[0].selectize;
 	selectize.clear();
-	$select = $('#stationCntyInput').selectize();
+	$select = $('#stationCntyInputEdit').selectize();
 	selectize = $select[0].selectize;
 	selectize.clear();
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -2,6 +2,10 @@ $( document ).ready(function() {
 	clearTimeout();
 	set_timers();
 	updateStateDropdown();
+	$("#dxcc_id").change(function () {
+		updateStateDropdown();
+	});
+
 
 	function set_timers() {
 		setTimeout(function() {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1087,38 +1087,6 @@ $("#callsign").keyup(function() {
 	}
   });
 
-  function updateStateDropdown() {
-	console.log('dropdown triggered');
-	var selectedDxcc = $("#dxcc_id");
-
-	if (selectedDxcc.val() !== "") {
-		$.ajax({
-			url: base_url + "index.php/lookup/get_state_list",
-			type: "POST",
-			data: { dxcc: selectedDxcc.val() },
-			success: function (response) {
-				if (response.status === "ok") {
-					statesDropdown(response, set_state);
-					$('#stateInputLabel').html(response.subdivision_name);
-				} else {
-					statesDropdown(response);
-					$('#stateInputLabel').html('State');
-				}
-			},
-			error: function () {
-				console.log('ERROR', response.status);
-			},
-		});
-	} 
-
-	if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
-		$("#location_us_county").show();
-	} else {
-		$("#location_us_county").hide();
-		$("#stationCntyInputEdit").val();
-	}
-}
-
 //Reset QSO form Fields function
 function resetDefaultQSOFields() {
 	$('#callsign_info').text("");

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1,6 +1,7 @@
 $( document ).ready(function() {
 	clearTimeout();
 	set_timers();
+	updateStateDropdown();
 
 	function set_timers() {
 		setTimeout(function() {
@@ -581,6 +582,7 @@ function reset_fields() {
 	$('.callsign-suggest').hide();
 	$('.dxccsummary').remove();
 	$('#timesWorked').html(lang_qso_title_previous_contacts);
+	updateStateDropdown();
 }
 
 function resetTimers(manual) {
@@ -715,6 +717,7 @@ $("#callsign").focusout(function() {
 				}
 
 				$('#dxcc_id').val(result.dxcc.adif);
+				updateStateDropdown();
 				$('#cqz').val(result.dxcc.cqz);
 				$('#ituz').val(result.dxcc.ituz);
 
@@ -1079,6 +1082,38 @@ $("#callsign").keyup(function() {
 	  });
 	}
   });
+
+  function updateStateDropdown() {
+	console.log('dropdown triggered');
+	var selectedDxcc = $("#dxcc_id");
+
+	if (selectedDxcc.val() !== "") {
+		$.ajax({
+			url: base_url + "index.php/lookup/get_state_list",
+			type: "POST",
+			data: { dxcc: selectedDxcc.val() },
+			success: function (response) {
+				if (response.status === "ok") {
+					statesDropdown(response, set_state);
+					$('#stateInputLabel').html(response.subdivision_name);
+				} else {
+					statesDropdown(response);
+					$('#stateInputLabel').html('State');
+				}
+			},
+			error: function () {
+				console.log('ERROR', response.status);
+			},
+		});
+	} 
+
+	if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
+		$("#location_us_county").show();
+	} else {
+		$("#location_us_county").hide();
+		$("#stationCntyInputEdit").val();
+	}
+}
 
 //Reset QSO form Fields function
 function resetDefaultQSOFields() {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -216,8 +216,8 @@ var favs={};
 		}
 	});
 
-	$('#input_usa_state').change(function(){
-		var state = $("#input_usa_state option:selected").text();
+	$('#stateDropdown').change(function(){
+		var state = $("#stateDropdown option:selected").text();
 		if (state != "") {
 			$("#stationCntyInput").prop('disabled', false);
 
@@ -231,7 +231,7 @@ var favs={};
 				options: [],
 				create: false,
 				load: function(query, callback) {
-					var state = $("#input_usa_state option:selected").text();
+					var state = $("#stateDropdown option:selected").text();
 
 					if (!query || state == "") return callback();
 					$.ajax({
@@ -558,7 +558,7 @@ function reset_fields() {
 	$('#callsign-image-content').text("");
 	$('#qsl_via').val("");
 	$('#callsign_info').text("");
-	$('#input_usa_state').val("");
+	$('#stateDropdown').val("");
 	$('#qso-last-table').show();
 	$('#partial_view').hide();
 	$('.callsign-suggest').hide();
@@ -797,8 +797,8 @@ $("#callsign").focusout(function() {
 				/*
 				* Update state with returned value
 				*/
-				if($("#input_usa_state").val() == "") {
-					$("#input_usa_state").val(result.callsign_state).trigger('change');
+				if($("#stateDropdown").val() == "") {
+					$("#stateDropdown").val(result.callsign_state).trigger('change');
 				}
 
 				/*
@@ -1102,7 +1102,7 @@ function resetDefaultQSOFields() {
 	$('#callsign_info').removeClass("text-bg-secondary");
 	$('#callsign_info').removeClass("text-bg-success");
 	$('#callsign_info').removeClass("text-bg-danger");
-	$('#input_usa_state').val("");
+	$('#stateDropdown').val("");
 	$('#callsign-image').attr('style', 'display: none;');
 	$('#callsign-image-content').text("");
 	$('.dxccsummary').remove();

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
 		},
 	});
 
-	if (window.location.pathname.indexOf("/station/edit") !== -1) {
+	if (window.location.pathname.indexOf("/station/edit") !== -1 || window.location.pathname.indexOf("/station/create") !== -1) {
 		updateStateDropdown();
 		$("#dxcc_select").change(function () {
 			updateStateDropdown();
@@ -28,6 +28,7 @@ function updateStateDropdown() {
                     $('#stateInputLabel').html(response.subdivision_name);
 				} else {
                     statesDropdown(response);
+					$('#stateInputLabel').html('State');
                 }
 			},
 			error: function () {

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -1,31 +1,44 @@
-$(document).ready( function () {
+$(document).ready(function () {
+	$("#station_locations_table").DataTable({
+		stateSave: true,
+		language: {
+			url: getDataTablesLanguageUrl(),
+		},
+	});
 
-    // Use Jquery to hide div ca_state
+	if (window.location.pathname.indexOf("/station/edit") !== -1) {
+		updateStateDropdown();
+		$("#dxcc_select").change(function () {
+			updateStateDropdown();
+		});
+	}
+});
 
-    $('#station_locations_table').DataTable({
-        "stateSave": true,
-        "language": {
-            url: getDataTablesLanguageUrl(),
-        }
-    });
+function updateStateDropdown() {
+	var selectedDxcc = $("#dxcc_select");
 
-    $("#canada_state").hide();
+	if (selectedDxcc.val() !== "") {
+		$.ajax({
+			url: base_url + "index.php/lookup/get_state_list",
+			type: "POST",
+			data: { dxcc: selectedDxcc.val() },
+			success: function (response) {
+				if (response.status === "ok") {
+					statesDropdown(response, set_state);
+                    $('#stateInputLabel').html(response.subdivision_name);
+				} else {
+                    statesDropdown(response);
+                }
+			},
+			error: function () {
+				console.log('ERROR', response.status);
+			},
+		});
+	} 
 
-    var selectedDXCCID = $('#dxcc_select').find(":selected").val();
-
-    if(selectedDXCCID == '1'){
-        $("#canada_state").show();
-        $("#us_state").hide();
+    if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
+        $("#location_us_county").show();
+    } else {
+        $("#location_us_county").hide();
     }
-
-    $('#dxcc_select').change(function(){
-        if($(this).val() == '1'){ // or this.value == 'volvo'
-          console.log("CANADA!");
-          $("#canada_state").show();
-          $("#us_state").hide();
-        } else {
-            $("#canada_state").hide();
-            $("#us_state").show();
-        }
-    });
-} );
+}

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -7,6 +7,7 @@ $(document).ready(function () {
 	});
 
 	if (window.location.pathname.indexOf("/station/edit") !== -1 || window.location.pathname.indexOf("/station/create") !== -1) {
+		selectize_usa_county();
 		updateStateDropdown();
 		$("#dxcc_select").change(function () {
 			updateStateDropdown();

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -9,38 +9,9 @@ $(document).ready(function () {
 	if (window.location.pathname.indexOf("/station/edit") !== -1 || window.location.pathname.indexOf("/station/create") !== -1) {
 		selectize_usa_county();
 		updateStateDropdown();
-		$("#dxcc_select").change(function () {
+		$("#dxcc_id").change(function () {
 			updateStateDropdown();
 		});
 	}
 });
 
-function updateStateDropdown() {
-	var selectedDxcc = $("#dxcc_select");
-
-	if (selectedDxcc.val() !== "") {
-		$.ajax({
-			url: base_url + "index.php/lookup/get_state_list",
-			type: "POST",
-			data: { dxcc: selectedDxcc.val() },
-			success: function (response) {
-				if (response.status === "ok") {
-					statesDropdown(response, set_state);
-                    $('#stateInputLabel').html(response.subdivision_name);
-				} else {
-                    statesDropdown(response);
-					$('#stateInputLabel').html('State');
-                }
-			},
-			error: function () {
-				console.log('ERROR', response.status);
-			},
-		});
-	} 
-
-    if (selectedDxcc.val() == '291' || selectedDxcc.val() == '110' || selectedDxcc.val() == '6') {
-        $("#location_us_county").show();
-    } else {
-        $("#location_us_county").hide();
-    }
-}


### PR DESCRIPTION
Thx to @phl0 who introduced the subdivisions table

With this PR we fetch available states from the database. 

Made Changes:

- QSO Edit shows states dependent on qso dxcc (only if available in database, only on load - not live if dxcc is changed)
- QuickLookup WAS Check fetches from DB
- QSO Logging US State selection fetches from DB*
- Station Location has now all States aswell, means you can set the location station fix in database for all available DXCC (not only US)

