### PR TITLE
Make DXCC Award also show a map of not-worked DXCC

### DIFF
--- a/assets/js/sections/dxccmap.js
+++ b/assets/js/sections/dxccmap.js
@@ -81,7 +81,7 @@ function load_dxcc_map2(data, worked, confirmed, notworked) {
         }
     ).addTo(map);
 
-    var notworkedcount = data.length;
+    var notworkedcount = 0;
     var confirmedcount = 0;
     var workednotconfirmedcount = 0;
 
@@ -95,7 +95,6 @@ function load_dxcc_map2(data, worked, confirmed, notworked) {
                 if (confirmed != '0') {
                     addMarker(L, D, mapColor, map);
                     confirmedcount++;
-                    notworkedcount--;
                 }
             }
             if (D['status'] == 'W') {
@@ -103,15 +102,13 @@ function load_dxcc_map2(data, worked, confirmed, notworked) {
                 if (worked != '0') {
                     addMarker(L, D, mapColor, map);
                     workednotconfirmedcount++;
-                    notworkedcount--;
                 }
             }
-
-
-        // Make a check here and hide what I don't want to show
-            if (notworked != '0') {
-                if (mapColor == 'red') {
+            if (D['status'] == '-') {
+                mapColor = 'red';
+                if (notworked != '0') {
                     addMarker(L, D, mapColor, map);
+                    notworkedcount++;
                 }
             }
         }


### PR DESCRIPTION
The DXCC Award map only calculated the not worked DXCC right if either confirmed or worked was chosen as well. Generating a map of only the not-worked DXCC was right but legend didn't count number of not-worked DXCC correctly and shows all (i.e. 340) instead:

![Screenshot from 2024-04-19 23-37-27](https://github.com/wavelog/wavelog/assets/7112907/0b6ab660-2aaf-4b6c-825c-5805c3c3a9bf)

JS code was corrected so that also only number of not-worked DXCC is calculated correctly:

![Screenshot from 2024-04-19 23-37-38](https://github.com/wavelog/wavelog/assets/7112907/026e2d3e-c963-4bcd-8c41-79a8b677e993)
