### PR TITLE
Check and hide double announced grids in hams.at

### DIFF
--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -106,10 +106,12 @@ function loadActivationsTable(rows, show_workable_only) {
 		data.push("<span title=\""+activation.mode+"\" class=\"badge "+activation.mode_class+"\">"+activation.mode+"</span>");
 		grids = [];
 		for (var j=0; j < activation.grids_wkd.length; j++) {
-			if (activation.grids_wkd[j] == 1) {
-				grids.push("<span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-success\">"+activation.grids[j].substring(0, 4)+"</span>")
-			} else {
-				grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+activation.grids[j].substring(0, 4)+"</span>")
+			if (!grids.some(str => str.includes(activation.grids[j].substring(0, 4)))) {
+				if (activation.grids_wkd[j] == 1) {
+					grids.push("<span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-success\">"+activation.grids[j].substring(0, 4)+"</span>")
+				} else {
+					grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+activation.grids[j].substring(0, 4)+"</span>")
+				}
 			}
 		}
 		data.push(grids.join(' '));


### PR DESCRIPTION
Check and hide double or multiple entered grids in hams.at announcements.

Before:

![Screenshot from 2024-05-22 08-15-17](https://github.com/wavelog/wavelog/assets/7112907/059dc26f-b7a6-4787-a7f1-461a0a72f542)

After:

![Screenshot from 2024-05-22 08-14-54](https://github.com/wavelog/wavelog/assets/7112907/58a992ff-4830-4071-a7b4-3f0727164226)
