### PR TITLE
Do not update QRG if it wasn't provided via API-Call

### DIFF
--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -26,10 +26,14 @@
 				'sat_name' => $result['sat_name'] ?? NULL,
 				'timestamp' => $timestamp,
 			);
-			if (isset($result['frequency']) && $result['frequency'] != "NULL") {
+			if ( (isset($result['frequency'])) && ($result['frequency'] != "NULL") && ($result['frequency'] != '') ) {
 				$data['frequency'] = $result['frequency'];
 			} else {
-				$data['frequency'] = $result['uplink_freq'];
+				if ( (isset($result['uplink_freq'])) && ($result['uplink_freq'] != "NULL") && ($result['uplink_freq'] != '') ) {
+					$data['frequency'] = $result['uplink_freq'];
+				} else {
+					unset($data['frequency']);	// Do not update Frequency since it wasn't provided
+				}
 			}
 			if (isset($result['mode']) && $result['mode'] != "NULL") {
 				$data['mode'] = $result['mode'];


### PR DESCRIPTION
Fixes a bug, when QRG is empty/not provided at API-Call.

Old Behaviour:
- `curl -d '{ "key":"YOUR_KEY", "radio":"TEST", "frequency":14414000, "mode":"SSB"}' https://[YOUR_URL]/api/radio`
sets QRG to 14.414 MHz
- `curl -d '{ "key":"YOUR_KEY", "radio":"TEST", "frequency":"", "mode":"SSB"}' https://[YOUR_URL]/api/radio`
afterwards will cause a PHP-Error

New Behaviour:
- `curl -d '{ "key":"YOUR_KEY", "radio":"TEST", "frequency":14414000, "mode":"SSB"}' https://[YOUR_URL]/api/radio`
sets QRG to 14.414 MHz
- `curl -d '{ "key":"YOUR_KEY", "radio":"TEST", "frequency":"", "mode":"SSB"}' https://[YOUR_URL]/api/radio`
afterwards will leave the QRG at 14.414 MHz