### PR TITLE
fix REG1TEST format and expand it to include relevant parts of scoring

### DIFF
--- a/application/controllers/Reg1test.php
+++ b/application/controllers/Reg1test.php
@@ -211,6 +211,7 @@ class Reg1test extends CI_Controller {
 		$data['antenna'] = $this->input->post('antenna', true);
 		$data['antennaheight'] = $this->input->post('antennaheight', true);
 		$data['maxdistanceqso'] = $this->qra->getMaxDistanceQSO($station->station_gridsquare, $data['qsos'], "K");
+		$data['bandmultiplicator'] = $this->input->post('bandmultiplicator', true);
 
 		$data['soapbox'] = $this->input->post('soapbox', true);
 

--- a/application/libraries/Reg1testformat.php
+++ b/application/libraries/Reg1testformat.php
@@ -83,7 +83,7 @@ class Reg1testformat {
       //define result
       $result = [];
       $result['formatted_qso'] = "";
-      $result['totalpoints'] = 0;
+      $result['claimedpoints'] = 0;
 
       //iterate through every QSO and construct detail format
       foreach ($qsodata->result() as $row) {
@@ -114,7 +114,7 @@ class Reg1testformat {
 
          //determine QSO points and add those to the total
          $qsopoints = intval(round($distance * $bandmultiplicator, 0));
-         $result['totalpoints'] += $qsopoints;
+         $result['claimedpoints'] += $qsopoints;
 
          $qsorow .= $qsopoints . ";"; //qso points = distance * bandmultiplicatory
          

--- a/application/libraries/Reg1testformat.php
+++ b/application/libraries/Reg1testformat.php
@@ -82,7 +82,7 @@ class Reg1testformat {
 
       //define result
       $result = [];
-      $result['formatted_result'] = "";
+      $result['formatted_qso'] = "";
       $result['totalpoints'] = 0;
 
       //iterate through every QSO and construct detail format
@@ -142,7 +142,7 @@ class Reg1testformat {
          $qsorow .= ";\r\n"; //flag for duplicate QSO. Leave empty as Wavelog does not have this.
 
          //add row to overall result
-         $result['formatted_result'] .= $qsorow;
+         $result['formatted_qso'] .= $qsorow;
          
       }
 

--- a/application/libraries/Reg1testformat.php
+++ b/application/libraries/Reg1testformat.php
@@ -116,7 +116,7 @@ class Reg1testformat {
          $qsopoints = intval(round($distance * $bandmultiplicator, 0));
          $result['claimedpoints'] += $qsopoints;
 
-         $qsorow .= $qsopoints . ";"; //qso points = distance * bandmultiplicatory
+         $qsorow .= $qsopoints . ";"; //qso points = distance * bandmultiplicator
          
          //determine if the exchange is new or not
          if(!in_array($row->COL_SRX_STRING, $exchanges)){

--- a/application/views/reg1test/export.php
+++ b/application/views/reg1test/export.php
@@ -45,7 +45,7 @@ echo $CI->reg1testformat->header(
 );
 
 //write QSO details
-echo $qsodetails['formatted_result'];
+echo $qsodetails['formatted_qso'];
 
 //get seperate footer if QSO details won't provide one
 echo $qso_count < 1 ? $CI->reg1testformat->footer() : '';

--- a/application/views/reg1test/export.php
+++ b/application/views/reg1test/export.php
@@ -41,7 +41,7 @@ echo $CI->reg1testformat->header(
 	$antennaheight,
 	$maxdistanceqso,
 	$bandmultiplicator,
-	$qsodetails['totalpoints']
+	$qsodetails['claimedpoints']
 );
 
 //write QSO details

--- a/application/views/reg1test/export.php
+++ b/application/views/reg1test/export.php
@@ -7,6 +7,9 @@ $CI->load->library('Reg1testformat');
 header('Content-Type: text/plain; charset=utf-8');
 header('Content-Disposition: attachment; filename="' . $callsign . '-' . $contest_id . '-' . date('Ymd-Hi') . '-' . $CI->reg1testformat->reg1testbandstring($band) . '.edi"');
 
+//calculate qso details
+$qsodetails = $CI->reg1testformat->qsos($qsos, $gridlocator, $bandmultiplicator);
+
 //get header
 echo $CI->reg1testformat->header(
 	$contest_id,
@@ -36,11 +39,13 @@ echo $CI->reg1testformat->header(
 	$rxequipment,
 	$antenna,
 	$antennaheight,
-	$maxdistanceqso
+	$maxdistanceqso,
+	$bandmultiplicator,
+	$qsodetails['totalpoints']
 );
 
 //write QSO details
-echo $CI->reg1testformat->qsos($qsos, $gridlocator);
+echo $qsodetails['formatted_result'];
 
 //get seperate footer if QSO details won't provide one
 echo $qso_count < 1 ? $CI->reg1testformat->footer() : '';

--- a/application/views/reg1test/export.php
+++ b/application/views/reg1test/export.php
@@ -39,10 +39,8 @@ echo $CI->reg1testformat->header(
 	$maxdistanceqso
 );
 
-//write QSO details while keeping track of the QSO number
-foreach ($qsos->result() as $row) {
-	echo $CI->reg1testformat->qso($row);
-}
+//write QSO details
+echo $CI->reg1testformat->qsos($qsos, $gridlocator);
 
-//get footer
-echo $CI->reg1testformat->footer();
+//get seperate footer if QSO details won't provide one
+echo $qso_count < 1 ? $CI->reg1testformat->footer() : '';

--- a/application/views/reg1test/index.php
+++ b/application/views/reg1test/index.php
@@ -131,6 +131,11 @@
 						<small id="antennaheight_hint" class="form-text text-muted col-md-4"><?= __("Height of the antenna above the ground."); ?></small>
 					</div>
 					<div hidden="true" class="mb-3 d-flex align-items-center row additionalinfo">
+						<div class="col-md-4 control-label" for="bandmultiplicator"><?= __("Band multiplicator") ?> </div>
+						<input class="form-control my-1 me-sm-2 col-md-6 w-25 w-lg-75" id="bandmultiplicator" type="number" min="1" max="9999" step="0.01" name="bandmultiplicator" aria-label="bandmultiplicator" value="1">
+						<small id="bandmultiplicator_hint" class="form-text text-muted col-md-4"><?= __("Band multiplicator. This is usually 1. Only change this if necessary according to the contest scoring rules."); ?></small>
+					</div>
+					<div hidden="true" class="mb-3 d-flex align-items-center row additionalinfo">
 						<div class="col-md-4 control-label" for="soapbox"><?= __("Soapbox") ?> </div>
 						<input class="form-control my-1 me-sm-2 col-md-6 w-25 w-lg-75" id="soapbox" type="text" name="soapbox" aria-label="soapbox">
 						<small id="soapbox_hint" class="form-text text-muted col-md-4"><?= __("Any other remarks."); ?></small>


### PR DESCRIPTION
After consultation with one of the organizers of a German VHF contest, I fixed and extended the REG1TEST format:

- fixed format of time in qso details
- completely overhauled the way the qso detail data is calculated to allow for scoring
- added band multiplicator as an input field in GUI with a default value of 1. According to my contact, other values are possible, but highly unlikely.
- added calculation of claimed points in qso detail
- added calculation of the flags concerning "new DXCC", "new Exchange" and "new Locator"
- added claimed score to header

Testing can be done by exporting a contest above 50Mhz from the GUI and changing the band multiplicator field.
Also for verification of the format, change the dates of your QSOs to February 23rd, 2025 and [upload the log here](https://ham-awards.de/award/AC_upload.php). All the test logs will be removed before the next contest starts. Thanks to DL4EAX for providing the dummyupload!