### PR TITLE
Remove distance/bearing text if grid is cleared and also set distance to 0

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1258,6 +1258,12 @@ class Logbook_model extends CI_Model {
 		  $lotwrdate = $qso->COL_LOTW_QSLRDATE;
 	  }
 
+	  if ($this->input->post('distance')) {
+		  $distance = $this->input->post('distance');
+	  } else {
+		  $distance = null;
+	  }
+
 	  $data = array(
 		  'COL_TIME_ON' => $this->input->post('time_on'),
 		  'COL_TIME_OFF' => $this->input->post('time_off'),
@@ -1271,7 +1277,7 @@ class Logbook_model extends CI_Model {
 		  'COL_RST_SENT' => $this->input->post('rst_sent'),
 		  'COL_GRIDSQUARE' => strtoupper(trim($this->input->post('locator'))),
 		  'COL_VUCC_GRIDS' => strtoupper(preg_replace('/\s+/', '', $this->input->post('vucc_grids'))),
-		  'COL_DISTANCE' => $this->input->post('distance'),
+		  'COL_DISTANCE' => $distance,
 		  'COL_COMMENT' => $this->input->post('comment'),
 		  'COL_NAME' => $this->input->post('name'),
 		  'COL_COUNTRY' => $country,

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -246,6 +246,9 @@ function qso_edit(id) {
                                   document.getElementById("distance").value = null;
                                },
                             });
+                        } else if ($(this).val().length == 0) {
+                           $('#locator_info').fadeOut("slow");
+                           document.getElementById("distance").value = null;
                         }
                     });
 


### PR DESCRIPTION
If a QSO is edited and grid is removed the distance data is still displayed and stored. We need to set it 0 in this case.