### PR TITLE
Changed to use contest name in Cabrillo export, if available

### DIFF
--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -265,8 +265,8 @@ class Contesting_model extends CI_Model {
 		$station_id = $this->Stations->find_active();
 
 		$sql = "select col_contest_id, min(date(col_time_on)) mindate, max(date(col_time_on)) maxdate, year(col_time_on) year, month(col_time_on) month
-			from " . $this->config->item('table_name') . " 
-			where coalesce(COL_CONTEST_ID, '') <> '' 
+			from " . $this->config->item('table_name') . "
+			where coalesce(COL_CONTEST_ID, '') <> ''
 			and station_id =" . $station_id;
 
 		$sql .= " group by COL_CONTEST_ID , year(col_time_on), month(col_time_on) order by year(col_time_on) desc";
@@ -279,8 +279,8 @@ class Contesting_model extends CI_Model {
 	function get_logged_years($station_id) {
 
 		$sql = "select distinct year(col_time_on) year
-			from " . $this->config->item('table_name') . " 
-			where coalesce(COL_CONTEST_ID, '') <> '' 
+			from " . $this->config->item('table_name') . "
+			where coalesce(COL_CONTEST_ID, '') <> ''
 			and station_id =" . $station_id;
 
 		$sql .= " order by year(col_time_on) desc";
@@ -291,9 +291,10 @@ class Contesting_model extends CI_Model {
 	}
 
 	function get_logged_contests($station_id, $year) {
-		$sql = "select distinct col_contest_id
-			from " . $this->config->item('table_name') . " 
-			where coalesce(COL_CONTEST_ID, '') <> '' 
+		$sql = "select distinct col_contest_id, coalesce(contest.name, col_contest_id) contestname
+			from " . $this->config->item('table_name') . " thcv
+			left outer join contest on thcv.col_contest_id = contest.adifname
+			where coalesce(COL_CONTEST_ID, '') <> ''
 			and station_id =" . $station_id .
 			" and year(col_time_on) ='" . $year . "'";
 
@@ -306,8 +307,8 @@ class Contesting_model extends CI_Model {
 
 	function get_contest_dates($station_id, $year, $contestid) {
 		$sql = "select distinct (date(col_time_on)) date
-			from " . $this->config->item('table_name') . " 
-			where coalesce(COL_CONTEST_ID, '') <> '' 
+			from " . $this->config->item('table_name') . "
+			where coalesce(COL_CONTEST_ID, '') <> ''
 			and station_id =" . $station_id .
 			" and year(col_time_on) ='" . $year . "' and col_contest_id ='" . $contestid . "'";
 

--- a/assets/js/sections/cabrillo.js
+++ b/assets/js/sections/cabrillo.js
@@ -12,7 +12,7 @@ function loadYears() {
                 $(".contestyear").append('<div class="col-md-3 control-label" for="year">' + lang_export_cabrillo_select_year + '</div>' +
                 '<select id="year" class="form-select my-1 me-sm-2 col-md-2 w-auto" name="year">' +
                 '</select>' +
-                '  <button onclick="loadContests();" class="btn btn-sm btn-primary w-auto" type="button">' + lang_export_cabrillo_proceed + '</button>'); 
+                '  <button onclick="loadContests();" class="btn btn-sm btn-primary w-auto" type="button">' + lang_export_cabrillo_proceed + '</button>');
 
                 $.each(data, function(key, value) {
                     $('#year')
@@ -40,13 +40,13 @@ function loadContests() {
                 $(".contestname").append('<div class="col-md-3 control-label" for="contestid">' + lang_export_cabrillo_select_contest + '</div>' +
                 '<select class="form-select my-1 me-sm-2 col-md-4 w-auto" id="contestid" name="contestid">' +
                 '</select>' +
-                '  <button onclick="loadContestDates();" class="btn btn-sm btn-primary w-auto" type="button">' + lang_export_cabrillo_proceed + '</button>'); 
+                '  <button onclick="loadContestDates();" class="btn btn-sm btn-primary w-auto" type="button">' + lang_export_cabrillo_proceed + '</button>');
 
                 $.each(data, function(key, value) {
                     $('#contestid')
                         .append($("<option></option>")
                         .attr("value",value.col_contest_id)
-                        .text(value.col_contest_id));
+                        .text(value.contestname));
                 });
         }
     });
@@ -66,7 +66,7 @@ function loadContestDates() {
                 '</select>' +
                 '<select class="form-select my-1 me-sm-2 col-md-2 w-auto" id="contestdatesto" name="contestdatesto">' +
                 '</select>' +
-                '  <button class="btn btn-sm btn-primary w-auto" onclick="addAdditionalInfo();" type="button">' + lang_export_cabrillo_proceed + '</button>'); 
+                '  <button class="btn btn-sm btn-primary w-auto" onclick="addAdditionalInfo();" type="button">' + lang_export_cabrillo_proceed + '</button>');
 
                 $.each(data, function(key, value) {
                     $('#contestdatesfrom')
@@ -75,7 +75,7 @@ function loadContestDates() {
                         .text(value.date));
                 });
 
-                
+
                 $.each(data, function(key, value) {
                     $('#contestdatesto')
                         .append($("<option></option>")


### PR DESCRIPTION
Use contest name if available (contest id if not) when doing a Cabrillo export:
![image](https://github.com/user-attachments/assets/ff4620a9-d799-4b46-97af-229b47dafda0)
