### PR TITLE
Show freq and dir tooltip only if freq is given

### DIFF
--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -122,14 +122,18 @@ function loadActivationsTable(rows, show_workable_only) {
 			data.push(activation.callsign.replaceAll('0', 'Ø'));
 		}
 		data.push(activation.comment);
-		freq = parseFloat(activation.mhz).toFixed(3);
-		dir = '';
-		if (activation.mhz_direction == "up") {
-			dir = '&uarr;';
-		} else if (activation.mhz_direction == "down") {
-			dir = '&darr;';
+		if (activation.mhz != null) {
+			freq = parseFloat(activation.mhz).toFixed(3);
+			dir = '';
+			if (activation.mhz_direction == "up") {
+				dir = '&uarr;';
+			} else if (activation.mhz_direction == "down") {
+				dir = '&darr;';
+			}
+			data.push("<span data-bs-toggle=\"tooltip\" data-bs-original-title=\""+freq+" MHz "+dir+"\">"+activation.satellite.name+"</span>");
+		} else {
+			data.push(activation.satellite.name);
 		}
-		data.push("<span data-bs-toggle=\"tooltip\" data-bs-original-title=\""+freq+" MHz "+dir+"\">"+activation.satellite.name+"</span>");
 		data.push("<span title=\""+activation.mode+"\" class=\"badge "+activation.mode_class+"\">"+activation.mode+"</span>");
 		grids = [];
 		for (var j=0; j < activation.grids_wkd.length; j++) {


### PR DESCRIPTION
Fixes a small bug when frequency is not given in hams.at:

![Screenshot from 2024-06-24 13-11-02](https://github.com/wavelog/wavelog/assets/7112907/5bf405f1-0887-47ef-a02d-097be5ae593e)
