### PR TITLE
Fixes a bug where qrz/hamqth links aren't shown

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -849,8 +849,10 @@ $( document ).ready(function() {
 							}
 							$('#qrz_info').html('<a target="_blank" href="https://www.qrz.com/db/'+callsign+'"><img width="30" height="30" src="'+base_url+'images/icons/qrz.com.png"></a>');
 							$('#qrz_info').attr('title', 'Lookup '+callsign+' info on qrz.com').removeClass('d-none');
+							$('#qrz_info').show();
 							$('#hamqth_info').html('<a target="_blank" href="https://www.hamqth.com/'+callsign+'"><img width="30" height="30" src="'+base_url+'images/icons/hamqth.com.png"></a>');
 							$('#hamqth_info').attr('title', 'Lookup '+callsign+' info on hamqth.com').removeClass('d-none');
+							$('#hamqth_info').show();
 
 							var $dok_select = $('#darc_dok').selectize();
 							var dok_selectize = $dok_select[0].selectize;


### PR DESCRIPTION
When looking up the first Call after entering the QSO-Page, links to hamqth/qrz are shown.
if doing this the 2nd time (e.g. after a reset or new QSO) the links/symbols were not shown.

This fixes the bug