### PR TITLE
Catch frequency being null / empty

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -431,9 +431,11 @@ class QSO extends CI_Controller {
 
 	function band_to_freq($band, $mode) {
 
-		$this->load->library('frequency');
+		if ($band != null and $band != 'null') {
+			$this->load->library('frequency');
+			echo $this->frequency->convert_band($band, $mode);
+		}
 
-		echo $this->frequency->convert_band($band, $mode);
 	}
 
 	/*


### PR DESCRIPTION
If a radio is selected which has not been updated via CAT API yet the frequency being asked for is set to 'null':

![Screenshot from 2024-05-20 17-48-01](https://github.com/wavelog/wavelog/assets/7112907/281be4fe-2533-4e5d-811c-887392999620)

That results in a PHP error being inserted into the frequency input field:
![Screenshot from 2024-05-20 17-36-36](https://github.com/wavelog/wavelog/assets/7112907/c7c64e08-1774-4ea4-9e16-d23665620271)

The error message reads:

```
<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;"><h4>A PHP Error was encountered</h4><p>Severity: Warning</p><p>Message:  Attempt to read property "data" on null</p><p>Filename: libraries/Frequency.php</p><p>Line Number: 138</p></div>
```

So we need to catch this case and return an empty result for the default frequency if the band was null or 'null'. This PR achieves that.
