### PR TITLE
Added support for format without comma

### DIFF
--- a/application/controllers/Contestcalendar.php
+++ b/application/controllers/Contestcalendar.php
@@ -72,7 +72,6 @@ class Contestcalendar extends CI_Controller {
 		return $rssData;
 	}
 
-
 	private function parseTimeRange($string) {
 		$timeData = array();
 
@@ -86,7 +85,19 @@ class Contestcalendar extends CI_Controller {
 
 			// create proper dateTime
 			$timeData['start'] = DateTime::createFromFormat('Hi\Z, M d', $start);
+
+			if (!$timeData['start']) {
+				// If the first format didn't match, try the format without the comma
+				$timeData['start'] = DateTime::createFromFormat('Hi\Z M d', $start);
+			}
+
 			$timeData['end'] = DateTime::createFromFormat('Hi\Z, M d', $end);
+
+			if (!$timeData['end']) {
+				// If the first format didn't match, try the format without the comma
+				$timeData['end'] = DateTime::createFromFormat('Hi\Z M d', $end);
+			}
+
 		} else {
 
 			// split in start and end time


### PR DESCRIPTION
Now supports this format as well: 0600Z Aug 24 to 0559Z, Aug 25

Does not support this: 2200Z, Aug 23 to 1200Z, Aug 24 and 1200Z-2359Z, Aug 25
or this 1400Z, Aug 24 to 0200Z, Aug 25 and 1400Z-2000Z, Aug 25.

The code can't fetch end date.