### PR TITLE
Repair display of country flags

### DIFF
--- a/application/libraries/DxccFlag.php
+++ b/application/libraries/DxccFlag.php
@@ -409,8 +409,11 @@ class DxccFlag
       '522' => "\u{1F1FD}\u{1F1F0}" //REPUBLIC OF KOSOVO
     );
 
-    public function get($dxcc) {
-		if ($dxcc ?? '' == '') { $dxcc='0'; }	// Failover if Empty or NULL
-        return $this->dxccFlags[$dxcc];
+    public function get($dxcc = 0) {
+       if ($dxcc == 0) {
+          return 0;
+       } else {
+          return $this->dxccFlags[$dxcc];
+       }
     }
 }

--- a/application/libraries/DxccFlag.php
+++ b/application/libraries/DxccFlag.php
@@ -409,11 +409,8 @@ class DxccFlag
       '522' => "\u{1F1FD}\u{1F1F0}" //REPUBLIC OF KOSOVO
     );
 
-    public function get($dxcc = 0) {
-       if ($dxcc == 0) {
-          return 0;
-       } else {
-          return $this->dxccFlags[$dxcc];
-       }
+    public function get($dxcc) {
+		if ($dxcc ?? '' == '') { $dxcc='0'; }	// Failover if Empty or NULL
+        return $this->dxccFlags[$dxcc];
     }
 }

--- a/application/libraries/DxccFlag.php
+++ b/application/libraries/DxccFlag.php
@@ -410,7 +410,7 @@ class DxccFlag
     );
 
     public function get($dxcc) {
-		if ($dxcc ?? '' == '') { $dxcc='0'; }	// Failover if Empty or NULL
-        return $this->dxccFlags[$dxcc];
+      if (($dxcc ?? '') == '') { $dxcc='0'; }	// Failover if Empty or NULL
+      return $this->dxccFlags[$dxcc];
     }
 }


### PR DESCRIPTION
Handling null or empty strings in https://github.com/wavelog/wavelog/commit/de00bcca05a8c3131b7bd34abce7e84e8b923356 broke the code so that flags would not be displayed at all any more. This should fix it.