### PR TITLE
Qsl foldersize

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -13,8 +13,9 @@ class eqsl extends CI_Controller {
 
         $this->lang->load('qslcard');
 		$this->load->model('eqsl_images');
+		$this->load->library('Genfunctions');
         $folder_name = $this->eqsl_images->get_imagePath('p');
-        $data['storage_used'] = $this->sizeFormat($this->folderSize($folder_name));
+        $data['storage_used'] = $this->genfunctions->sizeFormat($this->genfunctions->folderSize($folder_name));
 
 
         // Render Page
@@ -748,50 +749,6 @@ class eqsl extends CI_Controller {
 			$adif = $this->generateAdif($qsl, $data);
 			
 			$status = $this->uploadQso($adif, $qsl);
-		}
-	}
-
-// Functions for storage, these need shifted to a libary to use across Wavelog
-	function folderSize($dir){
-		$count_size = 0;
-		$count = 0;
-		$dir_array = scandir($dir);
-		foreach($dir_array as $key=>$filename){
-			if($filename!=".." && $filename!="."){
-				if(is_dir($dir."/".$filename)){
-					$new_foldersize = $this->foldersize($dir."/".$filename);
-					$count_size = $count_size+ $new_foldersize;
-				}else if(is_file($dir."/".$filename)){
-					$count_size = $count_size + filesize($dir."/".$filename);
-					$count++;
-				}
-			}
-		}
-		return $count_size;
-	}
-
-	function sizeFormat($bytes){
-		$kb = 1024;
-		$mb = $kb * 1024;
-		$gb = $mb * 1024;
-		$tb = $gb * 1024;
-
-		if (($bytes >= 0) && ($bytes < $kb)) {
-			return $bytes . ' B';
-
-		} elseif (($bytes >= $kb) && ($bytes < $mb)) {
-			return ceil($bytes / $kb) . ' KB';
-
-		} elseif (($bytes >= $mb) && ($bytes < $gb)) {
-			return ceil($bytes / $mb) . ' MB';
-
-		} elseif (($bytes >= $gb) && ($bytes < $tb)) {
-			return ceil($bytes / $gb) . ' GB';
-
-		} elseif ($bytes >= $tb) {
-			return ceil($bytes / $tb) . ' TB';
-		} else {
-			return $bytes . ' B';
 		}
 	}
 

--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -17,8 +17,9 @@ class Qsl extends CI_Controller {
     public function index() {
 
         $this->load->model('qsl_model');
+        $this->load->library('Genfunctions');
         $folder_name = $this->qsl_model->get_imagePath('p');
-        $data['storage_used'] = sizeFormat(folderSize($folder_name));
+        $data['storage_used'] = $this->genfunctions->sizeFormat($this->genfunctions->folderSize($folder_name));
 
         // Render Page
         $data['page_title'] = "QSL Cards";
@@ -173,48 +174,4 @@ class Qsl extends CI_Controller {
         $this->load->view('qslcard/qslcarousel', $data);
     }
 
-}
-
-// Functions for storage, these need shifted to a libary to use across Wavelog
-function folderSize($dir){
-    $count_size = 0;
-    $count = 0;
-    $dir_array = scandir($dir);
-      foreach($dir_array as $key=>$filename){
-        if($filename!=".." && $filename!="."){
-           if(is_dir($dir."/".$filename)){
-              $new_foldersize = foldersize($dir."/".$filename);
-              $count_size = $count_size+ $new_foldersize;
-            }else if(is_file($dir."/".$filename)){
-              $count_size = $count_size + filesize($dir."/".$filename);
-              $count++;
-            }
-       }
-     }
-    return $count_size;
-}
-
-function sizeFormat($bytes){
-    $kb = 1024;
-    $mb = $kb * 1024;
-    $gb = $mb * 1024;
-    $tb = $gb * 1024;
-
-    if (($bytes >= 0) && ($bytes < $kb)) {
-    return $bytes . ' B';
-
-    } elseif (($bytes >= $kb) && ($bytes < $mb)) {
-    return ceil($bytes / $kb) . ' KB';
-
-    } elseif (($bytes >= $mb) && ($bytes < $gb)) {
-    return ceil($bytes / $mb) . ' MB';
-
-    } elseif (($bytes >= $gb) && ($bytes < $tb)) {
-    return ceil($bytes / $gb) . ' GB';
-
-    } elseif ($bytes >= $tb) {
-    return ceil($bytes / $tb) . ' TB';
-    } else {
-    return $bytes . ' B';
-    }
 }

--- a/application/libraries/Genfunctions.php
+++ b/application/libraries/Genfunctions.php
@@ -1,7 +1,7 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed');
 
 /***
- * Libary for common functions, used at many places
+ * Library for common functions, used at many places
  */
 class Genfunctions
 {

--- a/application/libraries/Genfunctions.php
+++ b/application/libraries/Genfunctions.php
@@ -66,4 +66,49 @@ class Genfunctions
 		return $qsl;
 	}
 
+	// functions to read folder size and calculate size format
+
+	function folderSize($dir){
+		$count_size = 0;
+		$count = 0;
+		$dir_array = scandir($dir);
+		foreach($dir_array as $key=>$filename){
+			if($filename!=".." && $filename!="."){
+				if(is_dir($dir."/".$filename)){
+					$new_foldersize = $this->foldersize($dir."/".$filename);
+					$count_size = $count_size+ $new_foldersize;
+				}else if(is_file($dir."/".$filename)){
+					$count_size = $count_size + filesize($dir."/".$filename);
+					$count++;
+				}
+			}
+		}
+		return $count_size;
+	}
+
+	function sizeFormat($bytes){
+		$kb = 1024;
+		$mb = $kb * 1024;
+		$gb = $mb * 1024;
+		$tb = $gb * 1024;
+
+		if (($bytes >= 0) && ($bytes < $kb)) {
+			return $bytes . ' B';
+
+		} elseif (($bytes >= $kb) && ($bytes < $mb)) {
+			return ceil($bytes / $kb) . ' KB';
+
+		} elseif (($bytes >= $mb) && ($bytes < $gb)) {
+			return ceil($bytes / $mb) . ' MB';
+
+		} elseif (($bytes >= $gb) && ($bytes < $tb)) {
+			return ceil($bytes / $gb) . ' GB';
+
+		} elseif ($bytes >= $tb) {
+			return ceil($bytes / $tb) . ' TB';
+		} else {
+			return $bytes . ' B';
+		}
+	}
+
 }

--- a/application/libraries/Paths.php
+++ b/application/libraries/Paths.php
@@ -1,7 +1,7 @@
 <?php defined('BASEPATH') or exit('No direct script access allowed');
 
 /***
- * Paths Libary to return specific paths
+ * Paths Library to return specific paths
  */
 class Paths
 {

--- a/application/views/eqslcard/index.php
+++ b/application/views/eqslcard/index.php
@@ -4,9 +4,12 @@
 
     <h2><?php echo $this->lang->line('general_word_eqslcards'); ?></h2>
 
-    <div class="alert alert-info" role="alert">
-    <?php echo $this->lang->line('qslcard_string_your_are_using'); ?> <?php echo $storage_used; ?> <?php echo $this->lang->line('qslcard_string_disk_space'); ?>
-    </div>
+    <?php $userdata_dir = $this->config->item('userdata');
+    if (isset($userdata_dir)) { ?>
+        <div class="alert alert-info" role="alert">
+            <?php echo lang('qslcard_string_your_are_using'); ?> <?php echo $storage_used; ?> <?php echo lang('qslcard_string_disk_space'); ?>
+        </div>
+    <?php } ?>
 
     <?php
 

--- a/application/views/qslcard/index.php
+++ b/application/views/qslcard/index.php
@@ -4,30 +4,33 @@
 
     <h2><?php echo lang('general_word_qslcards'); ?></h2>
 
-    <div class="alert alert-info" role="alert">
-    <?php echo lang('qslcard_string_your_are_using'); ?> <?php echo $storage_used; ?> <?php echo lang('qslcard_string_disk_space'); ?>
-    </div>
+    <?php $userdata_dir = $this->config->item('userdata');
+    if (isset($userdata_dir)) { ?>
+        <div class="alert alert-info" role="alert">
+            <?php echo lang('qslcard_string_your_are_using'); ?> <?php echo $storage_used; ?> <?php echo lang('qslcard_string_disk_space'); ?>
+        </div>
+    <?php } ?>
 
     <?php
 
-	if($this->session->userdata('user_date_format')) {
-		// If Logged in and session exists
-		$custom_date_format = $this->session->userdata('user_date_format');
-	} else {
-		// Get Default date format from /config/wavelog.php
-		$custom_date_format = $this->config->item('qso_date_format');
-	}
+    if ($this->session->userdata('user_date_format')) {
+        // If Logged in and session exists
+        $custom_date_format = $this->session->userdata('user_date_format');
+    } else {
+        // Get Default date format from /config/wavelog.php
+        $custom_date_format = $this->config->item('qso_date_format');
+    }
 
     if (is_array($qslarray->result())) {
         echo '<table style="width:100%" class="qsltable table table-sm table-bordered table-hover table-striped table-condensed">
         <thead>
         <tr>
-        <th style=\'text-align: center\'>'.lang('gen_hamradio_callsign').'</th>
-        <th style=\'text-align: center\'>'.lang('gen_hamradio_mode').'</th>
-        <th style=\'text-align: center\'>'.lang('general_word_date').'</th>
-        <th style=\'text-align: center\'>'.lang('general_word_time').'</th>
-        <th style=\'text-align: center\'>'.lang('gen_hamradio_band').'</th>
-        <th style=\'text-align: center\'>'.lang('gen_hamradio_qsl').'</th>
+        <th style=\'text-align: center\'>' . lang('gen_hamradio_callsign') . '</th>
+        <th style=\'text-align: center\'>' . lang('gen_hamradio_mode') . '</th>
+        <th style=\'text-align: center\'>' . lang('general_word_date') . '</th>
+        <th style=\'text-align: center\'>' . lang('general_word_time') . '</th>
+        <th style=\'text-align: center\'>' . lang('gen_hamradio_band') . '</th>
+        <th style=\'text-align: center\'>' . lang('gen_hamradio_qsl') . '</th>
         <th style=\'text-align: center\'></th>
         <th style=\'text-align: center\'></th>
         <th style=\'text-align: center\'></th>
@@ -36,23 +39,29 @@
 
         foreach ($qslarray->result() as $qsl) {
             echo '<tr>';
-            echo '<td style=\'text-align: center\'>' . str_replace("0","&Oslash;",$qsl->COL_CALL) . '</td>';
-			echo '<td style=\'text-align: center\'>';
-			echo $qsl->COL_SUBMODE==null?$qsl->COL_MODE:$qsl->COL_SUBMODE;
-			echo '</td>';
-			echo '<td style=\'text-align: center\'>';
-			$timestamp = strtotime($qsl->COL_TIME_ON); echo date($custom_date_format, $timestamp);
-			echo '</td>';
-			echo '<td style=\'text-align: center\'>';
-			$timestamp = strtotime($qsl->COL_TIME_ON); echo date('H:i', $timestamp);
-			echo '</td>';
-			echo '<td style=\'text-align: center\'>';
-			if($qsl->COL_SAT_NAME != null) { echo $qsl->COL_SAT_NAME; } else { echo strtolower($qsl->COL_BAND); };
-			echo '</td>';
-			echo '<td style=\'text-align: center\'>' . $qsl->filename . '</td>';
-			echo '<td id="'.$qsl->id.'" style=\'text-align: center\'><button onclick="deleteQsl(\''.$qsl->id.'\')" class="btn btn-sm btn-danger">Delete</button></td>';
-            echo '<td style=\'text-align: center\'><button onclick="viewQsl(\''.$qsl->filename.'\', \''. $qsl->COL_CALL . '\')" class="btn btn-sm btn-success">View</button></td>';
-			echo '<td style=\'text-align: center\'><button onclick="addQsosToQsl(\''.$qsl->filename.'\')" class="btn btn-sm btn-success">Add Qsos</button></td>';
+            echo '<td style=\'text-align: center\'>' . str_replace("0", "&Oslash;", $qsl->COL_CALL) . '</td>';
+            echo '<td style=\'text-align: center\'>';
+            echo $qsl->COL_SUBMODE == null ? $qsl->COL_MODE : $qsl->COL_SUBMODE;
+            echo '</td>';
+            echo '<td style=\'text-align: center\'>';
+            $timestamp = strtotime($qsl->COL_TIME_ON);
+            echo date($custom_date_format, $timestamp);
+            echo '</td>';
+            echo '<td style=\'text-align: center\'>';
+            $timestamp = strtotime($qsl->COL_TIME_ON);
+            echo date('H:i', $timestamp);
+            echo '</td>';
+            echo '<td style=\'text-align: center\'>';
+            if ($qsl->COL_SAT_NAME != null) {
+                echo $qsl->COL_SAT_NAME;
+            } else {
+                echo strtolower($qsl->COL_BAND);
+            };
+            echo '</td>';
+            echo '<td style=\'text-align: center\'>' . $qsl->filename . '</td>';
+            echo '<td id="' . $qsl->id . '" style=\'text-align: center\'><button onclick="deleteQsl(\'' . $qsl->id . '\')" class="btn btn-sm btn-danger">Delete</button></td>';
+            echo '<td style=\'text-align: center\'><button onclick="viewQsl(\'' . $qsl->filename . '\', \'' . $qsl->COL_CALL . '\')" class="btn btn-sm btn-success">View</button></td>';
+            echo '<td style=\'text-align: center\'><button onclick="addQsosToQsl(\'' . $qsl->filename . '\')" class="btn btn-sm btn-success">Add Qsos</button></td>';
             echo '</tr>';
         }
 


### PR DESCRIPTION
The info banner on QSL/eQSL Card page shows the same foldersize for all users, no matter how many QSL cards they've uploaded. 

With this change we only show this info banner if the config option "userdata" is enabled. 

Also I moved the functions `folderSize($dir)` and `sizeFormat($dir)` to the `Genfunctions.php` Library (@phl0)

<img width="381" alt="qsl" src="https://github.com/wavelog/wavelog/assets/80885850/ee110227-af77-4e5e-bf94-d6679af24276">
