### PR TITLE
Only overwrite incoming LoTW grid if at least of the same precision

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -525,7 +525,10 @@ class Lotw extends CI_Controller {
 					}
 					// Present only if the QSLing station specified a single valid grid square value in its station location uploaded to LoTW.
 					if (isset($record['gridsquare'])) {
-						$qsl_gridsquare = $record['gridsquare'];
+						// Only overwrite if incoming grid is at least of the same length/precision than existing in the QSO record
+						if (strlen($record['gridsquare']) >= strlen($status[2])) {
+							$qsl_gridsquare = $record['gridsquare'];
+						}
 					} else {
 						$qsl_gridsquare = "";
 					}

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -524,15 +524,11 @@ class Lotw extends CI_Controller {
 						$state = "";
 					}
 					// Present only if the QSLing station specified a single valid grid square value in its station location uploaded to LoTW.
+					$qsl_gridsquare = "";
 					if (isset($record['gridsquare'])) {
-						// Only overwrite if incoming grid is at least of the same length/precision than existing in the QSO record
-						if (strlen($record['gridsquare']) >= strlen($status[2])) {
+						if (strlen($record['gridsquare']) > strlen($status[2]) || substr(strtoupper($status[2]), 0, 4) != substr(strtoupper($record['gridsquare']), 0, 4)) {
 							$qsl_gridsquare = $record['gridsquare'];
-						} else {
-							$qsl_gridsquare = "";
 						}
-					} else {
-						$qsl_gridsquare = "";
 					}
 
 					if (isset($record['vucc_grids'])) {

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -528,6 +528,8 @@ class Lotw extends CI_Controller {
 						// Only overwrite if incoming grid is at least of the same length/precision than existing in the QSO record
 						if (strlen($record['gridsquare']) >= strlen($status[2])) {
 							$qsl_gridsquare = $record['gridsquare'];
+						} else {
+							$qsl_gridsquare = "";
 						}
 					} else {
 						$qsl_gridsquare = "";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3184,7 +3184,7 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
     function import_check($datetime, $callsign, $band, $mode, $station_callsign, $station_id = null) {
 	    $mode=$this->get_main_mode_from_mode($mode);
 
-	    $this->db->select('COL_PRIMARY_KEY, COL_TIME_ON, COL_CALL, COL_BAND');
+	    $this->db->select('COL_PRIMARY_KEY, COL_TIME_ON, COL_CALL, COL_BAND, COL_GRIDSQUARE');
 	    $this->db->where('COL_TIME_ON >= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL -15 MINUTE )');
 	    $this->db->where('COL_TIME_ON <= DATE_ADD(DATE_FORMAT("'.$datetime.'", \'%Y-%m-%d %H:%i\' ), INTERVAL 15 MINUTE )');
 	    $this->db->where('COL_CALL', $callsign);
@@ -3201,9 +3201,9 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    if ($query->num_rows() > 0)
 	    {
 		    $ret = $query->row();
-		    return ["Found", $ret->COL_PRIMARY_KEY];
+		    return ["Found", $ret->COL_PRIMARY_KEY, $ret->COL_GRIDSQUARE];
 	    } else {
-		    return ["No Match", 0];
+		    return ["No Match", 0, ''];
 	    }
     }
 


### PR DESCRIPTION
The current code always overwrites existing gridsquare in logbook. This may be inconvenient if the user logged a more specific gridsquare than the QSO partner configured in his LoTW profile. As a first fix we only overwrite the grid now if it is at least of the same precision as the one in the logbook. 