### PR TITLE
Edit_Ajax Background

### DIFF
--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -128,7 +128,7 @@ function qso_edit(id) {
             $('.menuOnBody').remove();
             BootstrapDialog.show({
                 title: lang_general_word_qso_data,
-                cssClass: 'edit-dialog',
+                cssClass: 'edit-dialog, bg-black bg-opacity-50',
                 size: BootstrapDialog.SIZE_WIDE,
                 nl2br: false,
                 message: html,


### PR DESCRIPTION
Just a small Frontend adjustment

Added another background layer to make it easier for the eyes to differe between the qso details modal and the edit ajax dialog

Without my change:

<img width="550" alt="without" src="https://github.com/wavelog/wavelog/assets/80885850/1f120efc-dcfc-449e-8294-f0e78fa00a73">

with the change

<img width="600" alt="with" src="https://github.com/wavelog/wavelog/assets/80885850/240228ab-c41a-4228-9ced-5431f10a31a4">
