### PR TITLE
Revert "RDA support for ADIF export"

### DIFF
--- a/application/libraries/AdifHelper.php
+++ b/application/libraries/AdifHelper.php
@@ -198,30 +198,12 @@ class AdifHelper {
 
         $line .= $this->getAdifFieldLine("MY_STATE", $qso->state);
 
-        // We fill county only if it has a value and it's USA, Alaska, Hawaii or Russia (European or Asiaric). Other countrys are not supported at the moment due complex adif specs
-
-	if ($qso->station_cnty) {
-		switch ($qso->station_dxcc) {
-		    case '291':
-		    case '6':
-		    case '110':
-			$county = trim($qso->state) . "," . trim($qso->station_cnty);
-		        break;
-		    case '54':
-		    case '15':
-		    case '61':
-		    case '126':
-		    case '151':
-	    	        $county = trim($qso->station_cnty);
-		        break;
-		    default:
-	    		$county = '';
-		}
-	} else {
-	    $county = '';
-	}
-	
-
+        // We fill county only if it has a value and it's USA, Alaska or Hawaii. Other countrys are not supported at the moment due complex adif specs
+		if ($qso->station_cnty && ($qso->station_dxcc == '291' || $qso->station_dxcc == '006' || $qso->station_dxcc == '110')) {
+            $county = trim($qso->state) . "," . trim($qso->station_cnty);
+        } else {
+            $county = '';
+        }        
 
         $line .= $this->getAdifFieldLine("MY_CNTY", $county);
 


### PR DESCRIPTION
Reverts wavelog/wavelog#462

Sri this patch does not help because we currently do not support entering county for DXCCs other than U.S., Hawaii and Alaska. This would have to be implemented first.