### PR TITLE
Fix visitor satellite page grids not showing when logged out

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -224,7 +224,7 @@ class Visitor extends CI_Controller {
 
 
 		// Get Confirmed LoTW & Paper Squares (non VUCC)
-		$query = $this->gridmap_model->get_band_confirmed('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band_confirmed('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', 'All', $logbooks_locations_array);
 
 
 		if ($query && $query->num_rows() > 0)
@@ -260,7 +260,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Get worked squares
-		$query = $this->gridmap_model->get_band('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', 'All', $logbooks_locations_array);
 
 		if ($query && $query->num_rows() > 0)
 		{
@@ -294,7 +294,7 @@ class Visitor extends CI_Controller {
 			}
 		}
 
-		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', 'All', $logbooks_locations_array);
 
 		if ($query && $query_vucc->num_rows() > 0)
 		{
@@ -321,7 +321,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Confirmed Squares
-		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'false', 'All', 'All', 'All', $logbooks_locations_array);
 
 		if ($query && $query_vucc->num_rows() > 0)
 		{


### PR DESCRIPTION
### Issue: 

If the user is logged out, the grids not showing in visitor satellite page (`/visitor/satellites/<slug>`). It shows nothing on the map. While being logged in, it shows again.


### Root cause: 

```
get_band_confirmed() 
get_band() 
get_band_worked_vucc_squares() 
get_band_confirmed_vucc_squares()
```

Each of these 4 functions takes 10 arguments, while we only give them 9 in `/application/controllers/Visitor.php`. 

The last two arguments are `.., $propagation, $logbooks_locations_array = NULL`. 

If we give it 9 arguments and we are logged in, the code will re-fetch the associated logbook id from session. 

And it seems that whatever propogation mode string we pass, it just works without warnings.