### PR TITLE
Catch empty Station-Grid to prevent Errors for Sattimers

### DIFF
--- a/application/controllers/Sattimers.php
+++ b/application/controllers/Sattimers.php
@@ -26,7 +26,7 @@ class Sattimers extends CI_Controller {
 
 		$json = $RawData;
 
-		$data['activations'] = json_decode($json, true)['data'];
+		$data['activations'] = json_decode($json, true)['data'] ?? [];
 		$data['gridsquare'] = strtoupper($this->stations->find_gridsquare());
 
 		$data['page_title'] = "Satellite Timers";


### PR DESCRIPTION
If no station was created or Grid was left accidently empty, the Sat-Timers are throwing an Error.

Before:
```
ERROR - 2024-05-22 14:13:37 --> Severity: Warning --> Undefined array key "data" /var/www/html/application/controllers/Sattimers.php 29
ERROR - 2024-05-22 14:13:37 --> Severity: Warning --> foreach() argument must be of type array|object, null given /var/www/html/application/views/sattimers/index.php 13
ERROR - 2024-05-22 14:13:37 --> Severity: Warning --> foreach() argument must be of type array|object, null given /var/www/html/application/views/sattimers/index.php 44
```

With this fix, the array will be populated "empty" instead of NULL. So no Error will appear