### PR TITLE
Improve user experience when logging unknown calls

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1638,7 +1638,7 @@ class Logbook_model extends CI_Model {
 			$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 			$this->db->join('dxcc_entities', $this->config->item('table_name').'.col_dxcc = dxcc_entities.adif', 'left');
 			$this->db->join('lotw_users', 'lotw_users.callsign = '.$this->config->item('table_name').'.col_call', 'left outer');
-	
+
 			return $this->db->get($this->config->item('table_name'));
 		} else {
 			return;
@@ -4226,7 +4226,7 @@ function lotw_last_qsl_date($user_id) {
      */
     public function check_dxcc_table($call, $date){
 
-	    $csadditions = '/^T$|^P$|^R$|^A$|^M$/';
+	    $csadditions = '/^X$|^D$|^T$|^P$|^R$|^A$|^M$/';
 
 	    $dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`, `cont`')
 				 ->where('`call`', $call)
@@ -4312,7 +4312,13 @@ function lotw_last_qsl_date($user_id) {
 		    }
 	    }
 
-	    return array("Not Found", "Not Found");
+	    return array(
+			'adif' => 0,
+			'cqz' => 0,
+			'long' => 0,
+			'lat' => 0,
+			'entity' => 'None',
+		);
 
     }
 
@@ -4408,7 +4414,14 @@ function lotw_last_qsl_date($user_id) {
 		    }
 	    }
 
-	    return array("Not Found", "Not Found");
+	    return array(
+			'adif' => 0,
+			'cqz' => 0,
+			'long' => 0,
+			'lat' => 0,
+			'entity' => 'None',
+		);
+
     }
 
     function wpx($testcall, $i) {
@@ -4418,7 +4431,7 @@ function lotw_last_qsl_date($user_id) {
       $c = '';
 
       $lidadditions = '/^QRP$|^LGT$/';
-      $csadditions = '/^T$|^P$|^R$|^A$|^M$|^LH$/';
+      $csadditions = '/^X$^D$^T$|^P$|^R$|^A$|^M$|^LH$/';
       $noneadditions = '/^MM$|^AM$/';
 
       # First check if the call is in the proper format, A/B/C where A and C

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4315,8 +4315,8 @@ function lotw_last_qsl_date($user_id) {
 	    return array(
 			'adif' => 0,
 			'cqz' => 0,
-			'long' => 0,
-			'lat' => 0,
+			'long' => '',
+			'lat' => '',
 			'entity' => 'None',
 		);
 
@@ -4417,8 +4417,8 @@ function lotw_last_qsl_date($user_id) {
 	    return array(
 			'adif' => 0,
 			'cqz' => 0,
-			'long' => 0,
-			'lat' => 0,
+			'long' => '',
+			'lat' => '',
 			'entity' => 'None',
 		);
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4324,7 +4324,7 @@ function lotw_last_qsl_date($user_id) {
 
     public function dxcc_lookup($call, $date) {
 
-	    $csadditions = '/^T$|^P$|^R$|^A$|^M$/';
+		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^A$|^M$|^LH$/';
 
 	    $dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`,`cont`')
 				 ->where('`call`', $call)
@@ -4431,7 +4431,7 @@ function lotw_last_qsl_date($user_id) {
       $c = '';
 
       $lidadditions = '/^QRP$|^LGT$/';
-      $csadditions = '/^X$^D$^T$|^P$|^R$|^A$|^M$|^LH$/';
+      $csadditions = '/^X$|^D$|^T$|^P$|^R$|^A$|^M$|^LH$/';
       $noneadditions = '/^MM$|^AM$/';
 
       # First check if the call is in the proper format, A/B/C where A and C


### PR DESCRIPTION
I propose to ignore /D and /X in callsigns.

Also return empty array if DXCC is not identified.