### PR TITLE
[WIP] OpenSSL signatures need a newline after base64 string

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -304,21 +304,9 @@ class Lotw extends CI_Controller {
 				//Tell cURL to return the output as a string.
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
-				//If the function curl_file_create exists
-				if(function_exists('curl_file_create')){
-					//Use the recommended way, creating a CURLFile object.
-					$uploadfile = curl_file_create($filePath);
-					$uploadfile->setPostFilename(basename($filePath));
-				} else{
-					//Otherwise, do it the old way.
-					//Get the canonicalized pathname of our file and prepend
-					//the @ character.
-					$uploadfile = '@' . realpath($filePath).';filename='.basename($filePath);
-					//Turn off SAFE UPLOAD so that it accepts files
-					//starting with an @
-					curl_setopt($ch, CURLOPT_SAFE_UPLOAD, false);
-				}
-
+				//Use the recommended way, creating a CURLFile object.
+				$uploadfile = curl_file_create($filePath);
+				$uploadfile->setPostFilename(basename($filePath));
 
 				//Setup our POST fields
 				$postFields = array(

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -976,7 +976,7 @@ class Lotw extends CI_Controller {
 					openssl_free_key($pkeyid);
 				}
 				$signature_b64 = base64_encode($signature);
-				return $signature_b64;
+				return $signature_b64."\n";
 			}
 		} else {
 			log_message('error', 'Error signing LoTW log.');

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -307,20 +307,22 @@ class Lotw extends CI_Controller {
 				//If the function curl_file_create exists
 				if(function_exists('curl_file_create')){
 					//Use the recommended way, creating a CURLFile object.
-					$filePath = curl_file_create($filePath);
+					$uploadfile = curl_file_create($filePath);
+					$uploadfile->setPostFilename(basename($filePath));
 				} else{
 					//Otherwise, do it the old way.
 					//Get the canonicalized pathname of our file and prepend
 					//the @ character.
-					$filePath = '@' . realpath($filePath);
+					$uploadfile = '@' . realpath($filePath).';filename='.basename($filePath);
 					//Turn off SAFE UPLOAD so that it accepts files
 					//starting with an @
 					curl_setopt($ch, CURLOPT_SAFE_UPLOAD, false);
 				}
 
+
 				//Setup our POST fields
 				$postFields = array(
-					$uploadFieldName => $filePath
+					$uploadFieldName => $uploadfile
 				);
 
 				curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);


### PR DESCRIPTION
As per definition the OpenSSL signatures should have a newline at the end.

In addition we strip the complete upload path for LoTW uploads.

Before:
![Screenshot from 2024-05-13 08-14-15](https://github.com/wavelog/wavelog/assets/7112907/91ec2818-1dea-440f-a1be-bf8fb069546e)

After:
![Screenshot from 2024-05-13 09-26-49](https://github.com/wavelog/wavelog/assets/7112907/23aaca94-dd55-438d-ae15-19a99163a332)
