### PR TITLE
Limit QSL-Queue to 1000

### DIFF
--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -86,6 +86,7 @@ class Qslprint_model extends CI_Model {
         	$this->db->order_by("COL_BAND_RX", "ASC");
         	$this->db->order_by("COL_TIME_ON", "ASC");
         	$this->db->order_by("COL_MODE", "ASC");
+		$this->db->limit(1000);
 		$query = $this->db->get($this->config->item('table_name'));
 
 		return $query;


### PR DESCRIPTION
Reason:
if one accidently loads up an ADIF with 20k QSOs and all 20k QSOs are marked as "R"(equested), WL will throw a 500 (memory exhaustion).

This one limits the view to 1000.
If one REALLY has so much queued QSL-Cards, he can still print/view those in chunks (need to be printed).

Also thought about raising the memory_limit. But that's not a good idea, because if many people do this you're still running out of memory.