### PR TITLE
Qso reset language

### DIFF
--- a/application/language/bulgarian/qso_lang.php
+++ b/application/language/bulgarian/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Нулирай';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Запази QSO';
 $lang['qso_btn_edit_qso'] = 'Редактирай QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/chinese_simplified/qso_lang.php
+++ b/application/language/chinese_simplified/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "结束时间小于开始时间";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = '重置';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = '保存 QSO';
 $lang['qso_btn_edit_qso'] = '编辑 QSO';
 $lang['qso_delete_warning'] = "警告！您确定要删除 QSO 和 ";

--- a/application/language/czech/qso_lang.php
+++ b/application/language/czech/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Vymazat';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Uložit spojení';
 $lang['qso_btn_edit_qso'] = 'Editovat spojení';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/dutch/qso_lang.php
+++ b/application/language/dutch/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Wis QSO';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Bewaar QSO';
 $lang['qso_btn_edit_qso'] = 'Edit QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/english/qso_lang.php
+++ b/application/language/english/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Reset';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Save QSO';
 $lang['qso_btn_edit_qso'] = 'Edit QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/finnish/qso_lang.php
+++ b/application/language/finnish/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Tyhjennä';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'TALLENNA QSO';
 $lang['qso_btn_edit_qso'] = 'muokkaa QSO:a';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/french/qso_lang.php
+++ b/application/language/french/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "Heure de fin inférieure à celle de d
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Réinitialiser';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Enregistrer QSO';
 $lang['qso_btn_edit_qso'] = 'Edit QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/german/qso_lang.php
+++ b/application/language/german/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Zurücksetzen';
+$lang['qso_btn_clear_qso'] = 'Leeren';
+$lang['qso_btn_reset_to_default'] = 'Auf Standardwerte zurücksetzen';
 $lang['qso_btn_save_qso'] = 'Speichere QSO';
 $lang['qso_btn_edit_qso'] = 'Editiere QSO';
 $lang['qso_delete_warning'] = "Warnung! Bist du sicher, dass du dieses QSO löschen willst mit ";

--- a/application/language/greek/qso_lang.php
+++ b/application/language/greek/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Επαναφορά';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Αποθήκευση QSO';
 $lang['qso_btn_edit_qso'] = 'Επεξεργασία QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/italian/qso_lang.php
+++ b/application/language/italian/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Reset';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Salva QSO';
 $lang['qso_btn_edit_qso'] = 'Modifica QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/polish/qso_lang.php
+++ b/application/language/polish/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Resetuj';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Zapisz QSO';
 $lang['qso_btn_edit_qso'] = 'Edytuj QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/russian/qso_lang.php
+++ b/application/language/russian/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Сброс';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Сохранить QSO';
 $lang['qso_btn_edit_qso'] = 'Изменить QSO';
 $lang['qso_delete_warning'] = "Предупреждение! Вы уверены в том, что хотите удалить QSO c ";

--- a/application/language/spanish/qso_lang.php
+++ b/application/language/spanish/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff es menor que TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Reinicializar';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Guardar QSO';
 $lang['qso_btn_edit_qso'] = 'Editar QSO';
 $lang['qso_delete_warning'] = "¡Advertencia! ¿Está seguro que desea eliminar QSOs con ";

--- a/application/language/swedish/qso_lang.php
+++ b/application/language/swedish/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Reset';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'Spara QSO';
 $lang['qso_btn_edit_qso'] = 'Redigera QSO';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/language/turkish/qso_lang.php
+++ b/application/language/turkish/qso_lang.php
@@ -35,7 +35,8 @@ $lang['qso_error_timeoff_less_timeon'] = "TimeOff is less than TimeOn";
 
 // Button Text on /qso Display
 
-$lang['qso_btn_reset_qso'] = 'Baştan başla';
+$lang['qso_btn_clear_qso'] = 'Clear';
+$lang['qso_btn_reset_to_default'] = 'Reset to Default';
 $lang['qso_btn_save_qso'] = 'QSO\'yu kaydet';
 $lang['qso_btn_edit_qso'] = 'QSO\'yu düzenle';
 $lang['qso_delete_warning'] = "Warning! Are you sure you want delete QSO with ";

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -506,13 +506,13 @@
           <input size="20" id="country" type="hidden" name="country" value="" />
         </div>
 
-	<div class="btn-group" role="group">
-        <button type="button" class="btn btn-secondary" id="btn_reset"><?php echo lang('qso_btn_reset_qso'); ?></button>
-	<button id="btnGroupDrop1" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"></button>
-	<ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
-      		<li><a class="dropdown-item" href="#" id="btn_fullreset">Reset to Default</a></li>
-    	</ul>
-	</div>
+        <div class="btn-group" role="group">
+              <button type="button" class="btn btn-secondary" id="btn_reset"><?php echo lang('qso_btn_clear_qso'); ?></button>
+        <button id="btnGroupDrop1" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"></button>
+        <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+                <li><a class="dropdown-item" href="#" id="btn_fullreset"><?php echo lang('qso_btn_reset_to_default'); ?></a></li>
+            </ul>
+        </div>
         <button type="submit" id="saveQso" name="saveQso" class="btn btn-primary"><i class="fas fa-save"></i> <?php echo lang('qso_btn_save_qso'); ?></button>
         <div class="alert alert-danger warningOnSubmit mt-3" style="display:none;"><span><i class="fas fa-times-circle"></i></span> <span class="warningOnSubmit_txt ms-1">Error</span></div>
       </div>


### PR DESCRIPTION
Let's make the language in the QSO Reset Button more clear for the user

<img width="274" alt="reset" src="https://github.com/wavelog/wavelog/assets/80885850/9e79610f-21a4-4fb3-badf-9d557aced934">
