### PR TITLE
Create a helper to read in a optional local_url to bypass the need to…

### DIFF
--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -89,7 +89,9 @@ class cron extends CI_Controller {
 						echo "CRON: " . $cron->id . " -> RUNNING...\n";
 
 						$url = local_url() . $cron->function;
-						echo "CRON: " . $cron->id . " -> URL: " . $url . "\n";
+                        if (ENVIRONMENT == "development") {
+						    echo "CRON: " . $cron->id . " -> URL: " . $url . "\n";
+                        }
 
 						$ch = curl_init();
 						curl_setopt($ch, CURLOPT_URL, $url);

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -88,7 +88,7 @@ class cron extends CI_Controller {
 						echo "CRON: " . $cron->id . " -> is due: " . $isdue_result . "\n";
 						echo "CRON: " . $cron->id . " -> RUNNING...\n";
 
-						$url = base_url() . $cron->function;
+						$url = local_url() . $cron->function;
 
 						$ch = curl_init();
 						curl_setopt($ch, CURLOPT_URL, $url);

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -89,6 +89,7 @@ class cron extends CI_Controller {
 						echo "CRON: " . $cron->id . " -> RUNNING...\n";
 
 						$url = local_url() . $cron->function;
+						echo "CRON: " . $cron->id . " -> URL: " . $url . "\n";
 
 						$ch = curl_init();
 						curl_setopt($ch, CURLOPT_URL, $url);

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -326,6 +326,8 @@ class CI_Config {
 	 * Local URL
 	 *
 	 * Returns local_url [. uri_string]
+	 * 
+	 * If local_url is not defined return base_url instead.
 	 *
 	 * @uses	CI_Config::_uri_string()
 	 *

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -335,7 +335,7 @@ class CI_Config {
 	 */
 	public function local_url($uri = '', $protocol = NULL)
 	{
-		$local_url = $this->slash_item('local_url');
+		$local_url = $this->slash_item('local_url') ?? $this->slash_item('base_url');
 		if (isset($protocol))
 		{
 			// For protocol-relative links

--- a/system/core/Config.php
+++ b/system/core/Config.php
@@ -322,6 +322,36 @@ class CI_Config {
 		return $base_url.$this->_uri_string($uri);
 	}
 
+	/**
+	 * Local URL
+	 *
+	 * Returns local_url [. uri_string]
+	 *
+	 * @uses	CI_Config::_uri_string()
+	 *
+	 * @param	string|string[]	$uri	URI string or an array of segments
+	 * @param	string	$protocol
+	 * @return	string
+	 */
+	public function local_url($uri = '', $protocol = NULL)
+	{
+		$local_url = $this->slash_item('local_url');
+		if (isset($protocol))
+		{
+			// For protocol-relative links
+			if ($protocol === '')
+			{
+				$local_url = substr($local_url, strpos($local_url, '//'));
+			}
+			else
+			{
+				$local_url = $protocol.substr($local_url, strpos($local_url, '://'));
+			}
+		}
+
+		return $local_url.$this->_uri_string($uri);
+	}
+
 	// -------------------------------------------------------------
 
 	/**

--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -97,8 +97,6 @@ if ( ! function_exists('local_url'))
 	 * within e.g. the docker container to the base_url use this url
 	 * for cron jobs.
 	 * 
-	 * If local_url is not defined return base_url instead.
-	 * 
 	 * @param	string	$uri
 	 * @param	string	$protocol
 	 * @return	string

--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -88,6 +88,28 @@ if ( ! function_exists('base_url'))
 	}
 }
 
+if ( ! function_exists('local_url'))
+{
+	/**
+	 * Local URL
+	 * 
+	 * For cornercases where you have no access to the base_url from 
+	 * within e.g. the docker container to the base_url use this url
+	 * for cron jobs.
+	 * 
+	 * If local_url is not defined return base_url instead.
+	 * 
+	 * @param	string	$uri
+	 * @param	string	$protocol
+	 * @return	string
+	 */
+
+	 function local_url($uri = '', $protocol = NULL)
+	 {
+		return get_instance()->config->local_url($uri, $protocol) ?? get_instance()->config->base_url($uri, $protocol);
+	 }
+}
+
 // ------------------------------------------------------------------------
 
 if ( ! function_exists('current_url'))

--- a/system/helpers/url_helper.php
+++ b/system/helpers/url_helper.php
@@ -106,7 +106,7 @@ if ( ! function_exists('local_url'))
 
 	 function local_url($uri = '', $protocol = NULL)
 	 {
-		return get_instance()->config->local_url($uri, $protocol) ?? get_instance()->config->base_url($uri, $protocol);
+		return get_instance()->config->local_url($uri, $protocol);
 	 }
 }
 


### PR DESCRIPTION
Hey,

I think i solved the issue with the cronmanager (at least for me). 

This patch will create a config option "local_url" which can be used to provide an alternative url to access the cronmanager  (e.g. "http://localhost/".

If this option is not set the base_url will be returned instead.