### PR TITLE
LBA and exportmap now uses tileurl from options

### DIFF
--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -36,6 +36,7 @@ foreach ($mapoptions as $mo) {
 	}
 }
 ?>
+	var tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"
 </script>
 <style>
 /*Legend specific*/

--- a/application/views/visitor/exportmap/exportmap.php
+++ b/application/views/visitor/exportmap/exportmap.php
@@ -1,5 +1,6 @@
 <script>
 var slug = '<?php echo $slug; ?>';
+var tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"
 </script>
 <style>
     #exportmap {

--- a/assets/js/sections/exportmap.js
+++ b/assets/js/sections/exportmap.js
@@ -68,7 +68,7 @@ function loadQsos(slug, iconsList) {
 }
 
 function loadMap(data, iconsList) {
-	var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+	var osmUrl=tileUrl;
 	var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
 	// If map is already initialized
 	var container = L.DomUtil.get('exportmap');

--- a/assets/js/sections/logbookadvanced_map.js
+++ b/assets/js/sections/logbookadvanced_map.js
@@ -262,7 +262,7 @@ const ituzonenames = [
 
 function loadMap(data, iconsList) {
 	$('#mapButton').prop("disabled", false).removeClass("running");
-	var osmUrl='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+	var osmUrl = tileUrl;
 	var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
 	// If map is already initialized
 	var container = L.DomUtil.get('advancedmap');


### PR DESCRIPTION
The advanced logbook and the exportmap now uses the tileurl that is set in the options table.