### PR TITLE
Prevent QRA lib being loaded over and over again (and spilling debug log)

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -33,7 +33,7 @@ class QSO extends CI_Controller {
 		$data['notice'] = false;
 		$data['stations'] = $this->stations->all_of_user();
 		$data['radios'] = $this->cat->radios();
-        $data['radio_last_updated'] = $this->cat->last_updated()->row();
+		$data['radio_last_updated'] = $this->cat->last_updated()->row();
 		$data['query'] = $this->logbook_model->last_custom('5');
 		$data['dxcc'] = $this->logbook_model->fetchDxcc();
 		$data['iota'] = $this->logbook_model->fetchIota();
@@ -596,14 +596,15 @@ class QSO extends CI_Controller {
 
    // Return Previous QSOs Made in the active logbook
    public function component_past_contacts() {
-	   if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
-	   $this->load->model('logbook_model');
-	   session_write_close();
+      $this->load->library('Qra');
+      if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
+      $this->load->model('logbook_model');
+      session_write_close();
 
-	   $data['query'] = $this->logbook_model->last_custom('5');
+      $data['query'] = $this->logbook_model->last_custom('5');
 
-	   // Load view
-	   $this->load->view('qso/components/previous_contacts', $data);
+      // Load view
+      $this->load->view('qso/components/previous_contacts', $data);
    }
 
    public function get_eqsl_default_qslmsg() {	// Get ONLY Default eQSL-Message with this function. This is ONLY for QSO relevant!

--- a/application/views/qso/components/previous_contacts.php
+++ b/application/views/qso/components/previous_contacts.php
@@ -62,7 +62,6 @@ function echo_table_col($row, $name) {
 		case 'WWFF':    echo '<td>' . ($row->COL_WWFF_REF) . '</td>'; break;
 		case 'POTA':    echo '<td>' . ($row->COL_POTA_REF) . '</td>'; break;
 		case 'Grid':
-			$ci->load->library('qra');
 			echo '<td>' . ($ci->qra->echoQrbCalcLink($row->COL_MY_GRIDSQUARE, $row->COL_VUCC_GRIDS, $row->COL_GRIDSQUARE)) . '</td>'; break;
 		case 'Distance':    echo '<td>' . ($row->COL_DISTANCE ? $row->COL_DISTANCE . '&nbsp;km' : '') . '</td>'; break;
 		case 'Band':    echo '<td>'; if($row->COL_SAT_NAME != null) { echo '<a href="https://db.satnogs.org/search/?q='.$row->COL_SAT_NAME.'" target="_blank">'.$row->COL_SAT_NAME.'</a></td>'; } else { echo strtolower($row->COL_BAND); } echo '</td>'; break;


### PR DESCRIPTION
Display of last 5 contacts tries to load QRA lib on every single line. This spills the debug log with 5 lines every 5 seconds (if activated). We should prevent this. Excerpt from the log:

```
DEBUG - 2024-08-27 10:38:33 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:33 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:33 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:33 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:40 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:40 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:40 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:40 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:46 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:46 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:46 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:46 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:52 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:52 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:52 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:52 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:58 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:58 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:58 --> Qra class already loaded. Second attempt ignored.
DEBUG - 2024-08-27 10:38:58 --> Qra class already loaded. Second attempt ignored.
```