### PR TITLE
[QSO] Only overwrite Frequency if no Radio is selected

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1029,20 +1029,24 @@ $( document ).ready(function() {
 
 	/* on mode change */
 	$('.mode').change(function() {
-		$.get(base_url + 'index.php/qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function(result) {
-			$('#frequency').val(result);
-			$('#frequency_rx').val("");
-		});
+		if ($('#radio').val() == 0) {
+			$.get(base_url + 'index.php/qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function(result) {
+				$('#frequency').val(result);
+			});
+		}
+		$('#frequency_rx').val("");
 	});
 
 	/* Calculate Frequency */
 	/* on band change */
 	$('#band').change(function() {
-		$.get(base_url + 'index.php/qso/band_to_freq/' + $(this).val() + '/' + $('.mode').val(), function(result) {
-			$('#frequency').val(result);
-			$('#frequency_rx').val("");
-			$('#band_rx').val("");
-		});
+		if ($('#radio').val() == 0) {
+			$.get(base_url + 'index.php/qso/band_to_freq/' + $(this).val() + '/' + $('.mode').val(), function(result) {
+				$('#frequency').val(result);
+			});
+		}
+		$('#frequency_rx').val("");
+		$('#band_rx').val("");
 		$("#selectPropagation").val("");
 		$("#sat_name").val("");
 		$("#sat_mode").val("");


### PR DESCRIPTION
It happens when choosing a radio in QSO form, that the frequency gets overwritten by `band/mode.change(function()`. 

Solution would be to just overwrite frequency if no radio is selected.

Fixes #430 