### PR TITLE
Tweaks to gui and spinner on update dxcc button

### DIFF
--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -11,7 +11,7 @@ class Update extends CI_Controller {
     function __construct()
 	{
 		parent::__construct();
-		
+
 		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
             echo "Maintenance Mode is active. Try again later.\n";
 			redirect('user/login');
@@ -258,22 +258,45 @@ class Update extends CI_Controller {
 	}
 
 	public function check_missing_dxcc($all = false){
-	    $this->load->model('logbook_model');
-        $this->logbook_model->check_missing_dxcc_id($all);
+		$this->load->model('user_model');
+		if (!$this->user_model->authorize(99)) {
+			$this->session->set_flashdata('notice', 'You\'re not allowed to do that!');
+			redirect('dashboard');
+		}
 
+		$this->load->model('logbook_model');
+        $this->logbook_model->check_missing_dxcc_id($all);
 	}
 
 	public function check_missing_continent() {
+		$this->load->model('user_model');
+		if (!$this->user_model->authorize(99)) {
+			$this->session->set_flashdata('notice', 'You\'re not allowed to do that!');
+			redirect('dashboard');
+		}
+
 		$this->load->model('logbook_model');
 		$this->logbook_model->check_missing_continent();
 	}
 
 	public function update_distances() {
+		$this->load->model('user_model');
+		if (!$this->user_model->authorize(99)) {
+			$this->session->set_flashdata('notice', 'You\'re not allowed to do that!');
+			redirect('dashboard');
+		}
+
 		$this->load->model('logbook_model');
 		$this->logbook_model->update_distances();
 	}
 
 	public function check_missing_grid($all = false){
+		$this->load->model('user_model');
+		if (!$this->user_model->authorize(99)) {
+			$this->session->set_flashdata('notice', 'You\'re not allowed to do that!');
+			redirect('dashboard');
+		}
+
 	    $this->load->model('logbook_model');
         $this->logbook_model->check_missing_grid_id($all);
 	}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4368,8 +4368,6 @@ function lotw_last_qsl_date($user_id) {
         if (!$all){
             $this->db->where("COL_DXCC is NULL");
         }
-		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
-		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 
         $r = $this->db->get($this->config->item('table_name'));
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4368,6 +4368,8 @@ function lotw_last_qsl_date($user_id) {
         if (!$all){
             $this->db->where("COL_DXCC is NULL");
         }
+		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 
         $r = $this->db->get($this->config->item('table_name'));
 
@@ -4382,15 +4384,12 @@ function lotw_last_qsl_date($user_id) {
                 // Manual call
                 $d = $this->check_dxcc_table($row['COL_CALL'], $qso_date);
 
-                // Stored procedure call
-                //$d = $this->check_dxcc_stored_proc($row["COL_CALL"], $qso_date);
-
                 if ($d[0] != 'Not Found'){
                     $sql = sprintf("update %s set COL_COUNTRY = '%s', COL_DXCC='%s' where COL_PRIMARY_KEY=%d",
                                     $this->config->item('table_name'), addslashes(ucwords(strtolower($d[1]), "- (/")), $d[0], $row['COL_PRIMARY_KEY']);
                     $this->db->query($sql);
                     //print($sql."\n");
-                    printf("Updating %s to %s and %s\n<br/>", $row['COL_PRIMARY_KEY'], ucwords(strtolower($d[1]), "- (/"), $d[0]);
+                    // printf("Updating %s to %s and %s\n<br/>", $row['COL_PRIMARY_KEY'], ucwords(strtolower($d[1]), "- (/"), $d[0]);
                     $count++;
                 }
             }

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1269,6 +1269,8 @@ $($('#callsign')).on('keypress',function(e) {
 <script>
 $(document).ready(function(){
     $('#btn_update_dxcc').bind('click', function(){
+		$(".ld-ext-right").addClass("running");
+		$(".ld-ext-right").prop("disabled", true);
         $('#dxcc_update_status').show();
         $.ajax({url:"update/dxcc"});
         setTimeout(update_stats,5000);
@@ -1279,7 +1281,10 @@ $(document).ready(function(){
 
             if ((val  === null) || (val.substring(0,4) !="DONE")){
                 setTimeout(update_stats, 5000);
-            }
+            } else {
+				$(".ld-ext-right").removeClass("running");
+				$(".ld-ext-right").prop("disabled", false);
+			}
         });
 
     }

--- a/application/views/update/index.php
+++ b/application/views/update/index.php
@@ -25,7 +25,7 @@
 						</div>
 					<?php } else { ?>
 						<h5>Check for DXCC Data Updates</h5>
-						<input type="submit" class="btn btn-primary" id="btn_update_dxcc" value="Update DXCC Data" />
+						<button type="submit" class="btn btn-primary ld-ext-right" id="btn_update_dxcc"><div class="ld ld-ring ld-spin"></div>Update DXCC Data</button>
 
 						<div id="dxcc_update_status">Status:</br></div>
 
@@ -37,14 +37,17 @@
 							You can choose to check just the QSOs in the logbook that are missing DXCC metadata or to re-check the entire logbook
 							and update existing metadata as well, in case it has changed.
 						</p>
-						<p><a class="btn btn-primary" href="<?php echo site_url('update/check_missing_dxcc');?>">Check QSOs missing DXCC data</a></p>
-						<p><a class="btn btn-primary" href="<?php echo site_url('update/check_missing_dxcc/all');?>">Re-check all QSOs in logbook</a></p>
+						<p><a class="btn btn-primary" hx-get="<?php echo site_url('update/check_missing_dxcc');?>"hx-target="#missing_dxcc_results" href="<?php echo site_url('update/check_missing_dxcc');?>">Check QSOs missing DXCC data</a></p>
+						<div id="missing_dxcc_results"></div>
+						<p><a class="btn btn-primary" hx-get="<?php echo site_url('update/check_missing_dxcc/all');?>" hx-target="#missing_dxcc_results_all" href="<?php echo site_url('update/check_missing_dxcc/all');?>">Re-check all QSOs in logbook</a></p>
+						<div id="missing_dxcc_results_all"></div>
 
 						<h5>Apply Continent Data to Logbook</h5>
 						<p class="card-text">
 							This function can be used to update QSO continent information for all QSOs in Wavelog missing that information.
 						</p>
-						<p><a class="btn btn-primary" href="<?php echo site_url('update/check_missing_continent');?>">Check QSOs missing continent data</a></p>
+						<p><a class="btn btn-primary" hx-get="<?php echo site_url('update/check_missing_continent');?>" hx-target="#continent_results" href="<?php echo site_url('update/check_missing_continent');?>">Check QSOs missing continent data</a></p>
+						<div id="continent_results"></div>
 						<style>
 							#dxcc_update_status{
 							display: None;


### PR DESCRIPTION
Added spinner to update button.
![image](https://github.com/wavelog/wavelog/assets/6977712/1b405a2a-76d6-43f3-9d9e-70108e7ea9df)

Used hx-get so that result will be placed below buttons on 
* Check QSOs missing DXCC data
* Re-check all QSOs in logbook - I removed printing of every QSO that is updated. The id from the table is listed, and is of very little use for the user. Only total at the end is displayed. I also limited this so that only the logged in users QSOs will be updated. Not 100% sure of this one though.
* Check QSOs missing continent data

