### PR TITLE
[QSO] Max input lenght for name and location

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -186,7 +186,7 @@
               <div class="mb-3 row">
                   <label for="name" class="col-sm-3 col-form-label"><?php echo lang('general_word_name'); ?></label>
                   <div class="col-sm-9">
-                    <input tabindex="4" type="text" class="form-control form-control-sm" name="name" id="name" value="">
+                    <input tabindex="4" type="text" class="form-control form-control-sm" name="name" id="name" maxlength="128" value="">
                 </div>
               </div>
 
@@ -270,7 +270,7 @@
               <div class="mb-3 row">
                 <label for="qth" class="col-sm-3 col-form-label"><?php echo lang('general_word_location'); ?></label>
                 <div class="col-sm-9">
-                    <input tabindex="5" type="text" class="form-control form-control-sm" name="qth" id="qth" value="">
+                    <input tabindex="5" type="text" class="form-control form-control-sm" name="qth" id="qth" maxlength="64" value="">
                 </div>
               </div>
 


### PR DESCRIPTION
Our DB allows 128 chars for COL_NAME and 64 chars for COL_QTH. 

At the moment you can enter longer strings as they can be in the database. This causes the qso save call to fail. This change limits the max input lenght for these two fields to the max chars set in database.