### PR TITLE
[Maps] Moved legend/info css from view to general.css

### DIFF
--- a/application/views/activated_gridmap/index.php
+++ b/application/views/activated_gridmap/index.php
@@ -1,32 +1,3 @@
-
-
-<style>
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  line-height: 24px;
-  color: #555;
-  border-radius: 10px;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-}
-</style>
 <div class="container">
 
 	<br>

--- a/application/views/awards/cq/index.php
+++ b/application/views/awards/cq/index.php
@@ -6,45 +6,6 @@
 	height: calc(100vh - 480px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-}
-.info {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-	color: #555;
-}
-.info h4 {
-    margin: 0 0 5px;
-    color: #555;
-}
 </style>
 
 <div class="container">

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -4,32 +4,6 @@
 	height: calc(100vh - 500px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-}
 </style>
 <div class="container">
         <!-- Award Info Box -->

--- a/application/views/awards/ffma/index.php
+++ b/application/views/awards/ffma/index.php
@@ -1,31 +1,6 @@
 
 
 <style>
-/*Legend specific*/
-.legend {
-  padding: 10px 10px 10px 10px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  line-height: 24px;
-  color: #555;
-  border-radius: 10px;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-}
 .coordinates {
     justify-content: center;
     align-items: stretch;

--- a/application/views/awards/gridmaster/index.php
+++ b/application/views/awards/gridmaster/index.php
@@ -1,32 +1,3 @@
-
-
-<style>
-/*Legend specific*/
-.legend {
-  padding: 10px 10px 10px 10px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  line-height: 24px;
-  color: #555;
-  border-radius: 10px;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-}
-</style>
 <div class="container">
         <!-- Award Info Box -->
         <br>

--- a/application/views/awards/helvetia/index.php
+++ b/application/views/awards/helvetia/index.php
@@ -7,48 +7,6 @@
 	height: calc(100vh - 500px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #555;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-  color: #555;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-  color: #555;
-}
-
-.info {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-	color: #555;
-}
-.info h4 {
-    margin: 0 0 5px;
-    color: #555;
-}
 </style>
 
 <div class="container">

--- a/application/views/awards/iota/index.php
+++ b/application/views/awards/iota/index.php
@@ -4,32 +4,6 @@
 	height: calc(100vh - 500px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-}
 </style>
 
 

--- a/application/views/awards/rac/index.php
+++ b/application/views/awards/rac/index.php
@@ -7,48 +7,6 @@
 	height: calc(100vh - 500px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #555;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-  color: #555;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-  color: #555;
-}
-
-.info {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-	color: #555;
-}
-.info h4 {
-    margin: 0 0 5px;
-    color: #555;
-}
 </style>
 
 <div class="container">

--- a/application/views/awards/waja/index.php
+++ b/application/views/awards/waja/index.php
@@ -7,48 +7,6 @@
 	height: calc(100vh - 500px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #555;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-  color: #555;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-  color: #555;
-}
-
-.info {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-	color: #555;
-}
-.info h4 {
-    margin: 0 0 5px;
-    color: #555;
-}
 </style>
 <div class="container">
         <!-- Award Info Box -->

--- a/application/views/awards/was/index.php
+++ b/application/views/awards/was/index.php
@@ -7,48 +7,6 @@
 	height: calc(100vh - 500px) !important;
 	max-height: 900px !important;
 }
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  background: rgba(255, 255, 255, 0.8);
-  line-height: 24px;
-  color: #555;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #555;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-  color: #555;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-  opacity: 0.7;
-  color: #555;
-}
-
-.info {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-	color: #555;
-}
-.info h4 {
-    margin: 0 0 5px;
-    color: #555;
-}
 </style>
 
 <div class="container">

--- a/application/views/gridmap/index.php
+++ b/application/views/gridmap/index.php
@@ -1,32 +1,3 @@
-
-
-<style>
-/*Legend specific*/
-.legend {
-  padding: 6px 8px;
-  font: 14px Arial, Helvetica, sans-serif;
-  background: white;
-  line-height: 24px;
-  color: #555;
-  border-radius: 10px;
-}
-.legend h4 {
-  text-align: center;
-  font-size: 16px;
-  margin: 2px 12px 8px;
-  color: #777;
-}
-.legend span {
-  position: relative;
-  bottom: 3px;
-}
-.legend i {
-  width: 18px;
-  height: 18px;
-  float: left;
-  margin: 0 8px 0 0;
-}
-</style>
 <div class="container">
 
 	<br>

--- a/assets/css/cyborg/overrides.css
+++ b/assets/css/cyborg/overrides.css
@@ -200,3 +200,21 @@ path.grid-worked {
 #searchbar-form .border {
     border-color: #4d4d4d !important;
 }
+
+.legend h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.legend {
+    background-color: rgba(22, 26, 27) !important;
+    color: rgb(255, 255, 255) !important;
+}
+
+.info h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.info {
+    background-color: rgba(22, 26, 27) !important;
+	color: rgb(255, 255, 255) !important;
+}

--- a/assets/css/cyborg_wide/overrides.css
+++ b/assets/css/cyborg_wide/overrides.css
@@ -255,3 +255,21 @@ path.grid-worked {
 #searchbar-form .border {
     border-color: #4d4d4d !important;
 }
+
+.legend h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.legend {
+    background-color: rgba(22, 26, 27) !important;
+    color: rgb(255, 255, 255) !important;
+}
+
+.info h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.info {
+    background-color: rgba(22, 26, 27) !important;
+	color: rgb(255, 255, 255) !important;
+}

--- a/assets/css/darkly/overrides.css
+++ b/assets/css/darkly/overrides.css
@@ -213,3 +213,21 @@ div.alert-danger {
 #searchbar-form .border {
     border-color: #757575 !important;
 }
+
+.legend h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.legend {
+    background-color: rgba(22, 26, 27) !important;
+    color: rgb(255, 255, 255) !important;
+}
+
+.info h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.info {
+    background-color: rgba(22, 26, 27) !important;
+	color: rgb(255, 255, 255) !important;
+}

--- a/assets/css/darkly_wide/overrides.css
+++ b/assets/css/darkly_wide/overrides.css
@@ -269,3 +269,21 @@ div.alert-danger {
 #searchbar-form .border {
     border-color: #757575 !important;
 }
+
+.legend h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.legend {
+    background-color: rgba(22, 26, 27) !important;
+    color: rgb(255, 255, 255) !important;
+}
+
+.info h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.info {
+    background-color: rgba(22, 26, 27) !important;
+	color: rgb(255, 255, 255) !important;
+}

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -876,3 +876,43 @@ label {
 	--bs-table-bg: none !important;
 	--bs-table-accent-bg: none !important;
 }
+
+/* Used in maps */
+.legend {
+	padding: 6px 8px;
+	font: 14px Arial, Helvetica, sans-serif;
+	background: white;
+	line-height: 24px;
+	color: #555;
+	border-radius: 10px;
+}
+.legend h4 {
+	text-align: center;
+	font-size: 16px;
+	margin: 2px 12px 8px;
+	color: #777;
+}
+.legend span {
+	position: relative;
+	bottom: 3px;
+}
+.legend i {
+	width: 18px;
+	height: 18px;
+	float: left;
+	margin: 0 8px 0 0;
+}
+
+.info {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+	color: #555;
+}
+.info h4 {
+    margin: 0 0 5px;
+    color: #555;
+}

--- a/assets/css/superhero/overrides.css
+++ b/assets/css/superhero/overrides.css
@@ -211,3 +211,21 @@ div.alert-danger {
 #searchbar-form .border {
     border-color: #959595 !important;
 }
+
+.legend h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.legend {
+    background-color: rgba(22, 26, 27) !important;
+    color: rgb(255, 255, 255) !important;
+}
+
+.info h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.info {
+    background-color: rgba(22, 26, 27) !important;
+	color: rgb(255, 255, 255) !important;
+}

--- a/assets/css/superhero_wide/overrides.css
+++ b/assets/css/superhero_wide/overrides.css
@@ -265,3 +265,21 @@ div.alert-danger {
 #searchbar-form .border {
     border-color: #959595 !important;
 }
+
+.legend h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.legend {
+    background-color: rgba(22, 26, 27) !important;
+    color: rgb(255, 255, 255) !important;
+}
+
+.info h4 {
+    color: rgb(255, 255, 255) !important;
+}
+
+.info {
+    background-color: rgba(22, 26, 27) !important;
+	color: rgb(255, 255, 255) !important;
+}


### PR DESCRIPTION
The same css was duplicated in all maps for awards. Removed the css from the views and added to general.css instead.

Added darkmode for legend/info too:
![image](https://github.com/wavelog/wavelog/assets/6977712/cf4c7f2f-d22c-41e6-8526-7c6c2e054965)
