### PR TITLE
Sorted userdata

### DIFF
--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -38,16 +38,18 @@ class Eqsl_images extends CI_Model {
 	// return path of eQsl file : u=url / p=real path 
 	function get_imagePath($pathorurl='u') {
 
-        // check if there is a user_id in the session data and it's not empty
-		$user_id = $this->session->userdata('user_id');
-        if ($user_id != '') {
+		// test if new folder directory option is enabled
+		$userdata_dir = $this->config->item('userdata');
+		
+		if (isset($userdata_dir)) {
 
-            $eqsl_dir = "eqsl_card";
+			$eqsl_dir = "eqsl_card";
 
-            // test if new folder directory exist 
-            $userdata_dir = $this->config->item('userdata');
-            if (isset($userdata_dir)) {
-
+			$user_id = $this->session->userdata('user_id');
+			
+			// check if there is a user_id in the session data and it's not empty
+			if ($user_id != '') {
+				
                 // create the folder
                 if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir)) {
                     mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir, 0755, true);
@@ -60,11 +62,13 @@ class Eqsl_images extends CI_Model {
                     return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
                 }
             } else {
+				log_message('Error', 'Can not get eqsl image path because no user_id in session data');
+			}
+        } else {
 
-                // if the config option is not set we just return the old path
-                return 'images/eqsl_card_images';
-            }
-        }
+			// if the config option is not set we just return the old path
+			return 'images/eqsl_card_images';
+		}
 	}
 }
 

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -38,9 +38,9 @@ class Eqsl_images extends CI_Model {
 	// return path of eQsl file : u=url / p=real path 
 	function get_imagePath($pathorurl='u') {
 
-        // check if there is a user_name in the session data and it's not emoty
-		$user_name = $this->session->userdata('user_name');
-        if ($user_name != '') {
+        // check if there is a user_id in the session data and it's not empty
+		$user_id = $this->session->userdata('user_id');
+        if ($user_id != '') {
 
             $eqsl_dir = "eqsl_card";
 
@@ -49,15 +49,15 @@ class Eqsl_images extends CI_Model {
             if (isset($userdata_dir)) {
 
                 // create the folder
-                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir)) {
-                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir, 0755, true);
+                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir)) {
+                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir, 0755, true);
                 }
 
                 // and return it
                 if ($pathorurl=='u') {
-                    return $userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
+                    return $userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
                 } else {
-                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
+                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
                 }
             } else {
 

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -40,17 +40,15 @@ class Eqsl_images extends CI_Model {
 		$eqsl_dir = "eqsl_card";
 		// test if new folder directory exist // 
 		$userdata_dir = $this->config->item('userdata');
+		$user_name = $this->session->userdata('user_name');
 		if (isset($userdata_dir)) {
-			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir)) {
-				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir, 0755, true);
-			}
-			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$eqsl_dir)) {
-				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$eqsl_dir, 0755, true);
+			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir)) {
+				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir, 0755, true);
 			}
 			if ($pathorurl=='u') {
-				return $userdata_dir.'/'.$eqsl_dir;
+				return $userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
 			} else {
-				return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$eqsl_dir;
+				return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
 			}
 		} else {
 			return 'images/eqsl_card_images';

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -35,24 +35,36 @@ class Eqsl_images extends CI_Model {
 		return $this->db->get('eQSL_images');
 	}
 
-	// return path of eQsl file : u=url / p=real path //
+	// return path of eQsl file : u=url / p=real path 
 	function get_imagePath($pathorurl='u') {
-		$eqsl_dir = "eqsl_card";
-		// test if new folder directory exist // 
-		$userdata_dir = $this->config->item('userdata');
+
+        // check if there is a user_name in the session data and it's not emoty
 		$user_name = $this->session->userdata('user_name');
-		if (isset($userdata_dir)) {
-			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir)) {
-				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir, 0755, true);
-			}
-			if ($pathorurl=='u') {
-				return $userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
-			} else {
-				return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
-			}
-		} else {
-			return 'images/eqsl_card_images';
-		}
+        if ($user_name != '') {
+
+            $eqsl_dir = "eqsl_card";
+
+            // test if new folder directory exist 
+            $userdata_dir = $this->config->item('userdata');
+            if (isset($userdata_dir)) {
+
+                // create the folder
+                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir)) {
+                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir, 0755, true);
+                }
+
+                // and return it
+                if ($pathorurl=='u') {
+                    return $userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
+                } else {
+                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$eqsl_dir;
+                }
+            } else {
+
+                // if the config option is not set we just return the old path
+                return 'images/eqsl_card_images';
+            }
+        }
 	}
 }
 

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -133,17 +133,15 @@ class Qsl_model extends CI_Model {
 		$qsl_dir = "qsl_card";
 		// test if new folder directory exist // 
 		$userdata_dir = $this->config->item('userdata');
+		$user_name = $this->session->userdata('user_name');
 		if (isset($userdata_dir)) {
-			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir)) {
-				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir, 0755, true);
-			}
-			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$qsl_dir)) {
-				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$qsl_dir, 0755, true);
+			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir)) {
+				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir, 0755, true);
 			}
 			if ($pathorurl=='u') {
-				return $userdata_dir.'/'.$qsl_dir;
+				return $userdata_dir.'/'.$user_name.'/'.$qsl_dir;
 			} else {
-				return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$qsl_dir;
+				return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir;
 			}
 		} else {
 			return 'assets/qslcard';

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -128,19 +128,21 @@ class Qsl_model extends CI_Model {
 		return $this->db->insert_id();
 	}
 
-	// return path of Qsl file : u=url / p=real path 
+	// return path of qsl file : u=url / p=real path 
 	function get_imagePath($pathorurl='u') {
 
-        // check if there is a user_id in the session data and it's not empty
-		$user_id = $this->session->userdata('user_id');
-        if ($user_id != '') {
+		// test if new folder directory option is enabled
+		$userdata_dir = $this->config->item('userdata');
+		
+		if (isset($userdata_dir)) {
 
-            $qsl_dir = "qsl_card";
+			$qsl_dir = "qsl_card";
 
-            // test if new folder directory exist 
-            $userdata_dir = $this->config->item('userdata');
-            if (isset($userdata_dir)) {
-
+			$user_id = $this->session->userdata('user_id');
+			
+			// check if there is a user_id in the session data and it's not empty
+			if ($user_id != '') {
+				
                 // create the folder
                 if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir)) {
                     mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir, 0755, true);
@@ -153,10 +155,12 @@ class Qsl_model extends CI_Model {
                     return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir;
                 }
             } else {
+				log_message('Error', 'Can not get qsl card image path because no user_id in session data');
+			}
+        } else {
 
-                // if the config option is not set we just return the old path
-                return 'assets/qslcard';
-            }
-        }
+			// if the config option is not set we just return the old path
+			return 'assets/qslcard';
+		}
 	}
 }

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -128,23 +128,35 @@ class Qsl_model extends CI_Model {
 		return $this->db->insert_id();
 	}
 
-	// return path of Qsl file : u=url / p=real path //
+	// return path of Qsl file : u=url / p=real path 
 	function get_imagePath($pathorurl='u') {
-		$qsl_dir = "qsl_card";
-		// test if new folder directory exist // 
-		$userdata_dir = $this->config->item('userdata');
+
+        // check if there is a user_name in the session data and it's not emoty
 		$user_name = $this->session->userdata('user_name');
-		if (isset($userdata_dir)) {
-			if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir)) {
-				mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir, 0755, true);
-			}
-			if ($pathorurl=='u') {
-				return $userdata_dir.'/'.$user_name.'/'.$qsl_dir;
-			} else {
-				return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir;
-			}
-		} else {
-			return 'assets/qslcard';
-		}
+        if ($user_name != '') {
+
+            $qsl_dir = "qsl_card";
+
+            // test if new folder directory exist 
+            $userdata_dir = $this->config->item('userdata');
+            if (isset($userdata_dir)) {
+
+                // create the folder
+                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir)) {
+                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir, 0755, true);
+                }
+
+                // and return it
+                if ($pathorurl=='u') {
+                    return $userdata_dir.'/'.$user_name.'/'.$qsl_dir;
+                } else {
+                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir;
+                }
+            } else {
+
+                // if the config option is not set we just return the old path
+                return 'assets/qslcard';
+            }
+        }
 	}
 }

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -131,9 +131,9 @@ class Qsl_model extends CI_Model {
 	// return path of Qsl file : u=url / p=real path 
 	function get_imagePath($pathorurl='u') {
 
-        // check if there is a user_name in the session data and it's not emoty
-		$user_name = $this->session->userdata('user_name');
-        if ($user_name != '') {
+        // check if there is a user_id in the session data and it's not empty
+		$user_id = $this->session->userdata('user_id');
+        if ($user_id != '') {
 
             $qsl_dir = "qsl_card";
 
@@ -142,15 +142,15 @@ class Qsl_model extends CI_Model {
             if (isset($userdata_dir)) {
 
                 // create the folder
-                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir)) {
-                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir, 0755, true);
+                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir)) {
+                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir, 0755, true);
                 }
 
                 // and return it
                 if ($pathorurl=='u') {
-                    return $userdata_dir.'/'.$user_name.'/'.$qsl_dir;
+                    return $userdata_dir.'/'.$user_id.'/'.$qsl_dir;
                 } else {
-                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_name.'/'.$qsl_dir;
+                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir;
                 }
             } else {
 


### PR DESCRIPTION
this is an addition to #70 

it's much better to sort the centralized userdata (if enabled, default: off) by the user. this makes it much easier to seperate userdata between users. 

Remark: Data has to be moved manually if it is already enabled. But since we release this feature just 3 weeks ago and it's default off, I doubt that this is a widly used feature at the moment.

<img width="122" alt="userdata" src="https://github.com/wavelog/wavelog/assets/80885850/8640b671-5810-4435-aca0-9be63571d03f">
