### PR TITLE
Add else clause in case of openssl sign failure

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1001,6 +1001,9 @@ class Lotw extends CI_Controller {
 				}
 				$signature_b64 = base64_encode($signature);
 				return $signature_b64."\n";
+			} else {
+				// in case of deprecation of SHA-1 in some distro
+				log_message('error', openssl_error_string());
 			}
 		} else {
 			log_message('error', 'Error signing LoTW log.');


### PR DESCRIPTION
#549 

In some distro (like RHELs), SHA-1 has been disabled by default. 
To avoid that a NULL is returned and nothing happens, this else clause is added to log the error.