### PR TITLE
Removed Reset / Clear on Backspace within qso-field

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -58,15 +58,6 @@ $( document ).ready(function() {
 		$('#charsLeft').text(" ");
 	});
 
-	var input = $('#callsign');
-	input.on('keydown', function() {
-		var key = event.keyCode || event.charCode;
-
-		if( key == 8 || key == 46 ) {
-			reset_fields();
-		}
-	});
-
 	$(document).keyup(function(e) {
 		if (e.charCode === 0) {
 			let fixedcall = $('#callsign').val();


### PR DESCRIPTION
This one was there for 5 years, but never fired within in the old-code.
As a result of relocation of some JS-Stuff to qso.js, it became active.

Very annoying.

In Detail:
- if you enter a call and press backspace, the whole Call (and all other things) were cleared immediately
- Due to unknown reasons this one never fired with the old codebase
- This patch resolves the issue, so form is not longer resetting if you press backspace. (You can press ESC or the button if you want to reset)