### PR TITLE
Fix a bug when 0 QSOs are returned for pull api

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -325,6 +325,7 @@ class API extends CI_Controller {
 		{
 			http_response_code(200);
 			echo json_encode(['status' => 'successfull', 'message' => 'No new QSOs available.', 'lastfetchedid' => $fetchfromid, 'exported_qsos' => 0, 'adif' => null]);
+			return;
 		}
 
 		//convert data to ADIF


### PR DESCRIPTION
There is a bug in PR #664.

If there are 0 QSOs returned, the API returns 2 different JSON-Responses due to a missing return statement.

I added the return statement.

Testing can be done like that:
`curl -d '{"key":"MYKEY","station_id":1, "fetchfromid":someidiotichighnumber}' http://log.address.here/index.php/api/get_contacts_adif`