### PR TITLE
Add curl to installer required modules

### DIFF
--- a/install/includes/install_config/install_config.php
+++ b/install/includes/install_config/install_config.php
@@ -39,3 +39,7 @@ $required_php_modules = [
 // MariaDB / MySQL
 $mariadb_version = 10.1;
 $mysql_version = 5.7;
+
+// PHP modules that are directly required for the installer
+global $installer_required_modules;
+$installer_required_modules = array("mbstring", "curl");

--- a/install/includes/install_config/install_lib.php
+++ b/install/includes/install_config/install_lib.php
@@ -133,3 +133,15 @@ function detect_nginx_php_setting($http_scheme) {
    curl_close($ch);
    return $code;
 }
+
+function installer_required_modules() {
+   $installer_required_modules = array("mbstring", "curl");
+   $not_found_modules = array();
+   foreach ($installer_required_modules as $module) {
+      if (!extension_loaded($module)) {
+         //unset($installer_required_modules[$module]);
+         array_push($not_found_modules, 'php-'.$module);
+      }
+   }
+   return $not_found_modules;
+}

--- a/install/includes/install_config/install_lib.php
+++ b/install/includes/install_config/install_lib.php
@@ -135,11 +135,10 @@ function detect_nginx_php_setting($http_scheme) {
 }
 
 function installer_required_modules() {
-   $installer_required_modules = array("mbstring", "curl");
+   global $installer_required_modules;
    $not_found_modules = array();
    foreach ($installer_required_modules as $module) {
       if (!extension_loaded($module)) {
-         //unset($installer_required_modules[$module]);
          array_push($not_found_modules, 'php-'.$module);
       }
    }

--- a/install/index.php
+++ b/install/index.php
@@ -16,7 +16,7 @@ if (!file_exists('.lock')) {
 
 	// php-mbstring has to be installed for the installer to work properly!!
 	// The other prechecks can be run within the installer.
-	if ($required_php_modules['php-mbstring']['condition']) { ?>
+	if ($required_php_modules['php-mbstring']['condition'] && $required_php_modules['php-curl']['condition']) { ?>
 
 
 		<body>
@@ -1897,9 +1897,9 @@ if (!file_exists('.lock')) {
 					<div class="card-body text-center p-4">
 						<h3 style="margin-top: 50px;"><?= __("PHP Module missing"); ?></h3>
 						<img src="assets/images/danger_triangle.png" alt="danger_triangle" style="max-width: 400px; height: auto; margin-bottom: 50px;">
-						<p><?= sprintf(__("The PHP module %s is missing."), "<code>php-mbstring</code>"); ?></p>
+						<p><?= __("The following PHP modules are missing:")." <code>".implode(',', installer_required_modules())."</code>"; ?></p>
 						<p><?= __("Without this module the Wavelog Installer does not work!"); ?></p>
-						<p><?= sprintf(__("Install %s and restart the webserver."), "<code>php-mbstring</code>"); ?></p>
+						<p><?= __("Please install the required modules and restart the webserver."); ?></p>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
PR https://github.com/wavelog/wavelog/pull/652 contained only half of the truth as curl is also required for the nginx checker to work. Without this the same bug as for mbstring occurs for users using nginx as webserver.

So made the function a little more versatile by adding a list for pre-installer required modules so that it is extendable should there be need in the future. Currently it has mbstring and curl.