### PR TITLE
[LoTW] Fix flash messages and catch the case if a user tries to upload a 'key-only' file

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -149,14 +149,14 @@ class Lotw extends CI_Controller {
         		$this->Lotw_model->store_certificate($this->session->userdata('user_id'), $info['issued_callsign'], $info['dxcc-id'], $info['validFrom'], $info['validTo_Date'], $info['qso-first-date'], $info['qso-end-date'], $info['pem_key'], $info['general_cert']);
 
         		// Cert success flash message
-        		$this->session->set_flashdata('Success', $info['issued_callsign'].' Certificate Imported.');
+        		$this->session->set_flashdata('success', $info['issued_callsign'] . ' ' . __("Certificate Imported."));
         	} else {
         		// Certificate is in the system time to update
 
 				$this->Lotw_model->update_certificate($this->session->userdata('user_id'), $info['issued_callsign'], $info['dxcc-id'], $info['validFrom'], $info['validTo_Date'], $info['qso-first-date'], $info['qso-end-date'], $info['pem_key'], $info['general_cert']);
 
         		// Cert success flash message
-        		$this->session->set_flashdata('Success', $info['issued_callsign'].' Certificate Updated.');
+        		$this->session->set_flashdata('success', $info['issued_callsign'] . ' ' . __("Certificate Updated."));
 
         	}
 
@@ -381,9 +381,9 @@ class Lotw extends CI_Controller {
 
     	$this->Lotw_model->delete_certificate($this->session->userdata('user_id'), $cert_id);
 
-    	$this->session->set_flashdata('Success', 'Certificate Deleted.');
+    	$this->session->set_flashdata('success', __("Certificate Deleted."));
 
-    	redirect('/lotw/');
+    	redirect('lotw');
     }
 
 
@@ -422,16 +422,16 @@ class Lotw extends CI_Controller {
 			    log_message('error', openssl_error_string());
 
 			    // Set warning message redirect to LoTW main page
-			    $this->session->set_flashdata('Warning', openssl_error_string());
-				redirect('/lotw/');
+			    $this->session->set_flashdata('warning', openssl_error_string());
+				redirect('lotw');
 			}
 		} else {
 			// Reading p12 failed log error message
 			log_message('error', openssl_error_string());
 
 			// Set warning message redirect to LoTW main page
-			$this->session->set_flashdata('Warning', openssl_error_string());
-			redirect('/lotw/');
+			$this->session->set_flashdata('warning', openssl_error_string());
+			redirect('lotw');
 		}
 
 		// Read Cert Data
@@ -742,7 +742,7 @@ class Lotw extends CI_Controller {
 				// TODO: We don't actually see the error message
 				if ($data['user_lotw_name'] == '' || $data['user_lotw_password'] == '')
 				{
-					$this->session->set_flashdata('warning', 'You have not defined your ARRL LoTW credentials!'); redirect('lotw/import');
+					$this->session->set_flashdata('warning', __("You have not defined your ARRL LoTW credentials!")); redirect('lotw/import');
 				}
 
 				$customDate = $this->input->post('from');
@@ -860,7 +860,7 @@ class Lotw extends CI_Controller {
 
 			if ($fields['login'] == '' || $fields['password'] == '')
 			{
-				$this->session->set_flashdata('warning', 'You have not defined your ARRL LoTW credentials!'); redirect('lotw/status');
+				$this->session->set_flashdata('warning', __("You have not defined your ARRL LoTW credentials!")); redirect('lotw/status');
 			}
 
 			// Curl stuff goes here
@@ -905,7 +905,7 @@ class Lotw extends CI_Controller {
 			$result = curl_exec($ch);
 			if (stristr($result, "Username/password incorrect"))
 			{
-			   $this->session->set_flashdata('warning', 'Your ARRL username and/or password is incorrect.'); redirect('lotw/status');
+			   $this->session->set_flashdata('warning', __("Your ARRL username and/or password is incorrect.")); redirect('lotw/status');
 			}
 
 

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -405,7 +405,14 @@ class Lotw extends CI_Controller {
 		$filename = file_get_contents('file://'.$file);
 		$worked = openssl_pkcs12_read($filename, $results, $password);
 
-		$data['general_cert'] = $results['cert'];
+		if ($results['cert']) {
+			$data['general_cert'] = $results['cert'];
+		} else {
+			log_message('error', 'Found no cert in '.$file);
+			unlink($file);
+			$this->session->set_flashdata('warning', sprintf(__("Found no cert in %s. If the filename contains 'key-only', this p12 file is not activated by LoTW yet."), $file));
+			redirect('lotw');
+		}
 
 
 		if($worked) {

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -22,13 +22,9 @@
 				<div class="alert alert-danger" role="alert">
 			  	<?php echo $error; ?>
 				</div>
-	    	<?php } ?>
-
-	    	<?php if(isset($_SESSION['Success'])) { ?>
-				<div class="alert alert-success" role="alert">
-			  	<?php echo $_SESSION['Success']; ?>
-				</div>
-	    	<?php } ?>
+	    	<?php } ?>	
+		
+			<?php $this->load->view('layout/messages'); ?>
 
 	    	<?php if ($lotw_cert_results->num_rows() > 0) { ?>
 


### PR DESCRIPTION
Fixed the flash messages in LoTW index and

if a user tries to upload a 'key-only' p12 file, Wavelog crashes with a Error 500. This catches this case and redirects to the lotw page with a warning (see second commit)