### PR TITLE
[LBA] Added "Not received" Action Button

### DIFF
--- a/application/language/bulgarian/filter_lang.php
+++ b/application/language/bulgarian/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/chinese_simplified/filter_lang.php
+++ b/application/language/chinese_simplified/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = '未获取 QSL';
 $lang['filter_actions_recv_bureau'] = '已接收 (卡片局)';
 $lang['filter_actions_recv_direct'] = '已接收 (直邮)';
 $lang['filter_actions_recv_electronic'] = '已接收 (电子)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = '创建 ADIF';
 $lang['filter_actions_print_label'] = '打印标签';
 $lang['filter_actions_start_print_title'] = '打印标签';

--- a/application/language/czech/filter_lang.php
+++ b/application/language/czech/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/dutch/filter_lang.php
+++ b/application/language/dutch/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/english/filter_lang.php
+++ b/application/language/english/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/finnish/filter_lang.php
+++ b/application/language/finnish/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/french/filter_lang.php
+++ b/application/language/french/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = "QSL Non requis";
 $lang['filter_actions_recv_bureau'] = "Reçue (Bureau)";
 $lang['filter_actions_recv_direct'] = "Reçue (Direct)";
 $lang['filter_actions_recv_electronic'] = "Reçue (Numérique)";
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = "Exporter en ADIF";
 $lang['filter_actions_print_label'] = "Imprimer Etiquette";
 $lang['filter_actions_start_print_title'] = "Impression d'étiquettes";

--- a/application/language/german/filter_lang.php
+++ b/application/language/german/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL nicht erforderlich';
 $lang['filter_actions_recv_bureau'] = 'Erhalten (Büro)';
 $lang['filter_actions_recv_direct'] = 'Erhalten (Direkt)';
 $lang['filter_actions_recv_electronic'] = 'Erhalten (Elektronisch)';
+$lang['filter_actions_not_rcvd'] = "Nicht erhalten";
 $lang['filter_actions_create_adif'] = 'Erstelle ADIF';
 $lang['filter_actions_print_label'] = 'Label drucken';
 $lang['filter_actions_start_print_title'] = 'Label Drucken';

--- a/application/language/greek/filter_lang.php
+++ b/application/language/greek/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/italian/filter_lang.php
+++ b/application/language/italian/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/polish/filter_lang.php
+++ b/application/language/polish/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/russian/filter_lang.php
+++ b/application/language/russian/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_recv_bureau'] = 'Получено (бюро)';
 $lang['filter_actions_recv_direct'] = 'Получено (напрямую)';
 $lang['filter_actions_recv_electronic'] = 'Получено (электронно)';
 $lang['filter_actions_create_adif'] = 'Создать ADIF';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_print_label'] = 'Напечатать наклейки';
 $lang['filter_actions_start_print_title'] = 'Печать наклеек';
 $lang['filter_actions_print_include_via'] = "Включить через?";

--- a/application/language/spanish/filter_lang.php
+++ b/application/language/spanish/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL no Requerida';
 $lang['filter_actions_recv_bureau'] = 'Recibido (Buró)';
 $lang['filter_actions_recv_direct'] = 'Recibido (Directa)';
 $lang['filter_actions_recv_electronic'] = 'Recibido (Electrónico)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Crear ADIF';
 $lang['filter_actions_print_label'] = 'Imprimir Etiqueta';
 $lang['filter_actions_start_print_title'] = 'Imprimir Etiquetas';

--- a/application/language/swedish/filter_lang.php
+++ b/application/language/swedish/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/language/turkish/filter_lang.php
+++ b/application/language/turkish/filter_lang.php
@@ -113,6 +113,7 @@ $lang['filter_actions_qsl_n_required'] = 'QSL Not Required';
 $lang['filter_actions_recv_bureau'] = 'Received (Bureau)';
 $lang['filter_actions_recv_direct'] = 'Received (Direct)';
 $lang['filter_actions_recv_electronic'] = 'Received (Electronic)';
+$lang['filter_actions_not_rcvd'] = "Not Received";
 $lang['filter_actions_create_adif'] = 'Create ADIF';
 $lang['filter_actions_print_label'] = 'Print Label';
 $lang['filter_actions_start_print_title'] = 'Print Labels';

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -370,9 +370,9 @@ $options = json_decode($options);
             <button type="button" class="btn btn-sm btn-success me-1" id="sentBureau"><?php echo lang('filter_actions_sent_bureau'); ?></button>
             <button type="button" class="btn btn-sm btn-success me-1" id="sentDirect"><?php echo lang('filter_actions_sent_direct'); ?></button>
             <button type="button" class="btn btn-sm btn-success me-1" id="sentElectronic"><?php echo lang('filter_actions_sent_electronic'); ?></button>
-            <button type="button" class="btn btn-sm btn-warning me-1" id="dontSend"><?php echo lang('filter_actions_not_sent'); ?></button>
-            <button type="button" class="btn btn-sm btn-warning me-1" id="notRequired"><?php echo lang('filter_actions_qsl_n_required'); ?></button>
-            <button type="button" class="btn btn-sm btn-warning me-1" id="notReceived"><?php echo lang('filter_actions_not_rcvd'); ?></button>
+            <button type="button" class="btn btn-sm btn-danger me-1" id="dontSend"><?php echo lang('filter_actions_not_sent'); ?></button>
+            <button type="button" class="btn btn-sm btn-danger me-1" id="notRequired"><?php echo lang('filter_actions_qsl_n_required'); ?></button>
+            <button type="button" class="btn btn-sm btn-danger me-1" id="notReceived"><?php echo lang('filter_actions_not_rcvd'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="receivedBureau"><?php echo lang('filter_actions_recv_bureau'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="receivedDirect"><?php echo lang('filter_actions_recv_direct'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="receivedElectronic"><?php echo lang('filter_actions_recv_electronic'); ?></button>

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -372,6 +372,7 @@ $options = json_decode($options);
             <button type="button" class="btn btn-sm btn-success me-1" id="sentElectronic"><?php echo lang('filter_actions_sent_electronic'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="dontSend"><?php echo lang('filter_actions_not_sent'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="notRequired"><?php echo lang('filter_actions_qsl_n_required'); ?></button>
+            <button type="button" class="btn btn-sm btn-warning me-1" id="notReceived"><?php echo lang('filter_actions_not_rcvd'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="receivedBureau"><?php echo lang('filter_actions_recv_bureau'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="receivedDirect"><?php echo lang('filter_actions_recv_direct'); ?></button>
             <button type="button" class="btn btn-sm btn-warning me-1" id="receivedElectronic"><?php echo lang('filter_actions_recv_electronic'); ?></button>

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -507,6 +507,9 @@ $(document).ready(function () {
 	$('#notRequired').click(function (event) {
 		handleQsl('I','', 'notRequired');
 	});
+	$('#notReceived').click(function (event) {
+		handleQslReceived('N','', 'notReceived');
+	});
 	$('#receivedBureau').click(function (event) {
 		handleQslReceived('Y','B', 'receivedBureau');
 	});

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -158,7 +158,7 @@ class QSO
 		$this->rstS = $data['COL_RST_SENT'];
 		$this->propagationMode = $data['COL_PROP_MODE'] ?? '';
 		$this->satelliteMode = $data['COL_SAT_MODE'] != '' ? (strlen($data['COL_SAT_MODE']) == 2 ? (strtoupper($data['COL_SAT_MODE'][0]).'/'.strtoupper($data['COL_SAT_MODE'][1])) : strtoupper($data['COL_SAT_MODE'])) : '';
-		$this->satelliteName = $data['COL_SAT_NAME'] != '' ? ($data['orbit'] != '' ? $data['COL_SAT_NAME']." (".$data['orbit'].") " : $data['COL_SAT_NAME']) : '';
+		$this->satelliteName = $data['COL_SAT_NAME'] != '' ? (isset($data['orbit']) && $data['orbit'] != '' ? $data['COL_SAT_NAME']." (".$data['orbit'].") " : $data['COL_SAT_NAME']) : '';
 
 		$this->name = $data['COL_NAME'] ?? '';
 		$this->email = $data['COL_EMAIL'] ?? '';


### PR DESCRIPTION
- Added an action button to LBA where a user can set QSL to not received
- Made "not" buttons red to seperate them and make it visually more intuitive
- Fixed a small bug where `$data['orbit']` is not set in $data array. Maybe @phl0 can check that.