### PR TITLE
fix adif county

### DIFF
--- a/application/libraries/AdifHelper.php
+++ b/application/libraries/AdifHelper.php
@@ -196,11 +196,14 @@ class AdifHelper {
 
         $line .= $this->getAdifFieldLine("MY_ITU_ZONE", $qso->station_itu);
 
-		if($qso->state) {
-			$county = trim($qso->state) . "," . trim($qso->station_cnty);
-		} else {
-			$county = trim($qso->station_cnty);
-		}
+        $line .= $this->getAdifFieldLine("MY_STATE", $qso->state);
+
+        // We fill county only if it has a value and it's USA, Alaska or Hawaii. Other countrys are not supported at the moment due complex adif specs
+		if ($qso->station_cnty && ($qso->station_dxcc == '291' || $qso->station_dxcc == '006' || $qso->station_dxcc == '110')) {
+            $county = trim($qso->state) . "," . trim($qso->station_cnty);
+        } else {
+            $county = '';
+        }        
 
         $line .= $this->getAdifFieldLine("MY_CNTY", $county);
 
@@ -234,7 +237,6 @@ class AdifHelper {
             MY_NAME
             MY_POSTAL_CODE
             MY_RIG
-            MY_STATE
             MY_STREET
             MY_USACA_COUNTIES
         */

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -80,6 +80,13 @@ class Stations extends CI_Model {
 			$state = $this->input->post('station_state');
 		}
 
+		// Check if DXCC is USA, Alaska or Hawaii. If not true, we clear the County field due to complex adif specs
+		if (($this->input->post('dxcc') == 291 || $this->input->post('dxcc') == 006 || $this->input->post('dxcc') == 110) && $this->input->post('station_cnty') !="") {
+			$county = $this->input->post('station_cnty');
+		} else {
+			$county = '';
+		}
+
 		// Create data array with field values
 		$data = array(
 			'user_id' => $this->session->userdata('user_id'),
@@ -96,7 +103,7 @@ class Stations extends CI_Model {
 			'station_callsign' =>  xss_clean($this->input->post('station_callsign', true)),
 			'station_power' => is_numeric(xss_clean($this->input->post('station_power', true))) ? xss_clean($this->input->post('station_power', true)) : NULL,
 			'station_dxcc' =>  xss_clean($this->input->post('dxcc', true)),
-			'station_cnty' =>  xss_clean($this->input->post('station_cnty', true)),
+			'station_cnty' =>  $county,
 			'station_cq' =>  xss_clean($this->input->post('station_cq', true)),
 			'station_itu' =>  xss_clean($this->input->post('station_itu', true)),
 			'state' =>  $state,
@@ -133,6 +140,13 @@ class Stations extends CI_Model {
 			$state = $this->input->post('station_state');
 		}
 
+		// Check if DXCC is USA, Alaska or Hawaii. If not true, we clear the County field due to complex adif specs
+		if (($this->input->post('dxcc') == 291 || $this->input->post('dxcc') == 006 || $this->input->post('dxcc') == 110) && $this->input->post('station_cnty') !="") {
+			$county = $this->input->post('station_cnty');
+		} else {
+			$county = '';
+		}
+
 		$data = array(
 			'station_profile_name' => xss_clean($this->input->post('station_profile_name', true)),
 			'station_gridsquare' => xss_clean($this->input->post('gridsquare', true)),
@@ -146,7 +160,7 @@ class Stations extends CI_Model {
 			'station_callsign' => xss_clean($this->input->post('station_callsign', true)),
 			'station_power' => is_numeric(xss_clean($this->input->post('station_power', true))) ? xss_clean($this->input->post('station_power', true)) : NULL,
 			'station_dxcc' => xss_clean($this->input->post('dxcc', true)),
-			'station_cnty' => xss_clean($this->input->post('station_cnty', true)),
+			'station_cnty' =>  $county,
 			'station_cq' => xss_clean($this->input->post('station_cq', true)),
 			'station_itu' => xss_clean($this->input->post('station_itu', true)),
 			'state' => $state,


### PR DESCRIPTION
This is a fix for the ADIF bug where the MY_CNTY field gets filled with invalid data. Wavelog currently only supports the MY_CNTY field if the DXCC is USA, Alaska or Hawaii. Reason for that are pretty complex Adif specs (each country has it's own "sponsor defined format"

<img width="137" alt="adif" src="https://github.com/wavelog/wavelog/assets/80885850/4fe68444-6b07-428a-bb61-89c1d70b2718">
