### PR TITLE
Fix lang selection in User Edit (other user as admin)

### DIFF
--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -171,7 +171,7 @@
 										foreach ($existing_languages as $lang) {
 											$options[$lang['folder']] = $lang['name_en'];
 										}
-										echo form_dropdown('user_language', $options, $language['folder']);
+										echo form_dropdown('user_language', $options, $user_language);
 										?>
 										<small id="language_Help" class="form-text text-muted"><?= __("Choose Wavelog language."); ?></small>
 									</div>


### PR DESCRIPTION
made a mistake here. This should be the `$user_language` which always respresents the chosen user (your own or as admin editing another user)