### PR TITLE
Prevent unsupported modes to be uploaded to LoTW

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4852,6 +4852,9 @@ function lotw_last_qsl_date($user_id) {
 
   function get_lotw_qsos_to_upload($station_id, $start_date, $end_date) {
 
+    // Missing in tqsl 2.7.3 config.xml
+    $lotw_upsupported_modes = array('INTERNET', 'RPT');
+
     $this->db->select('COL_PRIMARY_KEY,COL_CALL, COL_BAND, COL_BAND_RX, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_SUBMODE, COL_FREQ, COL_FREQ_RX, COL_GRIDSQUARE, COL_SAT_NAME, COL_PROP_MODE, COL_LOTW_QSL_SENT, station_id');
 
     $this->db->where("station_id", $station_id);
@@ -4859,7 +4862,7 @@ function lotw_last_qsl_date($user_id) {
     $this->db->where('COL_LOTW_QSL_SENT', NULL);
     $this->db->or_where('COL_LOTW_QSL_SENT !=', "Y");
     $this->db->group_end();
-    $this->db->where('COL_PROP_MODE !=', "INTERNET");
+    $this->db->where_not_in('COL_PROP_MODE', $lotw_upsupported_modes);
     $this->db->where('COL_TIME_ON >=', $start_date);
     $this->db->where('COL_TIME_ON <=', $end_date);
     $this->db->order_by("COL_TIME_ON", "desc");

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4853,7 +4853,7 @@ function lotw_last_qsl_date($user_id) {
   function get_lotw_qsos_to_upload($station_id, $start_date, $end_date) {
 
     // Missing in tqsl 2.7.3 config.xml
-    $lotw_upsupported_modes = array('INTERNET', 'RPT');
+    $lotw_unsupported_modes = array('INTERNET', 'RPT');
 
     $this->db->select('COL_PRIMARY_KEY,COL_CALL, COL_BAND, COL_BAND_RX, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_SUBMODE, COL_FREQ, COL_FREQ_RX, COL_GRIDSQUARE, COL_SAT_NAME, COL_PROP_MODE, COL_LOTW_QSL_SENT, station_id');
 
@@ -4862,7 +4862,7 @@ function lotw_last_qsl_date($user_id) {
     $this->db->where('COL_LOTW_QSL_SENT', NULL);
     $this->db->or_where('COL_LOTW_QSL_SENT !=', "Y");
     $this->db->group_end();
-    $this->db->where_not_in('COL_PROP_MODE', $lotw_upsupported_modes);
+    $this->db->where_not_in('COL_PROP_MODE', $lotw_unsupported_modes);
     $this->db->where('COL_TIME_ON >=', $start_date);
     $this->db->where('COL_TIME_ON <=', $end_date);
     $this->db->order_by("COL_TIME_ON", "desc");


### PR DESCRIPTION
Besides INTERNET we should also ignore QSOs with prop mode RPT to be uploaded to LoTW as they are not processed anyway. Even worse: Uploading results in strange error messages and valid QSOs in the same bunch to be ignored. Addresses https://github.com/wavelog/wavelog/issues/562