### PR TITLE
References to QSO tab

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -40,6 +40,13 @@ class QSO extends CI_Controller {
 			$data['user_iota_to_qso_tab'] = 0;
 		}
 
+		$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'sota','option_key'=>'show'))->result();
+		if (count($qkey_opt)>0) {
+			$data['user_sota_to_qso_tab'] = $qkey_opt[0]->option_value;
+		} else {
+			$data['user_sota_to_qso_tab'] = 0;
+		}
+
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('start_date', 'Date', 'required');

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -33,6 +33,13 @@ class QSO extends CI_Controller {
 		$data['user_default_band'] = $this->session->userdata('user_default_band');
 		$data['sat_active'] = array_search("SAT", $this->bands->get_user_bands(), true);
 
+		$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'iota','option_key'=>'show'))->result();
+		if (count($qkey_opt)>0) {
+			$data['user_iota_to_qso_tab'] = $qkey_opt[0]->option_value;
+		} else {
+			$data['user_iota_to_qso_tab'] = 0;
+		}
+
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('start_date', 'Date', 'required');

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -54,6 +54,13 @@ class QSO extends CI_Controller {
 			$data['user_wwff_to_qso_tab'] = 0;
 		}
 
+		$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'pota','option_key'=>'show'))->result();
+		if (count($qkey_opt)>0) {
+			$data['user_pota_to_qso_tab'] = $qkey_opt[0]->option_value;
+		} else {
+			$data['user_pota_to_qso_tab'] = 0;
+		}
+
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('start_date', 'Date', 'required');

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -68,6 +68,13 @@ class QSO extends CI_Controller {
 			$data['user_sig_to_qso_tab'] = 0;
 		}
 
+		$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'dok','option_key'=>'show'))->result();
+		if (count($qkey_opt)>0) {
+			$data['user_dok_to_qso_tab'] = $qkey_opt[0]->option_value;
+		} else {
+			$data['user_dok_to_qso_tab'] = 0;
+		}
+
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('start_date', 'Date', 'required');

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -61,6 +61,13 @@ class QSO extends CI_Controller {
 			$data['user_pota_to_qso_tab'] = 0;
 		}
 
+		$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'sig','option_key'=>'show'))->result();
+		if (count($qkey_opt)>0) {
+			$data['user_sig_to_qso_tab'] = $qkey_opt[0]->option_value;
+		} else {
+			$data['user_sig_to_qso_tab'] = 0;
+		}
+
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('start_date', 'Date', 'required');

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -47,6 +47,13 @@ class QSO extends CI_Controller {
 			$data['user_sota_to_qso_tab'] = 0;
 		}
 
+		$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'wwff','option_key'=>'show'))->result();
+		if (count($qkey_opt)>0) {
+			$data['user_wwff_to_qso_tab'] = $qkey_opt[0]->option_value;
+		} else {
+			$data['user_wwff_to_qso_tab'] = 0;
+		}
+
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('start_date', 'Date', 'required');

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -99,6 +99,7 @@ class User extends CI_Controller {
 				$data['user_hamsat_workable_only'] = $this->input->post('user_hamsat_workable_only');
 				$data['user_iota_to_qso_tab'] = $this->input->post('user_iota_to_qso_tab');
 				$data['user_sota_to_qso_tab'] = $this->input->post('user_sota_to_qso_tab');
+				$data['user_wwff_to_qso_tab'] = $this->input->post('user_wwff_to_qso_tab');
 				$data['language'] = $this->input->post('language');
 				$this->load->view('user/edit', $data);
 			} else {
@@ -141,7 +142,8 @@ class User extends CI_Controller {
 				$this->input->post('user_hamsat_key'),
 				$this->input->post('user_hamsat_workable_only'),
 				$this->input->post('user_iota_to_qso_tab'),
-				$this->input->post('user_sota_to_qso_tab')
+				$this->input->post('user_sota_to_qso_tab'),
+				$this->input->post('user_wwff_to_qso_tab')
 				)) {
 				// Check for errors
 				case EUSERNAMEEXISTS:
@@ -534,6 +536,15 @@ class User extends CI_Controller {
 				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'sota','option_key'=>'show'))->result();
 				if (count($qkey_opt)>0) {
 					$data['user_sota_to_qso_tab'] = $qkey_opt[0]->option_value;
+				}
+			}
+
+			if($this->input->post('user_wwff_to_qso_tab')) {
+				$data['user_wwff_to_qso_tab'] = $this->input->post('user_wwff_to_qso_tab', false);
+			} else {
+				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'wwff','option_key'=>'show'))->result();
+				if (count($qkey_opt)>0) {
+					$data['user_wwff_to_qso_tab'] = $qkey_opt[0]->option_value;
 				}
 			}
 

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -101,6 +101,7 @@ class User extends CI_Controller {
 				$data['user_sota_to_qso_tab'] = $this->input->post('user_sota_to_qso_tab');
 				$data['user_wwff_to_qso_tab'] = $this->input->post('user_wwff_to_qso_tab');
 				$data['user_pota_to_qso_tab'] = $this->input->post('user_pota_to_qso_tab');
+				$data['user_sig_to_qso_tab'] = $this->input->post('user_sig_to_qso_tab');
 				$data['language'] = $this->input->post('language');
 				$this->load->view('user/edit', $data);
 			} else {
@@ -145,7 +146,8 @@ class User extends CI_Controller {
 				$this->input->post('user_iota_to_qso_tab'),
 				$this->input->post('user_sota_to_qso_tab'),
 				$this->input->post('user_wwff_to_qso_tab'),
-				$this->input->post('user_pota_to_qso_tab')
+				$this->input->post('user_pota_to_qso_tab'),
+				$this->input->post('user_sig_to_qso_tab')
 				)) {
 				// Check for errors
 				case EUSERNAMEEXISTS:
@@ -556,6 +558,15 @@ class User extends CI_Controller {
 				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'pota','option_key'=>'show'))->result();
 				if (count($qkey_opt)>0) {
 					$data['user_pota_to_qso_tab'] = $qkey_opt[0]->option_value;
+				}
+			}
+
+			if($this->input->post('user_sig_to_qso_tab')) {
+				$data['user_sig_to_qso_tab'] = $this->input->post('user_sig_to_qso_tab', false);
+			} else {
+				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'sig','option_key'=>'show'))->result();
+				if (count($qkey_opt)>0) {
+					$data['user_sig_to_qso_tab'] = $qkey_opt[0]->option_value;
 				}
 			}
 

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -100,6 +100,7 @@ class User extends CI_Controller {
 				$data['user_iota_to_qso_tab'] = $this->input->post('user_iota_to_qso_tab');
 				$data['user_sota_to_qso_tab'] = $this->input->post('user_sota_to_qso_tab');
 				$data['user_wwff_to_qso_tab'] = $this->input->post('user_wwff_to_qso_tab');
+				$data['user_pota_to_qso_tab'] = $this->input->post('user_pota_to_qso_tab');
 				$data['language'] = $this->input->post('language');
 				$this->load->view('user/edit', $data);
 			} else {
@@ -143,7 +144,8 @@ class User extends CI_Controller {
 				$this->input->post('user_hamsat_workable_only'),
 				$this->input->post('user_iota_to_qso_tab'),
 				$this->input->post('user_sota_to_qso_tab'),
-				$this->input->post('user_wwff_to_qso_tab')
+				$this->input->post('user_wwff_to_qso_tab'),
+				$this->input->post('user_pota_to_qso_tab')
 				)) {
 				// Check for errors
 				case EUSERNAMEEXISTS:
@@ -545,6 +547,15 @@ class User extends CI_Controller {
 				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'wwff','option_key'=>'show'))->result();
 				if (count($qkey_opt)>0) {
 					$data['user_wwff_to_qso_tab'] = $qkey_opt[0]->option_value;
+				}
+			}
+
+			if($this->input->post('user_pota_to_qso_tab')) {
+				$data['user_pota_to_qso_tab'] = $this->input->post('user_pota_to_qso_tab', false);
+			} else {
+				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'pota','option_key'=>'show'))->result();
+				if (count($qkey_opt)>0) {
+					$data['user_pota_to_qso_tab'] = $qkey_opt[0]->option_value;
 				}
 			}
 

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -515,6 +515,15 @@ class User extends CI_Controller {
 				}
 			}
 
+			if($this->input->post('user_iota_to_qso_tab')) {
+				$data['user_iota_to_qso_tab'] = $this->input->post('user_iota_to_qso_tab', false);
+			} else {
+				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'iota','option_key'=>'show'))->result();
+				if (count($qkey_opt)>0) {
+					$data['user_iota_to_qso_tab'] = $qkey_opt[0]->option_value;
+				}
+			}
+
 			// [MAP Custom] GET user options //
 			$options_object = $this->user_options_model->get_options('map_custom')->result();
 			if (count($options_object)>0) {

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -97,6 +97,7 @@ class User extends CI_Controller {
 				$data['user_quicklog_enter'] = $this->input->post('user_quicklog_enter');
 				$data['user_hamsat_key'] = $this->input->post('user_hamsat_key');
 				$data['user_hamsat_workable_only'] = $this->input->post('user_hamsat_workable_only');
+				$data['user_iota_to_qso_tab'] = $this->input->post('user_iota_to_qso_tab');
 				$data['language'] = $this->input->post('language');
 				$this->load->view('user/edit', $data);
 			} else {
@@ -137,7 +138,8 @@ class User extends CI_Controller {
 				$this->input->post('user_quicklog_enter'),
 				$this->input->post('language'),
 				$this->input->post('user_hamsat_key'),
-				$this->input->post('user_hamsat_workable_only')
+				$this->input->post('user_hamsat_workable_only'),
+				$this->input->post('user_iota_to_qso_tab')
 				)) {
 				// Check for errors
 				case EUSERNAMEEXISTS:

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -102,6 +102,7 @@ class User extends CI_Controller {
 				$data['user_wwff_to_qso_tab'] = $this->input->post('user_wwff_to_qso_tab');
 				$data['user_pota_to_qso_tab'] = $this->input->post('user_pota_to_qso_tab');
 				$data['user_sig_to_qso_tab'] = $this->input->post('user_sig_to_qso_tab');
+				$data['user_dok_to_qso_tab'] = $this->input->post('user_dok_to_qso_tab');
 				$data['language'] = $this->input->post('language');
 				$this->load->view('user/edit', $data);
 			} else {
@@ -147,7 +148,8 @@ class User extends CI_Controller {
 				$this->input->post('user_sota_to_qso_tab'),
 				$this->input->post('user_wwff_to_qso_tab'),
 				$this->input->post('user_pota_to_qso_tab'),
-				$this->input->post('user_sig_to_qso_tab')
+				$this->input->post('user_sig_to_qso_tab'),
+				$this->input->post('user_dok_to_qso_tab')
 				)) {
 				// Check for errors
 				case EUSERNAMEEXISTS:
@@ -567,6 +569,15 @@ class User extends CI_Controller {
 				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'sig','option_key'=>'show'))->result();
 				if (count($qkey_opt)>0) {
 					$data['user_sig_to_qso_tab'] = $qkey_opt[0]->option_value;
+				}
+			}
+
+			if($this->input->post('user_dok_to_qso_tab')) {
+				$data['user_dok_to_qso_tab'] = $this->input->post('user_dok_to_qso_tab', false);
+			} else {
+				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'dok','option_key'=>'show'))->result();
+				if (count($qkey_opt)>0) {
+					$data['user_dok_to_qso_tab'] = $qkey_opt[0]->option_value;
 				}
 			}
 

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -98,6 +98,7 @@ class User extends CI_Controller {
 				$data['user_hamsat_key'] = $this->input->post('user_hamsat_key');
 				$data['user_hamsat_workable_only'] = $this->input->post('user_hamsat_workable_only');
 				$data['user_iota_to_qso_tab'] = $this->input->post('user_iota_to_qso_tab');
+				$data['user_sota_to_qso_tab'] = $this->input->post('user_sota_to_qso_tab');
 				$data['language'] = $this->input->post('language');
 				$this->load->view('user/edit', $data);
 			} else {
@@ -139,7 +140,8 @@ class User extends CI_Controller {
 				$this->input->post('language'),
 				$this->input->post('user_hamsat_key'),
 				$this->input->post('user_hamsat_workable_only'),
-				$this->input->post('user_iota_to_qso_tab')
+				$this->input->post('user_iota_to_qso_tab'),
+				$this->input->post('user_sota_to_qso_tab')
 				)) {
 				// Check for errors
 				case EUSERNAMEEXISTS:
@@ -523,6 +525,15 @@ class User extends CI_Controller {
 				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'iota','option_key'=>'show'))->result();
 				if (count($qkey_opt)>0) {
 					$data['user_iota_to_qso_tab'] = $qkey_opt[0]->option_value;
+				}
+			}
+
+			if($this->input->post('user_sota_to_qso_tab')) {
+				$data['user_sota_to_qso_tab'] = $this->input->post('user_sota_to_qso_tab', false);
+			} else {
+				$qkey_opt=$this->user_options_model->get_options('qso_tab',array('option_name'=>'sota','option_key'=>'show'))->result();
+				if (count($qkey_opt)>0) {
+					$data['user_sota_to_qso_tab'] = $qkey_opt[0]->option_value;
 				}
 			}
 

--- a/application/language/bulgarian/account_lang.php
+++ b/application/language/bulgarian/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/chinese_simplified/account_lang.php
+++ b/application/language/chinese_simplified/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/czech/account_lang.php
+++ b/application/language/czech/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/dutch/account_lang.php
+++ b/application/language/dutch/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/english/account_lang.php
+++ b/application/language/english/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/finnish/account_lang.php
+++ b/application/language/finnish/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/french/account_lang.php
+++ b/application/language/french/account_lang.php
@@ -130,3 +130,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/german/account_lang.php
+++ b/application/language/german/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "Siehe dein Profil unter <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Zeige nur Überflüge an, die gearbeitet werden können";
 $lang['account_hamsat_workable_only_hint'] = "Wenn aktiviert, werden nur sichtbare Überflüge basierend auf dem Locator des hams.at Profils angezeigt. Dazu muss der Private Feed Key konfiguriert sein.";
+
+$lang['account_references_show'] = "Zeige Referenzen auf QSO-Reiter";
+$lang['account_show_references_on_1st_tab'] = "Die aktivierten Elemente werden auf dem QSO-Reiter statt des allgemeinen Reiters angezeigt.";

--- a/application/language/greek/account_lang.php
+++ b/application/language/greek/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/italian/account_lang.php
+++ b/application/language/italian/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/polish/account_lang.php
+++ b/application/language/polish/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/russian/account_lang.php
+++ b/application/language/russian/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/spanish/account_lang.php
+++ b/application/language/spanish/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/swedish/account_lang.php
+++ b/application/language/swedish/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/language/turkish/account_lang.php
+++ b/application/language/turkish/account_lang.php
@@ -132,3 +132,6 @@ $lang['account_hamsat_private_feed_key'] = "Private Feed Key";
 $lang['account_hamsat_hint'] = "See your profile at <a href='https://hams.at/users/settings' target='_blank'>https://hams.at/users/settings</a>.";
 $lang['account_hamsat_workable_only'] = "Show Workable Passes Only";
 $lang['account_hamsat_workable_only_hint'] = "If enabled shows only workable passes based on the gridsquare set in your hams.at account. Requires private feed key to be set.";
+
+$lang['account_references_show'] = "Show Reference Fields on QSO Tab";
+$lang['account_show_references_on_1st_tab'] = "The enabled items will be shown on the QSO tab rather than the General tab.";

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -150,7 +150,8 @@ class User_Model extends CI_Model {
 		$user_pota_lookup, $user_show_notes, $user_column1, $user_column2, $user_column3, $user_column4, $user_column5,
 		$user_show_profile_image, $user_previous_qsl_type, $user_amsat_status_upload, $user_mastodon_url,
 		$user_default_band, $user_default_confirmation, $user_qso_end_times, $user_quicklog, $user_quicklog_enter,
-		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab) {
+		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab,
+		$user_wwff_to_qso_tab) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -212,6 +213,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'hamsat','hamsat_key','workable','".xss_clean($user_hamsat_workable_only)."');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','iota','show',".(xss_clean($user_iota_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','sota','show',".(xss_clean($user_sota_to_qso_tab) == "on" ? 1 : 0).");");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','wwff','show',".(xss_clean($user_wwff_to_qso_tab) == "on" ? 1 : 0).");");
 
 			return OK;
 		} else {
@@ -267,6 +269,7 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','workable','".xss_clean($fields['user_hamsat_workable_only'])."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','iota','show',".(xss_clean($fields['user_iota_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sota','show',".(xss_clean($fields['user_sota_to_qso_tab']) == "on" ? 1 : 0).");");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','wwff','show',".(xss_clean($fields['user_wwff_to_qso_tab']) == "on" ? 1 : 0).");");
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -150,7 +150,7 @@ class User_Model extends CI_Model {
 		$user_pota_lookup, $user_show_notes, $user_column1, $user_column2, $user_column3, $user_column4, $user_column5,
 		$user_show_profile_image, $user_previous_qsl_type, $user_amsat_status_upload, $user_mastodon_url,
 		$user_default_band, $user_default_confirmation, $user_qso_end_times, $user_quicklog, $user_quicklog_enter,
-		$language, $user_hamsat_key, $user_hamsat_workable_only) {
+		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -210,6 +210,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'map_custom','gridsquare','show','0');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'hamsat','hamsat_key','api','".xss_clean($user_hamsat_key)."');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'hamsat','hamsat_key','workable','".xss_clean($user_hamsat_workable_only)."');");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','iota','show',".(xss_clean($user_iota_to_qso_tab) == "on" ? 1 : 0).");");
 
 			return OK;
 		} else {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -263,6 +263,7 @@ class User_Model extends CI_Model {
 
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','api','".xss_clean($fields['user_hamsat_key'])."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','workable','".xss_clean($fields['user_hamsat_workable_only'])."');");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','iota','show',".(xss_clean($fields['user_iota_to_qso_tab']) == "on" ? 1 : 0).");");
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -151,7 +151,7 @@ class User_Model extends CI_Model {
 		$user_show_profile_image, $user_previous_qsl_type, $user_amsat_status_upload, $user_mastodon_url,
 		$user_default_band, $user_default_confirmation, $user_qso_end_times, $user_quicklog, $user_quicklog_enter,
 		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab,
-		$user_wwff_to_qso_tab, $user_pota_to_qso_tab) {
+		$user_wwff_to_qso_tab, $user_pota_to_qso_tab, $user_sig_to_qso_tab) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -215,6 +215,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','sota','show',".(xss_clean($user_sota_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','wwff','show',".(xss_clean($user_wwff_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','pota','show',".(xss_clean($user_pota_to_qso_tab) == "on" ? 1 : 0).");");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','sig','show',".(xss_clean($user_sig_to_qso_tab) == "on" ? 1 : 0).");");
 
 			return OK;
 		} else {
@@ -272,6 +273,7 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sota','show',".(xss_clean($fields['user_sota_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','wwff','show',".(xss_clean($fields['user_wwff_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','pota','show',".(xss_clean($fields['user_pota_to_qso_tab']) == "on" ? 1 : 0).");");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sig','show',".(xss_clean($fields['user_sig_to_qso_tab']) == "on" ? 1 : 0).");");
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -151,7 +151,7 @@ class User_Model extends CI_Model {
 		$user_show_profile_image, $user_previous_qsl_type, $user_amsat_status_upload, $user_mastodon_url,
 		$user_default_band, $user_default_confirmation, $user_qso_end_times, $user_quicklog, $user_quicklog_enter,
 		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab,
-		$user_wwff_to_qso_tab) {
+		$user_wwff_to_qso_tab, $user_pota_to_qso_tab) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -214,6 +214,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','iota','show',".(xss_clean($user_iota_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','sota','show',".(xss_clean($user_sota_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','wwff','show',".(xss_clean($user_wwff_to_qso_tab) == "on" ? 1 : 0).");");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','pota','show',".(xss_clean($user_pota_to_qso_tab) == "on" ? 1 : 0).");");
 
 			return OK;
 		} else {
@@ -270,6 +271,7 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','iota','show',".(xss_clean($fields['user_iota_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sota','show',".(xss_clean($fields['user_sota_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','wwff','show',".(xss_clean($fields['user_wwff_to_qso_tab']) == "on" ? 1 : 0).");");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','pota','show',".(xss_clean($fields['user_pota_to_qso_tab']) == "on" ? 1 : 0).");");
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -151,7 +151,7 @@ class User_Model extends CI_Model {
 		$user_show_profile_image, $user_previous_qsl_type, $user_amsat_status_upload, $user_mastodon_url,
 		$user_default_band, $user_default_confirmation, $user_qso_end_times, $user_quicklog, $user_quicklog_enter,
 		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab,
-		$user_wwff_to_qso_tab, $user_pota_to_qso_tab, $user_sig_to_qso_tab) {
+		$user_wwff_to_qso_tab, $user_pota_to_qso_tab, $user_sig_to_qso_tab, $user_dok_to_qso_tab) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -216,6 +216,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','wwff','show',".(xss_clean($user_wwff_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','pota','show',".(xss_clean($user_pota_to_qso_tab) == "on" ? 1 : 0).");");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','sig','show',".(xss_clean($user_sig_to_qso_tab) == "on" ? 1 : 0).");");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','dok','show',".(xss_clean($user_dok_to_qso_tab) == "on" ? 1 : 0).");");
 
 			return OK;
 		} else {
@@ -274,6 +275,7 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','wwff','show',".(xss_clean($fields['user_wwff_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','pota','show',".(xss_clean($fields['user_pota_to_qso_tab']) == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sig','show',".(xss_clean($fields['user_sig_to_qso_tab']) == "on" ? 1 : 0).");");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','dok','show',".(xss_clean($fields['user_dok_to_qso_tab']) == "on" ? 1 : 0).");");
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -150,7 +150,7 @@ class User_Model extends CI_Model {
 		$user_pota_lookup, $user_show_notes, $user_column1, $user_column2, $user_column3, $user_column4, $user_column5,
 		$user_show_profile_image, $user_previous_qsl_type, $user_amsat_status_upload, $user_mastodon_url,
 		$user_default_band, $user_default_confirmation, $user_qso_end_times, $user_quicklog, $user_quicklog_enter,
-		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab) {
+		$language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -211,6 +211,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'hamsat','hamsat_key','api','".xss_clean($user_hamsat_key)."');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'hamsat','hamsat_key','workable','".xss_clean($user_hamsat_workable_only)."');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','iota','show',".(xss_clean($user_iota_to_qso_tab) == "on" ? 1 : 0).");");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'qso_tab','sota','show',".(xss_clean($user_sota_to_qso_tab) == "on" ? 1 : 0).");");
 
 			return OK;
 		} else {
@@ -265,6 +266,7 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','api','".xss_clean($fields['user_hamsat_key'])."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','workable','".xss_clean($fields['user_hamsat_workable_only'])."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','iota','show',".(xss_clean($fields['user_iota_to_qso_tab']) == "on" ? 1 : 0).");");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sota','show',".(xss_clean($fields['user_sota_to_qso_tab']) == "on" ? 1 : 0).");");
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -190,6 +190,22 @@
                 </div>
               </div>
 
+            <?php if ($user_iota_to_qso_tab) { ?>
+            <div class="mb-3 row">
+              <label class="col-sm-3 col-form-label" for="iota_ref"><?php echo lang('gen_hamradio_iota_reference'); ?></label>
+                    <div class="col-sm-9">
+                    <select class="form-select" id="iota_ref" name="iota_ref">
+                        <option value =""></option>
+                        <?php
+                        foreach($iota as $i){
+                            echo '<option value=' . $i->tag . '>' . $i->tag . ' - ' . $i->name . '</option>';
+                        }
+                        ?>
+                    </select>
+                    </div>
+            </div>
+            <?php } ?>
+
               <div class="mb-3 row">
                 <label for="qth" class="col-sm-3 col-form-label"><?php echo lang('general_word_location'); ?></label>
                 <div class="col-sm-9">
@@ -356,6 +372,7 @@
                 <input class="form-control" id="stationCntyInputQso" type="text" name="county" value="" />
             </div>
 
+            <?php if (!$user_iota_to_qso_tab) { ?>
             <div class="mb-3">
               <label for="iota_ref"><?php echo lang('gen_hamradio_iota_reference'); ?></label>
                     <select class="form-select" id="iota_ref" name="iota_ref">
@@ -369,6 +386,7 @@
 
                     </select>
             </div>
+            <?php } ?>
 
             <div class="row">
               <div class="mb-3 col-md-9">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -190,21 +190,33 @@
                 </div>
               </div>
 
-            <?php if ($user_iota_to_qso_tab) { ?>
-            <div class="mb-3 row">
-              <label class="col-sm-3 col-form-label" for="iota_ref"><?php echo lang('gen_hamradio_iota_reference'); ?></label>
-                    <div class="col-sm-9">
-                    <select class="form-select" id="iota_ref" name="iota_ref">
-                        <option value =""></option>
-                        <?php
-                        foreach($iota as $i){
-                            echo '<option value=' . $i->tag . '>' . $i->tag . ' - ' . $i->name . '</option>';
-                        }
-                        ?>
-                    </select>
-                    </div>
-            </div>
-            <?php } ?>
+              <?php if ($user_iota_to_qso_tab) { ?>
+              <div class="mb-3 row">
+                <label class="col-sm-3 col-form-label" for="iota_ref"><?php echo lang('gen_hamradio_iota_reference'); ?></label>
+                      <div class="col-sm-9 align-self-center">
+                      <select class="form-select" id="iota_ref" name="iota_ref">
+                          <option value =""></option>
+                          <?php
+                          foreach($iota as $i){
+                              echo '<option value=' . $i->tag . '>' . $i->tag . ' - ' . $i->name . '</option>';
+                          }
+                          ?>
+                      </select>
+                      </div>
+              </div>
+              <?php } ?>
+
+              <?php if ($user_sota_to_qso_tab) { ?>
+              <div class="mb-3 row">
+                <label class="col-sm-3 col-form-label" for="sota_ref"><?php echo lang('gen_hamradio_sota_reference'); ?></label>
+                <div class="col-sm-7 align-self-center">
+                  <input class="form-control" id="sota_ref" type="text" name="sota_ref" value="" />
+                </div>
+                <div class="col-sm-2 align-self-center">
+                  <small id="sota_info" class="btn btn-secondary spw-buttons"></small>
+                </div>
+              </div>
+              <?php } ?>
 
               <div class="mb-3 row">
                 <label for="qth" class="col-sm-3 col-form-label"><?php echo lang('general_word_location'); ?></label>
@@ -388,6 +400,7 @@
             </div>
             <?php } ?>
 
+            <?php if (!$user_sota_to_qso_tab) { ?>
             <div class="row">
               <div class="mb-3 col-md-9">
                 <label for="sota_ref"><?php echo lang('gen_hamradio_sota_reference'); ?></label>
@@ -398,6 +411,7 @@
                 <small id="sota_info" class="btn btn-secondary spw-buttons"></small>
               </div>
             </div>
+            <?php } ?>
 
             <div class="row">
               <div class="mb-3 col-md-9">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -219,13 +219,25 @@
               <?php } ?>
 
               <?php if ($user_wwff_to_qso_tab) { ?>
-              <div class="mb3 row">
+              <div class="mb-3 row">
                 <label class="col-sm-3 col-form-label" for="wwff_ref"><?php echo lang('gen_hamradio_wwff_reference'); ?></label>
                 <div class="col-sm-7 align-self-center">
                   <input class="form-control" id="wwff_ref" type="text" name="wwff_ref" value="" />
                 </div>
                 <div class="col-sm-2 align-self-center">
                   <small id="wwff_info" class="btn btn-secondary spw-buttons"></small>
+                </div>
+              </div>
+              <?php } ?>
+
+              <?php if ($user_pota_to_qso_tab) { ?>
+              <div class="mb-3 row">
+                <label class="col-sm-3 col-form-label" for="pota_ref"><?php echo lang('gen_hamradio_pota_reference'); ?></label>
+                <div class="col-sm-7 align-self-center">
+                  <input class="form-control" id="pota_ref" type="text" name="pota_ref" value="" />
+                </div>
+                <div class="col-sm-2 align-self-center">
+                  <small id="pota_info" class="btn btn-secondary spw-buttons"></small>
                 </div>
               </div>
               <?php } ?>
@@ -438,6 +450,7 @@
             </div>
             <?php } ?>
 
+            <?php if (!$user_pota_to_qso_tab) { ?>
             <div class="row">
               <div class="mb-3 col-md-9">
                 <label for="pota_ref"><?php echo lang('gen_hamradio_pota_reference'); ?></label>
@@ -448,6 +461,7 @@
                 <small id="pota_info" class="btn btn-secondary spw-buttons"></small>
               </div>
             </div>
+            <?php } ?>
 
             <div class="mb-3">
               <label for="sig"><?php echo lang('gen_hamradio_sig'); ?></label>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -242,6 +242,22 @@
               </div>
               <?php } ?>
 
+              <?php if ($user_sig_to_qso_tab) { ?>
+              <div class="mb-3 row">
+                <label class="col-sm-3 col-form-label" for="sig"><?php echo lang('gen_hamradio_sig'); ?></label>
+                <div class="col-sm-9">
+                  <input class="form-control" id="sig" type="text" name="sig" value="" />
+                </div>
+              </div>
+
+              <div class="mb-3 row">
+                <label class="col-sm-3 col-form-label" for="sig_info"><?php echo lang('gen_hamradio_sig_info'); ?></label>
+                <div class="col-sm-9">
+                  <input class="form-control" id="sig_info" type="text" name="sig_info" value="" />
+                </div>
+              </div>
+              <?php } ?>
+
               <div class="mb-3 row">
                 <label for="qth" class="col-sm-3 col-form-label"><?php echo lang('general_word_location'); ?></label>
                 <div class="col-sm-9">
@@ -463,6 +479,7 @@
             </div>
             <?php } ?>
 
+            <?php if (!$user_sig_to_qso_tab) { ?>
             <div class="mb-3">
               <label for="sig"><?php echo lang('gen_hamradio_sig'); ?></label>
               <input class="form-control" id="sig" type="text" name="sig" value="" />
@@ -474,6 +491,7 @@
               <input class="form-control" id="sig_info" type="text" name="sig_info" value="" />
               <small id="sigInfoHelp" class="form-text text-muted"><?php echo lang('qso_sig_info_helptext'); ?></small>
             </div>
+            <?php } ?>
 
             <div class="mb-3">
               <label for="darc_dok"><?php echo lang('gen_hamradio_dok'); ?></label>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -218,6 +218,18 @@
               </div>
               <?php } ?>
 
+              <?php if ($user_wwff_to_qso_tab) { ?>
+              <div class="mb3 row">
+                <label class="col-sm-3 col-form-label" for="wwff_ref"><?php echo lang('gen_hamradio_wwff_reference'); ?></label>
+                <div class="col-sm-7 align-self-center">
+                  <input class="form-control" id="wwff_ref" type="text" name="wwff_ref" value="" />
+                </div>
+                <div class="col-sm-2 align-self-center">
+                  <small id="wwff_info" class="btn btn-secondary spw-buttons"></small>
+                </div>
+              </div>
+              <?php } ?>
+
               <div class="mb-3 row">
                 <label for="qth" class="col-sm-3 col-form-label"><?php echo lang('general_word_location'); ?></label>
                 <div class="col-sm-9">
@@ -413,6 +425,7 @@
             </div>
             <?php } ?>
 
+            <?php if (!$user_wwff_to_qso_tab) { ?>
             <div class="row">
               <div class="mb-3 col-md-9">
                 <label for="wwff_ref"><?php echo lang('gen_hamradio_wwff_reference'); ?></label>
@@ -423,6 +436,7 @@
                 <small id="wwff_info" class="btn btn-secondary spw-buttons"></small>
               </div>
             </div>
+            <?php } ?>
 
             <div class="row">
               <div class="mb-3 col-md-9">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -258,6 +258,15 @@
               </div>
               <?php } ?>
 
+              <?php if ($user_dok_to_qso_tab) { ?>
+              <div class="mb-3 row">
+                <label class="col-sm-3 col-form-label" for="darc_dok"><?php echo lang('gen_hamradio_dok'); ?></label>
+                <div class="col-sm-9">
+                  <input class="form-control" id="darc_dok" type="text" name="darc_dok" value="" />
+                </div>
+              </div>
+              <?php } ?>
+
               <div class="mb-3 row">
                 <label for="qth" class="col-sm-3 col-form-label"><?php echo lang('general_word_location'); ?></label>
                 <div class="col-sm-9">
@@ -493,11 +502,14 @@
             </div>
             <?php } ?>
 
+            <?php if (!$user_dok_to_qso_tab) { ?>
             <div class="mb-3">
               <label for="darc_dok"><?php echo lang('gen_hamradio_dok'); ?></label>
               <input class="form-control" id="darc_dok" type="text" name="darc_dok" value="" />
               <small id="dokHelp" class="form-text text-muted"><?php echo lang('qso_dok_helptext'); ?></small>
             </div>
+            <?php } ?>
+
           </div>
 
           <!-- Satellite Panel -->

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -590,7 +590,11 @@
 											</div>
 											<div class="form-check form-switch">
 												<input name="user_sig_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="sigToQsoTab" <?php if ($user_sig_to_qso_tab) { echo 'checked'; } ?>>
-                                    <label class="form-check-label" for="sigToQsoTab" ><?php echo lang('gen_hamradio_sig'); ?> / <?php echo lang('gen_hamradio_sig_info'); ?></label>
+												<label class="form-check-label" for="sigToQsoTab" ><?php echo lang('gen_hamradio_sig'); ?> / <?php echo lang('gen_hamradio_sig_info'); ?></label>
+											</div>
+											<div class="form-check form-switch">
+												<input name="user_dok_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="dokToQsoTab" <?php if ($user_dok_to_qso_tab) { echo 'checked'; } ?>>
+												<label class="form-check-label" for="dokToQsoTab" ><?php echo lang('gen_hamradio_dok'); ?></label>
 											</div>
 										</div>
 									</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -574,7 +574,11 @@
 											<label for="references_select"><?php echo lang('account_show_references_on_1st_tab'); ?></label>
 											<div class="form-check form-switch">
 												<input name="user_iota_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="iotaToQsoTab" <?php if ($user_iota_to_qso_tab) { echo 'checked'; } ?>>
-												<label class="form-check-label" for="iotaToQsoTab" ><?php echo lang('gen_hamradio_iota'); ?></label>
+												<label class="form-check-label" for="iotaToQsoTab" ><?php echo lang('gen_hamradio_iota_reference'); ?></label>
+											</div>
+											<div class="form-check form-switch">
+												<input name="user_sota_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="sotaToQsoTab" <?php if ($user_sota_to_qso_tab) { echo 'checked'; } ?>>
+												<label class="form-check-label" for="sotaToQsoTab" ><?php echo lang('gen_hamradio_sota_reference'); ?></label>
 											</div>
 										</div>
 									</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -598,6 +598,7 @@
 											</div>
 										</div>
 									</div>
+									<button type="button" onclick="clearRefSwitches();" class="btn btn-primary mb-5 mt-3"><i class="fas fa-recycle"></i> Reset</button>
 								</div>
 							</div>
 						</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -543,23 +543,41 @@
 						<?php } ?>
 					</div>
 
-					<div class="row">
+					<div class="row mb-3">
 						<!-- Previous QSL -->
 						<div class="col-md">
 							<div class="card">
 								<div class="card-header"><?php echo lang('account_previous_qsl_type'); ?></div>
 								<div class="card-body">
-									<div class="mb-3">
-										<label for="profileimages"><?php echo lang('account_select_the_type_of_qsl_to_show_in_the_previous_qsos_section'); ?></label>
-										<?php if(!isset($user_previous_qsl_type)) { $user_previous_qsl_type='0'; }?>
-										<select class="form-select" id="previousqsltype" name="user_previous_qsl_type">
-											<option value="0" <?php if ($user_previous_qsl_type == 0) { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_qsl'); ?></option>
-											<option value="1" <?php if ($user_previous_qsl_type == 1) { echo " selected =\"selected\""; } ?>><?php echo lang('lotw_short'); ?></option>
-											<option value="2" <?php if ($user_previous_qsl_type == 2) { echo " selected =\"selected\""; } ?>><?php echo lang('eqsl_short'); ?></option>
-											<option value="4" <?php if ($user_previous_qsl_type == 4) { echo " selected =\"selected\""; } ?>>QRZ</option>
-										</select>
+									<div class="row">
+										<div class="mb-3">
+											<label for="profileimages"><?php echo lang('account_select_the_type_of_qsl_to_show_in_the_previous_qsos_section'); ?></label>
+											<?php if(!isset($user_previous_qsl_type)) { $user_previous_qsl_type='0'; }?>
+											<select class="form-select" id="previousqsltype" name="user_previous_qsl_type">
+												<option value="0" <?php if ($user_previous_qsl_type == 0) { echo " selected =\"selected\""; } ?>><?php echo lang('gen_hamradio_qsl'); ?></option>
+												<option value="1" <?php if ($user_previous_qsl_type == 1) { echo " selected =\"selected\""; } ?>><?php echo lang('lotw_short'); ?></option>
+												<option value="2" <?php if ($user_previous_qsl_type == 2) { echo " selected =\"selected\""; } ?>><?php echo lang('eqsl_short'); ?></option>
+												<option value="4" <?php if ($user_previous_qsl_type == 4) { echo " selected =\"selected\""; } ?>>QRZ</option>
+											</select>
+										</div>
 									</div>
 
+								</div>
+							</div>
+						</div>
+						<div class="col-md">
+							<div class="card">
+								<div class="card-header"><?php echo lang('account_references_show'); ?></div>
+								<div class="card-body">
+									<div class="row">
+										<div class="mb-3">
+											<label for="references_select"><?php echo lang('account_show_references_on_1st_tab'); ?></label>
+											<div class="form-check form-switch">
+												<input name="user_iota_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="iotaToQsoTab" <?php if ($user_iota_to_qso_tab) { echo 'checked'; } ?>>
+												<label class="form-check-label" for="iotaToQsoTab" ><?php echo lang('gen_hamradio_iota'); ?></label>
+											</div>
+										</div>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -580,6 +580,10 @@
 												<input name="user_sota_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="sotaToQsoTab" <?php if ($user_sota_to_qso_tab) { echo 'checked'; } ?>>
 												<label class="form-check-label" for="sotaToQsoTab" ><?php echo lang('gen_hamradio_sota_reference'); ?></label>
 											</div>
+											<div class="form-check form-switch">
+												<input name="user_wwff_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="wwffToQsoTab" <?php if ($user_wwff_to_qso_tab) { echo 'checked'; } ?>>
+												<label class="form-check-label" for="wwffToQsoTab" ><?php echo lang('gen_hamradio_wwff_reference'); ?></label>
+											</div>
 										</div>
 									</div>
 								</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -584,6 +584,10 @@
 												<input name="user_wwff_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="wwffToQsoTab" <?php if ($user_wwff_to_qso_tab) { echo 'checked'; } ?>>
 												<label class="form-check-label" for="wwffToQsoTab" ><?php echo lang('gen_hamradio_wwff_reference'); ?></label>
 											</div>
+											<div class="form-check form-switch">
+												<input name="user_pota_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="potaToQsoTab" <?php if ($user_pota_to_qso_tab) { echo 'checked'; } ?>>
+												<label class="form-check-label" for="potaToQsoTab" ><?php echo lang('gen_hamradio_pota_reference'); ?></label>
+											</div>
 										</div>
 									</div>
 								</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -598,7 +598,7 @@
 											</div>
 										</div>
 									</div>
-									<button type="button" onclick="clearRefSwitches();" class="btn btn-primary mb-5 mt-3"><i class="fas fa-recycle"></i> Reset</button>
+									<button type="button" onclick="clearRefSwitches();" class="btn btn-primary"><i class="fas fa-recycle"></i> Reset</button>
 								</div>
 							</div>
 						</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -588,6 +588,10 @@
 												<input name="user_pota_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="potaToQsoTab" <?php if ($user_pota_to_qso_tab) { echo 'checked'; } ?>>
 												<label class="form-check-label" for="potaToQsoTab" ><?php echo lang('gen_hamradio_pota_reference'); ?></label>
 											</div>
+											<div class="form-check form-switch">
+												<input name="user_sig_to_qso_tab" class="form-check-input" type="checkbox" role="switch" id="sigToQsoTab" <?php if ($user_sig_to_qso_tab) { echo 'checked'; } ?>>
+                                    <label class="form-check-label" for="sigToQsoTab" ><?php echo lang('gen_hamradio_sig'); ?> / <?php echo lang('gen_hamradio_sig_info'); ?></label>
+											</div>
 										</div>
 									</div>
 								</div>

--- a/assets/js/sections/user.js
+++ b/assets/js/sections/user.js
@@ -24,7 +24,7 @@ $(document).ready(function(){
             }
         ]
     });
-    
+
     $('.icon_selectBox').off('click').on('click', function(){
         var boxcontent = $(this).attr('data-boxcontent');
         if ($('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').is(":hidden")) { $('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').show(); } else { $('.icon_selectBox_data[data-boxcontent="'+boxcontent+'"]').hide(); }
@@ -46,7 +46,7 @@ $(document).ready(function(){
     $('.collapse').on('shown.bs.collapse', function(e) {
         var $card = $(this).closest('.accordion-item');
         var $open = $($(this).data('parent')).find('.collapse.show');
-        
+
         var additionalOffset = 0;
         if($card.prevAll().filter($open.closest('.accordion-item')).length !== 0)
         {
@@ -91,7 +91,7 @@ $(document).ready(function(){
                         },
                         success: function(result) {
                             wait_dialog.close();
-        
+
                             if (result) {
                                 $('#pwd_reset_message').addClass('alert-success');
                                 $('#pwd_reset_message').text(lang_admin_password_reset_processed + " " + pwd_reset_user_name + " (" + pwd_reset_user_email + ")");
@@ -113,6 +113,21 @@ $(document).ready(function(){
                 }
             },
         }).getModalHeader().find('.modal-title').after('<i class="fas fa-spinner fa-spin fa-2x"></i>');
-        
+
     });
 });
+
+function clearRefSwitches() {
+   var iotaSwitch = document.getElementById("iotaToQsoTab");
+   iotaSwitch.checked = false;
+   var sotaSwitch = document.getElementById("sotaToQsoTab");
+   sotaSwitch.checked = false;
+   var wwffSwitch = document.getElementById("wwffToQsoTab");
+   wwffSwitch.checked = false;
+   var potaSwitch = document.getElementById("potaToQsoTab");
+   potaSwitch.checked = false;
+   var sigSwitch = document.getElementById("sigToQsoTab");
+   sigSwitch.checked = false;
+   var dokSwitch = document.getElementById("dokToQsoTab");
+   dokSwitch.checked = false;
+}


### PR DESCRIPTION
We had several requests to bring some of the fields in general tab to the front tab (i.e. QSO tab). So this brings a little flexibility by adding switches to choose which refs should be shown on QSO tab:

![Screenshot from 2024-03-22 08-35-27](https://github.com/wavelog/wavelog/assets/7112907/83fbeea2-4890-4efb-9308-39f668107cd0)
