### PR TITLE
[QRZ] Fix QSL downloads 

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -410,8 +410,8 @@ class Qrz extends CI_Controller {
 				$status = $this->logbook_model->import_check($time_on, $record['call'], $record['band'], $record['mode'], $record['station_callsign']);
 
 				if($status[0] == "Found") {
-					$qrz_status = $this->logbook_model->qrz_update($time_on, $record['call'], $record['band'], $qsl_date, $record['qsl_rcvd'],$record['station_callsign']);
-
+					$qrz_status = $this->logbook_model->qrz_update($status[1], $qsl_date, $record['qsl_rcvd']);
+					// log_message('error', $record['call'].": ".$qrz_status);
 					$table .= "<tr>";
 					$table .= "<td>".$record['station_callsign']."</td>";
 					$table .= "<td>".$time_on."</td>";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3251,17 +3251,14 @@ function check_if_callsign_worked_in_logbook($callsign, $StationLocationsArray =
 	    }
     }
 
-    function qrz_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $station_callsign) {
+    function qrz_update($primarykey, $qsl_date, $qsl_status) {
 
 	    $data = array(
 		    'COL_QRZCOM_QSO_DOWNLOAD_DATE' => $qsl_date,
 		    'COL_QRZCOM_QSO_DOWNLOAD_STATUS' => $qsl_status,
 	    );
 
-	    $this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = "'.$datetime.'"');
-	    $this->db->where('COL_CALL', $callsign);
-	    $this->db->where('COL_BAND', $band);
-	    $this->db->where('COL_STATION_CALLSIGN', $station_callsign);
+	    $this->db->where('COL_PRIMARY_KEY', $primarykey);
 
 	    if ($this->db->update($this->config->item('table_name'), $data)) {
 		    unset($data);


### PR DESCRIPTION
In a specific case the QRZ QSLs are not correctly downloaded. 

If the QSO time match EXACTLY with the time on QRZ.com the QSL will be downloaded successfully. But if the QSO time differs a few minutes the `import_check()` method in the `Logbook_model.php` Line 3205 says "FOUND" but the QSL does not get updated because in the `qrz_update()` method in Line 3254 we search for the QSO again without the 15 minute intervall as in the `import_check()`. This results in a wrong information. 

Import_check says QSO record FOUND, but the QSO does not get updated in the database because the time does not match exactly. 

I fixed this with the QSO ID. We get this QSO ID back in the import check so we can reuse it in the qrz update function to update the correct QSO without searching for it again. 