### PR TITLE
[DEBUG] Added permission check for cache folder

### DIFF
--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -42,6 +42,10 @@ class Debug extends CI_Controller
 		$backup_folder = $this->permissions->is_really_writable('backup');
 		$data['backup_folder'] = $backup_folder;
 
+		// Test writing to cache folder
+		$cache_folder = $this->permissions->is_really_writable('application/cache');
+		$data['cache_folder'] = $cache_folder;
+
 		// Test writing to updates folder
 		$updates_folder = $this->permissions->is_really_writable('updates');
 		$data['updates_folder'] = $updates_folder;

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -106,6 +106,17 @@
                         </tr>
 
                         <tr>
+                            <td>/cache</td>
+                            <td>
+                                <?php if ($cache_folder == true) { ?>
+                                    <span class="badge text-bg-success"><?= __("Success"); ?></span>
+                                <?php } else { ?>
+                                    <span class="badge text-bg-danger"><?= __("Failed"); ?></span>
+                                <?php } ?>
+                            </td>
+                        </tr>
+
+                        <tr>
                             <td>/updates</td>
                             <td>
                                 <?php if ($updates_folder == true) { ?>


### PR DESCRIPTION
The migrations use a locking file, which needs to be written into the caching folder `application/cache`

This adds a check in debug view