### PR TITLE
config-switch to disable qsl-image-feature

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -692,3 +692,6 @@ $config['disable_manual_lotw'] = false;
 $config['disable_manual_eqsl'] = false;
 $config['disable_manual_hrdlog'] = false;
 $config['disable_manual_qrz'] = false;
+
+# Disables QSL-Image-Feature if true. if non-existant or false the QSL-Feature is enabled
+$config['disable_qsl'] = false;

--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -11,6 +11,7 @@ class Qsl extends CI_Controller {
         $this->lang->load('qslcard');
         $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+	if (($this->config->item('disable_qsl') ?? false)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); exit; }
     }
 
     // Default view when loading controller.

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -99,8 +99,10 @@
 							<div class="dropdown-divider"></div>
 							<li><a class="dropdown-item" href="<?php echo site_url('logbookadvanced'); ?>"><i class="fas fa-book-open"></i> <?php echo lang('menu_advanced'); ?></a></li>
 							<div class="dropdown-divider"></div>
+							<?php if (!($this->config->item('disable_qsl') ?? false)) { ?>
 							<li><a class="dropdown-item" href="<?php echo site_url('qsl'); ?>" title="QSL"><i class="fa fa-id-card"></i> <?php echo lang('menu_view_qsl'); ?></a></li>
 							<div class="dropdown-divider"></div>
+							<?php } ?>
 							<li><a class="dropdown-item" href="<?php echo site_url('eqsl'); ?>" title="eQSL"><i class="fa fa-id-card"></i> <?php echo lang('menu_view_eqsl'); ?></a></li>
 						</ul>
 					</li>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -596,6 +596,7 @@
         ?>
         <div class="tab-pane fade" id="qslupload" role="tabpanel" aria-labelledby="table-tab">
             <?php
+	    if (!($this->config->item('disable_qsl') ?? false)) {
             if (count($qslimages) > 0) {
             echo '<table style="width:100%" class="qsltable table table-sm table-bordered table-hover table-striped table-condensed">
                 <thead>
@@ -644,6 +645,7 @@
                     </div>
                 </div>
             </form>
+	    <?php } ?>
             <p>
             <div class="row">
                 <div class="col-md">


### PR DESCRIPTION
Sometimes you don't want to have QSL-Image-Management at your instance (Various reasons).

This one implements a switch for that.
if absent or setted to false, everything works as before.

if set to true (config.php // `$config['disable_qsl'] = true;` the functions for QSL-Image-Management are disabled for the instance.

The Switch/PR has no real need for standard-installations. But since i built it for another instance i thought: y not sharing?