### PR TITLE
Only show and evaluate 4-char grids for hams.at

### DIFF
--- a/application/controllers/Hamsat.php
+++ b/application/controllers/Hamsat.php
@@ -102,7 +102,7 @@ class Hamsat extends CI_Controller {
 			}
 			$decoded_json->data[$i]->mode_class = $modeclass;
 			for($j = 0; $j < count($decoded_json->data[$i]->grids); $j++) {
-				$worked = $this->logbook_model->check_if_grid_worked_in_logbook($decoded_json->data[$i]->grids[$j], null, "SAT");
+				$worked = $this->logbook_model->check_if_grid_worked_in_logbook(substr($decoded_json->data[$i]->grids[$j], 0, 4), null, "SAT");
 				if ($worked->num_rows() != 0) {
 					$decoded_json->data[$i]->grids_wkd[$j] = 1;
 				} else {

--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -107,9 +107,9 @@ function loadActivationsTable(rows, show_workable_only) {
 		grids = [];
 		for (var j=0; j < activation.grids_wkd.length; j++) {
 			if (activation.grids_wkd[j] == 1) {
-				grids.push("<span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-success\">"+activation.grids[j]+"</span>")
+				grids.push("<span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-success\">"+activation.grids[j].substring(0, 4)+"</span>")
 			} else {
-				grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+activation.grids[j]+"</span>")
+				grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+activation.grids[j].substring(0, 4)+"</span>")
 			}
 		}
 		data.push(grids.join(' '));


### PR DESCRIPTION
We should only evaluate (and show) 4-char grids for hams.at display. 6-char grids lead to false information:

![Screenshot from 2024-05-16 12-59-35](https://github.com/wavelog/wavelog/assets/7112907/b77bd01e-80d7-4e15-bae4-7e3e62ba9889)
