### PR TITLE
Fix calculation of distance if wked from same-grid or other errors

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -140,7 +140,9 @@ class Qra {
 		} else if ($unit == "N") {
 			$dist *= 0.8684;
 		}
-
+		if ((is_nan($dist)) || !(is_numeric($dist))) { 	// Special-Case, catch same grid and/or Errors
+			$dist=0;
+		}
 		return round($dist, 1);
 	}
 


### PR DESCRIPTION
Unter special circumstances the PHP-function returns „NAN“, which causes trouble at some places.

This one sets the distance to `0` instead of `NAN`

Tnx to @dg9vh for finding this one