### PR TITLE
[Contesting} Set userdata radio when logging

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -71,6 +71,8 @@ class Contesting extends CI_Controller {
 	public function setSession() {
 		$this->load->model('Contesting_model');
 		$this->Contesting_model->setSession();
+
+		$this->session->set_userdata('radio', $this->input->post('radio'));
 		header('Content-Type: application/json');
 		echo json_encode($this->Contesting_model->getSession());
 	}


### PR DESCRIPTION
Since we set radio from user session, it's also good to set radio in user session when logging, just like the regular qso entry.