### PR TITLE
New API to pull ADIF QSO data for a defined station

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -273,6 +273,17 @@ class API extends CI_Controller {
 		$station_id = $obj['station_id'];
 		$goalpost = $obj['goalpost'];
 
+		//check if goalpost is numeric as an additional layer of SQL injection prevention
+		if(!is_numeric($goalpost))
+		{
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "Invalid goalpost."]);
+			return;
+		}
+
+		//make sure the goalpost is an integer
+		$goalpost = (int)$goalpost;
+
 		//load stations API
 		$this->load->model('stations');
 

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -237,6 +237,90 @@ class API extends CI_Controller {
 
 	}
 
+	function get_contacts_adif() {
+
+		//set header
+		header('Content-type: application/json');
+
+		//load API model
+		$this->load->model('api_model');
+
+		// Decode JSON and store
+		$obj = json_decode(file_get_contents("php://input"), true);
+		if ($obj === NULL) {
+		    http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "wrong JSON"]);
+			return;
+		}
+
+		//do authorization
+		if(!isset($obj['key']) || $this->api_model->authorize($obj['key']) == 0) {
+		   http_response_code(401);
+		   echo json_encode(['status' => 'failed', 'reason' => "missing api key"]);
+			return;
+		}
+
+		//check for relevant fields in JSON input
+		if(!isset($obj['station_id']) or !isset($obj['goalpost']))
+		{
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "Not all required fields were present in input JSON"]);
+			return;
+		}
+
+		//extract relevant data to variables
+		$key = $obj['key'];
+		$station_id = $obj['station_id'];
+		$goalpost = $obj['goalpost'];
+
+		//load stations API
+		$this->load->model('stations');
+
+		//get all stations of user to check if station_id should be readable
+		$userid = $this->api_model->key_userid($key);
+		$station_ids = array();
+		$stations=$this->stations->all_of_user($userid);
+
+		//extract to array
+		foreach ($stations->result() as $row) {
+			array_push($station_ids, $row->station_id);
+		}
+
+		//return error if station not accessible for the API key
+		if(!in_array($station_id, $station_ids))
+		{
+			http_response_code(401);
+	 	   	echo json_encode(['status' => 'failed', 'reason' => "Station ID not accessible for this API key"]);
+			return;
+		}
+
+		//load adif data module
+		$this->load->model('adif_data');
+		$data['qsos'] = $this->adif_data->export_past_goalpost($station_id, $goalpost);
+		$qso_count = count($data['qsos']->result());
+		
+		//if no new QSOs are ready, return that
+		if($qso_count <= 0)
+		{
+			http_response_code(200);
+			echo json_encode(['status' => 'successfull', 'message' => 'No new QSOs available.', 'newgoalpost' => $goalpost, 'exported_qsos' => 0, 'adif' => null]);
+		}
+
+		//convert data to ADIF
+		$adif_content = $this->load->view('adif/data/exportapi', $data, TRUE);
+
+		//get new goalpost
+		$newgoalpost = 0;
+		foreach ($data['qsos']->result() as $row) {
+			$newgoalpost = max($newgoalpost, $row->COL_PRIMARY_KEY);
+		}		
+
+		//return API result
+		http_response_code(200);
+		echo json_encode(['status' => 'successfull', 'message' => 'Export successfull', 'newgoalpost' => $newgoalpost, 'exported_qsos' => $qso_count, 'adif' => $adif_content]);
+	}
+
+
 	// API function to check if a callsign is in the logbook already
 	function logbook_check_callsign() {
 		header('Content-type: application/json');

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -297,7 +297,7 @@ class API extends CI_Controller {
 		//load adif data module
 		$this->load->model('adif_data');
 		$data['qsos'] = $this->adif_data->export_past_goalpost($station_id, $goalpost);
-		$qso_count = count($data['qsos']->result());
+		$qso_count = count($data['qsos']->result()); 
 		
 		//if no new QSOs are ready, return that
 		if($qso_count <= 0)

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -137,6 +137,20 @@ class adif_data extends CI_Model {
         return $this->db->get();
     }
 
+    function export_past_goalpost($station_id, $goalpost) {
+        //create query
+        $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
+        $this->db->from($this->config->item('table_name'));
+        $this->db->where($this->config->item('table_name').'.station_id', $station_id);
+        $this->db->where($this->config->item('table_name').".COL_PRIMARY_KEY > " . $goalpost); //only get values past the goalpost
+        $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
+        $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
+        $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif', 'left outer');
+
+        //return result
+        return $this->db->get();
+    }
+
     function export_lotw() {
         $this->load->model('stations');
         $active_station_id = $this->stations->find_active();

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -142,7 +142,7 @@ class adif_data extends CI_Model {
         $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $station_id);
-        $this->db->where($this->config->item('table_name').".COL_PRIMARY_KEY > " . $goalpost); //only get values past the goalpost
+        $this->db->where($this->config->item('table_name').".COL_PRIMARY_KEY > " , $goalpost); //only get values past the goalpost
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
         $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif', 'left outer');

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -137,12 +137,12 @@ class adif_data extends CI_Model {
         return $this->db->get();
     }
 
-    function export_past_goalpost($station_id, $goalpost) {
+    function export_past_id($station_id, $fetchfromid) {
         //create query
         $this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
         $this->db->from($this->config->item('table_name'));
         $this->db->where($this->config->item('table_name').'.station_id', $station_id);
-        $this->db->where($this->config->item('table_name').".COL_PRIMARY_KEY > " , $goalpost); //only get values past the goalpost
+        $this->db->where($this->config->item('table_name').".COL_PRIMARY_KEY > " , $fetchfromid); //only get values past the fetchfromid value
         $this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
         $this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
         $this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif', 'left outer');

--- a/application/views/adif/data/exportapi.php
+++ b/application/views/adif/data/exportapi.php
@@ -1,0 +1,13 @@
+Wavelog ADIF export
+<ADIF_VER:5>3.1.4
+<PROGRAMID:<?php echo strlen($this->config->item('app_name')); ?>><?php echo $this->config->item('app_name')."\r\n"; ?>
+<PROGRAMVERSION:<?php echo strlen($this->optionslib->get_option('version')); ?>><?php echo $this->optionslib->get_option('version')."\r\n"; ?>
+<EOH>
+
+<?php
+$CI =& get_instance();
+$CI->load->library('AdifHelper');
+
+foreach ($qsos->result() as $qso) {
+    echo $CI->adifhelper->getAdifLine($qso);
+}


### PR DESCRIPTION
Added a new API endpoint to pull ADIF QSO data out of wavelog from an external software using a read API key.

This enables other software to consistently pull new emerging QSO data for a station without wavelog having to deal with the "accounting" specifics. This will allow smaller software to integrate with wavelog without requiring wavelog to explicitly support each and every niche one of them.

Full disclosure: This API would be used by Hamawardz.app, a award tracking software written by me. Not yet open source, but it will be. This API would be an alternative to the native manual ADIF upload for the users.

Testing can be done like that:
`curl -d '{"key":"MYKEY","station_id":1, "fetchfromid":1}' http://log.address.here/index.php/api/get_contacts_adif`