### PR TITLE
Maintenance mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ sync.sh
 *.p12
 *.swp
 .debug
+.maintenance
 .htaccess

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -707,8 +707,13 @@ class User extends CI_Controller {
 				$this->input->set_cookie($cookie);
 				redirect('dashboard');
 			} else {
-				$this->session->set_flashdata('error', 'Incorrect username or password!');
-				redirect('user/login');
+				if(ENVIRONMENT == 'maintenance') {
+					$this->session->set_flashdata('notice', 'Sorry. This instance is currently in maintenance mode. If this message appears unexpectedly or keeps showing up, please contact an administrator. Only administrators are currently allowed to log in.');
+					redirect('user/login');
+				} else {
+					$this->session->set_flashdata('error', 'Incorrect username or password!');
+					redirect('user/login');
+				}
 			}
 		}
 	}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -397,13 +397,29 @@ class User_Model extends CI_Model {
 			$user_type = $this->session->userdata('user_type');
 			$user_hash = $this->session->userdata('user_hash');
 
-			if($this->_auth($user_id."-".$user_type, $user_hash)) {
-				// Freshen the session
-				$this->update_session($user_id);
-				return 1;
-			} else {
-				$this->clear_session();
-				return 0;
+			if(ENVIRONMENT != 'maintenance') {
+				if($this->_auth($user_id."-".$user_type, $user_hash)) {
+					// Freshen the session
+					$this->update_session($user_id);
+					return 1;
+				} else {
+					$this->clear_session();
+					return 0;
+				}
+			} else {  // handle the maintenance mode and kick out user on page reload if not an admin
+				if($user_type == '99') {
+					if($this->_auth($user_id."-".$user_type, $user_hash)) {
+						// Freshen the session
+						$this->update_session($user_id);
+						return 1;
+					} else {
+						$this->clear_session();
+						return 0;
+					}
+				} else {
+					$this->clear_session();
+					return 0;
+				}
 			}
 		} else {
 			return 0;

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -417,7 +417,15 @@ class User_Model extends CI_Model {
 		if($u->num_rows() != 0)
 		{
 			if($this->_auth($password, $u->row()->user_password)) {
-				return 1;
+				if (ENVIRONMENT != "maintenance") {
+					return 1;
+				} else {
+					if($u->row()->user_type != 99){
+						return 0;
+					} else {
+						return 1;
+					}
+				}
 			}
 		}
 		return 0;

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -69,7 +69,13 @@
 <body>
 	<nav class="navbar navbar-expand-lg navbar-light bg-light main-nav" id="header-menu">
 		<div class="container">
-			<a class="navbar-brand" href="<?php echo site_url(); ?>"><img class="headerLogo" src="<?php echo base_url(); ?>assets/logo/<?php echo $this->optionslib->get_logo('header_logo'); ?>.png" alt="Logo" /></a> <?php if (ENVIRONMENT == "development") { ?><span class="badge text-bg-danger"><?php echo lang('menu_badge_developer_mode'); ?></span><?php } ?>
+			<a class="navbar-brand" href="<?php echo site_url(); ?>"><img class="headerLogo" src="<?php echo base_url(); ?>assets/logo/<?php echo $this->optionslib->get_logo('header_logo'); ?>.png" alt="Logo" /></a> 
+			<?php if (ENVIRONMENT == "development") { ?>
+				<span class="badge text-bg-danger"><?php echo lang('menu_badge_developer_mode'); ?></span>
+			<?php } ?>
+			<?php if (ENVIRONMENT == "maintenance") { ?>
+				<span class="badge text-bg-info">Maintenance</span>
+			<?php } ?>
 
 			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
 

--- a/application/views/user/login.php
+++ b/application/views/user/login.php
@@ -31,6 +31,11 @@ body {
 </style>
 <main class="form-signin">
     <img src="<?php echo base_url(); ?>assets/logo/<?php echo $this->optionslib->get_logo('main_logo'); ?>.png" class="mx-auto d-block mainLogo" alt="">
+    <?php if (ENVIRONMENT == 'maintenance') { ?>
+        <div class="d-flex justify-content-center align-items-center">
+            <span class="badge text-bg-warning mb-4 pt-2 pb-2">MAINTENANCE MODE</span>
+        </div>
+    <?php } ?>
     <div class="my-2 rounded-0 shadow-sm card mb-2 shadow-sm">
         <div class="card-body">
             <form method="post" action="<?php echo site_url('user/login'); ?>" name="users">

--- a/index.php
+++ b/index.php
@@ -47,15 +47,17 @@
  *
  * This can be set to anything, but default usage is:
  *
- *     development
- *     testing
- *     production
+ *     development			Developer Mode - Shows for example PHP errors in frontend
+ *     maintenance			Maintenance Mode - Only Admin's are allowed to login
+ *     production			Production Mode - Regular Mode
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
 	#define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
 	if (file_exists('.debug')) {
 		define('ENVIRONMENT', 'development');
+	} else if (file_exists('.maintenance')) {
+		define('ENVIRONMENT', 'maintenance');
 	} else {
 		define('ENVIRONMENT', 'production');
 	}
@@ -75,7 +77,11 @@ switch (ENVIRONMENT)
 		ini_set('display_errors', 1);
 	break;
 
-	case 'testing':
+	case 'maintenance':
+		error_reporting(-1);
+		ini_set('display_errors', 1);
+	break;
+	
 	case 'production':
 		ini_set('display_errors', 0);
 		if (version_compare(PHP_VERSION, '5.3', '>='))


### PR DESCRIPTION
Added a "maintenance mode"

enabling is the same workflow as the developement mode. just adding a file `.maintenance` enables the maintenance mode.

Special thing is here that only Admins are allowed to login. This helps to test features and administrate an instance and avoid users to continue logging qso's

If a normal user is already logged in and the maintenance mode is enabled, the user won't get kicked out. If an admin want's to do that he has to restart the webserver.