### PR TITLE
fix osm tile copyright attribution

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -737,7 +737,7 @@ function showActivatorsMap(call, count, grids) {
     var maidenhead = new L.maidenheadactivators(grid_four).addTo(map);
 
     var osmUrl='<?php echo $this->optionslib->get_option('option_map_tile_server');?>';
-    var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
+    var osmAttrib='<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>';
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 12, attribution: osmAttrib});
 
     map.addLayer(osm);

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -736,8 +736,8 @@ function showActivatorsMap(call, count, grids) {
 
     var maidenhead = new L.maidenheadactivators(grid_four).addTo(map);
 
-    var osmUrl='<?php echo $this->optionslib->get_option('option_map_tile_server');?>';
-    var osmAttrib='<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>';
+    var osmUrl = '<?php echo $this->optionslib->get_option('option_map_tile_server');?>';
+    var osmAttrib = option_map_tile_server_copyright;
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 12, attribution: osmAttrib});
 
     map.addLayer(osm);

--- a/assets/js/leaflet/leafembed.js
+++ b/assets/js/leaflet/leafembed.js
@@ -14,7 +14,7 @@ function initmap(ShowGrid='No', MapTag='map', options={}) {
     // set up the map
     map = new L.Map(MapTag);
     // create the tile layer with correct attribution
-    var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
+	var osmAttrib = option_map_tile_server_copyright;
     var osm = new L.TileLayer(osmUrl, {minZoom: 1, maxZoom: 12, attribution: osmAttrib});
 
 	var printer = L.easyPrint({

--- a/assets/js/sections/cqmap.js
+++ b/assets/js/sections/cqmap.js
@@ -51,7 +51,7 @@ function load_cq_map2(data) {
     L.tileLayer(
         osmUrl,
         {
-            attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+            attribution: option_map_tile_server_copyright,
             maxZoom: 18
         }
     ).addTo(map);

--- a/assets/js/sections/dxccmap.js
+++ b/assets/js/sections/dxccmap.js
@@ -76,7 +76,7 @@ function load_dxcc_map2(data, worked, confirmed, notworked) {
     L.tileLayer(
         osmUrl,
         {
-            attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+            attribution: option_map_tile_server_copyright,
             maxZoom: 18
         }
     ).addTo(map);

--- a/assets/js/sections/helvetiamap.js
+++ b/assets/js/sections/helvetiamap.js
@@ -56,7 +56,7 @@ function load_helvetia_map2(data) {
   L.tileLayer(
 	  osmUrl,
 	  {
-		  attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+          attribution: option_map_tile_server_copyright,
 		  maxZoom: 18
 	  }
   ).addTo(map);

--- a/assets/js/sections/iotamap.js
+++ b/assets/js/sections/iotamap.js
@@ -55,7 +55,7 @@ function load_iota_map2(data, worked, confirmed, notworked) {
     L.tileLayer(
         osmUrl,
         {
-            attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+            attribution: option_map_tile_server_copyright,
             maxZoom: 18
         }
     ).addTo(map);

--- a/assets/js/sections/itumap.js
+++ b/assets/js/sections/itumap.js
@@ -144,7 +144,7 @@ function load_itu_map2(data) {
     L.tileLayer(
         osmUrl,
         {
-            attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+			attribution: option_map_tile_server_copyright,
             maxZoom: 18
         }
     ).addTo(map);

--- a/assets/js/sections/jccmap.js
+++ b/assets/js/sections/jccmap.js
@@ -47,7 +47,7 @@ function load_jcc_map2(data, worked, confirmed, notworked) {
     L.tileLayer(
         osmUrl,
         {
-            attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+            attribution: option_map_tile_server_copyright,
             maxZoom: 18
         }
     ).addTo(map);

--- a/assets/js/sections/racmap.js
+++ b/assets/js/sections/racmap.js
@@ -73,7 +73,7 @@ function load_rac_map2(data) {
   L.tileLayer(
 	  osmUrl,
 	  {
-		  attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+      attribution: option_map_tile_server_copyright,
 		  maxZoom: 18
 	  }
   ).addTo(map);

--- a/assets/js/sections/wajamap.js
+++ b/assets/js/sections/wajamap.js
@@ -157,7 +157,7 @@ const mapcoordinates = { "type": "FeatureCollection", "features": [
   L.tileLayer(
 	  osmUrl,
 	  {
-		  attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+      attribution: option_map_tile_server_copyright,
 		  maxZoom: 18
 	  }
   ).addTo(map);

--- a/assets/js/sections/wasmap.js
+++ b/assets/js/sections/wasmap.js
@@ -164,7 +164,7 @@ const mapcoordinates = { "type": "FeatureCollection", "features": [
   L.tileLayer(
 	  osmUrl,
 	  {
-		  attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+		  attribution: option_map_tile_server_copyright,
 		  maxZoom: 18
 	  }
   ).addTo(map);


### PR DESCRIPTION
In some places where we call Leaflet, the code still uses the hard-coded attribution: `Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors'`. 

This PR makes it use the value which is defined in database (row `map_tile_server_copyright` in `options` table).

Code description: 

JS variable `option_map_tile_server_copyright` is defined in `views/interface_assets/footer.php`. 
https://github.com/wavelog/wavelog/blob/646ccf2783042ba6390cea1ecc5ab4d3996b7b3c/application/views/interface_assets/footer.php#L6

All JS files which are changed in this PR can access it safely.