### PR TITLE
Autodisable QRZ-Upload if AUTH-Error // Logic-part

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -89,7 +89,8 @@ class Qrz extends CI_Controller {
 					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
 					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
 					$result['status'] = 'Error';
-					/* 'Update station_profile set qrz_realtime=-1 where station_id=?',$station_id)
+        				$sql = 'update station_profile set qrzrealtime = -1 where station_id = ?';
+        				$this->db->query($sql,$station_id);
 					break; /* If key is invalid, immediate stop syncing for more QSOs of this station */
 				} else {
 					log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -21,6 +21,45 @@ class Qrz extends CI_Controller {
 		$this->config->load('config');
 	}
 
+	/* 
+	 * API Key Status Test
+	 */
+
+	public function qrz_apitest() {
+		$apikey = xss_clean($this->input->post('APIKEY'));
+		$url = 'http://logbook.qrz.com/api'; // TODO: Move this to database
+  
+		$post_data['KEY'] = $apikey;
+		$post_data['ACTION'] = 'STATUS';
+  
+		$ch = curl_init( $url );
+		curl_setopt( $ch, CURLOPT_POST, true);
+		curl_setopt( $ch, CURLOPT_POSTFIELDS, $post_data);
+		curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, 1);
+		curl_setopt( $ch, CURLOPT_HEADER, 0);
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true);
+		
+		$content = curl_exec($ch);
+		curl_close($ch);
+
+		if ($content){
+			if (stristr($content,'RESULT=OK')) {
+				$result['status'] = 'OK';
+				$result['message'] = $content;
+			}
+			else {
+				$result['status'] = 'Failed';
+				$result['message'] = $content;
+			}
+		}
+		if(curl_errno($ch)){
+			$result['status'] = 'error';
+			$result['message'] = 'Curl error: '. curl_errno($ch);
+		}
+		header('Content-Type: application/json');
+		echo json_encode($result);
+	}
+
 	/*
 	 * Upload QSO to QRZ.com
 	 * When called from the url wavelog/qrz/upload, the function loops through all station_id's with a qrz api key defined.

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -37,6 +37,7 @@ class Qrz extends CI_Controller {
 		curl_setopt( $ch, CURLOPT_POSTFIELDS, $post_data);
 		curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, 1);
 		curl_setopt( $ch, CURLOPT_HEADER, 0);
+		curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 20);
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true);
 		
 		$content = curl_exec($ch);

--- a/application/language/bulgarian/general_words_lang.php
+++ b/application/language/bulgarian/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/bulgarian/station_lang.php
+++ b/application/language/bulgarian/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/chinese_simplified/general_words_lang.php
+++ b/application/language/chinese_simplified/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = '你没有电台日志。 请前往<a href
 $lang['hams_at_no_activations_found'] = '未找到即将进行的激活。 请稍后再回来查看。';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/chinese_simplified/station_lang.php
+++ b/application/language/chinese_simplified/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/czech/general_words_lang.php
+++ b/application/language/czech/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/czech/station_lang.php
+++ b/application/language/czech/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/dutch/general_words_lang.php
+++ b/application/language/dutch/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/dutch/station_lang.php
+++ b/application/language/dutch/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/english/general_words_lang.php
+++ b/application/language/english/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/english/station_lang.php
+++ b/application/language/english/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/finnish/general_words_lang.php
+++ b/application/language/finnish/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/finnish/station_lang.php
+++ b/application/language/finnish/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/french/general_words_lang.php
+++ b/application/language/french/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = "Vous n'avez pas de journal de travail pou
 $lang['hams_at_no_activations_found'] = "Aucune activation à venir trouvée. Veuillez revenir plus tard.";
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "fr-FR";

--- a/application/language/french/station_lang.php
+++ b/application/language/french/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Message (QSLMSG) par défaut";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Vous pouvez définir un message par défaut qui sera renseigné et envoyé pour chaque QSO pour ce lieu station.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/german/general_words_lang.php
+++ b/application/language/german/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'Es wurde kein Stationslogbuch angelegt. K
 $lang['hams_at_no_activations_found'] = 'Keine bevorstehenden Aktivierungen gefunden. Bitte später noch einmal vorbeischauen.';
 
 $lang['gen_add_to_contest'] = "QSOs zu Contest hinzuf&uuml;gen";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "de-DE";

--- a/application/language/german/station_lang.php
+++ b/application/language/german/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Standard QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Definiere eine Standard-Nachricht, welche für jedes QSO in diesem Stationsstandort an eQSL übertragen wird.";
 $lang['station_location_qrz_subscription'] = 'Abonnement erforderlich';
 $lang['station_location_qrz_hint'] = "Finde deinen 'QRZ Logbook API Key' in den <a href='https://logbook.qrz.com/logbook' target='_blank'>QRZ.com Logbuch Einstellungen";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbuch Echtzeit Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbuch Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Benutzername";
 $lang['station_location_hrdlog_username_hint'] = "Der Benutzername mit dem du bei HRDlog.net registriert bist (normalerweise dein Rufzeichen).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/greek/general_words_lang.php
+++ b/application/language/greek/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/greek/station_lang.php
+++ b/application/language/greek/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/italian/general_words_lang.php
+++ b/application/language/italian/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "it-IT";

--- a/application/language/italian/station_lang.php
+++ b/application/language/italian/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/polish/general_words_lang.php
+++ b/application/language/polish/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/polish/station_lang.php
+++ b/application/language/polish/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/russian/general_words_lang.php
+++ b/application/language/russian/general_words_lang.php
@@ -237,5 +237,7 @@ $lang['dashboard_logbooks_warning'] = 'У вас нет аппаратного �
 
 $lang['hams_at_no_activations_found'] = 'не найдены предстоящие активации. Проверьте позже.';
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/russian/station_lang.php
+++ b/application/language/russian/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Требуется подписка';
 $lang['station_location_qrz_hint'] = "Ваш ключ API находится на  <a href='https://logbook.qrz.com/logbook' target='_blank'>странице настроек журнала QRZ.com";
-$lang['station_location_qrz_realtime_upload'] = 'Загрузка в журнал QRZ.com в реальном времени';
+$lang['station_location_qrz_realtime_upload'] = 'Загрузка в журнал QRZ.com';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/spanish/general_words_lang.php
+++ b/application/language/spanish/general_words_lang.php
@@ -237,5 +237,7 @@ $lang['dashboard_logbooks_warning'] = 'No tiene libro de guardias. ¡Haga clic <
 
 $lang['hams_at_no_activations_found'] = 'No hay activaciones próximas. Por favor vuelve a revisar más tarde.';
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "es-ES";

--- a/application/language/spanish/station_lang.php
+++ b/application/language/spanish/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "QSLMSG por Defecto";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Defina un mensaje por defecto que será añadido y enviado para cada QSO para esta localización de estación.";
 $lang['station_location_qrz_subscription'] = 'Requiere Suscripción';
 $lang['station_location_qrz_hint'] = "Encuentre su clave API en la <a href='https://logbook.qrz.com/logbook' target='_blank'>página de Configuración de libro de guardia en QRZ.com";
-$lang['station_location_qrz_realtime_upload'] = 'Subida en Tiempo Real del Libro de Guardia a QRZ.com';
+$lang['station_location_qrz_realtime_upload'] = 'Subida del Libro de Guardia a QRZ.com';
 $lang['station_location_hrdlog_username'] = "Nombre de Usuario de HRDLog.net";
 $lang['station_location_hrdlog_username_hint'] = "El nombre de usuario con el que se registró en HRDlog.net (usualmente su indicativo).";
 $lang['station_location_hrdlog_code'] = "Código API de HRDLog.net";

--- a/application/language/swedish/general_words_lang.php
+++ b/application/language/swedish/general_words_lang.php
@@ -237,6 +237,8 @@ $lang['dashboard_locations_warning'] = 'You have no station locations. Go <a hre
 $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="'. site_url('stationsetup') . '">here</a> to create it!';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
+$lang['general_word_realtime'] = "Realtime";
 
 $lang['datatables_language'] = "en-GB";

--- a/application/language/swedish/station_lang.php
+++ b/application/language/swedish/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/language/turkish/general_words_lang.php
+++ b/application/language/turkish/general_words_lang.php
@@ -237,4 +237,5 @@ $lang['dashboard_logbooks_warning'] = 'You have no station logbook. Go <a href="
 $lang['hams_at_no_activations_found'] = 'No upcoming activations found. Please check back later.';
 
 $lang['gen_add_to_contest'] = "Add QSOs to Contest";
+$lang['general_word_realtime'] = "Realtime";
 $lang['datatables_language'] = "en-GB";

--- a/application/language/turkish/station_lang.php
+++ b/application/language/turkish/station_lang.php
@@ -100,7 +100,7 @@ $lang['station_location_eqsl_defaultqslmsg'] = "Default QSLMSG";
 $lang['station_location_eqsl_defaultqslmsg_hint'] = "Define a default message that will be populated and sent for each QSO for this station location.";
 $lang['station_location_qrz_subscription'] = 'Subscription Required';
 $lang['station_location_qrz_hint'] = "Find your API key on <a href='https://logbook.qrz.com/logbook' target='_blank'>the QRZ.com Logbook settings page";
-$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Realtime Upload';
+$lang['station_location_qrz_realtime_upload'] = 'QRZ.com Logbook Upload';
 $lang['station_location_hrdlog_username'] = "HRDLog.net Username";
 $lang['station_location_hrdlog_username_hint'] = "The username you are registered with at HRDlog.net (usually your callsign).";
 $lang['station_location_hrdlog_code'] = "HRDLog.net API Key";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1875,7 +1875,7 @@ class Logbook_model extends CI_Model {
      * Function returns all the station_id's with QRZ API Key's
      */
   function get_station_id_with_qrz_api() {
-	  $sql = 'select station_id, qrzapikey from station_profile
+	  $sql = 'select station_id, qrzapikey, qrzrealtime from station_profile
 		  where coalesce(qrzapikey, "") <> ""';
 
 	  $query = $this->db->query($sql);

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -227,7 +227,11 @@
             <div class="row">
                 <div class="mb-3 col-sm-6">
                     <label for="qrzApiKey">QRZ.com Logbook API Key</label>  <!-- This does not need Multilanguage Support -->
-                    <input type="text" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp">
+					<div class="input-group">
+                    	<input type="text" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp">
+						<button class="btn btn-secondary" type="button" id="qrz_apitest_btn">Test API-Key</button>
+					</div>
+					<div class="alert mt-3" style="display: none;" id="qrz_apitest_msg"></div>
                     <small id="qrzApiKeyHelp" class="form-text text-muted"><?php echo lang("station_location_qrz_hint"); ?></a></small>
                 </div>
                 <div class="mb-3 col-sm-6">

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -233,8 +233,9 @@
                 <div class="mb-3 col-sm-6">
                     <label for="qrzrealtime"><?php echo lang("station_location_qrz_realtime_upload"); ?></label>
                     <select class="form-select" id="qrzrealtime" name="qrzrealtime">
-                        <option value="1"><?php echo lang("general_word_yes"); ?></option>
-                        <option value="0" selected><?php echo lang("general_word_no"); ?></option>
+                        <option value="-1" selected><?php echo lang("general_word_disabled"); ?></option>
+                        <option value="1"><?php echo lang("general_word_realtime"); ?></option>
+                        <option value="0"><?php echo lang("general_word_enabled"); ?></option>
                     </select>
                 </div>
             </div>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -298,7 +298,11 @@
 				<div class="card-body">
 					<div class="mb-3">
 						<label for="qrzApiKey">QRZ.com Logbook API Key</label> <!-- This does not need Multilanguage Support -->
-						<input type="text" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(set_value('qrzapikey') != "") { echo set_value('qrzapikey'); } else { echo $my_station_profile->qrzapikey; } ?>">
+						<div class="input-group">
+							<input type="text" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(set_value('qrzapikey') != "") { echo set_value('qrzapikey'); } else { echo $my_station_profile->qrzapikey; } ?>">
+							<button class="btn btn-secondary" type="button" id="qrz_apitest_btn">Test API-Key</button>
+						</div>
+						<div class="alert mt-3" style="display: none;" id="qrz_apitest_msg"></div>
 						<small id="qrzApiKeyHelp" class="form-text text-muted"><?php echo lang("station_location_qrz_hint"); ?></a></small>
 					</div>
 

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -305,8 +305,9 @@
 					<div class="mb-3">
 						<label for="qrzrealtime"><?php echo lang("station_location_qrz_realtime_upload"); ?></label>
 						<select class="form-select" id="qrzrealtime" name="qrzrealtime">
-							<option value="1" <?php if ($my_station_profile->qrzrealtime == 1) { echo " selected =\"selected\""; } ?>><?php echo lang("general_word_yes"); ?></option>
-							<option value="0" <?php if ($my_station_profile->qrzrealtime == 0) { echo " selected =\"selected\""; } ?>><?php echo lang("general_word_no"); ?></option>
+							<option value="-1" <?php if ($my_station_profile->qrzrealtime == -1) { echo " selected =\"selected\""; } ?>><?php echo lang("general_word_disabled"); ?></option>
+							<option value="1" <?php if ($my_station_profile->qrzrealtime == 1) { echo " selected =\"selected\""; } ?>><?php echo lang("general_word_realtime"); ?></option>
+							<option value="0" <?php if ($my_station_profile->qrzrealtime == 0) { echo " selected =\"selected\""; } ?>><?php echo lang("general_word_enabled"); ?></option>
 						</select>
 					</div>
 				</div>

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -12,6 +12,41 @@ $(document).ready(function () {
 		$("#dxcc_id").change(function () {
 			updateStateDropdown('#dxcc_id', '#stateInputLabel', '#location_us_county', '#stationCntyInputEdit');
 		});
+
+		$('#qrz_apitest_btn').click(function(){
+
+			var apikey = $('#qrzApiKey').val();
+			var msg_div = $('#qrz_apitest_msg');
+
+			msg_div.hide();
+			msg_div.removeClass('alert-success alert-danger')
+
+			$.ajax({
+				url: base_url+'index.php/qrz/qrz_apitest',
+				type: 'POST',
+				data: {
+					'APIKEY': apikey
+				},
+				success: function(res) {
+					if(res.status == 'OK') {
+						msg_div.addClass('alert-success');
+						msg_div.text('Your API Key works. You are good to go!');
+						msg_div.show();
+					} else {
+						msg_div.addClass('alert-danger');
+						msg_div.text('Your API Key failed. Are you sure you have a valid QRZ subsription?');
+						msg_div.show();
+						$('#qrzrealtime').val(-1);
+					}
+				},
+				error: function(res) {
+					msg_div.addClass('alert-danger');
+					msg_div.text('ERROR: Something went wrong on serverside. We\'re sorry..');
+					msg_div.show();
+				},
+			});
+		});
+
 	}
 });
 


### PR DESCRIPTION
This one disables the QRZ-Upload for a station which has entered the wrong API-Key, and QRZ answers with "NO AUTH" temporary.

No new column is used, instead qrzrealtime is used. currently it is enumed as followed:
0 = no realtime (but cron)
1 = realtime (and cron)

new on Top:
-1 = temporary disabled (will be setable by user via UI / Stationsetup, or automaticly if auth fails)