### PR TITLE
Refactor QSO entries on dashboard map

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4862,9 +4862,13 @@ function lotw_last_qsl_date($user_id) {
       foreach ($qsos_result as $row) {
         $plot = array('lat'=>0, 'lng'=>0, 'html'=>'', 'label'=>'', 'confirmed'=>'N');
 
-        $plot['label'] = $row->COL_CALL;
+        $plot['label'] = str_replace('0', '&Oslash;', $row->COL_CALL);
 
-        $plot['html'] = "Callsign: ".$row->COL_CALL."<br />Date/Time: ".$row->COL_TIME_ON."<br />";
+        $plot['html'] = "";
+        if ($row->COL_NAME != null) {
+           $plot['html'] .= "Name: ".$row->COL_NAME."<br />";
+        }
+        $plot['html'] .= "Date/Time: ".$row->COL_TIME_ON."<br />";
         $plot['html'] .= ($row->COL_SAT_NAME != null) ? ("SAT: ".$row->COL_SAT_NAME."<br />") : ("Band: ".$row->COL_BAND."<br />");
         $plot['html'] .= "Mode: ".($row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE)."<br />";
 


### PR DESCRIPTION
Refactored QSO entries on dashboard map a little:
- Zeros replaced by slashed zero
- Separate 2nd entry for callsign removed
- Name displayed instead if present

**Before**:

![Screenshot from 2024-05-18 07-02-52](https://github.com/wavelog/wavelog/assets/7112907/ceb7e64d-b474-48e0-8412-c93f109594ae)

**After**:

![Screenshot from 2024-05-18 07-00-48](https://github.com/wavelog/wavelog/assets/7112907/25730c2c-a3fe-4579-a0cd-5b5860f775c8)

