### PR TITLE
Catch Clublogerror if log was already sent

### DIFF
--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -109,11 +109,16 @@ class Clublog extends CI_Controller {
 							// If Clublog Accepts mark the QSOs
 							if (preg_match('/\baccepted\b/', $response)) {
 								echo "QSOs uploaded and Logbook QSOs marked as sent to Clublog"."<br>";
-
 								$this->load->model('clublog_model');
 								$this->clublog_model->mark_qsos_sent($station_row->station_id);
 								echo "Clublog upload for ".$station_row->station_callsign."<br>";
 								log_message('info', 'Clublog upload for '.$station_row->station_callsign.' successfully sent.');
+							} else if (preg_match('/checksum duplicate/',$response)) {
+								echo "QSOs uploaded (asduplicate!) and Logbook QSOs marked as sent to Clublog"."<br>";
+								$this->load->model('clublog_model');
+								$this->clublog_model->mark_qsos_sent($station_row->station_id);
+								echo "Clublog upload for ".$station_row->station_callsign."<br>";
+								log_message('info', 'Clublog DUPLICATE upload for '.$station_row->station_callsign.' successfully sent.');
 							} else {
 								echo "Error ".$response;
 								log_message('error', 'Clublog upload for '.$station_row->station_callsign.' failed reason '.$response);

--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -120,7 +120,7 @@ class Clublog extends CI_Controller {
 								echo "Clublog upload for ".$station_row->station_callsign."<br>";
 								log_message('info', 'Clublog DUPLICATE upload for '.$station_row->station_callsign.' successfully sent.');
 							} else {
-								echo "Error ".$response;
+								echo "Error ".$response."<br />";
 								log_message('error', 'Clublog upload for '.$station_row->station_callsign.' failed reason '.$response);
 							}
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3141,6 +3141,10 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 		    $data['COL_CLUBLOG_QSO_UPLOAD_STATUS'] = 'M';
 	    }
 
+	    $this->db->group_start();
+	    $this->db->where('date_format(COL_LOTW_QSLRDATE, \'%Y-%m-%d %H:%i\') != "'.$qsl_date.'"');
+	    $this->db->or_where('COL_LOTW_QSLRDATE is null');
+	    $this->db->group_end();
 	    $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
 	    $this->db->where('COL_CALL', $callsign);
 	    $this->db->where('COL_BAND', $band);


### PR DESCRIPTION
In some special constellations it COULD be that the log was already sent to CL.
in that case clublog answers with a string like "checksum duplicate". This patch catches that message and marks the uploaded QSOs as sent