### PR TITLE
[IOTA Award] Fix second table loading, and add PK to speed up

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 206;
+$config['migration_version'] = 207;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -800,11 +800,11 @@ class Awards extends CI_Controller {
 	    $data['modes'] = $this->modes->active(); // Used in the view for mode select
 
 	    if($this->input->method() === 'post') {
-		    $postdata['qsl'] = $this->input->post('qsl') == 0 ? NULL: 1;
-		    $postdata['lotw'] = $this->input->post('lotw') == 0 ? NULL: 1;
-		    $postdata['eqsl'] = $this->input->post('eqsl') == 0 ? NULL: 1;
-		    $postdata['qrz'] = $this->input->post('qrz') == 0 ? NULL: 1;
-		    $postdata['clublog'] = $this->input->post('clublog') == 0 ? NULL: 1;
+		    $postdata['qsl'] = 1;
+		    $postdata['lotw'] = 1;
+		    $postdata['eqsl'] = 0;
+		    $postdata['qrz'] = 0;
+		    $postdata['clublog'] = 0;
 		    $postdata['worked'] = $this->security->xss_clean($this->input->post('worked')) ?? NULL;
 		    $postdata['confirmed'] = $this->security->xss_clean($this->input->post('confirmed')) ?? NULL;
 		    $postdata['notworked'] = $this->security->xss_clean($this->input->post('notworked')) ?? NULL;

--- a/application/migrations/207_add_pk_iota.php
+++ b/application/migrations/207_add_pk_iota.php
@@ -8,8 +8,6 @@ class Migration_add_pk_iota extends CI_Migration {
 		$this->add_ix('iota','idx_iota_Tag','`tag`');
 	}
 
-	// CREATE UNIQUE INDEX `idx_iota_Tag` ON `iota` (Tag) COMMENT '' ALGORITHM DEFAULT LOCK DEFAULT;
-
 	public function down() {
 		$this->rm_ix('iota','idx_iota_Tag');
 	}

--- a/application/migrations/207_add_pk_iota.php
+++ b/application/migrations/207_add_pk_iota.php
@@ -1,0 +1,33 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_add_pk_iota extends CI_Migration {
+
+	public function up() {
+		$this->add_ix('iota','idx_iota_Tag','`tag`');
+	}
+
+	// CREATE UNIQUE INDEX `idx_iota_Tag` ON `iota` (Tag) COMMENT '' ALGORITHM DEFAULT LOCK DEFAULT;
+
+	public function down() {
+		$this->rm_ix('iota','idx_iota_Tag');
+	}
+
+	private function add_ix($table_name,$index,$cols) {
+		$ix_exist = $this->db->query("SHOW INDEX FROM ".$table_name." WHERE Key_name = '".$index."'")->num_rows();
+		if ($ix_exist == 0) {
+			$sql = "CREATE UNIQUE INDEX `idx_iota_Tag` ON `iota` (Tag) COMMENT '' ALGORITHM DEFAULT LOCK DEFAULT";
+			$this->db->query($sql);
+		}
+	}
+
+	private function rm_ix($table_name,$index) {
+		$ix_exist = $this->db->query("SHOW INDEX FROM ".$table_name." WHERE Key_name = '".$index."'")->num_rows();
+		if ($ix_exist >= 1) {
+			$sql = "ALTER TABLE ".$table_name." DROP INDEX `".$index."`;";
+			$this->db->query($sql);
+		}
+	}
+
+}


### PR DESCRIPTION
I noticed that the IOTA award was terribly slow. Tracing this down to adding a primary key on the iota table.

While investigating, I also noticed that if you load the table a second time, confirmed contacts were not counted.

Thanks to @int2001 for db help.