### PR TITLE
[CRON] Allow insecure self-signed certificates with config switch

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -683,3 +683,16 @@ $config['sc_hide_usermenu'] = true;
 */
 
 $config['disable_impersonate'] = false;   
+
+
+/*
+|--------------------------------------------------------------------------
+| Cronmanager Allow Insecure
+|--------------------------------------------------------------------------
+|
+| The cronmanager needs http or https with a valid certificate to work.
+| If you want to use it with https and a self-signed certificate, you need to set this to true.
+| 
+*/
+
+$config['cron_allow_insecure'] = false;   

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -37,7 +37,7 @@ class cron extends CI_Controller {
 
 		$data['page_title'] = __("Cron Manager");
 		$data['crons'] = $this->cron_model->get_crons();
-		$data['cron_allow_insecure'] = $this->config->item('cron_allow_insecure');
+		$data['cron_allow_insecure'] = $this->config->item('cron_allow_insecure') ?? false;
 
 		$mastercron = array();
 		$mastercron = $this->get_mastercron_status();
@@ -95,7 +95,7 @@ class cron extends CI_Controller {
 						curl_setopt($ch, CURLOPT_HEADER, false);
 						curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
 						curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-						if ($this->config->item('cron_allow_insecure') == true) {
+						if ($this->config->item('cron_allow_insecure') ?? false == true) {
 							curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 						}
 						$crun = curl_exec($ch);

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -94,6 +94,9 @@ class cron extends CI_Controller {
 						curl_setopt($ch, CURLOPT_HEADER, false);
 						curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
 						curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+						if ($this->config->item('cron_allow_insecure') == true) {
+							curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+						}
 						$crun = curl_exec($ch);
 						curl_close($ch);
 

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -37,6 +37,7 @@ class cron extends CI_Controller {
 
 		$data['page_title'] = __("Cron Manager");
 		$data['crons'] = $this->cron_model->get_crons();
+		$data['cron_allow_insecure'] = $this->config->item('cron_allow_insecure');
 
 		$mastercron = array();
 		$mastercron = $this->get_mastercron_status();
@@ -257,19 +258,19 @@ class cron extends CI_Controller {
 			$diff = $now->getTimestamp() - $timestamp_last_run->getTimestamp(); 
 
 			if ($diff >= 0 && $diff <= $warning_timelimit_seconds) {
-				$result['status'] = 'OK';
+				$result['status'] = __("OK");
 				$result['status_class'] = 'success';
 			} else {
 				if ($diff <= $error_timelimit_seconds) {
-					$result['status'] = 'Last run occurred more than ' . $warning_timelimit_seconds . ' seconds ago.<br>Please check your master cron! It should run every minute (* * * * *).';
+					$result['status'] = sprintf(__("Last run occurred more than %s seconds ago.<br>Please check your master cron! It should run every minute (* * * * *)."), $warning_timelimit_seconds);
 					$result['status_class'] = 'warning';
 				} else {
-					$result['status'] = 'Last run occurred more than ' . ($error_timelimit_seconds / 60) . ' minutes ago.<br>Seems like your Mastercron isn\'t running!<br>It should run every minute (* * * * *).';
+					$result['status'] = sprintf(__("Last run occurred more than %s minutes ago.<br>Seems like your Mastercron isn't running!<br>It should run every minute (* * * * *)."), ($error_timelimit_seconds / 60));
 					$result['status_class'] = 'danger';
 				}
 			}
 		} else {
-			$result['status'] = 'Not running';
+			$result['status'] = _pgettext("Master Cron", "Not running");
 			$result['status_class'] = 'danger';
 		}
 	

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -262,10 +262,10 @@ class cron extends CI_Controller {
 				$result['status_class'] = 'success';
 			} else {
 				if ($diff <= $error_timelimit_seconds) {
-					$result['status'] = sprintf(__("Last run occurred more than %s seconds ago.<br>Please check your master cron! It should run every minute (* * * * *)."), $warning_timelimit_seconds);
+					$result['status'] = sprintf(__("Last run occurred more than %s seconds ago.%sPlease check your master cron! It should run every minute (* * * * *)."), $warning_timelimit_seconds, '<br>');
 					$result['status_class'] = 'warning';
 				} else {
-					$result['status'] = sprintf(__("Last run occurred more than %s minutes ago.<br>Seems like your Mastercron isn't running!<br>It should run every minute (* * * * *)."), ($error_timelimit_seconds / 60));
+					$result['status'] = sprintf(__("Last run occurred more than %s minutes ago.%sSeems like your Mastercron isn't running!%sIt should run every minute (* * * * *)."), ($error_timelimit_seconds / 60), '<br>', '<br>');
 					$result['status_class'] = 'danger';
 				}
 			}

--- a/application/views/cron/index.php
+++ b/application/views/cron/index.php
@@ -14,17 +14,19 @@
                     <p class="card-text">
                         <?= __("The Cron Manager assists the administrator in managing cron jobs without requiring CLI access."); ?>
                     </p>
-                    <p class="card-text">
-                        <?= __("To execute cron jobs based on the data below, remove all old cron jobs and create a new one:"); ?>
-                    </p>
-                    <div class="main_cronjob">
-                        <pre><code id="main_cronjob">* * * * * curl --silent <?php echo base_url(); ?>index.php/cron/run &>/dev/null</code><span data-bs-toggle="tooltip" title="<?= __("Copy to clipboard"); ?>" onclick='copyCron("main_cronjob")'><i class="copy-icon fas fa-copy"></i></span></pre>
-                    </div>
+                    <?php if ($mastercron['status_class'] != 'success') { ?>
+                        <p class="card-text">
+                            <?= __("To execute cron jobs based on the data below, remove all old cron jobs and create a new one:"); ?>
+                        </p>
+                        <div class="main_cronjob">
+                            <pre><code id="main_cronjob">* * * * * curl --silent <?php if ($cron_allow_insecure) { echo '--insecure '; } echo base_url(); ?>index.php/cron/run &>/dev/null</code><span data-bs-toggle="tooltip" title="<?= __("Copy to clipboard"); ?>" onclick='copyCron("main_cronjob")'><i class="copy-icon fas fa-copy"></i></span></pre>
+                        </div>
+                    <?php } ?>
                 </div>
                 <div class="col text-end" id="alert_status">
                     <?php if (version_compare(PHP_VERSION, $min_php_version) >= 0) { ?>
                         <div class="alert alert-<?php echo $mastercron['status_class'] ?? 'danger'; ?> d-inline-block">
-                            <?= __("Status Master-Cron"); ?>: <?php echo $mastercron['status'] ?? 'Not running'; ?>
+                            <?= __("Status Master-Cron"); ?>: <?php echo $mastercron['status'] ?? _pgettext("Master Cron", "Not running"); ?>
                         </div>
                     <?php } else { ?>
                         <div class="alert alert-danger d-inline-block">

--- a/application/views/cron/index.php
+++ b/application/views/cron/index.php
@@ -26,11 +26,11 @@
                 <div class="col text-end" id="alert_status">
                     <?php if (version_compare(PHP_VERSION, $min_php_version) >= 0) { ?>
                         <div class="alert alert-<?php echo $mastercron['status_class'] ?? 'danger'; ?> d-inline-block">
-                            <?= __("Status Master-Cron"); ?>: <?php echo $mastercron['status'] ?? _pgettext("Master Cron", "Not running"); ?>
+                            <?= __("Status Master-Cron:"); ?><br><?php echo $mastercron['status'] ?? _pgettext("Master Cron", "Not running"); ?>
                         </div>
                     <?php } else { ?>
                         <div class="alert alert-danger d-inline-block">
-                            <?= __("Status Master-Cron"); ?>:<br><?= __("PHP Version not supported."); ?><br><?= _pgettext("PHP Version", "Min. Version is"); ?> <?php echo $min_php_version; ?>
+                            <?= __("Status Master-Cron:"); ?><br><?= __("PHP Version not supported."); ?><br><?= _pgettext("PHP Version", "Min. Version is"); ?> <?php echo $min_php_version; ?>
                         </div>
                     <?php } ?>
                 </div>

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -683,3 +683,16 @@ $config['sc_hide_usermenu'] = true;
 */
 
 $config['disable_impersonate'] = false;   
+
+
+/*
+|--------------------------------------------------------------------------
+| Cronmanager Allow Insecure
+|--------------------------------------------------------------------------
+|
+| The cronmanager needs http or https with a valid certificate to work.
+| If you want to use it with https and a self-signed certificate, you need to set this to true.
+| 
+*/
+
+$config['cron_allow_insecure'] = false;   


### PR DESCRIPTION
Some users want to use the cronmanager while `$config['base_url]` contains a https url with a self-signed certificate. This does not work and results in failing jobs.

In this case you now can set `$config['cron_allow_insecure'] = true; ` in the `config.php` to allow the curl option `--insecure` (or `-k`)

In addition to that I did some small UI adjustments