### PR TITLE
[STATION] fix default qslmsg empty when duplicate station

### DIFF
--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -61,7 +61,6 @@ class Station extends CI_Controller
 				// [eQSL default msg] ADD to user options (option_type='eqsl_default_qslmsg'; option_name='key_station_id'; option_key=station_id; option_value=value) //
 				$eqsl_default_qslmsg = xss_clean($this->input->post('eqsl_default_qslmsg', true));
 				if (!empty(trim($eqsl_default_qslmsg))) {
-					$this->load->model('user_options_model');
 					$this->user_options_model->set_option('eqsl_default_qslmsg', 'key_station_id', array($station_id => $eqsl_default_qslmsg));
 				}
 			}
@@ -78,7 +77,6 @@ class Station extends CI_Controller
 
 			if ($this->form_validation->run() == FALSE) {
 				// [eQSL default msg] GET from user options (option_type='eqsl_default_qslmsg'; option_name='key_station_id'; option_key=station_id) //
-				$this->load->model('user_options_model');
 				$options_object = $this->user_options_model->get_options('eqsl_default_qslmsg', array('option_name' => 'key_station_id', 'option_key' => $id))->result();
 				$data['eqsl_default_qslmsg'] = (isset($options_object[0]->option_value)) ? $options_object[0]->option_value : '';
 
@@ -89,7 +87,6 @@ class Station extends CI_Controller
 				if ($this->stations->edit() !== false) {
 					// [eQSL default msg] ADD to user options (option_type='eqsl_default_qslmsg'; option_name='key_station_id'; option_key=station_id; option_value=value) //
 					$eqsl_default_qslmsg = xss_clean($this->input->post('eqsl_default_qslmsg', true));
-					$this->load->model('user_options_model');
 					if (!empty(trim($eqsl_default_qslmsg))) {
 						$this->user_options_model->set_option('eqsl_default_qslmsg', 'key_station_id', array($id => $eqsl_default_qslmsg));
 					} else {
@@ -120,7 +117,6 @@ class Station extends CI_Controller
 
 			if ($this->form_validation->run() == FALSE) {
 				// [eQSL default msg] GET from user options (same as edit()) //
-				$this->load->model('user_options_model');
 				$options_object = $this->user_options_model->get_options('eqsl_default_qslmsg', array('option_name' => 'key_station_id', 'option_key' => $id))->result();
 				$data['eqsl_default_qslmsg'] = (isset($options_object[0]->option_value)) ? $options_object[0]->option_value : '';
 
@@ -132,7 +128,6 @@ class Station extends CI_Controller
 					// [eQSL default msg] ADD to user options (same as create()) //
 					$eqsl_default_qslmsg = xss_clean($this->input->post('eqsl_default_qslmsg', true));
 					if (!empty(trim($eqsl_default_qslmsg))) {
-						$this->load->model('user_options_model');
 						$this->user_options_model->set_option('eqsl_default_qslmsg', 'key_station_id', array($station_id => $eqsl_default_qslmsg));
 					}
 				}

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -119,12 +119,23 @@ class Station extends CI_Controller
 			$data['my_station_profile']->station_profile_name = '';
 
 			if ($this->form_validation->run() == FALSE) {
+				// [eQSL default msg] GET from user options (same as edit()) //
+				$this->load->model('user_options_model');
+				$options_object = $this->user_options_model->get_options('eqsl_default_qslmsg', array('option_name' => 'key_station_id', 'option_key' => $id))->result();
+				$data['eqsl_default_qslmsg'] = (isset($options_object[0]->option_value)) ? $options_object[0]->option_value : '';
+
 				$this->load->view('interface_assets/header', $data);
 				$this->load->view('station_profile/edit');
 				$this->load->view('interface_assets/footer');
 			} else {
-				$this->stations->add();
-
+				if (($station_id = $this->stations->add()) !== false) {
+					// [eQSL default msg] ADD to user options (same as create()) //
+					$eqsl_default_qslmsg = xss_clean($this->input->post('eqsl_default_qslmsg', true));
+					if (!empty(trim($eqsl_default_qslmsg))) {
+						$this->load->model('user_options_model');
+						$this->user_options_model->set_option('eqsl_default_qslmsg', 'key_station_id', array($station_id => $eqsl_default_qslmsg));
+					}
+				}
 				redirect('station');
 			}
 		} else {

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -252,7 +252,7 @@ class Station extends CI_Controller
 		echo json_encode($json);
 	}
 
-	// [eQSL default msg] Function return options from this station (but can be general use) //
+	// [eQSL default msg] Function return options from this station (but can be general use), using with js call on qso page //
 	public function get_options()
 	{
 		$return_json = array();


### PR DESCRIPTION
hello, 
fix copy eqsl_default_qslmsg when duplicate station

tested : 
- duplicate station with empty default qslmsg = ok
- duplicate station with value on default qslmsg = ok
- duplicate station with value on default qslmsg and change with new value = ok