### PR TITLE
Delete all fragments which belongs to a user upon deleting

### DIFF
--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -42,15 +42,8 @@ class Qsl extends CI_Controller {
     public function delete() {
         $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
-
         $id = $this->input->post('id');
         $this->load->model('Qsl_model');
-
-        $path = $this->Qsl_model->get_imagePath('p');
-        $file = $this->Qsl_model->getFilename($id)->row();
-        $filename = $file->filename;
-        unlink($path.'/'.$filename);
-
         $this->Qsl_model->deleteQsl($id);
     }
 

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -27,6 +27,7 @@ class Eqsl_images extends CI_Model {
 			}
 			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->image_file;
 			unlink($image);
+			$this->db->delete('eQSL_images', array('id' => $row->id));
 			return $image;
 		}
 	}

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -19,7 +19,7 @@ class Eqsl_images extends CI_Model {
 		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
 		$eqsl_img=$this->db->query('SELECT e.image_file,e.id, qso.station_id, s.user_id FROM `eQSL_images` e INNER JOIN '.$this->config->item('table_name').' qso ON (e.qso_id = qso.COL_PRIMARY_KEY) inner join station_profile s on (s.station_id=qso.station_id) where qso.COL_PRIMARY_KEY=?',$qso_id);
 		foreach ($eqsl_img->result() as $row) {
-			if ($user_id ?? '' == '') {					// Calling as User? Check if User-id matches User-id from QSO
+			if (($user_id ?? '') == '') {					// Calling as User? Check if User-id matches User-id from QSO
 				$user_id = $this->session->userdata('user_id');
 				if ($row->user_id != $user_id) {
 					return "No Image";				// Image doesn't belong to user, so return

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -26,7 +26,7 @@ class Eqsl_images extends CI_Model {
 				}
 			}
 			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->image_file;
-			log_message("Error",$image);	// todo: chk and unlink
+			unlink($image);
 			return $image;
 		}
 	}
@@ -61,7 +61,7 @@ class Eqsl_images extends CI_Model {
 
 			$eqsl_dir = "eqsl_card"; // make sure this is the same as in Debug_model.php function migrate_userdata()
 
-			if ($user_id ?? '' == '') {
+			if (($user_id ?? '') == '') {
 				$user_id = $this->session->userdata('user_id');
 			}
 

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -25,7 +25,7 @@ class Eqsl_images extends CI_Model {
 					return "No Image";				// Image doesn't belong to user, so return
 				}
 			}
-			$image=get_imagePath('p',$row->user_id).'/'.$row->image_file;
+			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->image_file;
 			log_message("Error",$image);	// todo: chk and unlink
 			return $image;
 		}

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -15,6 +15,22 @@ class Eqsl_images extends CI_Model {
 		}
 	}
 
+	function del_image($qso_id, $user_id = null) {
+		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
+		$eqsl_img=$this->db->query('SELECT e.image_file,e.id, qso.station_id, s.user_id FROM `eQSL_images` e INNER JOIN '.$this->config->item('table_name').' qso ON (e.qso_id = qso.COL_PRIMARY_KEY) inner join station_profile s on (s.station_id=qso.station_id) where qso.COL_PRIMARY_KEY=?',$qso_id);
+		foreach ($eqsl_img->result() as $row) {
+			if ($user_id ?? '' == '') {					// Calling as User? Check if User-id matches User-id from QSO
+				$user_id = $this->session->userdata('user_id');
+				if ($row->user_id != $user_id) {
+					return "No Image";				// Image doesn't belong to user, so return
+				}
+			}
+			$image=get_imagePath('p',$row->user_id).'/'.$row->image_file;
+			log_message("Error",$image);	// todo: chk and unlink
+			return $image;
+		}
+	}
+
 	function save_image($qso_id, $image_name) {
 		$data = array(
 		        'qso_id' => $qso_id,
@@ -36,36 +52,37 @@ class Eqsl_images extends CI_Model {
 	}
 
 	// return path of eQsl file : u=url / p=real path 
-	function get_imagePath($pathorurl='u') {
+	function get_imagePath($pathorurl='u', $user_id = null) {
 
 		// test if new folder directory option is enabled
 		$userdata_dir = $this->config->item('userdata');
-		
+
 		if (isset($userdata_dir)) {
 
 			$eqsl_dir = "eqsl_card"; // make sure this is the same as in Debug_model.php function migrate_userdata()
 
-			$user_id = $this->session->userdata('user_id');
-			
+			if ($user_id ?? '' == '') {
+				$user_id = $this->session->userdata('user_id');
+			}
+
 			// check if there is a user_id in the session data and it's not empty
 			if ($user_id != '') {
-				
-                // create the folder
-                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir)) {
-                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir, 0755, true);
-                }
 
-                // and return it
-                if ($pathorurl=='u') {
-                    return $userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
-                } else {
-                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
-                }
-            } else {
+				// create the folder
+				if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir)) {
+					mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir, 0755, true);
+				}
+
+				// and return it
+				if ($pathorurl=='u') {
+					return $userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
+				} else {
+					return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
+				}
+			} else {
 				log_message('info', 'Can not get eqsl image path because no user_id in session data');
 			}
-        } else {
-
+		} else {
 			// if the config option is not set we just return the old path
 			return 'images/eqsl_card_images';
 		}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3047,16 +3047,14 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
     /* Delete QSO based on the QSO ID */
     function delete($id) {
 	    if ($this->check_qso_is_accessible($id)) {
+		    $this->load->model('qsl_model');
+		    $this->load->model('eqsl_images');
+
+		    $this->qsl_model->del_image_for_qso($id);
+		    $this->eqsl_images->del_image($id);
+
 		    $this->db->where('COL_PRIMARY_KEY', $id);
 		    $this->db->delete($this->config->item('table_name'));
-
-		    // todo: remove qsl_image from Filesystem
-		    $this->db->where('qsoid', $id);
-		    $this->db->delete("qsl_images");
-
-		    // todo: remove eqsl_image from Filesystem
-		    $this->db->where('qso_id', $id);
-		    $this->db->delete("`eQSL_images`");
 
 		    $this->db->where('qsoid', $id);
 		    $this->db->delete("oqrs");

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3045,14 +3045,25 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
     }
 
     /* Delete QSO based on the QSO ID */
-  function delete($id) {
-	  if ($this->check_qso_is_accessible($id)) {
-		  $this->db->where('COL_PRIMARY_KEY', $id);
-		  $this->db->delete($this->config->item('table_name'));
-	  } else {
-		  return;
-	  }
-  }
+    function delete($id) {
+	    if ($this->check_qso_is_accessible($id)) {
+		    $this->db->where('COL_PRIMARY_KEY', $id);
+		    $this->db->delete($this->config->item('table_name'));
+
+		    // todo: remove qsl_image from Filesystem
+		    $this->db->where('qsoid', $id);
+		    $this->db->delete("qsl_images");
+
+		    // todo: remove eqsl_image from Filesystem
+		    $this->db->where('qso_id', $id);
+		    $this->db->delete("`eQSL_images`");
+
+		    $this->db->where('qsoid', $id);
+		    $this->db->delete("oqrs");
+	    } else {
+		    return;
+	    }
+    }
 
   /* Used to check if the qso is already in the database */
     function import_check($datetime, $callsign, $band, $mode, $station_callsign, $station_id = null) {

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -60,9 +60,8 @@ class Qsl_model extends CI_Model {
 					return "No Image";				// Image doesn't belong to user, so return
 				}
 			}
-			$image=get_imagePath('p',$row->user_id).'/'.$row->filename;
-			log_message("Error",$image);	// todo: chk and unlink
-			return $image;
+			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->filename;
+			unlink($image);
 		}
 	}
 

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -1,97 +1,117 @@
 <?php
 class Qsl_model extends CI_Model {
-    function getQsoWithQslList() {
-        $this->load->model('logbooks_model');
-        $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+	function getQsoWithQslList() {
+		$this->load->model('logbooks_model');
+		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        $this->db->select('*');
-        $this->db->from($this->config->item('table_name'));
-        $this->db->join('qsl_images', 'qsl_images.qsoid = ' . $this->config->item('table_name') . '.col_primary_key');
-        $this->db->where_in('station_id', $logbooks_locations_array);
-        $this->db->order_by("id", "desc");
+		$this->db->select('*');
+		$this->db->from($this->config->item('table_name'));
+		$this->db->join('qsl_images', 'qsl_images.qsoid = ' . $this->config->item('table_name') . '.col_primary_key');
+		$this->db->where_in('station_id', $logbooks_locations_array);
+		$this->db->order_by("id", "desc");
 
-        return $this->db->get();
-    }
+		return $this->db->get();
+	}
 
-    function getQslForQsoId($id) {
-        // Clean ID
-        $clean_id = $this->security->xss_clean($id);
+	function getQslForQsoId($id) {
+		// Clean ID
+		$clean_id = $this->security->xss_clean($id);
 
-        // be sure that QSO belongs to user
-        $this->load->model('logbook_model');
-        if (!$this->logbook_model->check_qso_is_accessible($clean_id)) {
-            return;
-        }
+		// be sure that QSO belongs to user
+		$this->load->model('logbook_model');
+		if (!$this->logbook_model->check_qso_is_accessible($clean_id)) {
+			return;
+		}
 
-        $this->db->select('*');
-        $this->db->from('qsl_images');
-        $this->db->where('qsoid', $clean_id);
+		$this->db->select('*');
+		$this->db->from('qsl_images');
+		$this->db->where('qsoid', $clean_id);
 
-        return $this->db->get()->result();
-    }
+		return $this->db->get()->result();
+	}
 
-    function saveQsl($qsoid, $filename) {
-        // Clean ID
-        $clean_id = $this->security->xss_clean($qsoid);
+	function saveQsl($qsoid, $filename) {
+		// Clean ID
+		$clean_id = $this->security->xss_clean($qsoid);
 
-        // be sure that QSO belongs to user
-        $this->load->model('logbook_model');
-        if (!$this->logbook_model->check_qso_is_accessible($clean_id)) {
-            return;
-        }
+		// be sure that QSO belongs to user
+		$this->load->model('logbook_model');
+		if (!$this->logbook_model->check_qso_is_accessible($clean_id)) {
+			return;
+		}
 
-        $data = array(
-            'qsoid' => $clean_id,
-            'filename' => $filename
-        );
+		$data = array(
+			'qsoid' => $clean_id,
+			'filename' => $filename
+		);
 
-        $this->db->insert('qsl_images', $data);
+		$this->db->insert('qsl_images', $data);
 
-        return $this->db->insert_id();
-    }
+		return $this->db->insert_id();
+	}
 
-    function deleteQsl($id) {
-        // Clean ID
-        $clean_id = $this->security->xss_clean($id);
+	function del_image_for_qso($qso_id, $user_id = null) {
+		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
+		$qsl_img=$this->db->query('SELECT e.filename, e.id, qso.station_id, s.user_id FROM qsl_images e INNER JOIN '.$this->config->item('table_name').' qso ON (e.qsoid = qso.COL_PRIMARY_KEY) inner join station_profile s on (s.station_id=qso.station_id) where qso.COL_PRIMARY_KEY=?',$qso_id);
+		foreach ($qsl_img->result() as $row) {
+			if ($user_id ?? '' == '') {					// Calling as User? Check if User-id matches User-id from QSO
+				$user_id = $this->session->userdata('user_id');
+				if ($row->user_id != $user_id) {
+					return "No Image";				// Image doesn't belong to user, so return
+				}
+			}
+			$image=get_imagePath('p',$row->user_id).'/'.$row->filename;
+			log_message("Error",$image);	// todo: chk and unlink
+			return $image;
+		}
+	}
 
-        // be sure that QSO belongs to user
-        $this->load->model('logbook_model');
-        $this->db->select('qsoid');
-        $this->db->from('qsl_images');
-        $this->db->where('id', $clean_id);
-        $qsoid = $this->db->get()->row()->qsoid;
-        if (!$this->logbook_model->check_qso_is_accessible($qsoid)) {
-            return;
-        }
+	function deleteQsl($id) {
+		// Clean ID
+		$clean_id = $this->security->xss_clean($id);
 
-        // Delete Mode
-        $this->db->delete('qsl_images', array('id' => $clean_id));
-    }
+		// be sure that QSO belongs to user
+		$this->load->model('logbook_model');
+		$this->db->select('qsoid');
+		$this->db->from('qsl_images');
+		$this->db->where('id', $clean_id);
+		$qsoid = $this->db->get()->row()->qsoid;
+		if (!$this->logbook_model->check_qso_is_accessible($qsoid)) {
+			return;
+		}
+		// We cannot call del_image_for_qso here, since this one only deletes ONE QSL-Card (Multiple QSL-Cards can belong to one QSO)
+		$path = $this->get_imagePath('p');
+		$file = $this->getFilename($clean_id)->row();
+		$filename = $file->filename;
+		unlink($path.'/'.$filename);
+		// Delete Mode
+		$this->db->delete('qsl_images', array('id' => $clean_id));
+	}
 
-    function getFilename($id) {
-        // Clean ID
-        $clean_id = $this->security->xss_clean($id);
+	function getFilename($id) {
+		// Clean ID
+		$clean_id = $this->security->xss_clean($id);
 
-        // be sure that QSO belongs to user
-        $this->load->model('logbook_model');
-        $this->db->select('qsoid');
-        $this->db->from('qsl_images');
-        $this->db->where('id', $clean_id);
-        $qsoid = $this->db->get()->row()->qsoid;
-        if (!$this->logbook_model->check_qso_is_accessible($qsoid)) {
-            return;
-        }
+		// be sure that QSO belongs to user
+		$this->load->model('logbook_model');
+		$this->db->select('qsoid');
+		$this->db->from('qsl_images');
+		$this->db->where('id', $clean_id);
+		$qsoid = $this->db->get()->row()->qsoid;
+		if (!$this->logbook_model->check_qso_is_accessible($qsoid)) {
+			return;
+		}
 
-        $this->db->select('filename');
-        $this->db->from('qsl_images');
-        $this->db->where('id', $clean_id);
+		$this->db->select('filename');
+		$this->db->from('qsl_images');
+		$this->db->where('id', $clean_id);
 
-        return $this->db->get();
-    }
+		return $this->db->get();
+	}
 
-    function searchQsos($callsign) {
-        $this->load->model('logbooks_model');
-        $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+	function searchQsos($callsign) {
+		$this->load->model('logbooks_model');
+		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
 		$this->db->select('*');
 		$this->db->from($this->config->item('table_name'));
@@ -122,35 +142,37 @@ class Qsl_model extends CI_Model {
 	}
 
 	// return path of qsl file : u=url / p=real path 
-	function get_imagePath($pathorurl='u') {
+	function get_imagePath($pathorurl='u', $user_id=null) {
 
 		// test if new folder directory option is enabled
 		$userdata_dir = $this->config->item('userdata');
-		
+
 		if (isset($userdata_dir)) {
 
 			$qsl_dir = "qsl_card"; // make sure this is the same as in Debug_model.php function migrate_userdata()
 
-			$user_id = $this->session->userdata('user_id');
-			
+			if ($user_id ?? '' == '') {
+				$user_id = $this->session->userdata('user_id');
+			}
+
 			// check if there is a user_id in the session data and it's not empty
 			if ($user_id != '') {
-				
-                // create the folder
-                if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir)) {
-                    mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir, 0755, true);
-                }
 
-                // and return it
-                if ($pathorurl=='u') {
-                    return $userdata_dir.'/'.$user_id.'/'.$qsl_dir;
-                } else {
-                    return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir;
-                }
-            } else {
+				// create the folder
+				if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir)) {
+					mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir, 0755, true);
+				}
+
+				// and return it
+				if ($pathorurl=='u') {
+					return $userdata_dir.'/'.$user_id.'/'.$qsl_dir;
+				} else {
+					return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir;
+				}
+			} else {
 				log_message('info', 'Can not get qsl card image path because no user_id in session data');
 			}
-        } else {
+		} else {
 
 			// if the config option is not set we just return the old path
 			return 'assets/qslcard';

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -62,6 +62,7 @@ class Qsl_model extends CI_Model {
 			}
 			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->filename;
 			unlink($image);
+			$this->db->delete('qsl_images', array('id' => $row->id));
 		}
 	}
 

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -54,7 +54,7 @@ class Qsl_model extends CI_Model {
 		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
 		$qsl_img=$this->db->query('SELECT e.filename, e.id, qso.station_id, s.user_id FROM qsl_images e INNER JOIN '.$this->config->item('table_name').' qso ON (e.qsoid = qso.COL_PRIMARY_KEY) inner join station_profile s on (s.station_id=qso.station_id) where qso.COL_PRIMARY_KEY=?',$qso_id);
 		foreach ($qsl_img->result() as $row) {
-			if ($user_id ?? '' == '') {					// Calling as User? Check if User-id matches User-id from QSO
+			if (($user_id ?? '') == '') {					// Calling as User? Check if User-id matches User-id from QSO
 				$user_id = $this->session->userdata('user_id');
 				if ($row->user_id != $user_id) {
 					return "No Image";				// Image doesn't belong to user, so return
@@ -150,7 +150,7 @@ class Qsl_model extends CI_Model {
 
 			$qsl_dir = "qsl_card"; // make sure this is the same as in Debug_model.php function migrate_userdata()
 
-			if ($user_id ?? '' == '') {
+			if (($user_id ?? '') == '') {
 				$user_id = $this->session->userdata('user_id');
 			}
 

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -202,7 +202,7 @@ class Stations extends CI_Model {
 		$this->user_options_model->set_option('eqsl_default_qslmsg', 'key_station_id', array(xss_clean($this->input->post('station_id', true)) => $eqsl_default_qslmsg));
 	}
 
-	function delete($id,$force = false) {
+	function delete($id,$force = false, $user_id = null) {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);
 
@@ -215,7 +215,7 @@ class Stations extends CI_Model {
 		$this->user_options_model->del_option('eqsl_default_qslmsg', 'key_station_id', array('option_key' => $id));
 
 		// Delete Contents of log for that station_id
-		$this->deletelog($clean_id);
+		$this->deletelog($clean_id, $user_id);
 
 		// Delete Station Profile, links, contests and oqrs-requests
 		$this->db->query("DELETE c FROM contest_session c WHERE c.station_id =?",$clean_id);
@@ -224,15 +224,18 @@ class Stations extends CI_Model {
 		$this->db->delete('station_profile', array('station_id' => $clean_id));
 	}
 
-	function deletelog($id) {
+	function deletelog($id, $user_id = null) {
 		// Clean ID
 		$clean_id = $this->security->xss_clean($id);
 
-		// Todo: Fetch EACH COL_PRIMARY_KEY (via inner join) from Log-table and delete also eQSL-file within filesystem (Function missing here) depending on path-configuration
-		$this->db->query("DELETE e FROM `eQSL_images` e inner join ".$this->config->item('table_name')." qsos where e.qso_id=qsos.COL_PRIMARY_KEY and qsos.station_id=?",$clean_id);
-		// Todo: Fetch EACH COL_PRIMARY_KEY (via inner join) from Log-table and delete also QSL-file within filesystem (Function missing here) depending on path-configuration
-		$this->db->query("DELETE q FROM qsl_images q inner join ".$this->config->item('table_name')." qsos WHERE q.qsoid=qsos.COL_PRIMARY_KEY and qsos.station_id = ?",$clean_id);
+		$this->load->model('qsl_model');
+		$this->load->model('eqsl_images');
 
+		$qsos=$this->db->query("select COL_PRIMARY_KEY as id from ".$this->config->item('table_name')." where station_id=?",$clean_id);
+		foreach ($qsos->result() as $qso) {
+			$this->qsl_model->del_image_for_qso($qso->id, $user_id);
+			$this->eqsl_images->del_image($qso->id, $user_id);
+		}
 		// Delete QSOs
 		$this->db->query("DELETE FROM ".$this->config->item('table_name')." WHERE station_id = ?",$clean_id);
 	}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -335,8 +335,11 @@ class User_Model extends CI_Model {
 			$this->load->model('Stations');
 			$stations = $this->Stations->all_of_user($user_id);
                         foreach ($stations->result() as $row) {
+				// Todo: Fetch EACH COL_PRIMARY_KEY (via inner join) from Log-table and delete also eQSL-file within filesystem (Function missing here) depending on path-configuration
 				$this->db->query("DELETE e FROM `eQSL_images` e inner join ".$this->config->item('table_name')." qsos where e.qso_id=qsos.COL_PRIMARY_KEY and qsos.station_id=?",$row->station_id);
+				// Todo: Fetch EACH COL_PRIMARY_KEY (via inner join) from Log-table and delete also QSL-file within filesystem (Function missing here) depending on path-configuration
 				$this->db->query("DELETE q FROM qsl_images q inner join ".$this->config->item('table_name')." qsos WHERE q.qsoid=qsos.COL_PRIMARY_KEY and qsos.station_id = ?",$row->station_id);
+
 				$this->db->query("DELETE c FROM contest_session c WHERE c.station_id =?",$row->station_id);
 				$this->db->query("DELETE FROM oqrs WHERE station_id = ?",$row->station_id);
 				$this->db->query("DELETE FROM ".$this->config->item('table_name')." WHERE station_id = ?",$row->station_id);
@@ -353,8 +356,8 @@ class User_Model extends CI_Model {
 			$this->db->query("DELETE FROM queries WHERE userid = ?",$user_id);
 			$this->db->query("DELETE FROM station_profile WHERE user_id = ?",$user_id);
 			$this->db->query("DELETE FROM station_logbooks WHERE user_id = ?",$user_id);
-			$this->db->query("DELETE FROM ".$this->config->item('auth_table')." WHERE user_id = ?",$user_id);
 			$this->db->query("delete from user_options where user_id=?",$user_id);
+			$this->db->query("DELETE FROM ".$this->config->item('auth_table')." WHERE user_id = ?",$user_id);
 			return 1;
 		} else {
 			return 0;

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -330,21 +330,12 @@ class User_Model extends CI_Model {
 	// FUNCTION: bool delete()
 	// Deletes a user
 	function delete($user_id) {
-
 		if($this->exists_by_id($user_id)) {
 			$this->load->model('Stations');
 			$stations = $this->Stations->all_of_user($user_id);
-                        foreach ($stations->result() as $row) {
-				// Todo: Fetch EACH COL_PRIMARY_KEY (via inner join) from Log-table and delete also eQSL-file within filesystem (Function missing here) depending on path-configuration
-				$this->db->query("DELETE e FROM `eQSL_images` e inner join ".$this->config->item('table_name')." qsos where e.qso_id=qsos.COL_PRIMARY_KEY and qsos.station_id=?",$row->station_id);
-				// Todo: Fetch EACH COL_PRIMARY_KEY (via inner join) from Log-table and delete also QSL-file within filesystem (Function missing here) depending on path-configuration
-				$this->db->query("DELETE q FROM qsl_images q inner join ".$this->config->item('table_name')." qsos WHERE q.qsoid=qsos.COL_PRIMARY_KEY and qsos.station_id = ?",$row->station_id);
-
-				$this->db->query("DELETE c FROM contest_session c WHERE c.station_id =?",$row->station_id);
-				$this->db->query("DELETE FROM oqrs WHERE station_id = ?",$row->station_id);
-				$this->db->query("DELETE FROM ".$this->config->item('table_name')." WHERE station_id = ?",$row->station_id);
-				$this->db->query("DELETE FROM station_logbooks_relationship WHERE station_location_id = ?",$row->station_id);
-                        }
+			foreach ($stations->result() as $row) {
+				$this->Stations->delete($row->station_id,true);
+			}
 			// Delete QSOs from $this->config->item('table_name')
 			$this->db->query("DELETE FROM bandxuser WHERE userid = ?",$user_id);
 			$this->db->query("DELETE FROM api WHERE user_id = ?",$user_id);

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -332,9 +332,29 @@ class User_Model extends CI_Model {
 	function delete($user_id) {
 
 		if($this->exists_by_id($user_id)) {
-			$this->db->query("DELETE FROM ".$this->config->item('auth_table')." WHERE user_id = '".$user_id."'");
+			$this->load->model('Stations');
+			$stations = $this->Stations->all_of_user($user_id);
+                        foreach ($stations->result() as $row) {
+				$this->db->query("DELETE e FROM `eQSL_images` e inner join ".$this->config->item('table_name')." qsos where e.qso_id=qsos.COL_PRIMARY_KEY and qsos.station_id=?",$row->station_id);
+				$this->db->query("DELETE q FROM qsl_images q inner join ".$this->config->item('table_name')." qsos WHERE q.qsoid=qsos.COL_PRIMARY_KEY and qsos.station_id = ?",$row->station_id);
+				$this->db->query("DELETE c FROM contest_session c WHERE c.station_id =?",$row->station_id);
+				$this->db->query("DELETE FROM oqrs WHERE station_id = ?",$row->station_id);
+				$this->db->query("DELETE FROM ".$this->config->item('table_name')." WHERE station_id = ?",$row->station_id);
+				$this->db->query("DELETE FROM station_logbooks_relationship WHERE station_location_id = ?",$row->station_id);
+                        }
+			// Delete QSOs from $this->config->item('table_name')
+			$this->db->query("DELETE FROM bandxuser WHERE userid = ?",$user_id);
+			$this->db->query("DELETE FROM api WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM cat WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM lotw_certs WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM notes WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM paper_types WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM label_types WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM queries WHERE userid = ?",$user_id);
+			$this->db->query("DELETE FROM station_profile WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM station_logbooks WHERE user_id = ?",$user_id);
+			$this->db->query("DELETE FROM ".$this->config->item('auth_table')." WHERE user_id = ?",$user_id);
 			$this->db->query("delete from user_options where user_id=?",$user_id);
-
 			return 1;
 		} else {
 			return 0;

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -334,7 +334,7 @@ class User_Model extends CI_Model {
 			$this->load->model('Stations');
 			$stations = $this->Stations->all_of_user($user_id);
 			foreach ($stations->result() as $row) {
-				$this->Stations->delete($row->station_id,true);
+				$this->Stations->delete($row->station_id,true, $user_id);
 			}
 			// Delete QSOs from $this->config->item('table_name')
 			$this->db->query("DELETE FROM bandxuser WHERE userid = ?",$user_id);


### PR DESCRIPTION
While testing on my instance i recognized a lot of old QSOs and other fragments where still in Database active.
In preparation of activating contraints somewhere in the future, we should delete everything which belongs to the User.

Affected Actions:
- Delete User (should delete everything from the user: OQRS, Certs, QSOs, eQSLs, QSLs, bandx, stations, logbooks, etc.)
- Delete Station-Location (should delete everything from the station: OQRS, QSOs, eQSLs, QSLs)