### PR TITLE
VUCC grids are not plotted correctly on the dashboard map

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5002,6 +5002,7 @@ function lotw_last_qsl_date($user_id) {
           $stn_loc = $this->qra->qra2latlong($row->COL_GRIDSQUARE);
 
         } elseif ($row->COL_VUCC_GRIDS != null) {
+          $coords = array();
           $grids = explode(",", $row->COL_VUCC_GRIDS);
           if (count($grids) == 2) {
             $grid1 = $this->qra->qra2latlong(trim($grids[0]));


### PR DESCRIPTION
VUCC grids are not plotted correctly on the dashboard map at least.

![Screenshot from 2024-07-30 22-39-20](https://github.com/user-attachments/assets/f82d1631-ed27-443c-a0c4-e6e988f73cd0)

The reason is that the array holding to grids for a specific QSO is not reset but added to for multiple QSOs. Thus all further multi grid QSOs after the first one get an unplausible midpoint. See screenshot.