### PR TITLE
[QUICKSWITCHER] Change Station in QSO tab aswell if active station is changed

### DIFF
--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -901,6 +901,13 @@ function set_active_loc_quickswitcher(new_active) {
             }
         });
     });
+
+    // If the user is in the QSO view we change the station in the QSO input aswell
+    if (window.location.pathname.indexOf("qso") !== -1) {
+        if ($('#stationProfile option[value="' + new_active + '"]').length > 0) {
+            $('#stationProfile').val(new_active);
+        }
+    }
 }
 
 

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -895,19 +895,19 @@ function set_active_loc_quickswitcher(new_active) {
                 if (typeof reloadStations === 'function') {
                     reloadStations();
                 }
+
+                // If the user is in the QSO view we change the station in the QSO input aswell
+                if (window.location.pathname.indexOf("qso") !== -1) {
+                    if ($('#stationProfile option[value="' + new_active + '"]').length > 0) {
+                        $('#stationProfile').val(new_active);
+                    }
+                }
             },
             error: function(xhr, status, error) {
                 console.error('Error while setting the new active location: ' + error);
             }
         });
     });
-
-    // If the user is in the QSO view we change the station in the QSO input aswell
-    if (window.location.pathname.indexOf("qso") !== -1) {
-        if ($('#stationProfile option[value="' + new_active + '"]').length > 0) {
-            $('#stationProfile').val(new_active);
-        }
-    }
 }
 
 


### PR DESCRIPTION
If the user is currently in the QSO Logging view and he changes the active station location with the quickswitcher we want to change the station in the QSO Station tab aswell. 

![ezgif com-video-to-gif-converter](https://github.com/wavelog/wavelog/assets/80885850/6aa04928-b020-4200-aa6f-28001663367a)
