### PR TITLE
Resized droplist for station location name and contest name 

### DIFF
--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -67,7 +67,7 @@
                             <?php } ?>
                         </select>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>
-                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 20%;">
+                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 100%;">
                         	<option value="" selected><?= __("No Contest"); ?></option>
                             <?php
 				foreach ($contests as $contest) {

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -58,7 +58,7 @@
                     <form class="form" id="upform" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="fhash" id="fhash" value="<?php echo hash('sha256', $this->session->userdata('user_callsign') );?>">
                         <div class="small form-text text-muted"><?= __("Select Station Location") ?></div>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $active_station_id) {
@@ -67,7 +67,7 @@
                             <?php } ?>
                         </select>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>
-                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 50%;">
+                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 50%">
                         	<option value="" selected><?= __("No Contest"); ?></option>
                             <?php
 				foreach ($contests as $contest) {
@@ -166,7 +166,7 @@
                     <form class="form" action="<?php echo site_url('adif/export_custom'); ?>" method="post" enctype="multipart/form-data">
                         <h5 class="card-title"><?= __("Take your logbook file anywhere!") ?> </h5>
                         <p class="card-text"><?= __("Exporting ADIFs allows you to import contacts into third party applications like LoTW, Awards or just for keeping a backup.") ?> </p>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-auto">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $this->stations->find_active()) {
@@ -213,7 +213,7 @@
 
                 <div class="tab-pane fade" id="lotw" role="tabpanel" aria-labelledby="home-tab">
                     <form class="form" action="<?php echo site_url('adif/mark_lotw'); ?>" method="post" enctype="multipart/form-data">
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-auto">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>"><?= __("Callsign") . ": " ?><?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -75,7 +75,9 @@
                             } ?>
 			</select>
  			<label class="visually-hidden" for="inlineFormInputName2"><?= __("ADIF File") ?></label>
-                        <input class="form-control mb-2 me-sm-2 w-auto" type="file" name="userfile" id="userfile" size="20" />
+			<div style="margin-top: 1em; width: 50%">
+                        	<input class="form-control mb-2 me-sm-2" type="file" name="userfile" id="userfile" />
+                        </div>
 
                         <div class="mb-3 row">
                             <div class="col-md-10">

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -58,7 +58,7 @@
                     <form class="form" id="upform" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="fhash" id="fhash" value="<?php echo hash('sha256', $this->session->userdata('user_callsign') );?>">
                         <div class="small form-text text-muted"><?= __("Select Station Location") ?></div>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $active_station_id) {
@@ -67,7 +67,7 @@
                             <?php } ?>
                         </select>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>
-                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 100%;">
+                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 50%;">
                         	<option value="" selected><?= __("No Contest"); ?></option>
                             <?php
 				foreach ($contests as $contest) {
@@ -164,7 +164,7 @@
                     <form class="form" action="<?php echo site_url('adif/export_custom'); ?>" method="post" enctype="multipart/form-data">
                         <h5 class="card-title"><?= __("Take your logbook file anywhere!") ?> </h5>
                         <p class="card-text"><?= __("Exporting ADIFs allows you to import contacts into third party applications like LoTW, Awards or just for keeping a backup.") ?> </p>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $this->stations->find_active()) {
@@ -211,7 +211,7 @@
 
                 <div class="tab-pane fade" id="lotw" role="tabpanel" aria-labelledby="home-tab">
                     <form class="form" action="<?php echo site_url('adif/mark_lotw'); ?>" method="post" enctype="multipart/form-data">
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>"><?= __("Callsign") . ": " ?><?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -58,7 +58,7 @@
                     <form class="form" id="upform" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
 			<input type="hidden" name="fhash" id="fhash" value="<?php echo hash('sha256', $this->session->userdata('user_callsign') );?>">
                         <div class="small form-text text-muted"><?= __("Select Station Location") ?></div>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 20%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $active_station_id) {
@@ -164,7 +164,7 @@
                     <form class="form" action="<?php echo site_url('adif/export_custom'); ?>" method="post" enctype="multipart/form-data">
                         <h5 class="card-title"><?= __("Take your logbook file anywhere!") ?> </h5>
                         <p class="card-text"><?= __("Exporting ADIFs allows you to import contacts into third party applications like LoTW, Awards or just for keeping a backup.") ?> </p>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 20%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $this->stations->find_active()) {
@@ -211,7 +211,7 @@
 
                 <div class="tab-pane fade" id="lotw" role="tabpanel" aria-labelledby="home-tab">
                     <form class="form" action="<?php echo site_url('adif/mark_lotw'); ?>" method="post" enctype="multipart/form-data">
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 20%;">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>"><?= __("Callsign") . ": " ?><?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -56,9 +56,9 @@
                     <p><span class="badge text-bg-warning"><?= __("Warning") ?></span> <?= __("Maximum file upload size is ") ?><?php echo $max_upload; ?>B.</p>
 
                     <form class="form" id="upform" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
-			<input type="hidden" name="fhash" id="fhash" value="<?php echo hash('sha256', $this->session->userdata('user_callsign') );?>">
+                        <input type="hidden" name="fhash" id="fhash" value="<?php echo hash('sha256', $this->session->userdata('user_callsign')); ?>">
                         <div class="small form-text text-muted"><?= __("Select Station Location") ?></div>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $active_station_id) {
@@ -67,17 +67,15 @@
                             <?php } ?>
                         </select>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>
-                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2" style="width: 50%">
-                        	<option value="" selected><?= __("No Contest"); ?></option>
+                        <select name="contest" id="contest" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
+                            <option value="" selected><?= __("No Contest"); ?></option>
                             <?php
-				foreach ($contests as $contest) {
-                                echo '<option value="'.$contest['adifname'].'">'.$contest['name'].'</option>';
+                            foreach ($contests as $contest) {
+                                echo '<option value="' . $contest['adifname'] . '">' . $contest['name'] . '</option>';
                             } ?>
-			</select>
- 			<label class="visually-hidden" for="inlineFormInputName2"><?= __("ADIF File") ?></label>
-			<div style="margin-top: 1em; width: 50%">
-                        	<input class="form-control mb-2 me-sm-2" type="file" name="userfile" id="userfile" />
-                        </div>
+                        </select>
+                        <label class="visually-hidden" for="inlineFormInputName2"><?= __("ADIF File") ?></label>
+                        <input class="form-control mb-2 me-sm-2 mt-1 w-50 w-lg-100" type="file" name="userfile" id="userfile" />
 
                         <div class="mb-3 row">
                             <div class="col-md-10">
@@ -166,7 +164,7 @@
                     <form class="form" action="<?php echo site_url('adif/export_custom'); ?>" method="post" enctype="multipart/form-data">
                         <h5 class="card-title"><?= __("Take your logbook file anywhere!") ?> </h5>
                         <p class="card-text"><?= __("Exporting ADIFs allows you to import contacts into third party applications like LoTW, Awards or just for keeping a backup.") ?> </p>
-                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-auto">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $this->stations->find_active()) {
@@ -213,7 +211,7 @@
 
                 <div class="tab-pane fade" id="lotw" role="tabpanel" aria-labelledby="home-tab">
                     <form class="form" action="<?php echo site_url('adif/mark_lotw'); ?>" method="post" enctype="multipart/form-data">
-                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-auto">
+                        <select name="station_profile" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
                             <option value="0"><?= __("Select Station Location") ?></option>
                             <?php foreach ($station_profile->result() as $station) { ?>
                                 <option value="<?php echo $station->station_id; ?>"><?= __("Callsign") . ": " ?><?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>
@@ -241,7 +239,7 @@
                         </div>
                     <?php } ?>
 
-                    <p class="card-text"><?= sprintf(__("Go to %s and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put 'DL' into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info."), "<a href='http://dcl.darc.de/dml/export_adif_form.php' target='_blank'>". __("DARC DCL")."</a>")?></p>
+                    <p class="card-text"><?= sprintf(__("Go to %s and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put 'DL' into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info."), "<a href='http://dcl.darc.de/dml/export_adif_form.php' target='_blank'>" . __("DARC DCL") . "</a>") ?></p>
                     <form class="form" action="<?php echo site_url('adif/dcl'); ?>" method="post" enctype="multipart/form-data">
 
                         <div class="mb-3 row">
@@ -278,3 +276,4 @@
             </div>
         </div>
     </div>
+</div>

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -32,7 +32,7 @@
  			  <br>
 			  <p><?= sprintf(__("Upload the Exported ADIF file from eQSL from the %s page, to mark QSOs as confirmed on eQSL."), '<a href="https://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">' . __("Download Inbox") . '</a>'); ?></p>
 			<p><?= __("Choose Station(location) eQSL File belongs to:"); ?></p>
-                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
+                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
                     <option value="0"><?= __("Select Station Location"); ?></option>
                     <?php foreach ($station_profile->result() as $station) {
                             if($station->eqslqthnickname) { ?>

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -1,69 +1,70 @@
 <div class="container eqsl">
-<h2><?php echo $page_title; ?></h2>
-<div class="card">
-  <div class="card-header">
-    <ul class="nav nav-tabs card-header-tabs">
-      <li class="nav-item">
-        <a class="nav-link active" href="<?php echo site_url('eqsl/import');?>"><?= __("Download QSOs"); ?></a>
-      </li>
-<?php if (!($this->config->item('disable_manual_eqsl'))) { ?>
-      <li class="nav-item">
-        <a class="nav-link" href="<?php echo site_url('eqsl/Export');?>"><?= __("Upload QSOs"); ?></a>
-      </li>
-<?php } ?>
-      <li class="nav-item">
-        <a class="nav-link" href="<?php echo site_url('eqsl/tools');?>"><?= __("Tools"); ?></a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="<?php echo site_url('eqsl/download');?>"><?= __("Download eQSL cards"); ?></a>
-      </li>
-    </ul>
-  </div>
-  <div class="card-body">
-		<?php $this->load->view('layout/messages'); ?>
+	<h2><?php echo $page_title; ?></h2>
+	<div class="card">
+		<div class="card-header">
+			<ul class="nav nav-tabs card-header-tabs">
+				<li class="nav-item">
+					<a class="nav-link active" href="<?php echo site_url('eqsl/import'); ?>"><?= __("Download QSOs"); ?></a>
+				</li>
+				<?php if (!($this->config->item('disable_manual_eqsl'))) { ?>
+					<li class="nav-item">
+						<a class="nav-link" href="<?php echo site_url('eqsl/Export'); ?>"><?= __("Upload QSOs"); ?></a>
+					</li>
+				<?php } ?>
+				<li class="nav-item">
+					<a class="nav-link" href="<?php echo site_url('eqsl/tools'); ?>"><?= __("Tools"); ?></a>
+				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="<?php echo site_url('eqsl/download'); ?>"><?= __("Download eQSL cards"); ?></a>
+				</li>
+			</ul>
+		</div>
+		<div class="card-body">
+			<?php $this->load->view('layout/messages'); ?>
 
-		<?php echo form_open_multipart('eqsl/import');?>
+			<?php echo form_open_multipart('eqsl/import'); ?>
 
 			<div class="form-check">
-			  <input class="form-check-input" type="radio" name="eqslimport" id="upload" value="upload" checked /> 
-			  <label class="form-check-label" for="exampleRadios1">
-			    <?= __("Import from file..."); ?>
-			  </label>
- 			  <br>
-			  <p><?= sprintf(__("Upload the Exported ADIF file from eQSL from the %s page, to mark QSOs as confirmed on eQSL."), '<a href="https://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">' . __("Download Inbox") . '</a>'); ?></p>
-			<p><?= __("Choose Station(location) eQSL File belongs to:"); ?></p>
-                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%">
-                    <option value="0"><?= __("Select Station Location"); ?></option>
-                    <?php foreach ($station_profile->result() as $station) {
-                            if($station->eqslqthnickname) { ?>
-                    <option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $this->stations->find_active()) { echo " selected =\"selected\""; } ?>><?= __("Callsign"); ?>: <?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name.") eQSL: ".$station->eqslqthnickname; ?></option>
-                    <?php } } ?>
-                    </select>
-                    <p><span class="badge bg-info me-1"><?= __("Important"); ?></span><?= __("Log files must have the file type .adi"); ?></p>
-		    <div style="margin-top: 1em; width: 50%">
-            		<input class="form-control  mb-2 me-sm-2" type="file" name="userfile" size="20" />
-		    </div>
+				<input class="form-check-input" type="radio" name="eqslimport" id="upload" value="upload" checked />
+				<label class="form-check-label" for="exampleRadios1">
+					<?= __("Import from file..."); ?>
+				</label>
+				<br>
+				<p><?= sprintf(__("Upload the Exported ADIF file from eQSL from the %s page, to mark QSOs as confirmed on eQSL."), '<a href="https://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">' . __("Download Inbox") . '</a>'); ?></p>
+				<p><?= __("Choose Station(location) eQSL File belongs to:"); ?></p>
+				<select name="station_profile" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
+					<option value="0"><?= __("Select Station Location"); ?></option>
+					<?php foreach ($station_profile->result() as $station) {
+						if ($station->eqslqthnickname) { ?>
+							<option value="<?php echo $station->station_id; ?>" <?php if ($station->station_id == $this->stations->find_active()) {
+																					echo " selected =\"selected\"";
+																				} ?>><?= __("Callsign"); ?>: <?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name . ") eQSL: " . $station->eqslqthnickname; ?></option>
+					<?php }
+					} ?>
+				</select>
+				<p><span class="badge bg-info me-1"><?= __("Important"); ?></span><?= __("Log files must have the file type .adi"); ?></p>
+				<input class="form-control mb-2 me-sm-2 mt-1 w-50 w-lg-100" type="file" name="userfile" size="20" />
 			</div>
 			<hr class="divider">
-<?php if (!($this->config->item('disable_manual_eqsl'))) { ?>
-			<div class="form-check">
-			  <input class="form-check-input" type="radio" name="eqslimport" id="fetch" value="fetch"  checked="checked"/>
-			  <label class="form-check-label" for="exampleRadios1"><?= __("Import directly from eQSL"); ?></label>
-			  <p><?= __("Wavelog will use the eQSL credentials from your Wavelog user profile to connect to eQSL and download confirmations."); ?></p>
-				<div class="row">
-		        	<div class="mb-3 col-sm-2">
-			          	<div class="dxatlasdatepicker input-group date" id="eqsl_force_from_date" data-target-input="nearest">
-                        	<input name="eqsl_force_from_date" id="eqsl_force_from_date" type="date" class="form-control w-auto">
-			          	</div>
-		        	</div>
-		         	<div class="mb-3 col-sm-5" style="vertical-align:middle;"><label class="form-label"><?php echo "(Select a date, only if you want to force an import with an older date)"; ?></label></div>
+			<?php if (!($this->config->item('disable_manual_eqsl'))) { ?>
+				<div class="form-check">
+					<input class="form-check-input" type="radio" name="eqslimport" id="fetch" value="fetch" checked="checked" />
+					<label class="form-check-label" for="exampleRadios1"><?= __("Import directly from eQSL"); ?></label>
+					<p><?= __("Wavelog will use the eQSL credentials from your Wavelog user profile to connect to eQSL and download confirmations."); ?></p>
+					<div class="row">
+						<div class="mb-3 col-sm-2">
+							<div class="dxatlasdatepicker input-group date" id="eqsl_force_from_date" data-target-input="nearest">
+								<input name="eqsl_force_from_date" id="eqsl_force_from_date" type="date" class="form-control w-auto">
+							</div>
+						</div>
+						<div class="mb-3 col-sm-5" style="vertical-align:middle;"><label class="form-label"><?php echo "(Select a date, only if you want to force an import with an older date)"; ?></label></div>
+					</div>
 				</div>
-			</div>
-			<hr class="divider">
-<?php } ?>
+				<hr class="divider">
+			<?php } ?>
 			<div class="mb-3"><input class="btn btn-primary" type="submit" value="Import eQSL QSO Matches" /></div>
-		</form>
-  </div>
-</div>
+			</form>
+		</div>
+	</div>
 
 </div>

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -32,7 +32,7 @@
  			  <br>
 			  <p><?= sprintf(__("Upload the Exported ADIF file from eQSL from the %s page, to mark QSOs as confirmed on eQSL."), '<a href="https://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">' . __("Download Inbox") . '</a>'); ?></p>
 			<p><?= __("Choose Station(location) eQSL File belongs to:"); ?></p>
-                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 20%;">
+                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 100%;">
                     <option value="0"><?= __("Select Station Location"); ?></option>
                     <?php foreach ($station_profile->result() as $station) {
                             if($station->eqslqthnickname) { ?>

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -32,7 +32,7 @@
  			  <br>
 			  <p><?= sprintf(__("Upload the Exported ADIF file from eQSL from the %s page, to mark QSOs as confirmed on eQSL."), '<a href="https://eqsl.cc/qslcard/DownloadInBox.cfm" target="_blank">' . __("Download Inbox") . '</a>'); ?></p>
 			<p><?= __("Choose Station(location) eQSL File belongs to:"); ?></p>
-                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%;">
+                    <select name="station_profile" class="form-select mb-2 me-sm-2" style="width: 50%">
                     <option value="0"><?= __("Select Station Location"); ?></option>
                     <?php foreach ($station_profile->result() as $station) {
                             if($station->eqslqthnickname) { ?>
@@ -40,7 +40,9 @@
                     <?php } } ?>
                     </select>
                     <p><span class="badge bg-info me-1"><?= __("Important"); ?></span><?= __("Log files must have the file type .adi"); ?></p>
-                    <input class="form-control w-auto" type="file" name="userfile" size="20" />
+		    <div style="margin-top: 1em; width: 50%">
+            		<input class="form-control  mb-2 me-sm-2" type="file" name="userfile" size="20" />
+		    </div>
 			</div>
 			<hr class="divider">
 <?php if (!($this->config->item('disable_manual_eqsl'))) { ?>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -9,6 +9,49 @@ body {
 	}
 }
 
+@media (max-width: 991px) {
+
+	.h-lg-25 {
+		height: 25% !important;
+	}
+
+	.h-lg-50 {
+		height: 50% !important;
+	}
+
+	.h-lg-75 {
+		height: 75% !important;
+	}
+
+	.h-lg-100 {
+		height: 100% !important;
+	}
+
+	.h-lg-auto {
+		height: auto !important;
+	}
+
+	.w-lg-25 {
+		width: 25% !important;
+	}
+
+	.w-lg-50 {
+		width: 50% !important;
+	}
+
+	.w-lg-75 {
+		width: 75% !important;
+	}
+
+	.w-lg-100 {
+		width: 100% !important;
+	}
+
+	.w-lg-auto {
+		width: auto !important;
+	}
+
+}
 /* ============  HEADER MENU ============ */
 /* Adapted from https://bootstrap-menu.com/detail-multilevel.html  */
 /* ============ desktop view ============ */


### PR DESCRIPTION
Resized droplist for station location name and contest name to full width on pages Import/Export ADIF and eQSL Import.

Before resize the width of the droplist was less then station location name width:
![изображение](https://github.com/wavelog/wavelog/assets/16667173/700bd7b6-3d83-4d8c-ac2f-97a4549e6459)

After resize it looks better. IMHO
![изображение](https://github.com/wavelog/wavelog/assets/16667173/eecad1e8-dec2-434b-a04b-a2d33b7698ff)
