### PR TITLE
Download Clublog-"QSLs" to Wavelog

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 196;
+$config['migration_version'] = 197;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -36,7 +36,7 @@ class Clublog extends CI_Controller {
 		}
 	}
 
-	// Download ADIF to Clublog
+	// Download ADIF from Clublog
 	public function download() {
 		$this->load->model('clublog_model');
 
@@ -72,8 +72,6 @@ class Clublog extends CI_Controller {
 			foreach ($station_profiles->result() as $station_row) {
 				if($station_row->qso_total > 0) {
 					$lastrec=$this->clublog_model->clublog_last_qsl_rcvd_date($station_row->station_callsign);
-					// $string = $this->load->view('adif/data/clublog_down', $data, TRUE);
-
 					$url='https://clublog.org/getmatches.php?api=608df94896cb9c5421ae748235492b43815610c9&email='.$clean_username.'&password='.$clean_password.'&callsign='.$station_row->station_callsign.'&startyear='.substr($lastrec,0,4).'&startmonth='.substr($lastrec,4,2).'&startday='.substr($lastrec,6,2);
 					$request = curl_init($url);
 
@@ -86,7 +84,11 @@ class Clublog extends CI_Controller {
 					if(curl_errno($request)) {
 						echo curl_error($request);
 					} else {
-						log_message("Error",$response);
+						$cl_qsls=json_decode($response);
+						var_dump($cl_qsls);
+						// todo: iterate
+						// todo: transform plain band to real_band // no way to do that, so fallback to "like". e.g.: "6" was provided by Clublog. Do they mean 6m or 6cm?
+    						$this->logbook_model->clublog_update($oneqsl[2], $onesql[0], $onesql[3], 'Y', $station_row->station_callsign);
 					}
 					
 				}

--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -72,6 +72,7 @@ class Clublog extends CI_Controller {
 							$file_info = get_file_info('uploads/clublog'.$ranid.$station_row->station_id.'.adi');
 
 							// initialise the curl request
+							// New: https://clublog.org/getmatches.php?api=[key]&email=$clean_username&password=$clean_password&callsign=$station_row->station_callsign&startyear=2024&startmonth=4&startday=17
 							$request = curl_init('https://clublog.org/putlogs.php');
 
 							if($this->config->item('directory') != "") {

--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -36,6 +36,113 @@ class Clublog extends CI_Controller {
 		}
 	}
 
+	function downloadUser($userid, $username, $password) {
+		$clean_username = $this->security->xss_clean($username);
+		$clean_passord = $this->security->xss_clean($password);
+		$clean_userid = $this->security->xss_clean($userid);
+
+		$this->config->load('config');
+		ini_set('memory_limit', '-1');
+		ini_set('display_errors', 1);
+		ini_set('display_startup_errors', 1);
+		error_reporting(E_ALL);
+
+		$this->load->helper('file');
+
+		$this->load->model('clublog_model');
+
+		$station_profiles = $this->clublog_model->all_with_count($clean_userid);
+
+		if($station_profiles->num_rows()){
+			foreach ($station_profiles->result() as $station_row)
+			{
+				if($station_row->qso_total > 0) {
+					$data['qsos'] = $this->clublog_model->get_clublog_qsos($station_row->station_id);
+
+					if($data['qsos']->num_rows()){
+						$string = $this->load->view('adif/data/clublog', $data, TRUE);
+
+						$ranid = uniqid();
+
+						if ( ! write_file('uploads/clublog'.$ranid.$station_row->station_id.'.adi', $string)) {
+						     echo 'Unable to write the file - Make the folder Upload folder has write permissions.';
+						}
+						else {
+
+							$file_info = get_file_info('uploads/clublog'.$ranid.$station_row->station_id.'.adi');
+
+							// initialise the curl request
+							$request = curl_init('https://clublog.org/putlogs.php');
+
+							if($this->config->item('directory') != "") {
+								 $filepath = $_SERVER['DOCUMENT_ROOT']."/".$this->config->item('directory')."/".$file_info['server_path'];
+							} else {
+								 $filepath = $_SERVER['DOCUMENT_ROOT']."/".$file_info['server_path'];
+							}
+
+							if (function_exists('curl_file_create')) { // php 5.5+
+							  $cFile = curl_file_create($filepath);
+							} else { //
+							  $cFile = '@' . realpath($filepath);
+							}
+
+							// send a file
+							curl_setopt($request, CURLOPT_POST, true);
+							curl_setopt(
+							    $request,
+							    CURLOPT_POSTFIELDS,
+							    array(
+							      'email' => $clean_username,
+							      'password' => $clean_passord,
+							      'callsign' => $station_row->station_callsign,
+							      'api' => "608df94896cb9c5421ae748235492b43815610c9",
+							      'file' => $cFile
+							    ));
+
+							// output the response
+							curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+							$response = curl_exec($request);
+							$info = curl_getinfo($request);
+
+							if(curl_errno($request)) {
+							    echo curl_error($request);
+							}
+							curl_close ($request);
+
+
+							// If Clublog Accepts mark the QSOs
+							if (preg_match('/\baccepted\b/', $response)) {
+								echo "QSOs uploaded and Logbook QSOs marked as sent to Clublog"."<br>";
+								$this->load->model('clublog_model');
+								$this->clublog_model->mark_qsos_sent($station_row->station_id);
+								echo "Clublog upload for ".$station_row->station_callsign."<br>";
+								log_message('info', 'Clublog upload for '.$station_row->station_callsign.' successfully sent.');
+							} else if (preg_match('/checksum duplicate/',$response)) {
+								echo "QSOs uploaded (asduplicate!) and Logbook QSOs marked as sent to Clublog"."<br>";
+								$this->load->model('clublog_model');
+								$this->clublog_model->mark_qsos_sent($station_row->station_id);
+								echo "Clublog upload for ".$station_row->station_callsign."<br>";
+								log_message('info', 'Clublog DUPLICATE upload for '.$station_row->station_callsign.' successfully sent.');
+							} else {
+								echo "Error ".$response."<br />";
+								log_message('error', 'Clublog upload for '.$station_row->station_callsign.' failed reason '.$response);
+							}
+
+							// Delete the ADIF file used for clublog
+							unlink('uploads/clublog'.$ranid.$station_row->station_id.'.adi');
+
+						}
+
+					} else {
+						echo "Nothing awaiting upload to clublog for ".$station_row->station_callsign."<br>";
+
+						log_message('info', 'Nothing awaiting upload to clublog for '.$station_row->station_callsign);
+					}
+				}
+			}
+		}
+	}
+
 	function uploadUser($userid, $username, $password) {
 		$clean_username = $this->security->xss_clean($username);
 		$clean_passord = $this->security->xss_clean($password);

--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -36,9 +36,24 @@ class Clublog extends CI_Controller {
 		}
 	}
 
+	// Download ADIF to Clublog
+	public function download() {
+		$this->load->model('clublog_model');
+
+		// set the last run in cron table for the correct cron id
+		$this->load->model('cron_model');
+		$this->cron_model->set_last_run($this->router->class.'_'.$this->router->method);
+
+		$users = $this->clublog_model->get_clublog_users();
+
+		foreach ($users as $user) {
+			$this->downloadUser($user->user_id, $user->user_clublog_name, $user->user_clublog_password);
+		}
+	}
+
 	function downloadUser($userid, $username, $password) {
 		$clean_username = $this->security->xss_clean($username);
-		$clean_passord = $this->security->xss_clean($password);
+		$clean_password = $this->security->xss_clean($password);
 		$clean_userid = $this->security->xss_clean($userid);
 
 		$this->config->load('config');
@@ -51,94 +66,29 @@ class Clublog extends CI_Controller {
 
 		$this->load->model('clublog_model');
 
-		$station_profiles = $this->clublog_model->all_with_count($clean_userid);
+		$station_profiles = $this->clublog_model->all_enabled($clean_userid);
 
 		if($station_profiles->num_rows()){
-			foreach ($station_profiles->result() as $station_row)
-			{
+			foreach ($station_profiles->result() as $station_row) {
 				if($station_row->qso_total > 0) {
-					$data['qsos'] = $this->clublog_model->get_clublog_qsos($station_row->station_id);
+					$lastrec=$this->clublog_model->clublog_last_qsl_rcvd_date($station_row->station_callsign);
+					// $string = $this->load->view('adif/data/clublog_down', $data, TRUE);
 
-					if($data['qsos']->num_rows()){
-						$string = $this->load->view('adif/data/clublog', $data, TRUE);
+					$url='https://clublog.org/getmatches.php?api=608df94896cb9c5421ae748235492b43815610c9&email='.$clean_username.'&password='.$clean_password.'&callsign='.$station_row->station_callsign.'&startyear='.substr($lastrec,0,4).'&startmonth='.substr($lastrec,4,2).'&startday='.substr($lastrec,6,2);
+					$request = curl_init($url);
 
-						$ranid = uniqid();
+					// recieve a file
+					curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+					$response = curl_exec($request);
+					$info = curl_getinfo($request);
+					curl_close ($request);
 
-						if ( ! write_file('uploads/clublog'.$ranid.$station_row->station_id.'.adi', $string)) {
-						     echo 'Unable to write the file - Make the folder Upload folder has write permissions.';
-						}
-						else {
-
-							$file_info = get_file_info('uploads/clublog'.$ranid.$station_row->station_id.'.adi');
-
-							// initialise the curl request
-							// New: https://clublog.org/getmatches.php?api=[key]&email=$clean_username&password=$clean_password&callsign=$station_row->station_callsign&startyear=2024&startmonth=4&startday=17
-							$request = curl_init('https://clublog.org/putlogs.php');
-
-							if($this->config->item('directory') != "") {
-								 $filepath = $_SERVER['DOCUMENT_ROOT']."/".$this->config->item('directory')."/".$file_info['server_path'];
-							} else {
-								 $filepath = $_SERVER['DOCUMENT_ROOT']."/".$file_info['server_path'];
-							}
-
-							if (function_exists('curl_file_create')) { // php 5.5+
-							  $cFile = curl_file_create($filepath);
-							} else { //
-							  $cFile = '@' . realpath($filepath);
-							}
-
-							// send a file
-							curl_setopt($request, CURLOPT_POST, true);
-							curl_setopt(
-							    $request,
-							    CURLOPT_POSTFIELDS,
-							    array(
-							      'email' => $clean_username,
-							      'password' => $clean_passord,
-							      'callsign' => $station_row->station_callsign,
-							      'api' => "608df94896cb9c5421ae748235492b43815610c9",
-							      'file' => $cFile
-							    ));
-
-							// output the response
-							curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
-							$response = curl_exec($request);
-							$info = curl_getinfo($request);
-
-							if(curl_errno($request)) {
-							    echo curl_error($request);
-							}
-							curl_close ($request);
-
-
-							// If Clublog Accepts mark the QSOs
-							if (preg_match('/\baccepted\b/', $response)) {
-								echo "QSOs uploaded and Logbook QSOs marked as sent to Clublog"."<br>";
-								$this->load->model('clublog_model');
-								$this->clublog_model->mark_qsos_sent($station_row->station_id);
-								echo "Clublog upload for ".$station_row->station_callsign."<br>";
-								log_message('info', 'Clublog upload for '.$station_row->station_callsign.' successfully sent.');
-							} else if (preg_match('/checksum duplicate/',$response)) {
-								echo "QSOs uploaded (asduplicate!) and Logbook QSOs marked as sent to Clublog"."<br>";
-								$this->load->model('clublog_model');
-								$this->clublog_model->mark_qsos_sent($station_row->station_id);
-								echo "Clublog upload for ".$station_row->station_callsign."<br>";
-								log_message('info', 'Clublog DUPLICATE upload for '.$station_row->station_callsign.' successfully sent.');
-							} else {
-								echo "Error ".$response."<br />";
-								log_message('error', 'Clublog upload for '.$station_row->station_callsign.' failed reason '.$response);
-							}
-
-							// Delete the ADIF file used for clublog
-							unlink('uploads/clublog'.$ranid.$station_row->station_id.'.adi');
-
-						}
-
+					if(curl_errno($request)) {
+						echo curl_error($request);
 					} else {
-						echo "Nothing awaiting upload to clublog for ".$station_row->station_callsign."<br>";
-
-						log_message('info', 'Nothing awaiting upload to clublog for '.$station_row->station_callsign);
+						log_message("Error",$response);
 					}
+					
 				}
 			}
 		}

--- a/application/migrations/197_clublog_recvd.php
+++ b/application/migrations/197_clublog_recvd.php
@@ -3,13 +3,25 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 class Migration_clublog_recvd extends CI_Migration {
 	public function up() {
-                if (!$this->db->field_exists('COL_CLUBLOG_QSO_DOWNLOAD_STATUS', $this->config->item('table_name'))) {
-                        $fields = array(
-                                'COLUMN COL_CLUBLOG_QSO_DOWNLOAD_DATE DATETIME NULL DEFAULT NULL',
-                                'COLUMN COL_CLUBLOG_QSO_DOWNLOAD_STATUS VARCHAR(10) DEFAULT NULL',
-                        );
-                        $this->dbforge->add_column($this->config->item('table_name'), $fields);
+		if (!$this->db->field_exists('COL_CLUBLOG_QSO_DOWNLOAD_STATUS', $this->config->item('table_name'))) {
+			$fields = array(
+				'COLUMN COL_CLUBLOG_QSO_DOWNLOAD_DATE DATETIME NULL DEFAULT NULL',
+				'COLUMN COL_CLUBLOG_QSO_DOWNLOAD_STATUS VARCHAR(10) DEFAULT NULL',
+			);
+			$this->dbforge->add_column($this->config->item('table_name'), $fields);
 		}
+		$data = array(
+			array(
+				'id' => 'clublog_download',
+				'enabled' => '0',
+				'status' => 'pending',
+				'description' => 'Download QSOs from Clublog',
+				'function' => 'index.php/clublog/download',
+				'expression' => '7 00 * * *',
+				'last_run' => null,
+				'next_run' => null
+			));
+			$this->db->insert_batch('cron', $data);
 	}
 
 	public function down() {

--- a/application/migrations/197_clublog_recvd.php
+++ b/application/migrations/197_clublog_recvd.php
@@ -10,18 +10,20 @@ class Migration_clublog_recvd extends CI_Migration {
 			);
 			$this->dbforge->add_column($this->config->item('table_name'), $fields);
 		}
-		$data = array(
-			array(
-				'id' => 'clublog_download',
-				'enabled' => '0',
-				'status' => 'pending',
-				'description' => 'Download QSOs from Clublog',
-				'function' => 'index.php/clublog/download',
-				'expression' => '7 00 * * *',
-				'last_run' => null,
-				'next_run' => null
-			));
+		if ($this->chk4cron('clublog_download') == 0) {
+			$data = array(
+				array(
+					'id' => 'clublog_download',
+					'enabled' => '0',
+					'status' => 'pending',
+					'description' => 'Download QSOs from Clublog',
+					'function' => 'index.php/clublog/download',
+					'expression' => '7 00 * * *',
+					'last_run' => null,
+					'next_run' => null
+				));
 			$this->db->insert_batch('cron', $data);
+		}
 	}
 
 	public function down() {
@@ -31,5 +33,14 @@ class Migration_clublog_recvd extends CI_Migration {
                 if ($this->db->field_exists('COL_CLUBLOG_QSO_DOWNLOAD_STATUS', $this->config->item('table_name'))) {
                         $this->dbforge->drop_column($this->config->item('table_name'), 'COL_CLUBLOG_QSO_DOWNLOAD_STATUS');
                 }
+		if ($this->chk4cron('clublog_download') > 0) {
+			$this->db->query("delete from cron where id='clublog_download'");
+		}
+	}
+
+	function chk4cron($cronkey) {
+		$query = $this->db->query("select count(id) as cid from cron where id=?",$cronkey);
+		$row = $query->row();
+		return $row->cid ?? 0;
 	}
 }

--- a/application/migrations/197_clublog_recvd.php
+++ b/application/migrations/197_clublog_recvd.php
@@ -1,0 +1,23 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_clublog_recvd extends CI_Migration {
+	public function up() {
+                if (!$this->db->field_exists('COL_CLUBLOG_QSO_DOWNLOAD_STATUS', $this->config->item('table_name'))) {
+                        $fields = array(
+                                'COLUMN COL_CLUBLOG_QSO_DOWNLOAD_DATE DATETIME NULL DEFAULT NULL',
+                                'COLUMN COL_CLUBLOG_QSO_DOWNLOAD_STATUS VARCHAR(10) DEFAULT NULL',
+                        );
+                        $this->dbforge->add_column($this->config->item('table_name'), $fields);
+		}
+	}
+
+	public function down() {
+                if ($this->db->field_exists('COL_CLUBLOG_QSO_DOWNLOAD_DATE', $this->config->item('table_name'))) {
+                        $this->dbforge->drop_column($this->config->item('table_name'), 'COL_CLUBLOG_QSO_DOWNLOAD_DATE');
+                }
+                if ($this->db->field_exists('COL_CLUBLOG_QSO_DOWNLOAD_STATUS', $this->config->item('table_name'))) {
+                        $this->dbforge->drop_column($this->config->item('table_name'), 'COL_CLUBLOG_QSO_DOWNLOAD_STATUS');
+                }
+	}
+}

--- a/application/models/Clublog_model.php
+++ b/application/models/Clublog_model.php
@@ -103,7 +103,12 @@ class Clublog_model extends CI_Model {
 			return '19700101';
 		}
 	}
-	
+
+	function disable_sync4call($call, $stations) {
+		$sql="update station_profile set clublogignore=1 where station_callsign=? and station_id in (".$stations.")";
+		$query = $this->db->query($sql,$call);
+	}
+
 	function all_enabled($userid) {
 		$sql="select sp.station_callsign, group_concat(sp.station_id) as station_ids from station_profile sp 
 			inner join users u on (u.user_id=sp.user_id)

--- a/application/models/Clublog_model.php
+++ b/application/models/Clublog_model.php
@@ -10,13 +10,6 @@ class Clublog_model extends CI_Model {
 		return $query->result();
 	}
 
-	function get_clublog_auth_info($username) {
-		$this->db->select('user_name, user_clublog_name, user_clublog_password');
-		$this->db->where('user_name', $username);
-		$query = $this->db->get($this->config->item('auth_table'));
-		return $row = $query->row_array();
-	}
-
 	function mark_qsos_sent($station_id) {
 		$data = array(
 	        'COL_CLUBLOG_QSO_UPLOAD_DATE' => date('Y-m-d'),
@@ -86,11 +79,46 @@ class Clublog_model extends CI_Model {
 		return $query;
 	  }
 
-	  function all_with_count($userid) {
+	function clublog_last_qsl_rcvd_date($callsign) {
+		$qso_table_name = $this->config->item('table_name');
+		$this->db->from($qso_table_name);
+
+		$this->db->join('station_profile', 'station_profile.station_id = '.$qso_table_name.'.station_id');
+		$this->db->where('station_profile.station_callsign', $callsign);
+
+		$this->db->select("DATE_FORMAT(COL_CLUBLOG_QSO_DOWNLOAD_DATE,'%Y%m%d') AS COL_CLUBLOG_QSO_DOWNLOAD_DATE", FALSE);
+		$this->db->where('COL_CLUBLOG_QSO_DOWNLOAD_DATE IS NOT NULL');
+		$this->db->where('station_profile.clublogignore', 0);
+		$this->db->order_by("COL_CLUBLOG_QSO_DOWNLOAD_DATE", "desc");
+		$this->db->limit(1);
+
+		$query = $this->db->get();
+		$row = $query->row();
+
+		if (isset($row->COL_CLUBLOG_QSO_DOWNLOAD_DATE)){
+			return $row->COL_CLUBLOG_QSO_DOWNLOAD_DATE;
+		} else {
+			// No previous date (first time import has run?), so choose UNIX EPOCH!
+			// Note: date is yyyy/mm/dd format
+			return '19700101';
+		}
+	}
+	
+	function all_enabled($userid) {
 		$this->db->select('station_profile.station_id, station_profile.station_callsign, count('.$this->config->item('table_name').'.station_id) as qso_total');
-        $this->db->from('station_profile');
-        $this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
-       	$this->db->group_by('station_profile.station_id');
+		$this->db->from('station_profile');
+		$this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
+		$this->db->group_by('station_profile.station_id');
+		$this->db->where('station_profile.user_id', $userid);
+		$this->db->where('station_profile.clublogignore', 0);
+		return $this->db->get();
+	}
+
+	function all_with_count($userid) {
+		$this->db->select('station_profile.station_id, station_profile.station_callsign, count('.$this->config->item('table_name').'.station_id) as qso_total');
+		$this->db->from('station_profile');
+		$this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
+		$this->db->group_by('station_profile.station_id');
 		$this->db->where('station_profile.user_id', $userid);
 		$this->db->where('station_profile.clublogignore', 0);
 		$this->db->group_start();
@@ -99,8 +127,8 @@ class Clublog_model extends CI_Model {
 		$this->db->or_where("COL_CLUBLOG_QSO_UPLOAD_STATUS", "M");
 		$this->db->or_where("COL_CLUBLOG_QSO_UPLOAD_STATUS", "N");
 		$this->db->group_end();
-		
-        return $this->db->get();
+
+		return $this->db->get();
 	}
 }
 

--- a/application/models/Clublog_model.php
+++ b/application/models/Clublog_model.php
@@ -105,13 +105,12 @@ class Clublog_model extends CI_Model {
 	}
 	
 	function all_enabled($userid) {
-		$this->db->select('station_profile.station_id, station_profile.station_callsign, count('.$this->config->item('table_name').'.station_id) as qso_total');
-		$this->db->from('station_profile');
-		$this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
-		$this->db->group_by('station_profile.station_id');
-		$this->db->where('station_profile.user_id', $userid);
-		$this->db->where('station_profile.clublogignore', 0);
-		return $this->db->get();
+		$sql="select sp.station_callsign, group_concat(sp.station_id) as station_ids from station_profile sp 
+			inner join users u on (u.user_id=sp.user_id)
+			where u.user_clublog_name is not null and u.user_clublog_password is not null and sp.clublogignore=0 and u.user_id=?
+			group by sp.station_callsign";
+		$query = $this->db->query($sql,$userid);
+		return $query;
 	}
 
 	function all_with_count($userid) {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3209,29 +3209,47 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    }
     }
 
-  function qrz_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $station_callsign) {
+    function clublog_update($datetime, $callsign, $band, $qsl_status, $station_callsign) {
 
-	  $data = array(
-		  'COL_QRZCOM_QSO_DOWNLOAD_DATE' => $qsl_date,
-		  'COL_QRZCOM_QSO_DOWNLOAD_STATUS' => $qsl_status,
-	  );
+	    $data = array(
+		    'COL_CLUBLOG_QSO_DOWNLOAD_DATE' => date('Y-m-d'),
+		    'COL_CLUBLOG_QSO_DOWNLOAD_STATUS' => $qsl_status,
+	    );
 
+	    $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
+	    $this->db->where('COL_CALL', $callsign);
+	    $this->db->where('COL_BAND', $band);
+	    $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
 
-	  $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
-	  $this->db->where('COL_CALL', $callsign);
-	  $this->db->where('COL_BAND', $band);
-	  $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
+	    if ($this->db->update($this->config->item('table_name'), $data)) {
+		    unset($data);
+		    return "Updated";
+	    } else {
+		    unset($data);
+		    return "Not updated";
+	    }
+    }
 
-	  if ($this->db->update($this->config->item('table_name'), $data)) {
-		  unset($data);
-		  return "Updated";
-	  } else {
-		  unset($data);
-		  return "Not updated";
-	  }
+    function qrz_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $station_callsign) {
 
+	    $data = array(
+		    'COL_QRZCOM_QSO_DOWNLOAD_DATE' => $qsl_date,
+		    'COL_QRZCOM_QSO_DOWNLOAD_STATUS' => $qsl_status,
+	    );
 
-  }
+	    $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
+	    $this->db->where('COL_CALL', $callsign);
+	    $this->db->where('COL_BAND', $band);
+	    $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
+
+	    if ($this->db->update($this->config->item('table_name'), $data)) {
+		    unset($data);
+		    return "Updated";
+	    } else {
+		    unset($data);
+		    return "Not updated";
+	    }
+    }
 
     function lotw_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $station_callsign, $qsoid) {
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3209,19 +3209,21 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    }
     }
 
-    function clublog_update($datetime, $callsign, $band, $qsl_status, $station_callsign) {
+    function clublog_update($datetime, $callsign, $band, $qsl_status, $station_callsign, $station_ids) {
 
+	    $logbooks_locations_array=explode(",",$station_ids);
 	    $data = array(
 		    'COL_CLUBLOG_QSO_DOWNLOAD_DATE' => date('Y-m-d'),
 		    'COL_CLUBLOG_QSO_DOWNLOAD_STATUS' => $qsl_status,
 	    );
 
-	    $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
+	    $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i:%s\') = "'.$datetime.'"');
 	    $this->db->where('COL_CALL', $callsign);
-	    $this->db->where('COL_BAND', $band);
+	    $this->db->where("replace(replace(COL_BAND,'cm',''),'m','')", $band); // no way to achieve a real bandmatch, so fallback to match without unit. e.g.: "6" was provided by Clublog. Do they mean 6m or 6cm?
 	    $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
+	    $this->db->where_in('station_id', $logbooks_locations_array);
 
-	    if ($this->db->update($this->config->item('table_name'), $data)) {
+	    if ($this->db->update($this->config->item('table_name'). ' use index (idx_HRD_COL_CALL_station_id)', $data)) {
 		    unset($data);
 		    return "Updated";
 	    } else {

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -418,6 +418,11 @@
                     <h3>QRZ.com</h3>
                         <p><?php echo lang('gen_this_qso_was_confirmed_on'); ?> <?php $timestamp = strtotime($row->COL_QRZCOM_QSO_DOWNLOAD_DATE); echo date($custom_date_format, $timestamp); ?>.</p>
                     <?php } ?>
+
+                    <?php if($row->COL_CLUBLOG_QSO_DOWNLOAD_STATUS == "Y" && $row->COL_CLUBLOG_QSO_DOWNLOAD_DATE != null) { ?>
+                    <h3>Clublog</h3>
+                        <p><?php echo lang('gen_this_qso_was_confirmed_on'); ?> <?php $timestamp = strtotime($row->COL_CLUBLOG_QSO_DOWNLOAD_DATE); echo date($custom_date_format, $timestamp); ?>.</p>
+                    <?php } ?>
             </div>
 
                 <div class="col-md">


### PR DESCRIPTION
This one brings "QSLs" from Clublog to wavelog and adds a cronjob for it to the new Cron-Manager.
Wiki-Entry (for classic users) will follow after merging it.

Includes:
- Taking care of "Clublog-Ignore" for Stations
- Setting Clublog-Ignore to true, if someone tries to download QSLs for Calls he's not granted at Clublog
- Aggregates the Download by "Call" - since Clublog doesn't handle our station_profiles
- Shows QSL-State at QSO-Detail-View

Does not include (to reduce PR, overview, etc.):
- Arrows for Clublog-status (Will do that in a later PR)
- UI for triggering the DL (There's also no UI for manually triggering the upload)