### PR TITLE
Fixes showing other stations QSL-Requests

### DIFF
--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -137,7 +137,7 @@ class Qslprint_model extends CI_Model {
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		// always filter user. this ensures that no inaccesible QSOs will be returned
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
-		$this->db->where('COL_CALL like "%/'.$callsign.'/%" OR COL_CALL like "%/'.$callsign.'" OR COL_CALL like "'.$callsign.'/%" OR COL_CALL = "'.$callsign.'"');
+		$this->db->where('(COL_CALL like "%/'.$callsign.'/%" OR COL_CALL like "%/'.$callsign.'" OR COL_CALL like "'.$callsign.'/%" OR COL_CALL = "'.$callsign.'")');
 		$this->db->where('coalesce(COL_QSL_SENT, "") not in ("R", "Q")');
 		$this->db->order_by("COL_DXCC", "ASC");
         	$this->db->order_by("COL_CALL", "ASC");


### PR DESCRIPTION
Missing bracket at OR-Statement causes other people QSOs showing up in the List of requested QSOs.

e.g.

DL1ABC marked his QSO with DL2ABC as queued for printing
DL1XYZ made and logged (within his own account) a QSO with DL2ABC.

When calling "Labels -> View QSOs -> QSO-List" as DL1ABC the QSO from DL1XYZ was shown as well