### PR TITLE
Migration Lock

### DIFF
--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -321,9 +321,6 @@ class CI_Migration {
 					$this->_update_version($current_version);
 				}
 
-				// After the migrations we can remove the lockfile
-				unlink($this->_migration_lockfile);
-
 				// This is necessary when moving down, since the the last migration applied
 				// will be the down() method for the next migration up from the target
 				if ($current_version <> $target_version)
@@ -332,6 +329,9 @@ class CI_Migration {
 					$this->_update_version($current_version);
 				}
 				
+				// After the migrations we can remove the lockfile
+				unlink($this->_migration_lockfile);
+
 				log_message('debug', 'Finished migrating to '.$current_version);
 
 			} else {

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -309,6 +309,7 @@ class CI_Migration {
 
 			// Create the lockfile
 			if (touch($this->_migration_lockfile)) {
+				log_message('debug', 'Created migration lockfile');
 
 				// Now just run the necessary migrations
 				foreach ($pending as $number => $migration)
@@ -329,10 +330,11 @@ class CI_Migration {
 					$this->_update_version($current_version);
 				}
 				
+				log_message('debug', 'Finished migrating to '.$current_version);
+
 				// After the migrations we can remove the lockfile
 				unlink($this->_migration_lockfile);
-
-				log_message('debug', 'Finished migrating to '.$current_version);
+				log_message('debug', 'Deleted migration lockfile');
 
 			} else {
 				log_message('error', 'Failed to create Migration Lockfile. Check directory permissions.');

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -324,6 +324,16 @@ class CI_Migration {
 				// After the migrations we can remove the lockfile
 				unlink($this->_migration_lockfile);
 
+				// This is necessary when moving down, since the the last migration applied
+				// will be the down() method for the next migration up from the target
+				if ($current_version <> $target_version)
+				{
+					$current_version = $target_version;
+					$this->_update_version($current_version);
+				}
+				
+				log_message('debug', 'Finished migrating to '.$current_version);
+
 			} else {
 				log_message('error', 'Failed to create Migration Lockfile. Check directory permissions.');
 			}
@@ -332,15 +342,6 @@ class CI_Migration {
 			log_message('debug', 'Migration process is currently locked. Second migration attempt ignored.');
 		}
 
-		// This is necessary when moving down, since the the last migration applied
-		// will be the down() method for the next migration up from the target
-		if ($current_version <> $target_version)
-		{
-			$current_version = $target_version;
-			$this->_update_version($current_version);
-		}
-
-		log_message('debug', 'Finished migrating to '.$current_version);
 		return $current_version;
 	}
 

--- a/system/libraries/Migration.php
+++ b/system/libraries/Migration.php
@@ -87,6 +87,13 @@ class CI_Migration {
 	protected $_migration_table = 'migrations';
 
 	/**
+	 * Name and Path of the migration lockfile
+	 * 
+	 * @var string
+	 */
+	protected $_migration_lockfile = APPPATH . 'cache/.migration_running';
+
+	/**
 	 * Whether to automatically run migrations
 	 *
 	 * @var	bool
@@ -297,15 +304,32 @@ class CI_Migration {
 			$pending[$number] = array($class, $method);
 		}
 
-		// Now just run the necessary migrations
-		foreach ($pending as $number => $migration)
-		{
-			log_message('debug', 'Migrating '.$method.' from version '.$current_version.' to version '.$number);
+		// Let's check if a migration is currently running
+        if (!file_exists($this->_migration_lockfile)) {
 
-			$migration[0] = new $migration[0];
-			call_user_func($migration);
-			$current_version = $number;
-			$this->_update_version($current_version);
+			// Create the lockfile
+			if (touch($this->_migration_lockfile)) {
+
+				// Now just run the necessary migrations
+				foreach ($pending as $number => $migration)
+				{
+					log_message('debug', 'Migrating '.$method.' from version '.$current_version.' to version '.$number);
+
+					$migration[0] = new $migration[0];
+					call_user_func($migration);
+					$current_version = $number;
+					$this->_update_version($current_version);
+				}
+
+				// After the migrations we can remove the lockfile
+				unlink($this->_migration_lockfile);
+
+			} else {
+				log_message('error', 'Failed to create Migration Lockfile. Check directory permissions.');
+			}
+
+		} else {
+			log_message('debug', 'Migration process is currently locked. Second migration attempt ignored.');
 		}
 
 		// This is necessary when moving down, since the the last migration applied


### PR DESCRIPTION
In big environments or on really slow machines it can happen that a migration is called twice. This causes bad error messages and should not happen. Therefore we create a lockfile `application/cache/.migration_running` to avoid that. Migration gets locked when running and unlocked when done. 

Please test and break. For me this works for `up()` and `down()` functions. 

To test add `sleep(10)` to the latest migration and test up and down by changing `application/config/migration.php`. You need to use two seperate browsers to simulate different sessions. 