### PR TITLE
Apply user defined units to distance plots on map

### DIFF
--- a/assets/js/leaflet/geocoding.js
+++ b/assets/js/leaflet/geocoding.js
@@ -107,7 +107,29 @@ function onMapClick(event) {
 
 	var result = bearingDistance(homegrid, locator);
 
-	var distance = Math.round(result.km * 10) / 10 + ' km';
+	let unit;
+
+	switch (measurement_base) {
+		case 'M':
+			result.distance = result.distance * 3959;
+			unit = 'mi';
+			break;
+		case 'K':
+			result.distance = result.distance * 6371;
+			unit = 'km';
+			break;
+		case 'N':
+			result.distance = result.distance * 3440;
+			unit = 'nmi';
+			break;
+		default:
+			result.distance = result.distance * 6371;
+			unit = 'km';
+			break;
+	}
+
+
+	var distance = Math.round(result.distance * 10) / 10 + ' ' +unit;
 	var bearing = Math.round(result.deg * 10) / 10 + ' deg';
 	var popupmessage = '<div class="popup">' +
 	'From gridsquare: ' + homegrid + '<br />To gridsquare: ' + locator +'<br />Distance: ' + distance+ '<br />Bearing: ' + bearing +

--- a/assets/js/leaflet/geocoding.js
+++ b/assets/js/leaflet/geocoding.js
@@ -90,7 +90,7 @@ function onMapMove(event) {
 			break;
 	}
 
-	$('#bearing').html(distance.deg + ' deg');
+	$('#bearing').html(distance.deg + '°');
 	$('#distance').html(Math.round(distance.distance * 10) / 10 + ' ' +unit);
 };
 
@@ -130,7 +130,7 @@ function onMapClick(event) {
 
 
 	var distance = Math.round(result.distance * 10) / 10 + ' ' +unit;
-	var bearing = Math.round(result.deg * 10) / 10 + ' deg';
+	var bearing = Math.round(result.deg * 10) / 10 + '°';
 	var popupmessage = '<div class="popup">' +
 	'From gridsquare: ' + homegrid + '<br />To gridsquare: ' + locator +'<br />Distance: ' + distance+ '<br />Bearing: ' + bearing +
 	'</div>';


### PR DESCRIPTION
Distance plot on map was broken in https://github.com/wavelog/wavelog/pull/605 as user defined units where added. Results in distance being shown an NaN:

![Screenshot from 2024-07-31 08-53-14](https://github.com/user-attachments/assets/d4f7b70e-8aa8-4296-9097-ede8f1eddc71)
