### PR TITLE
Impersonate maintenance

### DIFF
--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -1254,7 +1254,7 @@ class User extends CI_Controller {
 		// Update the session with the new user_id
 		// TODO: Find a solution for sessiondata 'radio', so a user would be able to use e.g. his own radio while impersonating another user
 		// Due the fact that the user is now impersonating another user, he can't use his default radio anymore
-		$this->user_model->update_session($target_uid); 
+		$this->user_model->update_session($target_uid, null, $impersonate = true); 
 		
 		// Redirect to the dashboard, the user should now be logged in as the other user
 		redirect('dashboard');

--- a/application/views/user/index.php
+++ b/application/views/user/index.php
@@ -135,7 +135,7 @@
 															</tr>
 															<tr>
 																<td class="pe-3"><?= __("Last Seen:"); ?></td>
-																<td><strong><?php echo date($custom_date_format . ' H:i:s', strtotime($row->last_seen)); ?></strong></td>
+																<td><strong><?php if (isset($row->last_seen)) { echo date($custom_date_format . ' H:i:s', strtotime($row->last_seen)); } else { echo __("never"); }; ?></strong></td>
 															</tr>
 														</table>
 														<?php } else { ?>


### PR DESCRIPTION
When maintenance mode is active it should be possible for an admin to still impersonate an user, while the user is not able to login from outside a session.