### PR TITLE
Fix post dxcclookup

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -84,13 +84,17 @@ class Logbook extends CI_Controller {
         echo json_encode($return, JSON_PRETTY_PRINT);
     }
 
-	function json($tempcallsign, $tempband, $tempmode, $tempstation_id = null) {
+	function json($tempcallsign, $tempband, $tempmode, $tempstation_id = null, $date = "") {
 		session_write_close();
+		if (($date ?? '') != '') {
+			$date=date("Y-m-d",strtotime($date));
+		}
 		// Cleaning for security purposes
 		$callsign = $this->security->xss_clean($tempcallsign);
 		$band = $this->security->xss_clean($tempband);
 		$mode = $this->security->xss_clean($tempmode);
 		$station_id = $this->security->xss_clean($tempstation_id);
+		$date = $this->security->xss_clean($date);
 
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
@@ -129,7 +133,7 @@ class Logbook extends CI_Controller {
 			"image" => "",
 		];
 
-		$return['dxcc'] = $this->dxcheck($callsign);
+		$return['dxcc'] = $this->dxcheck($callsign,$date);
 
 		$lookupcall=$this->get_plaincall($callsign);
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -765,7 +765,7 @@ $( document ).ready(function() {
 				find_callsign=find_callsign.replace('Ø', '0');
 
 				// Replace / in a callsign with - to stop urls breaking
-				$.getJSON(base_url + 'index.php/logbook/json/' + find_callsign + '/' + json_band + '/' + json_mode + '/' + $('#stationProfile').val(), async function(result)
+				$.getJSON(base_url + 'index.php/logbook/json/' + find_callsign + '/' + json_band + '/' + json_mode + '/' + $('#stationProfile').val() + '/' + $('#start_date').val(), async function(result)
 					{
 
 						// Make sure the typed callsign and json result match


### PR DESCRIPTION
This one fixes a bug, when looking up "past" calls at qso-form.

e.g.:
- GB6WW normally belongs to Great Britain
- There was an exception during May (1st till 28th) where GB6WW belongs to Scotland. Well documented at Clublog and our dxcc-exceptions
- if you logged GB6WW during that time everything resolved to Scotland (assumed Countryfiles up2date)

Consider "Post-Logging". Here's the bug.
When logging GB6WW (today) with the QSO-Date 24th of May it'll resolve to "England" which is wrong.

Solution:
added an optional parameter for the date to the json-lookup function. default is - as before - sysdate.