### PR TITLE
[eQSL] Error Handling

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -186,6 +186,10 @@ class eqsl extends CI_Controller {
 
 				$status = $this->eqslmethods_model->uploadQso($adif, $qsl);
 
+				if($status == 'Error') {
+					redirect('eqsl/export');
+				}
+
 				$timestamp = strtotime($qsl['COL_TIME_ON']);
 				$rows .= "<td>" . date($custom_date_format, $timestamp) . "</td>";
 				$rows .= "<td>" . date('H:i', $timestamp) . "</td>";

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -10,13 +10,17 @@ class Eqslmethods_model extends CI_Model {
         $users = $this->get_eqsl_users();
 
         foreach ($users as $user) {
+            log_message('debug', 'eQSL Upload for: '.$user->user_eqsl_name);
             $this->uploadUser($user->user_id, $user->user_eqsl_name, $user->user_eqsl_password);
+            log_message('debug', 'eQSL Download for: '.$user->user_eqsl_name);
             $this->downloadUser($user->user_id, $user->user_eqsl_name, $user->user_eqsl_password);
         }
     }
 
     function downloadUser($userid, $username, $password) {
-        $this->load->library('EqslImporter');
+        if(!$this->load->is_loaded('EqslImporter')) {
+            $this->load->library('EqslImporter');
+        }
 
         $config['upload_path'] = './uploads/';
         $eqsl_locations = $this->all_of_user_with_eqsl_nick_defined($userid);
@@ -47,6 +51,11 @@ class Eqslmethods_model extends CI_Model {
             $adif = $this->generateAdif($qsl, $data);
 
             $status = $this->uploadQso($adif, $qsl);
+
+            if ($status == 'Error') {
+                log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
+                break;
+            }
         }
     }
 
@@ -269,12 +278,16 @@ class Eqslmethods_model extends CI_Model {
                 $this->eqsl_mark_sent($qsl['COL_PRIMARY_KEY']);
             } else {
                 if (stristr($result, "Error: No match on eQSL_User/eQSL_Pswd")) {
-                    $this->session->set_flashdata('warning', 'Your eQSL username and/or password is incorrect.');
-                    redirect('eqsl/export');
+                    $msg = __("Your eQSL username and/or password is incorrect.");
+                    log_message('error', 'eQSL: '.$msg);
+                    $this->session->set_flashdata('warning', $msg);
+                    $status = "Error";
                 } else {
                     if (stristr($result, "Result: 0 out of 0 records added")) {
-                        $this->session->set_flashdata('warning', 'Something went wrong with eQSL.cc!');
-                        redirect('eqsl/export');
+                        $msg = __("Something went wrong with eQSL.cc!");
+                        log_message('error', 'eQSL: '.$msg);
+                        $this->session->set_flashdata('warning', $msg);
+                        $status = "Error";
                     } else {
                         if (stristr($result, "Bad record: Duplicate")) {
                             $status = "Duplicate";
@@ -287,17 +300,22 @@ class Eqslmethods_model extends CI_Model {
             }
         } else {
             if ($chi['http_code'] == "500") {
-                $this->session->set_flashdata('warning', 'eQSL.cc is experiencing issues. Please try exporting QSOs later.');
-                redirect('eqsl/export');
+                $msg = __("eQSL.cc is experiencing issues. Please try exporting QSOs later.");
+                log_message('error', 'eQSL: '.$msg);
+                $this->session->set_flashdata('warning', $msg);
+                $status = "Error";
             } else {
                 if ($chi['http_code'] == "400") {
-                    $this->session->set_flashdata('warning', 'There was an error in one of the QSOs. You might want to manually upload them.');
-                    redirect('eqsl/export');
+                    $msg = __("There was an error in one of the QSOs. You might want to manually upload them.");
+                    log_message('error', 'eQSL: '.$msg);
+                    $this->session->set_flashdata('warning', $msg);
                     $status = "Error";
                 } else {
                     if ($chi['http_code'] == "404") {
-                        $this->session->set_flashdata('warning', 'It seems that the eQSL site has changed. Please open up an issue on GitHub.');
-                        redirect('eqsl/export');
+                        $msg = __("It seems that the eQSL site has changed. Please open up an issue on GitHub.");
+                        log_message('error', 'eQSL: '.$msg);
+                        $this->session->set_flashdata('warning', $msg);
+                        $status = "Error";
                     }
                 }
             }

--- a/application/views/eqsl/tools.php
+++ b/application/views/eqsl/tools.php
@@ -23,7 +23,10 @@
 
   <div class="card-body">
 		<?php $this->load->view('layout/messages'); ?>
-        <p><a class="btn btn-primary" href="<?php echo site_url('eqsl/mark_all_sent'); ?>"><?= __("Mark All QSOs as Sent to eQSL"); ?></a> <?= __("Use this if you have lots of QSOs to upload to eQSL it will save the server timing out."); ?></p>
+    <div class="alert alert-warning">
+      <p><?= __("This does NOT upload any QSOs. It only marks QSOs as sent. If you use this button you need to upload them manually on the eQSL.cc website."); ?></p>
+    </div>
+    <p><a class="btn btn-primary" href="<?php echo site_url('eqsl/mark_all_sent'); ?>"><?= __("Mark All QSOs as Sent to eQSL"); ?></a> <?= __("Use this if you have lots of QSOs to upload to eQSL it will save the server timing out."); ?></p>
   </div>
 </div>
 

--- a/system/core/Router.php
+++ b/system/core/Router.php
@@ -322,7 +322,7 @@ class CI_Router {
 			2 => $method
 		);
 
-		log_message('debug', 'No URI present. Default controller set.');
+		log_message('info', 'No URI present. Default controller set.');
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
When eQSL Sync was called by a cronjob and the upload for one user failed due a wrong password or another issue, there was a `redirect` in the code which caused the whole sync process to stop. In result of that all users AFTER the failing one weren't synced. This solves this issue by setting a proper status and breaks the foreach only for this user. By the way I added gettext to the flashmessages. 