### PR TITLE
[OQRS] iFrame Widget für Wavelog OQRS

### DIFF
--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -53,8 +53,20 @@ class Oqrs extends CI_Controller {
 		$this->load->model('oqrs_model');
 		$data['result'] = $this->oqrs_model->getQueryDataGrouped($this->input->post('callsign'));
 		$data['callsign'] = $this->security->xss_clean($this->input->post('callsign'));
+		
+		if($this->input->post('widget') != 'true') {
+			$this->load->view('oqrs/request_grouped', $data);
+		} else {
+			$data['stations'] = $this->oqrs_model->get_oqrs_stations();
+			$data['page_title'] = __("Log Search & OQRS");
+			$data['global_oqrs_text'] = $this->optionslib->get_option('global_oqrs_text');
+			$data['groupedSearch'] = 'on';
+			$data['widget_call'] = true;
 
-		$this->load->view('oqrs/request_grouped', $data);
+			$this->load->view('visitor/layout/header', $data);
+			$this->load->view('oqrs/index');
+			$this->load->view('interface_assets/footer');
+		}
 	}
 
 	public function not_in_log() {

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -46,7 +46,7 @@ class Widgets extends CI_Controller {
 		}
 	}
 
-	public function oqrs($user_callsign) {
+	public function oqrs($user_callsign = 'CALL MISSING') {
 		$this->load->model('oqrs_model');
 		$stations = $this->oqrs_model->get_oqrs_stations();
 	

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -57,7 +57,7 @@ class Widgets extends CI_Controller {
 
 		$slug = $this->security->xss_clean($this->input->get('slug'));
 		if ($slug != null) {
-			$data['logo_url'] = site_url() . '/visitor/' . $slug;
+			$data['logo_url'] = base_url() . 'index.php/visitor/' . $slug;
 		} else {
 			$data['logo_url'] = 'https://github.com/wavelog/wavelog';
 		}

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -46,26 +46,7 @@ class Widgets extends CI_Controller {
 		}
 	}
 
-	public function oqrs($logbook_slug = null) {
-		if ($logbook_slug == null || !$this->logbooks_model->public_slug_exists($logbook_slug)) {
-			show_404(__("Unknown Public Page, please make sure the public slug is correct."));
-			return;
-		}
-	
-		$logbook_id = $this->logbooks_model->public_slug_exists_logbook_id($logbook_slug);
-		if ($logbook_id == false) {
-			show_404(__("Unknown Public Page, please make sure the public slug is correct."));
-			return;
-		}
-		$this->load->model('user_model');
-		$this->load->model('stationsetup_model');
-		$user_callsign = $this->user_model->get_by_id($this->stationsetup_model->public_slug_exists_userid($logbook_slug))->row()->user_callsign;
-		if ($user_callsign == false) {
-			log_message('error', 'No user_id or user_callsign for public slug: '. $logbook_slug);
-			show_404(__("Can't find any users for this public slug."));
-			return;
-		}
-
+	public function oqrs($user_callsign) {
 		$this->load->model('oqrs_model');
 		$stations = $this->oqrs_model->get_oqrs_stations();
 	
@@ -73,11 +54,22 @@ class Widgets extends CI_Controller {
 			show_404(__("No stations found that are using Wavelog OQRS."));
 			return;
 		}
+
+		$slug = $this->security->xss_clean($this->input->get('slug'));
+		if ($slug != null) {
+			$data['logo_url'] = site_url() . '/visitor/' . $slug;
+		} else {
+			$data['logo_url'] = 'https://github.com/wavelog/wavelog';
+		}
+
+		$theme = $this->security->xss_clean($this->input->get('theme'));
+		if ($theme != null) {
+			$data['theme'] = $theme;
+		} else {
+			$data['theme'] = $this->config->item('option_theme');
+		}
 	
-		$data['slug'] = $logbook_slug;
 		$data['user_callsign'] = $user_callsign;
-		$data['groupedSearch'] = $this->optionslib->get_option('groupedSearch');
-	
-		$this->load->view('oqrs/oqrs_widget', $data);
+		$this->load->view('widgets/oqrs', $data);
 	}
 }

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -18,7 +18,7 @@ class Widgets extends CI_Controller {
 	public function qsos($logbook_slug = null) {
 
 		if($logbook_slug == null) {
-			show_error('Unknown Public Page, please make sure the public slug is correct.');
+			show_error(__("Unknown Public Page, please make sure the public slug is correct."));
 		}
 		$this->load->model('logbook_model');
 
@@ -33,16 +33,51 @@ class Widgets extends CI_Controller {
 				$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
 				if (!$logbooks_locations_array) {
-					show_404('Empty Logbook');
+					show_404(__("Empty Logbook"));
 				}
 			} else {
 				log_message('error', $logbook_slug.' has no associated station locations');
-				show_404('Unknown Public Page.');
+				show_404(__("Unknown Public Page."));
 			}
 
 			$data['last_five_qsos'] = $this->logbook_model->get_last_qsos(15, $logbooks_locations_array);
 			
 			$this->load->view('widgets/qsos', $data);
 		}
+	}
+
+	public function oqrs($logbook_slug = null) {
+		if ($logbook_slug == null || !$this->logbooks_model->public_slug_exists($logbook_slug)) {
+			show_404(__("Unknown Public Page, please make sure the public slug is correct."));
+			return;
+		}
+	
+		$logbook_id = $this->logbooks_model->public_slug_exists_logbook_id($logbook_slug);
+		if ($logbook_id == false) {
+			show_404(__("Unknown Public Page, please make sure the public slug is correct."));
+			return;
+		}
+		$this->load->model('user_model');
+		$this->load->model('stationsetup_model');
+		$user_callsign = $this->user_model->get_by_id($this->stationsetup_model->public_slug_exists_userid($logbook_slug))->row()->user_callsign;
+		if ($user_callsign == false) {
+			log_message('error', 'No user_id or user_callsign for public slug: '. $logbook_slug);
+			show_404(__("Can't find any users for this public slug."));
+			return;
+		}
+
+		$this->load->model('oqrs_model');
+		$stations = $this->oqrs_model->get_oqrs_stations();
+	
+		if ($stations->result() === NULL) {
+			show_404(__("No stations found that are using Wavelog OQRS."));
+			return;
+		}
+	
+		$data['slug'] = $logbook_slug;
+		$data['user_callsign'] = $user_callsign;
+		$data['groupedSearch'] = $this->optionslib->get_option('groupedSearch');
+	
+		$this->load->view('oqrs/oqrs_widget', $data);
 	}
 }

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -119,12 +119,14 @@ class OptionsLib {
 
     }
         
-    function get_logo($logo_location) {
+    function get_logo($logo_location, $theme = null) {
 
         $CI =& get_instance();
 
         // get the theme with the get_theme() function above
-        $theme = $this->get_theme();
+        if ($theme == null) {
+            $theme = $this->get_theme();
+        }
         
         // load the themes model and fetch the logo name from it
         $CI->load->model('Themes_model');

--- a/application/views/oqrs/index.php
+++ b/application/views/oqrs/index.php
@@ -17,9 +17,14 @@
 			echo $global_oqrs_text;
 			echo '<br /><br />';
 		}
+        if ($widget_call == true) {
+            $callsign_value = 'value="'.$callsign.'"';
+        } else {
+            $callsign_value = '';
+        }
 		if ($groupedSearch == 'on') {
 			echo __("This search will search in all station locations where OQRS is active.").'<br /><br /><form class="d-flex align-items-center" onsubmit="return false;"><label class="my-1 me-2" for="oqrssearch">' . __("Enter your callsign") . ': </label>
-			<input class="form-control me-sm-2 w-auto" id="oqrssearch" type="search" name="callsign" placeholder="' . __("Search Callsign") . '" aria-label="Search" required="required">
+			<input class="form-control me-sm-2 w-auto" id="oqrssearch" type="search" name="callsign" placeholder="' . __("Search Callsign") . '" aria-label="Search" '.$callsign_value.' required="required">
 			<button onclick="searchOqrsGrouped();" class="btn btn-sm btn-primary" id="stationbuttonsubmit" type="button"><i class="fas fa-search"></i> ' . __("Search") . '</button>
 			</form>';
 			echo '<div class="searchinfo"></div>';

--- a/application/views/oqrs/index.php
+++ b/application/views/oqrs/index.php
@@ -17,7 +17,7 @@
 			echo $global_oqrs_text;
 			echo '<br /><br />';
 		}
-        if ($widget_call == true) {
+        if (($widget_call ?? false) == true) {
             $callsign_value = 'value="'.$callsign.'"';
         } else {
             $callsign_value = '';

--- a/application/views/oqrs/oqrs_widget.php
+++ b/application/views/oqrs/oqrs_widget.php
@@ -1,0 +1,110 @@
+<!-- 
+ 
+This is a OQRS widget to place in your QRZ.com Bio or somewhere else. 
+
+To use this widget insert this Element:
+
+<iframe name="iframe" src="[YOUR WAVELOG URL]/widgets/oqrs/[PUBLIC SLUG]" height="240" width="640" frameborder="0" align="top"></iframe> -->
+
+
+<!DOCTYPE html>
+<html lang="<?php echo $language['code']; ?>">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/darkly/bootstrap.min.css">
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/darkly/overrides.css">
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
+
+    <title><?= __("Wavelog OQRS"); ?></title>
+    <style>
+        body {
+            font-family: Arial, Helvetica, sans-serif;
+        }
+
+        .widget {
+            background-color: #222222;
+            color: white;
+            display: flex;
+        }
+
+        .left-column {
+            width: 150px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            border-right: 1px solid #444;
+            padding: 10px;
+        }
+
+        .right-column {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            padding: 10px;
+        }
+
+        .top-right {
+            height: 60px;
+            display: flex;
+        }
+
+        .top-right,
+        .bottom-right {
+            justify-content: center;
+            align-items: center;
+            border-bottom: 1px solid #444;
+            padding: 10px;
+        }
+
+        .bottom-right {
+            flex: 1;
+            border-bottom: none;
+        }
+
+        .headerLogo {
+            width: 150px;
+            height: 150px;
+        }
+
+        #oqrs_callsign {
+            background-color: #343434;
+            border-color: #757575 !important;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="widget">
+        <div class="left-column">
+            <a href="<?php echo (site_url() . '/visitor/' . $slug); ?>" target="_blank"><img class="headerLogo" src="<?php echo base_url(); ?>assets/logo/<?php echo $this->optionslib->get_logo('header_logo'); ?>.png" alt="Logo" /></a>
+        </div>
+        <div class="right-column">
+            <div class="top-right">
+                <h3><?= __("Wavelog OQRS Request"); ?></h3>
+            </div>
+            <div class="bottom-right mt-3">
+                <p><?= sprintf(__("Request a QSL card for your QSO with %s."), $user_callsign); ?></p>
+                <form action="<?php echo site_url() . '/oqrs/get_qsos_grouped'; ?>" method="POST" target="_blank">
+                    <div class="row g-3 align-items-center mt-3 d-flex">
+                        <div class="col-auto">
+                            <label for="oqrs_callsign" class="col-form-label"><?= __("Your Callsign:"); ?></label>
+                        </div>
+                        <div class="col-auto">
+                            <input type="text" name="callsign" id="oqrs_callsign" class="form-control form-control-sm border">
+                        </div>
+                        <div class="col-auto">
+                            <input type="hidden" name="widget" value="true">
+                            <button type="submit" class="btn btn-sm btn-primary"><?= __("Submit Request"); ?></button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/application/views/widgets/oqrs.php
+++ b/application/views/widgets/oqrs.php
@@ -14,20 +14,14 @@ To use this widget insert this Element:
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/darkly/bootstrap.min.css">
-    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/darkly/overrides.css">
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/bootstrap.min.css">
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/overrides.css">
     <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
 
     <title><?= __("Wavelog OQRS"); ?></title>
     <style>
-        body {
-            font-family: Arial, Helvetica, sans-serif;
-        }
-
-        .widget {
-            background-color: #222222;
-            color: white;
-            display: flex;
+        .widget.container {
+            max-width: none;
         }
 
         .left-column {
@@ -65,7 +59,7 @@ To use this widget insert this Element:
             border-bottom: none;
         }
 
-        .headerLogo {
+        .widgetLogo {
             width: 150px;
             height: 150px;
         }
@@ -78,9 +72,9 @@ To use this widget insert this Element:
 </head>
 
 <body>
-    <div class="widget">
+    <div class="widget container d-flex">
         <div class="left-column">
-            <a href="<?php echo (site_url() . '/visitor/' . $slug); ?>" target="_blank"><img class="headerLogo" src="<?php echo base_url(); ?>assets/logo/<?php echo $this->optionslib->get_logo('header_logo'); ?>.png" alt="Logo" /></a>
+            <a href="<?php echo $logo_url; ?>" target="_blank"><img class="widgetLogo" src="<?php echo base_url(); ?>assets/logo/<?php echo $this->optionslib->get_logo('header_logo', $theme); ?>.png" alt="Logo" /></a>
         </div>
         <div class="right-column">
             <div class="top-right">

--- a/application/views/widgets/oqrs.php
+++ b/application/views/widgets/oqrs.php
@@ -82,7 +82,7 @@ To use this widget insert this Element:
             </div>
             <div class="bottom-right mt-3">
                 <p><?= sprintf(__("Request a QSL card for your QSO with %s."), $user_callsign); ?></p>
-                <form action="<?php echo site_url() . '/oqrs/get_qsos_grouped'; ?>" method="POST" target="_blank">
+                <form action="<?php echo base_url() . 'index.php/oqrs/get_qsos_grouped'; ?>" method="POST" target="_blank">
                     <div class="row g-3 align-items-center mt-3 d-flex">
                         <div class="col-auto">
                             <label for="oqrs_callsign" class="col-form-label"><?= __("Your Callsign:"); ?></label>

--- a/application/views/widgets/oqrs.php
+++ b/application/views/widgets/oqrs.php
@@ -88,7 +88,7 @@ To use this widget insert this Element:
                             <label for="oqrs_callsign" class="col-form-label"><?= __("Your Callsign:"); ?></label>
                         </div>
                         <div class="col-auto">
-                            <input type="text" name="callsign" id="oqrs_callsign" class="form-control form-control-sm border">
+                            <input type="text" name="callsign" id="oqrs_callsign" class="form-control form-control-sm border uppercase">
                         </div>
                         <div class="col-auto">
                             <input type="hidden" name="widget" value="true">

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1038,3 +1038,7 @@ label {
 .blank-row {
 	height: 20px !important;
 }
+
+.uppercase {
+	text-transform: uppercase;
+}

--- a/assets/js/sections/oqrs.js
+++ b/assets/js/sections/oqrs.js
@@ -592,6 +592,10 @@ $(document).ready(function () {
         });
     });
 
+    if($('#oqrssearch').val() != '') {
+        searchOqrsGrouped();
+    }
+
 });
 
 function selectQsoID(qsoID) {


### PR DESCRIPTION
Simple iFrame Widget which can be placed in a QRZ.com Bio or on any other website which allows iframes

<img width="653" alt="image" src="https://github.com/user-attachments/assets/5a27699c-1eae-421b-9a61-96d6a30a8070">

To use this widget place it somewhere with this iframe code:

```html
<iframe name="iframe" src="[WAVELOG URL]/widgets/oqrs/[CALLSIGN]" height="220" width="670" frameborder="0"></iframe>
```
> [!IMPORTANT]  
> Due the fact that this HTML is not responsive yet I recommend to stick with `height="220" width="670"` in the iframe. You may have to play a little bit with these settings to find the right spot. 
---
### Options 
The Widget is customizable. Currently available options:

- `theme`
  Choose the theme widget with one of the themes in Wavelog
  Example: `theme=darkly`

- `slug`
  The Widgetlogo is a link which shows per default on Wavelog's Github Repo (https://github.com/wavelog/wavelog). You can set your public view page instead by defining the public slug of the particular logbook. 
Example: `slug=hb9hil`
  
 To add options just place them as GET parameter in the URL like this:
```
[WAVELOG URL]/widgets/oqrs/[CALLSIGN]?theme=darkly&slug=hb9hil
```
