### PR TITLE
Fixes a bug where $band wasn't set

### DIFF
--- a/application/views/gridmap/index.php
+++ b/application/views/gridmap/index.php
@@ -56,7 +56,7 @@
                         <option value="MS"><?= _pgettext("Propagation Mode","Meteor scatter"); ?></option>
                         <option value="RPT"><?= _pgettext("Propagation Mode","Terrestrial or atmospheric repeater or transponder"); ?></option>
                         <option value="RS"><?= _pgettext("Propagation Mode","Rain scatter"); ?></option>
-                        <option value="SAT" <?php if ($user_default_band == ($band ?? '')) {echo 'selected="selected"';} ?>><?= _pgettext("Propagation Mode","Satellite"); ?></option>
+                        <option value="SAT" <?php if ($user_default_band == 'SAT') {echo 'selected="selected"';} ?>><?= _pgettext("Propagation Mode","Satellite"); ?></option>
                         <option value="TEP"><?= _pgettext("Propagation Mode","Trans-equatorial"); ?></option>
                         <option value="TR"><?= _pgettext("Propagation Mode","Tropospheric ducting"); ?></option>
                     </select>

--- a/application/views/gridmap/index.php
+++ b/application/views/gridmap/index.php
@@ -56,7 +56,7 @@
                         <option value="MS"><?= _pgettext("Propagation Mode","Meteor scatter"); ?></option>
                         <option value="RPT"><?= _pgettext("Propagation Mode","Terrestrial or atmospheric repeater or transponder"); ?></option>
                         <option value="RS"><?= _pgettext("Propagation Mode","Rain scatter"); ?></option>
-                        <option value="SAT" <?php if ($user_default_band == $band) {echo 'selected="selected"';} ?>><?= _pgettext("Propagation Mode","Satellite"); ?></option>
+                        <option value="SAT" <?php if ($user_default_band == ($band ?? '')) {echo 'selected="selected"';} ?>><?= _pgettext("Propagation Mode","Satellite"); ?></option>
                         <option value="TEP"><?= _pgettext("Propagation Mode","Trans-equatorial"); ?></option>
                         <option value="TR"><?= _pgettext("Propagation Mode","Tropospheric ducting"); ?></option>
                     </select>


### PR DESCRIPTION
Reproduceable by adding a new user and navigating (with that new user) directly to gridmap.

Reason was:
`$band` was iterated at the top of the view. So if the user had a QSO on `SAT` the Var `$band` stayed at SAT (even outside the loop).
This caused a correct behaviour (but was wrong implemented).

if there's a user without ANY QSO, `$band` is empty (because the loop found nothing to loop). This caused a PHP-Warning.

interesting bug ;)