### PR TITLE
Prevent HTTP error 500 on import with incorrect ADIF values

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -237,6 +237,7 @@ class adif extends CI_Controller {
 						$custom_errors = $this->logbook_model->import_bulk($alladif, $this->input->post('station_profile'), $this->input->post('skipDuplicate'), $this->input->post('markClublog'),$this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markHrd'), true, $this->input->post('operatorName'), false, $this->input->post('skipStationCheck'));
 					} catch (Exception $e) {
 						log_message('error', 'Import error: '.$e->getMessage());
+						$custom_errors .= __("Failed to parse at least one ADIF record. Please check the imported ADIF file.").'<br />';
 					}
 				} else {	// Failure, if no ADIF inside ZIP
 					$data['max_upload'] = ini_get('upload_max_filesize');

--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -237,7 +237,11 @@ class adif extends CI_Controller {
 						$custom_errors = $this->logbook_model->import_bulk($alladif, $this->input->post('station_profile'), $this->input->post('skipDuplicate'), $this->input->post('markClublog'),$this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markHrd'), true, $this->input->post('operatorName'), false, $this->input->post('skipStationCheck'));
 					} catch (Exception $e) {
 						log_message('error', 'Import error: '.$e->getMessage());
-						$custom_errors .= __("Failed to parse at least one ADIF record. Please check the imported ADIF file.").'<br />';
+						$data['page_title'] = __("ADIF Import failed!");
+						$this->load->view('interface_assets/header', $data);
+						$this->load->view('adif/import_failed');
+						$this->load->view('interface_assets/footer');
+						return;
 					}
 				} else {	// Failure, if no ADIF inside ZIP
 					$data['max_upload'] = ini_get('upload_max_filesize');

--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -233,7 +233,11 @@ class adif extends CI_Controller {
 						array_push($alladif,$record);
 					};
 					$record='';	// free memory
-					$custom_errors = $this->logbook_model->import_bulk($alladif, $this->input->post('station_profile'), $this->input->post('skipDuplicate'), $this->input->post('markClublog'),$this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markHrd'), true, $this->input->post('operatorName'), false, $this->input->post('skipStationCheck'));
+					try {
+						$custom_errors = $this->logbook_model->import_bulk($alladif, $this->input->post('station_profile'), $this->input->post('skipDuplicate'), $this->input->post('markClublog'),$this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markHrd'), true, $this->input->post('operatorName'), false, $this->input->post('skipStationCheck'));
+					} catch (Exception $e) {
+						log_message('error', 'Import error: '.$e->getMessage());
+					}
 				} else {	// Failure, if no ADIF inside ZIP
 					$data['max_upload'] = ini_get('upload_max_filesize');
 					$this->load->view('interface_assets/header', $data);

--- a/application/views/adif/import_failed.php
+++ b/application/views/adif/import_failed.php
@@ -1,0 +1,22 @@
+<div class="container">
+<br>
+	<?php if($this->session->flashdata('message')) { ?>
+		<!-- Display Message -->
+		<div class="alert-message error">
+		  <p><?php echo $this->session->flashdata('message'); ?></p>
+		</div>
+	<?php } ?>
+
+<div class="card">
+  <div class="card-header">
+    <?= __("ADIF Import failed!")?>
+  </div>
+  <div class="card-body">
+    <h3 class="card-title"><?= __("The ADIF file could not be parsed correctly.")?></h3>
+    <p class="card-text"><?= __("At least one of the ADIF fields could not be parsed and/or inserted into the database. Please check the imported ADIF file. You can use an online ADIF file checker. For example:")?></p>
+    <p class="card-text"><a target="_blank" href="https://www.rickmurphy.net/adifvalidator.html">https://www.rickmurphy.net/adifvalidator.html</a></p>
+  </div>
+</div>
+
+
+</div>


### PR DESCRIPTION
Imports with incorrect ADIF data causes error 500. Example:

```
<QSO_DATE_OFF:9>-00011130
```

First measure: catch exception and continue with rest of code.