### PR TITLE
Fix LoTW signing for Quebec and Newfoundland and Labrador

### DIFF
--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -66,9 +66,9 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 
 $sign_string = "";
 
-// Adds CA Prov
+// Adds CA Province
 if($station_profile->state != "" && $station_profile->station_country == "CANADA") {
-	$sign_string .= strtoupper($station_profile->state);
+	$sign_string .= strtoupper($CI->lotw_ca_province_map($station_profile->state));
 }
 
 // Add CQ Zone


### PR DESCRIPTION
Resolves #689

Adds lotw_ca_province_map to the sign_string to avoid a missmatch when signing QSOs from Quebec and Newfoundland and Labrador

![image](https://github.com/user-attachments/assets/73d81bc1-e59b-4ae4-8bdf-1920c937fc25)
![image](https://github.com/user-attachments/assets/4c0e8585-c74e-487a-a1ec-aed7ad62a0b3)
