### PR TITLE
Added Option to add ADIF-Contest to Contest

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -139,6 +139,9 @@ class adif extends CI_Controller {
 	}
 
 	public function index() {
+		$this->load->model('contesting_model');
+		$data['contests']=$this->contesting_model->getActivecontests();
+
 		$this->load->model('stations');
 
 		$data['page_title'] = "ADIF Import / Export";
@@ -183,6 +186,7 @@ class adif extends CI_Controller {
 			$this->load->view('interface_assets/footer');
 		} else {
 			if ($this->stations->check_station_is_accessible($this->input->post('station_profile'))) {
+				$contest=$this->security->xss_clean($this->input->post('contest')) ?? '';
 				$stopnow=false;
 				$fdata = array('upload_data' => $this->upload->data());
 				ini_set('memory_limit', '-1');
@@ -222,6 +226,9 @@ class adif extends CI_Controller {
 					$alladif=[];
 					while($record = $this->adif_parser->get_record())
 					{
+						if ($contest != '') {
+							$record['contest_id']=$contest;
+						}
 						if(count($record) == 0) {
 							break;
 						};

--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = '你没有电台日志。 请前往<a href
 
 $lang['hams_at_no_activations_found'] = '未找到即将进行的激活。 请稍后再回来查看。';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = "Vous n'avez pas de journal de travail pou
 
 $lang['hams_at_no_activations_found'] = "Aucune activation à venir trouvée. Veuillez revenir plus tard.";
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "fr-FR";

--- a/application/language/german/general_words_lang.php
+++ b/application/language/german/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'Es wurde kein Stationslogbuch angelegt. K
 
 $lang['hams_at_no_activations_found'] = 'Keine bevorstehenden Aktivierungen gefunden. Bitte später noch einmal vorbeischauen.';
 
+$lang['gen_add_to_contest'] = "QSOs zu Contest hinzuf&uuml;gen";
 $lang['datatables_language'] = "de-DE";

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "it-IT";

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -232,5 +232,6 @@ $lang['dashboard_locations_warning'] = 'У вас нет расположени�
 $lang['dashboard_logbooks_warning'] = 'У вас нет аппаратного журнала! Перейдите <a href="'. site_url('stationsetup') . '">сюда</a>, чтобы создать его!';
 
 $lang['hams_at_no_activations_found'] = 'не найдены предстоящие активации. Проверьте позже.';
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 
 $lang['datatables_language'] = "en-GB";

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -232,5 +232,6 @@ $lang['dashboard_locations_warning'] = 'No tiene localizaciones de estaciones. �
 $lang['dashboard_logbooks_warning'] = 'No tiene libro de guardias. ¡Haga clic <a href="'. site_url('stationsetup') . '">aquí</a> para crear uno!';
 
 $lang['hams_at_no_activations_found'] = 'No hay activaciones próximas. Por favor vuelve a revisar más tarde.';
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 
 $lang['datatables_language'] = "es-ES";

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -232,6 +232,7 @@ $lang['dashboard_country_files_warning'] = 'You need to update country files! Go
 $lang['dashboard_locations_warning'] = 'You have no station locations. Go <a href="'. site_url('stationsetup') . '">here</a> to create it!';
 $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="'. site_url('stationsetup') . '">here</a> to create it!';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['datatables_language'] = "en-GB";

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -232,4 +232,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
+$lang['gen_add_to_contest'] = "Add QSOs to Contest";
 $lang['datatables_language'] = "en-GB";

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -57,6 +57,7 @@
 
                     <form class="form" id="upform" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="fhash" id="fhash" value="<?php echo hash('sha256', $this->session->userdata('user_callsign') );?>">
+                        <div class="small form-text text-muted"><?php echo lang('adif_select_stationlocation') ?></div>
                         <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 20%;">
                             <option value="0"><?php echo lang('adif_select_stationlocation') ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
@@ -65,7 +66,15 @@
                                                                                     } ?>><?php echo lang('gen_hamradio_callsign') . ": " ?><?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>
                             <?php } ?>
                         </select>
-                        <label class="visually-hidden" for="inlineFormInputName2"><?php echo lang('adif_file_label') ?></label>
+                        <div class="small form-text text-muted"><?php echo lang('gen_add_to_contest') ?></div>
+                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 20%;">
+                        	<option value="" selected>No Contest</option>
+                            <?php 
+				foreach ($contests as $contest) {
+                                echo '<option value="'.$contest['adifname'].'">'.$contest['name'].'</option>';
+                            } ?>
+			</select>
+ 			<label class="visually-hidden" for="inlineFormInputName2"><?php echo lang('adif_file_label') ?></label>
                         <input class="form-control mb-2 me-sm-2 w-auto" type="file" name="userfile" id="userfile" size="20" />
 
                         <div class="mb-3 row">

--- a/application/views/search/search_result_ajax.php
+++ b/application/views/search/search_result_ajax.php
@@ -209,7 +209,7 @@ $ci =& get_instance();
 				case 'SOTA':    echo '<td>' . ($row->COL_SOTA_REF); break;
 				case 'WWFF':    echo '<td>' . ($row->COL_WWFF_REF); break;
 				case 'POTA':    echo '<td>' . ($row->COL_POTA_REF); break;
-				case 'Grid':    echo '<td>'; echo strlen($row->COL_GRIDSQUARE)==0?$row->COL_VUCC_GRIDS:$row->COL_GRIDSQUARE; break;
+				case 'Grid':    echo '<td>'; echo strlen($row->COL_GRIDSQUARE ?? '')==0?$row->COL_VUCC_GRIDS ?? '':$row->COL_GRIDSQUARE ?? ''; break;
 				case 'Distance':echo '<td>' . ($row->COL_DISTANCE ? $row->COL_DISTANCE . '&nbsp;km' : ''); break;
 				case 'Band':    echo '<td>'; if($row->COL_SAT_NAME != null) { echo $row->COL_SAT_NAME; } else { echo strtolower($row->COL_BAND); }; break;
 				case 'State':   echo '<td>' . ($row->COL_STATE); break;


### PR DESCRIPTION
* If ADIF already contains "contest_id" and "No Contest" is selected, the QSOs will be treated as defined in ADIF.
* If (an active) contest is selected, the QSOs will be added to that contest, regardless what contest is setted or not setted at ADIF