### PR TITLE
Intercept eqsl image errors (which are not rate limits)

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -353,7 +353,6 @@ class eqsl extends CI_Controller {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
 		}
-		$this->load->library('electronicqsl');
 		$this->load->model('Eqsl_images');
 
 		$this->load->model('logbook_model');
@@ -438,6 +437,7 @@ class eqsl extends CI_Controller {
 			redirect('dashboard');
 		}
 		$errors = 0;
+		$this->load->library('electronicqsl');
 
 		if ($this->input->post('eqsldownload') == 'download') {
 			$i = 0;

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -318,7 +318,12 @@ class eqsl extends CI_Controller {
 			$images = $dom->getElementsByTagName('img');
 
 			if (!isset($images) || count($images) == 0) {
-				echo "Rate Limited";
+				$h3 = $dom->getElementsByTagName('h3');
+				if (isset($h3)) {
+					echo $h3->item(0)->nodeValue;
+				} else {
+					echo "Rate Limited";
+				}
 				exit;
 			}
 

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -384,7 +384,12 @@ class eqsl extends CI_Controller {
 		$images = $dom->getElementsByTagName('img');
 
 		if (!isset($images) || count($images) == 0) {
-			$error = "Rate Limited";
+			$h3 = $dom->getElementsByTagName('h3');
+			if (isset($h3)) {
+				$error = $h3->item(0)->nodeValue;
+			} else {
+				$error = "Rate Limited";
+			}
 			return $error;
 		}
 
@@ -402,7 +407,6 @@ class eqsl extends CI_Controller {
 				}
 			}
 		}
-		return $error;
 	}
 
 	public function tools() {


### PR DESCRIPTION
Sometimes eqsl fails to provide images. Looks like this:

![Screenshot from 2024-08-26 17-26-49](https://github.com/user-attachments/assets/9434d438-80f4-4d0e-be7b-277cabd9b87d)

We try to catch this error and proceed with the rest of the queue. After patch:

![Screenshot from 2024-08-26 17-25-16](https://github.com/user-attachments/assets/4b76ab49-428b-4abe-a612-19289b9e655b)
