### PR TITLE
[QRZ & HamQTH] Fix Callbook Lookup

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -123,7 +123,7 @@ class Logbook extends CI_Controller {
 
 		$return['dxcc'] = $this->dxcheck($callsign,$date);
 
-		$lookupcall=$this->get_plaincall($callsign);
+		$lookupcall=$this->logbook_model->get_plaincall($callsign);
 
 		$return['partial'] = $this->partial($lookupcall, $band);
 
@@ -167,24 +167,6 @@ class Logbook extends CI_Controller {
 		echo json_encode($return, JSON_PRETTY_PRINT);
 
 		return;
-	}
-
-	function get_plaincall($callsign) {
-		$split_callsign=explode('/',$callsign);
-		if (count($split_callsign)==1) {				// case F0ABC --> return cel 0 //
-			$lookupcall = $split_callsign[0];
-		} else if (count($split_callsign)==3) {			// case EA/F0ABC/P --> return cel 1 //
-			$lookupcall = $split_callsign[1];
-		} else {										// case F0ABC/P --> return cel 0 OR  case EA/FOABC --> retunr 1  (normaly not exist) //
-			if (in_array(strtoupper($split_callsign[1]), array('P','M','MM','QRP','0','1','2','3','4','5','6','7','8','9'))) {
-				$lookupcall = $split_callsign[0];
-			} else if (strlen($split_callsign[1])>3) {	// Last Element longer than 3 chars? Take that as call
-				$lookupcall = $split_callsign[1];
-			} else {									// Last Element up to 3 Chars? Take first element as Call
-				$lookupcall = $split_callsign[0];
-			}
-		}
-		return $lookupcall;
 	}
 
 	// Returns $val2 first if it has value, even if it is null or empty string, if not return $val1.

--- a/application/libraries/Hamqth.php
+++ b/application/libraries/Hamqth.php
@@ -58,9 +58,7 @@ class Hamqth {
 	}
 
 
-	public function search($callsign, $key)
-	{
-		$callsign = str_replace("/", "&#47", $callsign);
+	public function search($callsign, $key, $reduced = false) {
 	    $data = null;
         try {
             // URL to the XML Source
@@ -80,12 +78,13 @@ class Hamqth {
             $xml = simplexml_load_string($xml);
             if (!empty($xml->session->error)) return $data['error'] = $xml->session->error;
 
+			// we always want to return name and callsign
+			$data['callsign'] 	= (string)$xml->search->callsign;
+			$data['name'] 		= (string)$xml->search->nick;
+
 			// only return certain data of a callsign which does not contain a pre- or suffix (see https://github.com/wavelog/wavelog/issues/452)
-			if (strpos($callsign, '&#47') == false) {
+			if ($reduced == false) {
 				
-				// Return Required Fields
-				$data['callsign'] 	= (string)$xml->search->callsign;
-				$data['name'] 		= (string)$xml->search->nick;
 				$data['gridsquare'] = (string)$xml->search->grid;
 				$data['city'] 		= (string)$xml->search->adr_city;
 				$data['lat'] 		= (string)$xml->search->latitude;
@@ -104,8 +103,6 @@ class Hamqth {
 
 			} else {
 
-				$data['callsign'] 	= (string)$xml->search->callsign;
-				$data['name'] 		= (string)$xml->search->nick;
 				$data['gridsquare'] = '';
 				$data['city'] 		= '';
 				$data['lat'] 		= '';

--- a/application/libraries/Hamqth.php
+++ b/application/libraries/Hamqth.php
@@ -79,24 +79,45 @@ class Hamqth {
             $xml = simplexml_load_string($xml);
             if (!empty($xml->session->error)) return $data['error'] = $xml->session->error;
 
-            // Return Required Fields
-            $data['callsign'] = (string)$xml->search->callsign;
-            $data['name'] = (string)$xml->search->nick;
-            $data['gridsquare'] = (string)$xml->search->grid;
-            $data['city'] = (string)$xml->search->adr_city;
-            $data['lat'] = (string)$xml->search->latitude;
-            $data['long'] = (string)$xml->search->longitude;
-			$data['dxcc'] = (string)$xml->search->adif; 
-            $data['iota'] = (string)$xml->search->iota;
-            $data['image'] = (string)$xml->search->picture;
-			$data['state'] = (string)$xml->search->us_state;
-            $data['error'] = (string)$xml->session->error;
+			// only return certain data of a callsign which does not contain a pre- or suffix (see https://github.com/wavelog/wavelog/issues/452)
+			if (strpos($callsign, '&#47') == false) {
+				
+				// Return Required Fields
+				$data['callsign'] 	= (string)$xml->search->callsign;
+				$data['name'] 		= (string)$xml->search->nick;
+				$data['gridsquare'] = (string)$xml->search->grid;
+				$data['city'] 		= (string)$xml->search->adr_city;
+				$data['lat'] 		= (string)$xml->search->latitude;
+				$data['long'] 		= (string)$xml->search->longitude;
+				$data['dxcc'] 		= (string)$xml->search->adif; 
+				$data['iota'] 		= (string)$xml->search->iota;
+				$data['image'] 		= (string)$xml->search->picture;
+				$data['state'] 		= (string)$xml->search->us_state;
+				$data['error'] 		= (string)$xml->session->error;
 
-            if ($xml->search->country == "United States") {
-                $data['us_county'] = (string)$xml->search->us_county;
-            } else {
-                $data['us_county'] = null;
-            }
+				if ($xml->search->country == "United States") {
+					$data['us_county'] = (string)$xml->search->us_county;
+				} else {
+					$data['us_county'] = null;
+				}
+
+			} else {
+
+				$data['callsign'] 	= (string)$xml->search->callsign;
+				$data['name'] 		= (string)$xml->search->nick;
+				$data['gridsquare'] = '';
+				$data['city'] 		= '';
+				$data['lat'] 		= '';
+				$data['long'] 		= '';
+				$data['dxcc'] 		= '';
+				$data['iota'] 		= '';
+				$data['image'] 		= (string)$xml->search->picture;
+				$data['state'] 		= '';
+				$data['error'] 		= (string)$xml->session->error;
+
+				$data['us_county'] 	= '';
+
+			}
         } finally {
             return $data;
         }

--- a/application/libraries/Hamqth.php
+++ b/application/libraries/Hamqth.php
@@ -60,6 +60,7 @@ class Hamqth {
 
 	public function search($callsign, $key)
 	{
+		$callsign = str_replace("/", "&#47", $callsign);
 	    $data = null;
         try {
             // URL to the XML Source

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -10,7 +10,7 @@ class Qrz {
 	// Return session key
 	public function session($username, $password) {
 		// URL to the XML Source
-		$xml_feed_url = 'http://xmldata.qrz.com/xml/current/?username='.$username.';password='.urlencode($password).';agent=wavelog';
+		$xml_feed_url = 'https://xmldata.qrz.com/xml/current/?username='.$username.';password='.urlencode($password).';agent=wavelog';
 		
 		// CURL Functions
 		$ch = curl_init();
@@ -35,7 +35,7 @@ class Qrz {
 		$ci = & get_instance();
 		
 		// URL to the XML Source
-		$xml_feed_url = 'http://xmldata.qrz.com/xml/current/?username='.$username.';password='.urlencode($password).';agent=wavelog';
+		$xml_feed_url = 'https://xmldata.qrz.com/xml/current/?username='.$username.';password='.urlencode($password).';agent=wavelog';
 		
 		// CURL Functions
 		$ch = curl_init();
@@ -62,7 +62,7 @@ class Qrz {
 		$data = null;
 		try {
 			// URL to the XML Source
-			$xml_feed_url = 'http://xmldata.qrz.com/xml/current/?s=' . $key . ';callsign=' . $callsign . '';
+			$xml_feed_url = 'https://xmldata.qrz.com/xml/current/?s=' . $key . ';callsign=' . $callsign . '';
 
 			// CURL Functions
 			$ch = curl_init();

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -58,8 +58,7 @@ class Qrz {
 	}
 
 
-	public function search($callsign, $key, $use_fullname = false) {
-		$callsign = str_replace("/", "&#47", $callsign);
+	public function search($callsign, $key, $use_fullname = false, $reduced = false) {
 		$data = null;
 		try {
 			// URL to the XML Source
@@ -76,10 +75,13 @@ class Qrz {
 			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 			curl_close($ch);
 			if ($httpcode != 200) return $data['error'] = 'Problems with qrz.com communication'; // Exit function if no 200. If request fails, 0 is returned
+			
 			// Create XML object
 			$xml = simplexml_load_string($xml);
-			if (!empty($xml->Session->Error)) return $data['error'] = $xml->Session->Error;
-
+			if (!empty($xml->Session->Error)) {
+				return $data['error'] = $xml->Session->Error;
+			}
+			
 			// Return Required Fields
 			$data['callsign'] = (string)$xml->Callsign->call;
 
@@ -88,14 +90,15 @@ class Qrz {
 			} else {
 				$data['name'] = (string)$xml->Callsign->fname;
 			}
+
+			// we always give back the name, no matter if reduced data or not
 			$data['name'] = trim($data['name']);
 
-			// Sanitise gridsquare to only allow up to 8 characters
+			// Sanitize gridsquare to allow only up to 8 characters
 			$unclean_gridsquare = (string)$xml->Callsign->grid; // Get the gridsquare from QRZ convert to string
 			$clean_gridsquare = strlen($unclean_gridsquare) > 8 ? substr($unclean_gridsquare,0,8) : $unclean_gridsquare; // Trim gridsquare to 8 characters max
 
-			// only return certain data of a callsign which does not contain a pre- or suffix (see https://github.com/wavelog/wavelog/issues/452)
-			if (strpos($callsign, '&#47') == false) {
+			if ($reduced == false) {
 
 				$data['gridsquare'] = $clean_gridsquare;
 				$data['city'] 	= (string)$xml->Callsign->addr2;

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -93,21 +93,39 @@ class Qrz {
 			// Sanitise gridsquare to only allow up to 8 characters
 			$unclean_gridsquare = (string)$xml->Callsign->grid; // Get the gridsquare from QRZ convert to string
 			$clean_gridsquare = strlen($unclean_gridsquare) > 8 ? substr($unclean_gridsquare,0,8) : $unclean_gridsquare; // Trim gridsquare to 8 characters max
-			$data['gridsquare'] = $clean_gridsquare;
 
-			$data['city'] = (string)$xml->Callsign->addr2;
-			$data['lat'] = (string)$xml->Callsign->lat;
-			$data['long'] = (string)$xml->Callsign->lon;
-			$data['dxcc'] = (string)$xml->Callsign->dxcc;
-			$data['state'] = (string)$xml->Callsign->state;
-			$data['iota'] = (string)$xml->Callsign->iota;
-			$data['qslmgr'] = (string)$xml->Callsign->qslmgr;
-			$data['image'] = (string)$xml->Callsign->image;
+			// only return certain data of a callsign which does not contain a pre- or suffix (see https://github.com/wavelog/wavelog/issues/452)
+			if (strpos($callsign, '&#47') == false) {
 
-			if ($xml->Callsign->country == "United States") {
-				$data['us_county'] = (string)$xml->Callsign->county;
+				$data['gridsquare'] = $clean_gridsquare;
+				$data['city'] 	= (string)$xml->Callsign->addr2;
+				$data['lat'] 	= (string)$xml->Callsign->lat;
+				$data['long'] 	= (string)$xml->Callsign->lon;
+				$data['dxcc'] 	= (string)$xml->Callsign->dxcc;
+				$data['state'] 	= (string)$xml->Callsign->state;
+				$data['iota'] 	= (string)$xml->Callsign->iota;
+				$data['qslmgr'] = (string)$xml->Callsign->qslmgr;
+				$data['image'] 	= (string)$xml->Callsign->image;
+
+				if ($xml->Callsign->country == "United States") {
+					$data['us_county'] = (string)$xml->Callsign->county;
+				} else {
+					$data['us_county'] = null;
+				}
+
 			} else {
-				$data['us_county'] = null;
+
+				$data['gridsquare'] = '';
+				$data['city'] 	= '';
+				$data['lat'] 	= '';
+				$data['long'] 	= '';
+				$data['dxcc'] 	= '';
+				$data['state'] 	= '';
+				$data['iota'] 	= '';
+				$data['qslmgr'] = (string)$xml->Callsign->qslmgr;
+				$data['image'] 	= (string)$xml->Callsign->image;
+				$data['us_county'] = '';
+
 			}
 		} finally {
 

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -59,6 +59,7 @@ class Qrz {
 
 
 	public function search($callsign, $key, $use_fullname = false) {
+		$callsign = str_replace("/", "&#47", $callsign);
 		$data = null;
 		try {
 			// URL to the XML Source

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4759,7 +4759,13 @@ function lotw_last_qsl_date($user_id) {
                     $this->session->set_userdata('hamqth_session_key', $hamqth_session_key);
                 }
 
-                $callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'));
+				// if the callsign contains a pre- or suffix we only give back reduced data to avoid wrong data (location and other things are not valid then)
+				if (strpos($callsign, "/") !== false) {
+					$reduced = true;
+				} else {
+					$reduced = false;
+				}
+                $callbook = $this->hamqth->search($callsign, $this->session->userdata('hamqth_session_key'), $reduced);
 
                 // If HamQTH session has expired, start a new session and retry the search.
                 if ($callbook['error'] == "Session does not exist or expired") {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4703,6 +4703,24 @@ function lotw_last_qsl_date($user_id) {
       }
     }
 
+	function get_plaincall($callsign) {
+		$split_callsign=explode('/',$callsign);
+		if (count($split_callsign)==1) {				// case F0ABC --> return cel 0 //
+			$lookupcall = $split_callsign[0];
+		} else if (count($split_callsign)==3) {			// case EA/F0ABC/P --> return cel 1 //
+			$lookupcall = $split_callsign[1];
+		} else {										// case F0ABC/P --> return cel 0 OR  case EA/FOABC --> retunr 1  (normaly not exist) //
+			if (in_array(strtoupper($split_callsign[1]), array('P','M','MM','QRP','0','1','2','3','4','5','6','7','8','9'))) {
+				$lookupcall = $split_callsign[0];
+			} else if (strlen($split_callsign[1])>3) {	// Last Element longer than 3 chars? Take that as call
+				$lookupcall = $split_callsign[1];
+			} else {									// Last Element up to 3 Chars? Take first element as Call
+				$lookupcall = $split_callsign[0];
+			}
+		}
+		return $lookupcall;
+	}
+
 	public function loadCallBook($callsign, $use_fullname=false)
     {
         $callbook = null;
@@ -4718,13 +4736,18 @@ function lotw_last_qsl_date($user_id) {
 
                 $callbook = $this->qrz->search($callsign, $this->session->userdata('qrz_session_key'), $use_fullname);
 
-                // if we got nothing, it's probably because our session key is invalid, try again
-                if (($callbook['callsign'] ?? '') == '')
-                {
-                    $qrz_session_key = $this->qrz->session($this->config->item('qrz_username'), $this->config->item('qrz_password'));
-                    $this->session->set_userdata('qrz_session_key', $qrz_session_key);
+                // We need to handle, if the sessionkey is invalid
+                if ($callbook['error'] ?? '' == 'Invalid session key') {
+                    $this->qrz->set_session($this->config->item('qrz_username'), $this->config->item('qrz_password'));
                     $callbook = $this->qrz->search($callsign, $this->session->userdata('qrz_session_key'), $use_fullname);
                 }
+
+				// If the callsign contains a slash we have a pre- or suffix. If then the result is "Not found" we can try again with the plain call
+				if (strpos($callbook['error'] ?? '', 'Not found') !== false && strpos($callsign, "/") !== false) {
+					$plaincall = $this->get_plaincall($callsign);
+					// Now try again but give back reduced data, as we can't validate location and stuff (true at the end)
+					$callbook = $this->qrz->search($plaincall, $this->session->userdata('qrz_session_key'), $use_fullname, true);
+				}
             }
 
             if ($this->config->item('callbook') == "hamqth" && $this->config->item('hamqth_username') != null && $this->config->item('hamqth_password') != null) {


### PR DESCRIPTION
QRZ returns callbook information in this manner

Search for CALL/P
if /P does not exist return just info for CALL
if /P exist return this data

To escape the slash fixes this issue (referred in #452 )

Problem: We need to discuss if ....

1. We just update all fields even if we know that things like `Location (Grid)` are not valid

or

2. We just update certain fields in QSO logging if the callsign contains a suffix or prefix


In both cases the user needs to check the data by hand. Imho we can use 1. option but we can discuss this and I'm open for other arguments. 

This also affects #459  and #515. For this reason we should implement the decision in a central place (in the QRZ library functions)