### PR TITLE
Fix map attribution

### DIFF
--- a/application/views/visitor/exportmap/footer.php
+++ b/application/views/visitor/exportmap/footer.php
@@ -16,6 +16,7 @@
 	var base_url = "<?php echo base_url(); ?>"; // Base URL
 	var site_url = "<?php echo site_url(); ?>"; // Site URL
 	var icon_dot_url = "<?php echo base_url();?>assets/images/dot.png";
+	var option_map_tile_server_copyright = '<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>';
 </script>
     <script id="leafembed" type="text/javascript" src="<?php echo base_url();?>assets/js/leaflet/leafembed.js" tileUrl="<?php echo $this->optionslib->get_option('map_tile_server');?>"></script>
 	<script type="text/javascript" src="<?php echo base_url();?>assets/js/sections/exportmap.js"></script>

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -18,6 +18,7 @@
   var base_url = "<?php echo base_url(); ?>"; // Base URL
   var site_url = "<?php echo site_url(); ?>"; // Site URL
   var icon_dot_url = "<?php echo base_url();?>assets/images/dot.png";
+  var option_map_tile_server_copyright = '<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>';
 </script>
 
 <!-- DATATABLES LANGUAGE -->

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -94,7 +94,7 @@ if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_language
 <script type="text/javascript" src="<?php echo base_url();?>assets/js/sections/gridmap.js?"></script>
 
 <script>
-  
+
   // auto setting of gridmap height
   function set_map_height() {
 
@@ -117,13 +117,13 @@ if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_language
       $('#gridsquare_map').css('height', gridsquareMapHeight + 'px');
       // console.log('#gridsquare_map: ' + gridsquareMapHeight);
   }
-</script>  
+</script>
 
 <script>
 
   var layer = L.tileLayer('<?php echo $this->optionslib->get_option('option_map_tile_server');?>', {
     maxZoom: 18,
-    attribution: '<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>',
+    attribution: option_map_tile_server_copyright,
     id: 'mapbox.streets'
   });
 

--- a/assets/js/sections/exportmap.js
+++ b/assets/js/sections/exportmap.js
@@ -48,8 +48,7 @@ function loadQsos(slug, iconsList) {
 }
 
 function loadMap(data, iconsList) {
-	var osmUrl=tileUrl;
-	var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
+	var osmUrl = tileUrl;
 	// If map is already initialized
 	var container = L.DomUtil.get('exportmap');
 
@@ -71,7 +70,7 @@ function loadMap(data, iconsList) {
 	var osm = L.tileLayer(
 		osmUrl,
 		{
-			attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+			attribution: option_map_tile_server_copyright,
 			maxZoom: 18,
 			zoom: 3,
             minZoom: 2,

--- a/assets/js/sections/logbookadvanced_map.js
+++ b/assets/js/sections/logbookadvanced_map.js
@@ -220,7 +220,7 @@ const ituzonenames = [
 function loadMap(data, iconsList) {
 	$('#mapButton').prop("disabled", false).removeClass("running");
 	var osmUrl = tileUrl;
-	var osmAttrib='Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors';
+	var osmAttrib = option_map_tile_server_copyright;
 	// If map is already initialized
 	var container = L.DomUtil.get('advancedmap');
 
@@ -257,7 +257,7 @@ function loadMap(data, iconsList) {
 	var osm = L.tileLayer(
 		osmUrl,
 		{
-			attribution: '&copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+			attribution: osmAttrib,
 			maxZoom: 18,
 			zoom: 3,
             minZoom: 2,


### PR DESCRIPTION
Another part of #730.

This PR includes two commits:

1. In #730, a change was introduced to use the `option_map_tile_server_copyright` variable. But in some page, i.e. `/visitor/<callsign>`, the `/views/interface_assets/footer` is not included. So that `leafembed.js` cannot access that variable. This commit is a fix.
2. Make logbook_advanced map to use the attribution info. 

I'm still in the test to see if other page is affected with the change. So far there's no other impact. If I notice more I'll submit another PR.