### PR TITLE
show the "To Radio" string in the upper right corner

### DIFF
--- a/application/controllers/Labels.php
+++ b/application/controllers/Labels.php
@@ -345,14 +345,17 @@ class Labels extends CI_Controller {
 	function generateLabel($pdf, $current_callsign, $tableData,$numofqsos,$qso,$orientation,$grid=true, $via=false, $reference = false){
 		$builder = new \AsciiTable\Builder();
 		$builder->addRows($tableData);
-			$text = "To Radio: ";
-			$text .= $current_callsign;
+			$toradio = "To Radio: ";
+			$toradio .= $current_callsign;
 			if (($via) && ($qso['via'] ?? '' != '')) {
-				$text.=' via '.substr($qso['via'],0,8);
+				$toradio.=' via '.substr($qso['via'],0,8);
 			}
-			$text .= "\n";
-			$text .= "Confirming QSO".($numofqsos>1 ? 's' : '')."\n";
-			$text .= $builder->renderTable();
+			$builder->setTitle($toradio);
+
+			$additionalText = "Confirming QSO".($numofqsos>1 ? 's' : '');
+			$builder->setAdditionalText($additionalText);
+
+			$text = $builder->renderTable();
 		if($qso['sat'] != "") {
 			if (($qso['sat_mode'] == '') && ($qso['sat_band_rx'] !== '')) {
 				$text .= "\n".'Satellite: '.$qso['sat'].' Band RX: '.$qso['sat_band_rx'];

--- a/src/Label/vendor/malios/php-to-ascii-table/src/Builder.php
+++ b/src/Label/vendor/malios/php-to-ascii-table/src/Builder.php
@@ -77,6 +77,8 @@ class Builder
      */
     private $title;
 
+    private $additionalText;
+
     public function __construct()
     {
         $this->table = new Table();
@@ -124,6 +126,11 @@ class Builder
     public function setTitle(string $title)
     {
         $this->title = $title;
+    }
+
+    public function setAdditionalText(string $additionalText)
+    {
+        $this->additionalText = $additionalText;
     }
 
     /**
@@ -198,11 +205,11 @@ class Builder
         if ($this->title === null) {
             $titleString = '';
         } else {
-            $titlePadding = intdiv(max(0, mb_strwidth($borderTop) - mb_strwidth($this->title)), 2);
+            $titlePadding = max(0, mb_strwidth($borderTop) - mb_strwidth($this->title));
             $titleString = str_repeat(' ', $titlePadding) . $this->title . PHP_EOL;
         }
 
-        $tableAsString = $titleString . $borderTop . PHP_EOL . $header . PHP_EOL . $borderMiddle . PHP_EOL . $body . $borderBottom;
+        $tableAsString = $titleString . $this->additionalText . "\n" . $borderTop . PHP_EOL . $header . PHP_EOL . $borderMiddle . PHP_EOL . $body . $borderBottom;
         return $tableAsString;
     }
 


### PR DESCRIPTION
In addition to #857 let's show the "To Radio" in the upper right corner. 

Needs to be testet with various common formats but seems to work. I needed to introduce the `$additionalText` because the title is usually shown directly above the table which results in "Confirming QSOs" to be above "To Radio" which is not the idea. This way it works. "Confirming QSOs" is now an additional text under the title but above the QSO table. 

@int2001 please test this one

<img width="280" alt="image" src="https://github.com/user-attachments/assets/4a4c1713-18ab-483f-95e6-83f3675d959b">

<img width="268" alt="image" src="https://github.com/user-attachments/assets/570e5f62-eb9d-4af5-b684-67910c9aaf14">

