### PR TITLE
Set default language if detection fails

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -98,7 +98,7 @@ if (isset($_GET['lang'])) {
 // get the browsers language if no cookie exists and set one
 if (!isset($_COOKIE[$gt_conf['lang_cookie']])) {
 	$browser_language = _get_client_language();
-	setcookie($gt_conf['lang_cookie'], $browser_language['gettext']);
+	setcookie($gt_conf['lang_cookie'], ($browser_language['gettext'] ?? 'en-US'));
 	header("Location: " . $installer_url);
 	exit();
 }

--- a/install/index.php
+++ b/install/index.php
@@ -98,7 +98,7 @@ if (isset($_GET['lang'])) {
 // get the browsers language if no cookie exists and set one
 if (!isset($_COOKIE[$gt_conf['lang_cookie']])) {
 	$browser_language = _get_client_language();
-	setcookie($gt_conf['lang_cookie'], ($browser_language['gettext'] ?? 'en-US'));
+	setcookie($gt_conf['lang_cookie'], ($browser_language['gettext'] ?? 'en_US'));
 	header("Location: " . $installer_url);
 	exit();
 }


### PR DESCRIPTION
BG6HJE reports that the installer fails with following error message:

![q8l-UAHR](https://github.com/user-attachments/assets/c6c511dd-b262-42b4-bdac-693c953caaeb)

So we should set a default language if (auto)detection fails. Waiting for Op to confirm the fix so draft for now.