### PR TITLE
Activators Refactoring

### DIFF
--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -1,14 +1,18 @@
 <?php
-defined('BASEPATH') OR exit('No direct script access allowed');
+defined('BASEPATH') or exit('No direct script access allowed');
 
-class Activators extends CI_Controller {
+class Activators extends CI_Controller
+{
 
     function __construct()
     {
         parent::__construct();
 
         $this->load->model('user_model');
-        if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+        if (!$this->user_model->authorize(2)) {
+            $this->session->set_flashdata('notice', 'You\'re not allowed to do that!');
+            redirect('dashboard');
+        }
     }
 
     public function index()
@@ -20,8 +24,7 @@ class Activators extends CI_Controller {
 
         if ($this->input->post('band') != NULL) {   // Band is not set when page first loads.
             $band = $this->input->post('band');
-        }
-        else {
+        } else {
             $band = 'All';
         }
 
@@ -38,38 +41,44 @@ class Activators extends CI_Controller {
         $this->load->view('interface_assets/footer');
     }
 
-    public function details() {
+    public function details()
+    {
         $this->load->model('logbook_model');
 
         $call = str_replace('"', "", $this->input->post("Callsign"));
         $band = str_replace('"', "", $this->input->post("Band"));
         $leogeo = str_replace('"', "", $this->input->post("LeoGeo"));
         $data['results'] = $this->logbook_model->activator_details($call, $band, $leogeo);
-        $data['filter'] = "Call ".$call;
-        switch($band) {
-        case 'All':     $data['page_title'] = "Log View All Bands";
-                        $data['filter'] .= " and Band All";
-                        break;
-        case 'SAT':     $data['page_title'] = "Log View SAT";
-                        $data['filter'] .= " and Band SAT";
-                        break;
-        default:        $data['page_title'] = "Log View Band";
-                        $data['filter'] .= " and Band ".$band;
-                        break;
+        $data['filter'] = "Call " . $call;
+        switch ($band) {
+            case 'All':
+                $data['page_title'] = "Log View All Bands";
+                $data['filter'] .= " and Band All";
+                break;
+            case 'SAT':
+                $data['page_title'] = "Log View SAT";
+                $data['filter'] .= " and Band SAT";
+                break;
+            default:
+                $data['page_title'] = "Log View Band";
+                $data['filter'] .= " and Band " . $band;
+                break;
         }
         if ($band == "SAT") {
-            switch($leogeo) {
-            case 'both':    $data['filter'] .= " and GEO/LEO";
-                            break;
-            case 'leo':     $data['filter'] .= " and LEO";
-                            break;
-            case 'geo':     $data['filter'] .= " and GEO";
-                            break;
+            switch ($leogeo) {
+                case 'both':
+                    $data['filter'] .= " and GEO/LEO";
+                    break;
+                case 'leo':
+                    $data['filter'] .= " and LEO";
+                    break;
+                case 'geo':
+                    $data['filter'] .= " and GEO";
+                    break;
             }
         }
 
 
         $this->load->view('activators/details', $data);
     }
-
 }

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -27,12 +27,26 @@ class Activators extends CI_Controller
             $band = 'All';
         }
 
+        if ($this->input->post('mincount') != NULL) {   // mincount is not set when page first loads.
+            $mincount = $this->input->post('mincount');
+        } else {
+            $mincount = 2; 
+        }
+
+        if ($this->input->post('orbit') != NULL) {   // orbit is not set when page first loads.
+            $orbit = $this->input->post('orbit');
+        } else {
+            $orbit = 'both';
+        }
+
         $this->load->model('bands');
 
         $data['worked_bands'] = $this->bands->get_worked_bands();
+        $data['mincount'] = $mincount;
         $data['maxactivatedgrids'] = $this->Activators_model->get_max_activated_grids();
-        $data['activators_array'] = $this->Activators_model->get_activators($band, $this->input->post('mincount'), $this->input->post('leogeo'));
-        $data['activators_vucc_array'] = $this->Activators_model->get_activators_vucc($band, $this->input->post('leogeo'));
+        $data['orbit'] = $orbit;
+        $data['activators_array'] = $this->Activators_model->get_activators($band, $mincount, $orbit);
+        $data['activators_vucc_array'] = $this->Activators_model->get_activators_vucc($band, $orbit);
         $data['bandselect'] = $band;
 
         $footerData = [];

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -1,5 +1,5 @@
 <?php
-defined('BASEPATH') or exit('No direct script access allowed');
+defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Activators extends CI_Controller
 {

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -33,8 +33,8 @@ class Activators extends CI_Controller
             $mincount = 2; 
         }
 
-        if ($this->input->post('orbit') != NULL) {   // orbit is not set when page first loads.
-            $orbit = $this->input->post('orbit');
+        if ($this->input->post('leogeo') != NULL) {   // orbit is not set when page first loads.
+            $orbit = $this->input->post('leogeo');
         } else {
             $orbit = 'both';
         }

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -45,44 +45,4 @@ class Activators extends CI_Controller
         $this->load->view('interface_assets/footer', $footerData);
     }
 
-    public function details()
-    {
-        $this->load->model('logbook_model');
-
-        $call = str_replace('"', "", $this->input->post("Callsign"));
-        $band = str_replace('"', "", $this->input->post("Band"));
-        $leogeo = str_replace('"', "", $this->input->post("LeoGeo"));
-        $data['results'] = $this->logbook_model->activator_details($call, $band, $leogeo);
-        $data['filter'] = "Call " . $call;
-        switch ($band) {
-            case 'All':
-                $data['page_title'] = "Log View All Bands";
-                $data['filter'] .= " and Band All";
-                break;
-            case 'SAT':
-                $data['page_title'] = "Log View SAT";
-                $data['filter'] .= " and Band SAT";
-                break;
-            default:
-                $data['page_title'] = "Log View Band";
-                $data['filter'] .= " and Band " . $band;
-                break;
-        }
-        if ($band == "SAT") {
-            switch ($leogeo) {
-                case 'both':
-                    $data['filter'] .= " and GEO/LEO";
-                    break;
-                case 'leo':
-                    $data['filter'] .= " and LEO";
-                    break;
-                case 'geo':
-                    $data['filter'] .= " and GEO";
-                    break;
-            }
-        }
-
-
-        $this->load->view('activators/details', $data);
-    }
 }

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -17,7 +17,6 @@ class Activators extends CI_Controller
 
     public function index()
     {
-        // Render Page
         $data['page_title'] = "Gridsquare Activators";
 
         $this->load->model('Activators_model');
@@ -36,9 +35,14 @@ class Activators extends CI_Controller
         $data['activators_vucc_array'] = $this->Activators_model->get_activators_vucc($band, $this->input->post('leogeo'));
         $data['bandselect'] = $band;
 
+        $footerData = [];
+		$footerData['scripts'] = [
+			'assets/js/sections/activators.js?' . filemtime(realpath(__DIR__ . "/../../assets/js/sections/activators.js")),
+		];
+
         $this->load->view('interface_assets/header', $data);
         $this->load->view('activators/index');
-        $this->load->view('interface_assets/footer');
+        $this->load->view('interface_assets/footer', $footerData);
     }
 
     public function details()

--- a/application/models/Activators_model.php
+++ b/application/models/Activators_model.php
@@ -18,7 +18,11 @@ class Activators_model extends CI_Model
 
       $location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 
-      $sql = "select COL_CALL as `call`, COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count`, GROUP_CONCAT(DISTINCT SUBSTR(`COL_GRIDSQUARE`,1,4) ORDER BY `COL_GRIDSQUARE` SEPARATOR ', ') AS `grids` from " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ")";
+      $sql =   "SELECT COL_CALL as `call`, 
+               COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count`, 
+               GROUP_CONCAT(DISTINCT SUBSTR(`COL_GRIDSQUARE`,1,4) ORDER BY `COL_GRIDSQUARE` SEPARATOR ', ') AS `grids` 
+               FROM " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ")";
+               
       if ($band != 'All') {
          if ($band == 'SAT') {
             switch ($leogeo) {
@@ -60,7 +64,10 @@ class Activators_model extends CI_Model
 
       $location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 
-      $sql = "SELECT DISTINCT COL_CALL AS `call`, GROUP_CONCAT(COL_VUCC_GRIDS) AS `vucc_grids` FROM " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ")";
+      $sql =   "SELECT DISTINCT COL_CALL AS `call`, 
+               GROUP_CONCAT(COL_VUCC_GRIDS) AS `vucc_grids` FROM " . $this->config->item('table_name') . 
+               " WHERE station_id in (" . $location_list . ")";
+
       if ($band != 'All') {
          if ($band == 'SAT') {
             switch ($leogeo) {
@@ -103,7 +110,9 @@ class Activators_model extends CI_Model
 
       // Get max no of activated grids of single operator
       $data = $this->db->query(
-         "select COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count` from " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ") AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` ORDER BY `count` DESC LIMIT 1"
+         "SELECT COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count` from " . $this->config->item('table_name') . 
+         " WHERE station_id in (" . $location_list . ") AND 
+         `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` ORDER BY `count` DESC LIMIT 1"
       );
       foreach ($data->result() as $row) {
          $max =  $row->count;

--- a/application/models/Activators_model.php
+++ b/application/models/Activators_model.php
@@ -3,115 +3,115 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
 
 class Activators_model extends CI_Model
 {
-    function get_activators($band, $mincount, $leogeo)  {
-		$CI =& get_instance();
-		$CI->load->model('logbooks_model');
-		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+   function get_activators($band, $mincount, $leogeo)
+   {
+      $CI = &get_instance();
+      $CI->load->model('logbooks_model');
+      $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-      if ($mincount == '' || $mincount == 0 || ! is_numeric($mincount)) {
+      if ($mincount == '' || $mincount == 0 || !is_numeric($mincount)) {
          $mincount = 2;
       }
 
-        if (!$logbooks_locations_array) {
-            return null;
-        }
+      if (!$logbooks_locations_array) {
+         return null;
+      }
 
-		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+      $location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 
-		$sql = "select COL_CALL as `call`, COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count`, GROUP_CONCAT(DISTINCT SUBSTR(`COL_GRIDSQUARE`,1,4) ORDER BY `COL_GRIDSQUARE` SEPARATOR ', ') AS `grids` from ".$this->config->item('table_name')." WHERE station_id in (" . $location_list . ")";
-        if ($band != 'All') {
-            if ($band == 'SAT') {
-               switch ($leogeo) {
-               case 'both' :
+      $sql = "select COL_CALL as `call`, COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count`, GROUP_CONCAT(DISTINCT SUBSTR(`COL_GRIDSQUARE`,1,4) ORDER BY `COL_GRIDSQUARE` SEPARATOR ', ') AS `grids` from " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ")";
+      if ($band != 'All') {
+         if ($band == 'SAT') {
+            switch ($leogeo) {
+               case 'both':
                   $sql .= " and col_prop_mode ='" . $band . "'";
                   break;
-               case 'leo' :
+               case 'leo':
                   $sql .= " and col_prop_mode = '" . $band . "'";
                   $sql .= " and col_sat_name != 'QO-100'";
                   break;
-               case 'geo' :
+               case 'geo':
                   $sql .= " and col_prop_mode = '" . $band . "'";
                   $sql .= " and col_sat_name = 'QO-100'";
                   break;
-               default :
+               default:
                   $sql .= " and col_prop_mode ='" . $band . "'";
                   break;
-               }
             }
-            else {
-                $sql .= " and col_prop_mode !='SAT'";
-                $sql .= " and COL_BAND ='" . $band . "'";
-            }
-        }
-		$sql .= " AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` HAVING `count` >= ".$mincount." ORDER BY `count` DESC;";
+         } else {
+            $sql .= " and col_prop_mode !='SAT'";
+            $sql .= " and COL_BAND ='" . $band . "'";
+         }
+      }
+      $sql .= " AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` HAVING `count` >= " . $mincount . " ORDER BY `count` DESC;";
 
-        $query = $this->db->query($sql);
+      $query = $this->db->query($sql);
 
-        return $query->result();
-    }
+      return $query->result();
+   }
 
-    function get_activators_vucc($band, $leogeo)  {
-		$CI =& get_instance();
-		$CI->load->model('logbooks_model');
-		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+   function get_activators_vucc($band, $leogeo)
+   {
+      $CI = &get_instance();
+      $CI->load->model('logbooks_model');
+      $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if (!$logbooks_locations_array) {
-            return null;
-        }
+      if (!$logbooks_locations_array) {
+         return null;
+      }
 
-		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+      $location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 
-      $sql = "SELECT DISTINCT COL_CALL AS `call`, GROUP_CONCAT(COL_VUCC_GRIDS) AS `vucc_grids` FROM ".$this->config->item('table_name')." WHERE station_id in (" . $location_list . ")";
-        if ($band != 'All') {
-            if ($band == 'SAT') {
-               switch ($leogeo) {
-               case 'both' :
+      $sql = "SELECT DISTINCT COL_CALL AS `call`, GROUP_CONCAT(COL_VUCC_GRIDS) AS `vucc_grids` FROM " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ")";
+      if ($band != 'All') {
+         if ($band == 'SAT') {
+            switch ($leogeo) {
+               case 'both':
                   $sql .= " and col_prop_mode ='" . $band . "'";
                   break;
-               case 'leo' :
+               case 'leo':
                   $sql .= " and col_prop_mode = '" . $band . "'";
                   $sql .= " and col_sat_name != 'QO-100'";
                   break;
-               case 'geo' :
+               case 'geo':
                   $sql .= " and col_prop_mode = '" . $band . "'";
                   $sql .= " and col_sat_name = 'QO-100'";
                   break;
-               default :
+               default:
                   $sql .= " and col_prop_mode ='" . $band . "'";
                   break;
-               }
             }
-            else {
-                $sql .= " and col_prop_mode !='SAT'";
-                $sql .= " and COL_BAND ='" . $band . "'";
-            }
-        }
+         } else {
+            $sql .= " and col_prop_mode !='SAT'";
+            $sql .= " and COL_BAND ='" . $band . "'";
+         }
+      }
       $sql .= " AND COL_VUCC_GRIDS != '' GROUP BY COL_CALL;";
 
-        $query = $this->db->query($sql);
+      $query = $this->db->query($sql);
 
-        return $query->result();
-    }
-	function get_max_activated_grids() {
-		$CI =& get_instance();
-		$CI->load->model('logbooks_model');
-		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+      return $query->result();
+   }
+   function get_max_activated_grids()
+   {
+      $CI = &get_instance();
+      $CI->load->model('logbooks_model');
+      $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if (!$logbooks_locations_array) {
-			return array();
-		}
+      if (!$logbooks_locations_array) {
+         return array();
+      }
 
-		$location_list = "'".implode("','",$logbooks_locations_array)."'";
+      $location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 
-		// Get max no of activated grids of single operator
-		$data = $this->db->query(
-			"select COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count` from " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ") AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` ORDER BY `count` DESC LIMIT 1"
-		);
-		foreach($data->result() as $row){
-			$max =  $row->count;
-		}
+      // Get max no of activated grids of single operator
+      $data = $this->db->query(
+         "select COUNT(DISTINCT(SUBSTR(COL_GRIDSQUARE,1,4))) AS `count` from " . $this->config->item('table_name') . " WHERE station_id in (" . $location_list . ") AND `COL_GRIDSQUARE` != '' GROUP BY `COL_CALL` ORDER BY `count` DESC LIMIT 1"
+      );
+      foreach ($data->result() as $row) {
+         $max =  $row->count;
+      }
 
-		return ($max ?? 0);
-	}
-
+      return ($max ?? 0);
+   }
 }

--- a/application/models/Activators_model.php
+++ b/application/models/Activators_model.php
@@ -5,9 +5,8 @@ class Activators_model extends CI_Model
 {
    function get_activators($band, $mincount, $leogeo)
    {
-      $CI = &get_instance();
-      $CI->load->model('logbooks_model');
-      $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+      $this->load->model('logbooks_model');
+      $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
       if ($mincount == '' || $mincount == 0 || !is_numeric($mincount)) {
          $mincount = 2;
@@ -52,9 +51,8 @@ class Activators_model extends CI_Model
 
    function get_activators_vucc($band, $leogeo)
    {
-      $CI = &get_instance();
-      $CI->load->model('logbooks_model');
-      $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+      $this->load->model('logbooks_model');
+      $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
       if (!$logbooks_locations_array) {
          return null;
@@ -94,9 +92,8 @@ class Activators_model extends CI_Model
    }
    function get_max_activated_grids()
    {
-      $CI = &get_instance();
-      $CI->load->model('logbooks_model');
-      $logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+      $this->load->model('logbooks_model');
+      $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
       if (!$logbooks_locations_array) {
          return array();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -400,6 +400,9 @@ class Logbook_model extends CI_Model {
 			$this->db->join('satellite', 'satellite.name = '.$this->config->item('table_name').'.col_sat_name', 'left outer');
 		}
 		switch ($type) {
+    case 'CALL':
+      $this->db->where('COL_CALL', $searchphrase);
+      break;
 		case 'DXCC':
 			$this->db->where('COL_COUNTRY', $searchphrase);
 			if ($band == 'SAT' && $type == 'DXCC') {

--- a/application/views/activators/details.php
+++ b/application/views/activators/details.php
@@ -1,4 +1,0 @@
-<div class="container">
-    <h5><?php echo lang('general_word_filtering_on'); ?> <?php echo $filter ?></h5>
-
-    <?php $this->load->view('view_log/partial/log_ajax') ?>

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -16,7 +16,7 @@
                 </select>
             </div>
         </div>
-        <div class="mb-3 row" id="leogeo">
+        <div class="mb-3 row" id="leogeo" style="display: none;">
             <label class="col-md-1 control-label" for="leogeo">LEO/GEO</label>
             <div class="col-md-3">
                 <select id="leogeo" name="leogeo" class="form-select">

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -7,10 +7,10 @@
             <label class="col-md-1 control-label" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
             <div class="col-md-3">
                 <select id="band" name="band" class="form-select">
-                    <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>><?php echo lang('general_word_all'); ?></option>
+                    <option value="All" <?php if ($bandselect == "All") echo ' selected'; ?>><?php echo lang('general_word_all'); ?></option>
                     <?php foreach ($worked_bands as $band) {
                         echo '<option value="' . $band . '"';
-                        if ($this->input->post('band') == $band) echo ' selected';
+                        if ($bandselect == $band) echo ' selected';
                         echo '>' . $band . '</option>' . "\n";
                     } ?>
                 </select>
@@ -20,9 +20,9 @@
             <label class="col-md-1 control-label" for="leogeo">LEO/GEO</label>
             <div class="col-md-3">
                 <select id="leogeo" name="leogeo" class="form-select">
-                    <option value="both" <?php if ($this->input->post('leogeo') == "both" || $this->input->method() !== 'post') echo ' selected'; ?>>Both</option>
-                    <option value="leo" <?php if ($this->input->post('leogeo') == "leo") echo ' selected'; ?>>LEO</option>
-                    <option value="geo" <?php if ($this->input->post('leogeo') == "geo") echo ' selected'; ?>>GEO</option>
+                    <option value="both" <?php if ($orbit == 'both') echo ' selected'; ?>>Both</option>
+                    <option value="leo" <?php if ($orbit == 'leo') echo ' selected'; ?>>LEO</option>
+                    <option value="geo" <?php if ($orbit == 'geo') echo ' selected'; ?>>GEO</option>
                 </select>
             </div>
         </div>
@@ -34,7 +34,7 @@
                     $i = 1;
                     do {
                         echo '<option value="' . $i . '"';
-                        if ($this->input->post('mincount') == $i || ($this->input->method() !== 'post' && $i == 2)) echo ' selected';
+                        if ($mincount == $i) echo ' selected';
                         echo '>' . $i . '</option>' . "\n";
                         $i++;
                     } while ($i <= $maxactivatedgrids);
@@ -70,13 +70,11 @@
             $vucc_grids[$line->call] = $line->vucc_grids;
         }
     }
-    if ($this->input->post('band') != NULL) {
-        if ($activators_array) {
+    if ($activators_array) {
 
-            $result = write_activators($activators_array, $vucc_grids, $custom_date_format, $this->input->post('band'), $this->input->post('leogeo'));
-        } else {
-            echo '<div class="alert alert-danger" role="alert">Nothing found!</div>';
-        }
+        $result = write_activators($activators_array, $vucc_grids, $custom_date_format, $bandselect, $orbit);
+    } else {
+        echo '<div class="alert alert-danger" role="alert">Nothing found!</div>';
     }
     ?>
 

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -3,59 +3,59 @@
 
     <form class="form" action="<?php echo site_url('activators'); ?>" method="post" enctype="multipart/form-data">
         <!-- Select Basic -->
-                <div class="mb-3 row">
-                    <label class="col-md-1 control-label" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
-                    <div class="col-md-3">
-                        <select id="band" name="band" class="form-select">
-                            <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?php echo lang('general_word_all'); ?></option>
-                            <?php foreach($worked_bands as $band) {
-                                echo '<option value="' . $band . '"';
-                                if ($this->input->post('band') == $band) echo ' selected';
-                                echo '>' . $band . '</option>'."\n";
-                            } ?>
-                        </select>
-                    </div>
-                </div>
-                <div class="mb-3 row" id="leogeo">
-                    <label class="col-md-1 control-label" for="leogeo">LEO/GEO</label>
-                    <div class="col-md-3">
-                        <select id="leogeo" name="leogeo" class="form-select">
-                            <option value="both" <?php if ($this->input->post('leogeo') == "both" || $this->input->method() !== 'post') echo ' selected'; ?> >Both</option>
-                            <option value="leo" <?php if ($this->input->post('leogeo') == "leo") echo ' selected'; ?>>LEO</option>
-                            <option value="geo" <?php if ($this->input->post('leogeo') == "geo") echo ' selected'; ?>>GEO</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="mb-3 row">
-                    <label class="col-md-1 control-label" for="mincount"><?php echo lang('gridsquares_minimum_count'); ?></label>
-                    <div class="col-md-3">
-                        <select id="mincount" name="mincount" class="form-select">
-                            <?php
-                                $i = 1;
-                                do {
-                                   echo '<option value="'.$i.'"';
-                                   if ($this->input->post('mincount') == $i || ($this->input->method() !== 'post' && $i == 2)) echo ' selected';
-                                   echo '>'.$i.'</option>'."\n";
-                                   $i++;
-                                } while ($i <= $maxactivatedgrids);
-                            ?>
-                        </select>
-                    </div>
-
-                </div>
-
-            <div class="mb-3 row">
-                <label class="col-md-1 control-label" for="button1id"></label>
-                <div class="col-md-10">
-                    <button id="button1id" type="submit" name="button1id" class="btn btn-primary"><?php echo lang('filter_options_show'); ?></button>
-                </div>
+        <div class="mb-3 row">
+            <label class="col-md-1 control-label" for="band"><?php echo lang('gen_hamradio_band'); ?></label>
+            <div class="col-md-3">
+                <select id="band" name="band" class="form-select">
+                    <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>><?php echo lang('general_word_all'); ?></option>
+                    <?php foreach ($worked_bands as $band) {
+                        echo '<option value="' . $band . '"';
+                        if ($this->input->post('band') == $band) echo ' selected';
+                        echo '>' . $band . '</option>' . "\n";
+                    } ?>
+                </select>
             </div>
+        </div>
+        <div class="mb-3 row" id="leogeo">
+            <label class="col-md-1 control-label" for="leogeo">LEO/GEO</label>
+            <div class="col-md-3">
+                <select id="leogeo" name="leogeo" class="form-select">
+                    <option value="both" <?php if ($this->input->post('leogeo') == "both" || $this->input->method() !== 'post') echo ' selected'; ?>>Both</option>
+                    <option value="leo" <?php if ($this->input->post('leogeo') == "leo") echo ' selected'; ?>>LEO</option>
+                    <option value="geo" <?php if ($this->input->post('leogeo') == "geo") echo ' selected'; ?>>GEO</option>
+                </select>
+            </div>
+        </div>
+        <div class="mb-3 row">
+            <label class="col-md-1 control-label" for="mincount"><?php echo lang('gridsquares_minimum_count'); ?></label>
+            <div class="col-md-3">
+                <select id="mincount" name="mincount" class="form-select">
+                    <?php
+                    $i = 1;
+                    do {
+                        echo '<option value="' . $i . '"';
+                        if ($this->input->post('mincount') == $i || ($this->input->method() !== 'post' && $i == 2)) echo ' selected';
+                        echo '>' . $i . '</option>' . "\n";
+                        $i++;
+                    } while ($i <= $maxactivatedgrids);
+                    ?>
+                </select>
+            </div>
+
+        </div>
+
+        <div class="mb-3 row">
+            <label class="col-md-1 control-label" for="button1id"></label>
+            <div class="col-md-10">
+                <button id="button1id" type="submit" name="button1id" class="btn btn-primary"><?php echo lang('filter_options_show'); ?></button>
+            </div>
+        </div>
 
     </form>
 
-    <?php 
+    <?php
     // Get Date format
-    if($this->session->userdata('user_date_format')) {
+    if ($this->session->userdata('user_date_format')) {
         // If Logged in and session exists
         $custom_date_format = $this->session->userdata('user_date_format');
     } else {
@@ -63,19 +63,18 @@
         $custom_date_format = $this->config->item('qso_date_format');
     }
     ?>
-    <?php 
+    <?php
     $vucc_grids = array();
     if ($activators_vucc_array) {
-       foreach ($activators_vucc_array as $line) {
-          $vucc_grids[$line->call] = $line->vucc_grids;
-       }
+        foreach ($activators_vucc_array as $line) {
+            $vucc_grids[$line->call] = $line->vucc_grids;
+        }
     }
-    if( $this->input->post('band') != NULL) {
+    if ($this->input->post('band') != NULL) {
         if ($activators_array) {
 
             $result = write_activators($activators_array, $vucc_grids, $custom_date_format, $this->input->post('band'), $this->input->post('leogeo'));
-        }
-        else {
+        } else {
             echo '<div class="alert alert-danger" role="alert">Nothing found!</div>';
         }
     }
@@ -86,12 +85,13 @@
 
 <?php
 
-function write_activators($activators_array, $vucc_grids, $custom_date_format, $band, $leogeo) {
+function write_activators($activators_array, $vucc_grids, $custom_date_format, $band, $leogeo)
+{
     if ($band == '') {
-       $band = 'All';
+        $band = 'All';
     }
     if ($leogeo == '') {
-       $leogeo = 'both';
+        $leogeo = 'both';
     }
     $i = 1;
     echo '<table style="width:100%" class="table table-sm activatorstable table-bordered table-hover table-striped table-condensed text-center">
@@ -113,16 +113,16 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
         $grids = $line->grids;
         $count = $line->count;
         if (array_key_exists($line->call, $vucc_grids)) {
-           foreach(explode(',', $vucc_grids[$line->call]) as $vgrid) {
-              if(!strpos($grids, $vgrid)) {
-                 $grids .= ','.$vgrid;
-              }
-           }
-           $grids = str_replace(' ', '', $grids);
-           $grid_array = explode(',', $grids);
-           sort($grid_array);
-           $count = count($grid_array);
-           $grids = implode(', ', $grid_array);
+            foreach (explode(',', $vucc_grids[$line->call]) as $vgrid) {
+                if (!strpos($grids, $vgrid)) {
+                    $grids .= ',' . $vgrid;
+                }
+            }
+            $grids = str_replace(' ', '', $grids);
+            $grid_array = explode(',', $grids);
+            sort($grid_array);
+            $count = count($grid_array);
+            $grids = implode(', ', $grid_array);
         }
         array_push($activators, array($count, $call, $grids));
     }
@@ -130,11 +130,11 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
     foreach ($activators as $line) {
         echo '<tr>
                 <td>' . $i++ . '</td>
-                <td>'.$line[1].'</td>
-                <td>'.$line[0].'</td>
-                <td style="text-align: left; font-family: monospace;">'.$line[2].'</td>
-                <td><a href=javascript:displayActivatorsContacts("'.$line[1].'","'.$band.'","'.$leogeo.'")><i class="fas fa-list"></i></a></td>
-                <td><a href=javascript:spawnActivatorsMap("'.$line[1].'","'.$line[0].'","'.str_replace(' ', '', $line[2]).'")><i class="fas fa-globe"></i></a></td>
+                <td>' . $line[1] . '</td>
+                <td>' . $line[0] . '</td>
+                <td style="text-align: left; font-family: monospace;">' . $line[2] . '</td>
+                <td><a href=javascript:displayActivatorsContacts("' . $line[1] . '","' . $band . '","' . $leogeo . '")><i class="fas fa-list"></i></a></td>
+                <td><a href=javascript:spawnActivatorsMap("' . $line[1] . '","' . $line[0] . '","' . str_replace(' ', '', $line[2]) . '")><i class="fas fa-globe"></i></a></td>
                </tr>';
     }
     echo '</tfoot></table></div>';

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1981,75 +1981,7 @@ $(document).ready(function(){
             }
         </script>
         <?php } ?>
-    <?php if ($this->uri->segment(1) == "activators") { ?>
-        <script>
-            $('.activatorstable').DataTable({
-                "pageLength": 25,
-                responsive: false,
-                ordering: false,
-                "scrollY":        "500px",
-                "scrollCollapse": true,
-                "paging":         false,
-                "scrollX": true,
-                "language": {
-                    url: getDataTablesLanguageUrl(),
-                },
-                dom: 'Bfrtip',
-                buttons: [
-                    'csv'
-                ]
-            });
-
-            // change color of csv-button if dark mode is chosen
-            if (isDarkModeTheme()) {
-                $(".buttons-csv").css("color", "white");
-            }
-
-      $(document).ready(function(){
-         $('#band').change(function()
-         {
-            if($(this).val() == "SAT")
-            {
-               $('#leogeo').show();
-            } else {
-               $('#leogeo').hide();
-            }
-         });
-         <?php if ($this->input->post('band') != "SAT") { ?>
-         $('#leogeo').hide();
-         <?php } ?>
-      });
-            function displayActivatorsContacts(call, band, leogeo) {
-                var baseURL= "<?php echo base_url();?>";
-                $.ajax({
-                    url: baseURL + 'index.php/activators/details',
-                    type: 'post',
-                    data: {'Callsign': call,
-                        'Band': band,
-                        'LeoGeo': leogeo
-                    },
-                    success: function(html) {
-                        BootstrapDialog.show({
-                            title: lang_general_word_qso_data,
-                            size: BootstrapDialog.SIZE_WIDE,
-                            cssClass: 'qso-was-dialog',
-                            nl2br: false,
-                            message: html,
-                            onshown: function(dialog) {
-                               $('[data-bs-toggle="tooltip"]').tooltip();
-                            },
-                            buttons: [{
-                                label: lang_admin_close,
-                                action: function (dialogItself) {
-                                    dialogItself.close();
-                                }
-                            }]
-                        });
-                    }
-                });
-            }
-        </script>
-        <?php } ?>
+    
 
     <?php if ($this->uri->segment(1) == "mode") { ?>
 		<script src="<?php echo base_url(); ?>assets/js/sections/mode.js"></script>

--- a/assets/js/sections/activators.js
+++ b/assets/js/sections/activators.js
@@ -34,15 +34,20 @@ function showHideLeoGeo(bandselect) {
 }
 
 function displayActivatorsContacts(call, band, leogeo) {
+	var data = { 
+        Searchphrase: call, 
+        Band: band,
+        Type: 'CALL'
+    };
+
+    if (leogeo != 'both') {
+        data.Orbit = leogeo;
+    }
+
 	$.ajax({
 		url: base_url + "index.php/awards/qso_details_ajax",
 		type: "post",
-		data: { 
-			Searchphrase: call, 
-			Band: band, 
-			Orbit: leogeo,
-			Type: 'CALL'
-		},
+		data: data,
 		success: function (html) {
 			BootstrapDialog.show({
 				title: lang_general_word_qso_data,

--- a/assets/js/sections/activators.js
+++ b/assets/js/sections/activators.js
@@ -1,0 +1,62 @@
+$(".activatorstable").DataTable({
+	pageLength: 25,
+	responsive: false,
+	ordering: false,
+	scrollY: "500px",
+	scrollCollapse: true,
+	paging: false,
+	scrollX: true,
+	language: {
+		url: getDataTablesLanguageUrl(),
+	},
+	dom: "Bfrtip",
+	buttons: ["csv"],
+});
+
+$(document).ready(function () {
+
+	let bandselect = $('#band');
+
+	showHideLeoGeo(bandselect);
+	bandselect.change(function () {
+		showHideLeoGeo(bandselect);
+	});
+
+});
+
+function showHideLeoGeo(bandselect) {
+
+	if (bandselect.val() == "SAT") {
+		$("#leogeo").show();
+	} else {
+		$("#leogeo").hide();
+	}
+}
+
+function displayActivatorsContacts(call, band, leogeo) {
+	$.ajax({
+		url: base_url + "index.php/activators/details",
+		type: "post",
+		data: { Callsign: call, Band: band, LeoGeo: leogeo },
+		success: function (html) {
+			BootstrapDialog.show({
+				title: lang_general_word_qso_data,
+				size: BootstrapDialog.SIZE_WIDE,
+				cssClass: "qso-was-dialog",
+				nl2br: false,
+				message: html,
+				onshown: function (dialog) {
+					$('[data-bs-toggle="tooltip"]').tooltip();
+				},
+				buttons: [
+					{
+						label: lang_admin_close,
+						action: function (dialogItself) {
+							dialogItself.close();
+						},
+					},
+				],
+			});
+		},
+	});
+}

--- a/assets/js/sections/activators.js
+++ b/assets/js/sections/activators.js
@@ -35,9 +35,14 @@ function showHideLeoGeo(bandselect) {
 
 function displayActivatorsContacts(call, band, leogeo) {
 	$.ajax({
-		url: base_url + "index.php/activators/details",
+		url: base_url + "index.php/awards/qso_details_ajax",
 		type: "post",
-		data: { Callsign: call, Band: band, LeoGeo: leogeo },
+		data: { 
+			Searchphrase: call, 
+			Band: band, 
+			Orbit: leogeo,
+			Type: 'CALL'
+		},
 		success: function (html) {
 			BootstrapDialog.show({
 				title: lang_general_word_qso_data,
@@ -47,6 +52,9 @@ function displayActivatorsContacts(call, band, leogeo) {
 				message: html,
 				onshown: function (dialog) {
 					$('[data-bs-toggle="tooltip"]').tooltip();
+					$('.table-responsive .dropdown-toggle').off('mouseenter').on('mouseenter', function () {
+						showQsoActionsMenu($(this).closest('.dropdown'));
+					});
 				},
 				buttons: [
 					{


### PR DESCRIPTION
There was a frontend bug in gridsquare activators

<img width="376" alt="image" src="https://github.com/wavelog/wavelog/assets/80885850/488566a5-561e-4ecd-8528-f5c09bde5a6e">

I took this opportunity and did a small code refactoring. 

- we now call `qso_detail_ajax` instead a dedicated modal just for this category
- moved javascript from footer to a dedicated js file. Loading with timestamp caching
- also the datatable gets loaded on page load with some default values