### PR TITLE
Post logging focus

### DIFF
--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -13,6 +13,7 @@ class Contesting_model extends CI_Model {
 
         $contestid = $qsoarray[2];
         $date = DateTime::createFromFormat('d-m-Y H:i:s', $qsoarray[0]);
+        if ($date == false) $date = DateTime::createFromFormat('d-m-Y H:i', $qsoarray[0]);
         $date = $date->format('Y-m-d H:i:s');
 
         $sql = "SELECT date_format(col_time_on, '%d-%m-%Y %H:%i:%s') as col_time_on, col_call, col_band, col_mode,
@@ -217,6 +218,7 @@ class Contesting_model extends CI_Model {
 			$qsoarray = explode(',', $contest_session->qso);
 	
 			$date = DateTime::createFromFormat('d-m-Y H:i:s', $qsoarray[0]);
+			if ($date == false) $date = DateTime::createFromFormat('d-m-Y H:i', $qsoarray[0]);
 			$date = $date->format('Y-m-d H:i:s');
 
 			$this->db->select('timediff(UTC_TIMESTAMP(),col_time_off) b4, COL_TIME_OFF');

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -111,17 +111,10 @@ if ( ! manual ) {
 }
 
 // We don't want spaces to be written in callsign
-$(function () {
-	$('#callsign').on('keypress', function (e) {
-		if (e.which == 32) {
-			return false;
-		}
-	});
-});
-
 // We don't want spaces to be written in exchange
+// We don't want spaces to be written in time :)
 $(function () {
-	$('#exch_rcvd').on('keypress', function (e) {
+	$('#callsign, #exch_rcvd, #start_time').on('keypress', function (e) {
 		if (e.which == 32) {
 			return false;
 		}
@@ -174,6 +167,12 @@ document.onkeyup = function (e) {
 	} else if (e.which == 32) {
 		getCallbook();
 		var exchangetype = $("#exchangetype").val();
+
+		if (manual && $(document.activeElement).attr("id") == "start_time") {
+			$("#callsign").focus();
+			return false;
+		}
+        
 		if (exchangetype == 'Exchange') {
 			if ($(document.activeElement).attr("id") == "callsign") {
 				$("#exch_rcvd").focus();
@@ -519,7 +518,11 @@ function logQso() {
 				$('#exch_rcvd').val("");
 				$('#exch_gridsquare_r').val("");
 				$('#exch_serial_r').val("");
-				$("#callsign").focus();
+				if (manual) {
+					$("#start_time").focus().select();
+				} else {
+					$("#callsign").focus();
+				}
 				await setSession(formdata);
 
 				await refresh_qso_table(sessiondata);


### PR DESCRIPTION
Move post-qso-entry focus to time-field in contest-post-logging and move from time to callsign by pressing space.

Fix time-parsing on server-side.