### PR TITLE
[CONTEST] Store Settings in Database

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 214;
+$config['migration_version'] = 215;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -24,7 +24,7 @@ class Contesting extends CI_Controller {
 		// Getting the live/post mode from GET command
         // 0 = live
         // 1 = post (manual)
-        $get_manual_mode = $this->security->xss_clean($this->input->get('manual'));
+        $get_manual_mode = $this->input->get('manual', true);
         if ($get_manual_mode == '0' || $get_manual_mode == '1') {
             $data['manual_mode'] = $get_manual_mode;
         } else {
@@ -55,7 +55,7 @@ class Contesting extends CI_Controller {
 		session_write_close();
 		$this->load->model('Contesting_model');
 
-		$qso = $this->input->post('qso');
+		$qso = $this->input->post('qso', true);
 
 		header('Content-Type: application/json');
 		echo json_encode($this->Contesting_model->getSessionQsos($qso));
@@ -72,7 +72,7 @@ class Contesting extends CI_Controller {
 	public function deleteSession() {
 		$this->load->model('Contesting_model');
 
-		$qso = $this->input->post('qso');
+		$qso = $this->input->post('qso', true);
 
 		$data = $this->Contesting_model->deleteSession($qso);
 
@@ -83,7 +83,8 @@ class Contesting extends CI_Controller {
 		$this->load->model('Contesting_model');
 		$this->Contesting_model->setSession();
 
-		$this->session->set_userdata('radio', $this->input->post('radio'));
+		$this->session->set_userdata('radio', $this->input->post('radio', true));
+		
 		header('Content-Type: application/json');
 		echo json_encode($this->Contesting_model->getSession());
 	}
@@ -145,13 +146,13 @@ class Contesting extends CI_Controller {
 	}
 
 	public function delete() {
-		$id = $this->input->post('id');
+		$id = $this->input->post('id', true);
 		$this->load->model('Contesting_model');
 		$this->Contesting_model->delete($id);
 	}
 
 	public function activate() {
-		$id = $this->input->post('id');
+		$id = $this->input->post('id', true);
 		$this->load->model('Contesting_model');
 		$this->Contesting_model->activate($id);
 		header('Content-Type: application/json');
@@ -160,7 +161,7 @@ class Contesting extends CI_Controller {
 	}
 
 	public function deactivate() {
-		$id = $this->input->post('id');
+		$id = $this->input->post('id', true);
 		$this->load->model('Contesting_model');
 		$this->Contesting_model->deactivate($id);
 		header('Content-Type: application/json');
@@ -189,10 +190,10 @@ class Contesting extends CI_Controller {
 	 */
 	public function checkIfWorkedBefore() {
 		session_write_close();
-		$call = $this->input->post('call');
-		$band = $this->input->post('band');
-		$mode = $this->input->post('mode');
-		$contest = $this->input->post('contest');
+		$call = $this->input->post('call', true);
+		$band = $this->input->post('band', true);
+		$mode = $this->input->post('mode', true);
+		$contest = $this->input->post('contest', true);
 
 		$this->load->model('Contesting_model');
 

--- a/application/migrations/215_add_contest_settings.php
+++ b/application/migrations/215_add_contest_settings.php
@@ -1,0 +1,24 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_add_contest_settings extends CI_Migration {
+
+    public function up()
+    {
+		$fields = array(
+			'settings TEXT default NULL',
+		);
+
+		if (!$this->db->field_exists('settings', 'contest_session')) {
+			$this->dbforge->add_column('contest_session', $fields);
+		}
+	}
+
+    public function down()
+    {
+		if ($this->db->field_exists('settings', 'contest_session')) {
+			$this->dbforge->drop_column('contest_session', 'settings');
+		}
+	}
+}

--- a/application/migrations/215_add_contest_settings.php
+++ b/application/migrations/215_add_contest_settings.php
@@ -7,18 +7,60 @@ class Migration_add_contest_settings extends CI_Migration {
     public function up()
     {
 		$fields = array(
-			'settings TEXT default NULL',
+			'settings' => array(
+				'type' => 'TEXT',
+				'null' => TRUE,
+			),
 		);
 
+		// Get the current data so we can add it back in
+		$data = array(
+			'exchangetype' => $this->db->get('contest_session')->row()->exchangetype,
+			'exchange_sequence' => 's-g-e',
+			'copyexchangeto' => $this->db->get('contest_session')->row()->copytodok,
+		);
+
+		// Add the settings field to the contest_session table
 		if (!$this->db->field_exists('settings', 'contest_session')) {
 			$this->dbforge->add_column('contest_session', $fields);
+
+			// We also can drop the now unused columns
+			$this->dbforge->drop_column('contest_session', 'exchangetype');
+			$this->dbforge->drop_column('contest_session', 'copytodok');
+
+			// Update the settings field with the old data
+			$this->db->update('contest_session', array('settings' => json_encode($data)));
 		}
 	}
 
     public function down()
     {
+		// Drop the settings field from the contest_session table
 		if ($this->db->field_exists('settings', 'contest_session')) {
 			$this->dbforge->drop_column('contest_session', 'settings');
 		}
+
+		$fields = array(
+			'exchangetype' => array(
+				'type' => 'VARCHAR',
+				'constraint' => 20,
+				'unsigned' => TRUE,
+				'null' => TRUE,
+				'after' => 'contestid',
+			),
+			'copytodok' => array(
+				'type' => 'INT',
+				'constraint' => 10,
+				'unsigned' => TRUE,
+				'null' => TRUE,
+				'after' => 'serialsent',
+			),
+		);
+		
+		// Add the fields to the contest_session table
+		if (!$this->db->field_exists('exchangetype', 'contest_session')) {
+			$this->dbforge->add_column('contest_session', $fields);
+		}
+
 	}
 }

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -59,19 +59,24 @@ class Contesting_model extends CI_Model {
 		$qso = "";
 
 		if ($this->input->post('callsign', true) ?? '' != '') {
-			$qso = xss_clean($this->input->post('start_date', true)) . ' ' . xss_clean($this->input->post('start_time', true)) . ',' . xss_clean($this->input->post('callsign', true)) . ',' . xss_clean($this->input->post('contestname', true));
+			$qso = $this->input->post('start_date', true) . ' ' . $this->input->post('start_time', true) . ',' . $this->input->post('callsign', true) . ',' . $this->input->post('contestname', true);
 		} else {
-			$qso = xss_clean($this->input->post('start_date', true)) . ' ' . xss_clean($this->input->post('start_time', true)) . ',,' . xss_clean($this->input->post('contestname', true));
+			$qso = $this->input->post('start_date', true) . ' ' . $this->input->post('start_time', true) . ',,' . $this->input->post('contestname', true);
 		}
 
+		$settings = array(
+			'exchangetype' 			=> $this->input->post('exchangetype', true),
+			'exchangesequence' 		=> $this->input->post('exchangesequence_select', true),
+			'copyexchangeto'             => $this->input->post('copyexchangeto', true) == "" ? 0 : $this->input->post('copyexchangeto', true),
+		);
+
 		$data = array(
-			'contestid' 			=> xss_clean($this->input->post('contestname', true)),
-			'exchangetype' 			=> xss_clean($this->input->post('exchangetype', true)),
-			'exchangesent' 			=> xss_clean($this->input->post('exch_sent', true)),
-			'serialsent' 			=> xss_clean($this->input->post('exch_serial_s', true)),
-			'copytodok'             => $this->input->post('copyexchangeto', true) == "" ? 0 : xss_clean($this->input->post('copyexchangeto', true)),
+			'contestid' 			=> $this->input->post('contestname', true),
+			'exchangesent' 			=> $this->input->post('exch_sent', true),
+			'serialsent' 			=> $this->input->post('exch_serial_s', true),
 			'qso' 					=> $qso,
 			'station_id' 			=> $station_id,
+			'settings' 				=> json_encode($settings),
 		);
 
 		$binding = [];
@@ -160,8 +165,8 @@ class Contesting_model extends CI_Model {
 
 	function add() {
 		$data = array(
-			'name' => xss_clean($this->input->post('name', true)),
-			'adifname' => xss_clean($this->input->post('adifname', true)),
+			'name' => $this->input->post('name', true),
+			'adifname' => $this->input->post('adifname', true),
 		);
 
 		$this->db->insert('contest', $data);
@@ -185,9 +190,9 @@ class Contesting_model extends CI_Model {
 		$clean_id = $this->security->xss_clean($id);
 
 		$data = array(
-			'name' => xss_clean($this->input->post('name', true)),
-			'adifname' => xss_clean($this->input->post('adifname', true)),
-			'active' =>  xss_clean($this->input->post('active', true)),
+			'name' => $this->input->post('name', true),
+			'adifname' => $this->input->post('adifname', true),
+			'active' =>  $this->input->post('active', true),
 		);
 
 		$this->db->where('id', $clean_id);

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -67,7 +67,11 @@ class Contesting_model extends CI_Model {
 		$settings = array(
 			'exchangetype' 			=> $this->input->post('exchangetype', true),
 			'exchangesequence' 		=> $this->input->post('exchangesequence_select', true),
-			'copyexchangeto'             => $this->input->post('copyexchangeto', true) == "" ? 0 : $this->input->post('copyexchangeto', true),
+			'copyexchangeto'		=> $this->input->post('copyexchangeto', true) == "" ? 0 : $this->input->post('copyexchangeto', true),
+			'radio'					=> $this->input->post('radio', true),
+			'freq_display'			=> $this->input->post('freq_display', true),
+			'mode'					=> $this->input->post('mode', true),
+			'band'					=> $this->input->post('band', true),
 		);
 
 		$data = array(

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -187,30 +187,34 @@ class Logbook_model extends CI_Model {
     if ($this->input->post('copyexchangeto')) {
       switch($this->input->post('copyexchangeto')) {
         case 'dok':
-          $darc_dok = $srx_string;
+          $darc_dok = strtoupper($srx_string);
           break;
         case 'locator':
           // Matching 4-10 character-locator
           if ( preg_match('/^[A-R]{2}[0-9]{2}([A-X]{2}([0-9]{2}([A-X]{2})?)?)?$/',$srx_string) ) {
-            $qso_locator = $srx_string;
+            $qso_locator = strtoupper($srx_string);
           }
           break;
 		case 'qth':
 		  $qso_qth = ucfirst($srx_string);
 		  break;
         case 'name':
-          $qso_name = $srx_string;
+          $qso_name = ucfirst($srx_string);
           break;
         case 'age':
-          $qso_age = intval($srx_string);
+			if (is_numeric($srx_string))	{   // ADIF spec say this has to be a number https://adif.org/314/ADIF_314.htm#QSO_Field_AGE
+				$qso_age = intval($srx_string);
+			}
           break;
         case 'state':
           if ( preg_match('/^[A-Za-z]*$/', $srx_string) && $srx_string != "DX" ) {
-            $qso_state = $srx_string;
+            $qso_state = strtoupper($srx_string);
           }
           break;
         case 'power':
-          $qso_rx_power = intval($srx_string);
+		  if (is_numeric($srx_string))	{  		// ADIF spec say this has to be a number https://adif.org/314/ADIF_314.htm#QSO_Field_RX_PWR
+          	$qso_rx_power = intval($srx_string);
+		  }
           break;
         // Example for more sophisticated exchanges and their split into the db:
         //case 'name/power':

--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -69,12 +69,12 @@
                                                     </label>
                                                     <div class="form-check-inline col-auto">
                                                         <select class="form-select form-select-sm" id="exchangesequence_select" name="exchangesequence_select">
-                                                            <option value='s-g-e'>S - G - E</option>
-                                                            <option value='s-e-g'>S - E - G</option>
-                                                            <option value='g-s-e'>G - S - E</option>
-                                                            <option value='g-e-s'>G - E - S</option>
-                                                            <option value='e-s-g'>E - S - G</option>
-                                                            <option value='e-g-s'>E - G - S</option>
+                                                            <option value='s-g-e'><?= _pgettext("Keep the translation short!", "Serial"); ?> > <?= _pgettext("Keep the translation short!", "Grid"); ?> > <?= _pgettext("Keep the translation short!", "Exchange"); ?></option>
+                                                            <option value='s-e-g'><?= _pgettext("Keep the translation short!", "Serial"); ?> > <?= _pgettext("Keep the translation short!", "Exchange"); ?> > <?= _pgettext("Keep the translation short!", "Grid"); ?></option>
+                                                            <option value='g-s-e'><?= _pgettext("Keep the translation short!", "Grid"); ?> > <?= _pgettext("Keep the translation short!", "Serial"); ?> > <?= _pgettext("Keep the translation short!", "Exchange"); ?></option>
+                                                            <option value='g-e-s'><?= _pgettext("Keep the translation short!", "Grid"); ?> > <?= _pgettext("Keep the translation short!", "Exchange"); ?> > <?= _pgettext("Keep the translation short!", "Serial"); ?></option>
+                                                            <option value='e-s-g'><?= _pgettext("Keep the translation short!", "Exchange"); ?> > <?= _pgettext("Keep the translation short!", "Serial"); ?> > <?= _pgettext("Keep the translation short!", "Grid"); ?></option>
+                                                            <option value='e-g-s'><?= _pgettext("Keep the translation short!", "Exchange"); ?> > <?= _pgettext("Keep the translation short!", "Grid"); ?> > <?= _pgettext("Keep the translation short!", "Serial"); ?></option>
                                                         </select>
                                                     </div>
                                                 </div>

--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -144,7 +144,7 @@
                                 <select class="form-select form-select-sm radios" id="radio" name="radio">
                                     <option value="0" selected="selected"><?= __("None"); ?></option>
                                         <?php foreach ($radios->result() as $row) { ?>
-                                        <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "<i>(".__("last updated").")</i>"; } else { echo ''; } ?></option>
+                                        <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "(".__("last updated").")"; } else { echo ''; } ?></option>
                                         <?php } ?>
                                 </select>
                             </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -313,7 +313,7 @@
               <select class="form-select radios" id="radio" name="radio">
                 <option value="0" selected="selected"><?= __("None"); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
-                  <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "<i>(".__("last updated").")</i>"; } else { echo ''; } ?></option>
+                  <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "(".__("last updated").")"; } else { echo ''; } ?></option>
                 <?php } ?>
                 </select>
             </div>

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -463,6 +463,19 @@ $('#band').change(function () {
 	checkIfWorkedBefore();
 });
 
+/* on radio change */
+// in the footer is defined that we want to clear the frequency when changing the radio
+// this may fit for QSOs, but not for the contesting module
+// so we want atleast to set the frequency to the default frequency of the band
+$('#radio').change(function () {
+	if ($('#radio').val() == '0') {
+		$.get('qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function (result) {
+			$('#frequency').val(result);
+			$('#frequency_rx').val("");
+		});
+	}
+});
+
 function setSerial(data) {
 	var serialsent = 1;
 	if (data.serialsent != "") {

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -111,7 +111,7 @@ $('#moreSettingsButton').click(function () {
 });
 
 // Storing the contestid in contest session
-$('#contestname, #copyexchangeto, #exchangesequence_select').change(function () {
+$('#contestname, #copyexchangeto, #exchangesequence_select, #band, #mode, #frequency, #radio').change(function () {
 	var formdata = new FormData(document.getElementById("qso_input"));
 	setSession(formdata);
 });
@@ -702,6 +702,15 @@ async function restoreContestSession(data) {
 
 		if (data.exchangesent != "") {
 			$("#exch_sent").val(data.exchangesent);
+		}
+
+		if (settings.radio != "0") {
+			$("#radio").val(settings.radio);
+		} else {
+			$("#radio").val(settings.radio);
+			$("#band").val(settings.band);
+			$("#mode").val(settings.mode);
+			$("#frequency").val(settings.freq_display);
 		}
 
 		if (data.qso != "") {

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -677,7 +677,6 @@ async function getSession() {
 }
 
 async function restoreContestSession(data) {
-	console.log(data);
 	if (data) {
 		let settings = JSON.parse(data.settings);
 

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -111,7 +111,7 @@ $('#moreSettingsButton').click(function () {
 });
 
 // Storing the contestid in contest session
-$('#contestname, #copyexchangeto').change(function () {
+$('#contestname, #copyexchangeto, #exchangesequence_select').change(function () {
 	var formdata = new FormData(document.getElementById("qso_input"));
 	setSession(formdata);
 });
@@ -677,19 +677,27 @@ async function getSession() {
 }
 
 async function restoreContestSession(data) {
+	console.log(data);
 	if (data) {
-		if (data.copytodok != "") {
-			$('#copyexchangeto option')[data.copytodok].selected = true;
+		let settings = JSON.parse(data.settings);
+
+		if (settings.copyexchangeto != "") {
+			$('#copyexchangeto option')[settings.copyexchangeto].selected = true;
 		}
 
 		if (data.contestid != "") {
 			$("#contestname").val(data.contestid);
 		}
 
-		if (data.exchangetype != "") {
-			$("#exchangetype").val(data.exchangetype);
-			setExchangetype(data.exchangetype);
+		if (settings.exchangetype != "") {
+			$("#exchangetype").val(settings.exchangetype);
+			setExchangetype(settings.exchangetype);
 			setSerial(data);
+		}
+
+		if (settings.exchangesequence != "") {
+			$("#exchangesequence_select").val(settings.exchangesequence);
+			sort_exchange();
 		}
 
 		if (data.exchangesent != "") {

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -719,7 +719,6 @@ async function restoreContestSession(data) {
 	} else {
 		$("#exch_serial_s").val("1");
 	}
-	// sort_exchange();
 }
 
 async function refresh_qso_table(data) {

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -710,7 +710,13 @@ async function restoreContestSession(data) {
 			$("#radio").val(settings.radio);
 			$("#band").val(settings.band);
 			$("#mode").val(settings.mode);
-			$("#frequency").val(settings.freq_display);
+			if (settings.freq_display != "") {
+				$("#frequency").val(settings.freq_display);
+			} else {
+				$.get('qso/band_to_freq/' + settings.band + '/' + settings.mode, function (result) {
+					$('#frequency').val(result);
+				});
+			}
 		}
 
 		if (data.qso != "") {


### PR DESCRIPTION
To finish the "Mini" - Refactoring started in #812 we want to store the settings in the database. To make that as generic as possible I made the following changes:

- Migration 215 to 
  - drop the column "copytodok"
  - drop the column "exchangetype"
  - add a new column called "settings" which stores the settings as json (easy expandable without the need of further migs)
- Adjust the backend to store the settings
- Also stored now are the radio, mode, band, and qrg data. 
  - if radio is 0 (no radio selected) all values get restored
  - if radio is != 0 only the radio selection gets restored
- Added some xss_cleaning in the contesting controller