### PR TITLE
Support both operators and special callsigns on same instance

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -73,6 +73,9 @@ $config['use_auth'] = true;
 $config['auth_table'] = 'users';
 $config['auth_mode'] = '3';
 
+# enable this if you want a special / club callsign
+# $config['auth_level'][2] = 'Special Callsign';
+
 $config['auth_level'][3] = 'Operator';
 $config['auth_level'][99] = 'Administrator';
 
@@ -631,7 +634,7 @@ $config['disable_manual_qrz'] = false;
 | Disables QSL-Image-Feature
 |--------------------------------------------------------------------------
 |
-| This disabled the whole QSL image feature if you don't need it and want to hide it. 
+| This disabled the whole QSL image feature if you don't need it and want to hide it.
 | Set to true will hide all QSL image related stuff in Wavelog
 |
 */
@@ -643,7 +646,7 @@ $config['disable_qsl'] = false;
 | Disables OQRS-Feature
 |--------------------------------------------------------------------------
 |
-| This disabled the whole OQRS feature if you don't need it and want to hide it. 
+| This disabled the whole OQRS feature if you don't need it and want to hide it.
 | Set to true will hide all OQRS related stuff in Wavelog
 |
 */
@@ -658,15 +661,16 @@ $config['disable_oqrs'] = false;
 | This config switch is meant to use for Special Callsign operations in a dedicated Wavelog Installation
 | If this switch is set to true it will enable a dialog which pops up for each operator after login
 | to ask for his personal callsign. This causes the QSOs to get saved with the correct operator data.
-| Example:      Special Callsign:   DL250CDF 
+| Example:      Special Callsign:   DL250CDF
 |               Operator:           DF2TG
-| 
-| It is recommend to enable also "Disable Syncing to 3rd party-Services at UI" 
-| More Information about this feature and how to use it, you can find here: 
+|
+| It is recommend to enable also "Disable Syncing to 3rd party-Services at UI"
+| More Information about this feature and how to use it, you can find here:
 | https://github.com/wavelog/wavelog/wiki/Recommended-Setup-for-Special-Callsigns-and-Clubs
 */
 
 $config['special_callsign'] = false;
 
 // hides the usermenu; takes action only if "special_callsign" is true
-$config['sc_hide_usermenu'] = true;   
+$config['sc_hide_usermenu'] = true;
+

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -155,8 +155,8 @@ if($this->session->userdata('user_id') != null) {
     let sc_account_call = '<?php echo $account_call; ?>'
 
 	<?php
-    # if the operator call and the account call is the same we show the dialog (except for admins!)
-    if ($op_call == $account_call && $user_type != '99') { ?>
+    # if the operator call and the account call is the same we show the dialog (only for special callsigns)
+    if ($op_call == $account_call && $user_type == '2') { ?>
 
         // load the dialog with javascript
         displayOperatorDialog();

--- a/assets/js/sections/operator.js
+++ b/assets/js/sections/operator.js
@@ -33,7 +33,7 @@ function closeOperatorDialog() {
 
 function saveOperator() {
 	var operatorInput = $("#operator_callsign");
-	var operatorCallsign = operatorInput.val();
+	var operatorCallsign = operatorInput.val().trim();
 
 	if (operatorCallsign != "" && operatorCallsign != sc_account_call) {
 		$.ajax({


### PR DESCRIPTION
This patch adds a special auth_level for special callsings and only shows the operator popup if the user has the special_callsign auth_level.