### PR TITLE
Hide hint and button if number of workable passes matches number of all passes

### DIFF
--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -135,6 +135,11 @@ function loadActivationsTable(rows, show_workable_only) {
 		table.rows(createdRow).nodes().to$().data('activationID', activation.id);
 		table.row(createdRow).node().id = 'activationID-' + activation.id;
 	}
+	if (workable_rows == rows.length) {
+		console.log("TEST: "+rows.length+"-"+workable_rows);
+		$('#toggle_workable').hide();
+		$('#workable_hint').hide();
+	}
 	if (workable_only == '1') {
 		if (rows.length > workable_rows) {
 			$('#toggle_workable').html('Show all passes ('+rows.length+')');

--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -136,7 +136,6 @@ function loadActivationsTable(rows, show_workable_only) {
 		table.row(createdRow).node().id = 'activationID-' + activation.id;
 	}
 	if (workable_rows == rows.length) {
-		console.log("TEST: "+rows.length+"-"+workable_rows);
 		$('#toggle_workable').hide();
 		$('#workable_hint').hide();
 	}


### PR DESCRIPTION
We should hide the hint and the button re workable passes if the number of workable and non-workable passes matches (i.e. exactly same passes).