### PR TITLE
Just give empty result on frequency being 0

### DIFF
--- a/application/libraries/Frequency.php
+++ b/application/libraries/Frequency.php
@@ -258,6 +258,10 @@ class Frequency {
 	 */
 	function qrg_conversion($frequency, $r_option = 1, $source_unit = 'Hz', $target_unit = NULL) {
 
+		if ($frequency == 0) {
+			return null;
+		}
+
 		$CI = &get_instance();
 	
 		// Get the band

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -89,16 +89,19 @@
                     </tr>
 
                     <?php if($this->config->item('display_freq') == true) { ?>
-                    <tr>
-                        <td><?= __("Frequency"); ?></td>
-                        <td><?php echo $this->frequency->qrg_conversion($row->COL_FREQ); ?></td>
-                    </tr>
-                    <?php if($row->COL_FREQ_RX != 0) { ?>
-                    <tr>
-                        <td><?= __("Frequency (RX)"); ?></td>
-                        <td><?php echo $this->frequency->qrg_conversion($row->COL_FREQ_RX); ?></td>
-                    </tr>
-                    <?php }} ?>
+                        <?php if($row->COL_FREQ != 0) { ?>
+                        <tr>
+                            <td><?= __("Frequency"); ?></td>
+                            <td><?php echo $this->frequency->qrg_conversion($row->COL_FREQ); ?></td>
+                        </tr>
+                        <?php } ?>
+                        <?php if($row->COL_FREQ_RX != 0) { ?>
+                        <tr>
+                            <td><?= __("Frequency (RX)"); ?></td>
+                            <td><?php echo $this->frequency->qrg_conversion($row->COL_FREQ_RX); ?></td>
+                        </tr>
+                        <?php } ?>
+                    <?php } ?>
 
                     <tr>
                         <td><?= __("Mode"); ?></td>


### PR DESCRIPTION
It seems that some ADIF export allow FREQ (and FREQ_RX) being 0 which does not make much sense to display:

![image](https://github.com/user-attachments/assets/abbbc28a-a159-489a-88de-97c73e065557)

So in case of any of the values being zero we should return `Null` so it looks like this:

![Screenshot from 2024-09-03 14-43-24](https://github.com/user-attachments/assets/711605ae-7f23-4971-99f3-47f6f5887c30)
