### PR TITLE
Catch empty grid and inform user to correct config

### DIFF
--- a/application/controllers/Sattimers.php
+++ b/application/controllers/Sattimers.php
@@ -24,10 +24,22 @@ class Sattimers extends CI_Controller {
 			$this->cache->save('SatTimers'.strtoupper($this->stations->find_gridsquare()), $RawData, (60*1));
 		} 
 
-		$json = $RawData;
 
-		$data['activations'] = json_decode($json, true)['data'];
+		$json = $RawData;
+		$response = json_decode($json, true);
+		if (array_key_exists('data', $response)) {
+			$data['activations'] = json_decode($json, true)['data'] ?? [];
+		} else if (array_key_exists('error', $response)) {
+			$this->session->set_flashdata('message', 'Error: '.$response['error']);
+			$data['activations'] = [];
+		} else {
+			$data['activations'] = [];
+		}
+
 		$data['gridsquare'] = strtoupper($this->stations->find_gridsquare());
+		if ($data['gridsquare'] == "0") {
+			$this->session->set_flashdata('message', lang('dashboard_locations_warning'));
+		}
 
 		$data['page_title'] = "Satellite Timers";
 

--- a/application/views/sattimers/index.php
+++ b/application/views/sattimers/index.php
@@ -2,10 +2,18 @@
 var custom_date_format = "<?php echo $custom_date_format ?>";
 </script>
 <div class="container">
+    <?php if ($this->session->flashdata('message')) { ?>
+        <!-- Display Message -->
+        <div class="alert alert-danger" role="alert">
+            <p><?php echo $this->session->flashdata('message'); ?></p>
+        </div>
+    <?php } ?>
 <div class="table-responsive">
    <br>
     <h2>Satellite Timers</h2>
-    <p>This data is from <a target="_blank" href="https://www.df2et.de/tevel/">https://www.df2et.de/tevel/</a> calculated for current station location grid <?php echo strtoupper($gridsquare);?>.</p>
+    <?php if ($gridsquare != 0) { ?>
+       <p>This data is from <a target="_blank" href="https://www.df2et.de/tevel/">https://www.df2et.de/tevel/</a> calculated for current station location grid <?php echo strtoupper($gridsquare);?>.</p>
+    <?php } ?>
     <script type="text/javascript">
         let dateArray = [];
         dateArray.push(0);


### PR DESCRIPTION
Inform the user if not station location is configured (i.e. no grid set):

![Screenshot from 2024-05-22 17-38-44](https://github.com/wavelog/wavelog/assets/7112907/b1a96a93-636f-4f65-b677-99f00b9dae50)

Alternative to https://github.com/wavelog/wavelog/pull/391.