### PR TITLE
API messages should not be translated

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -117,11 +117,11 @@ class API extends CI_Controller {
 			header("Content-type: text/xml");
 		if($this->api_model->access($key) == __("No Key Found") || $this->api_model->access($key) == __("Key Disabled")) {
 			echo "<auth>";
-			echo "<message>" . __("Key Invalid - either not found or disabled") . "</message>";
+			echo "<message>Key Invalid - either not found or disabled</message>";
 			echo "</auth>";
 		} else {
 			echo "<auth>";
-			echo "<status>" . __("Valid") . "</status>";
+			echo "<status>Valid</status>";
 			echo "<rights>".$this->api_model->access($key)."</rights>";
 			echo "</auth>";
 			$this->api_model->update_last_used($key);


### PR DESCRIPTION
API messages are not allowed to be translated because software would need to handle all languages. Thus revert translation of API responses.

![Screenshot from 2024-08-28 14-26-39](https://github.com/user-attachments/assets/182aa758-658a-470f-aa8f-a659db57cd28)
