### PR TITLE
Fixes broken detail-view

### DIFF
--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -83,9 +83,7 @@ function echo_table_col($row, $name) {
                         <th><?= __("Clublog"); ?></th>
                     <?php } ?>
                 <?php } ?>
-                    <?php if(isset($row->station_callsign)) { ?>
                         <th><?= __("Station"); ?></th>
-                    <?php } ?>
                 <?php if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>
                     <th></th>
                 <?php } ?>
@@ -255,7 +253,9 @@ function echo_table_col($row, $name) {
                         <td>
                             <span class="badge text-bg-light"><?php echo str_replace("0","&Oslash;",strtoupper($row->station_callsign)); ?></span>
                         </td>
-                    <?php } ?>
+                    <?php } else { ?>
+			<td></td>
+		    <?php } ?>
 
             <?php if(($this->config->item('use_auth')) && ($this->session->userdata('user_type') >= 2)) { ?>
                 <td>


### PR DESCRIPTION
Detailview was broken, because the header for "Station Callsign" was tried to be setted by a dependency which could never be fullfilled (at the time the dep for `isset($station_callsign)` was asked that var wasn't filled).

This one heals the detail-view and displays the station_call always here