### PR TITLE
fix qsltable page title missing

### DIFF
--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -232,7 +232,7 @@ class Statistics extends CI_Controller {
 		$data['page_title'] = __("QSL Statistics");
 
 		// Load Views
-		$this->load->view('interface_assets/header');
+		$this->load->view('interface_assets/header', $data);
 		$this->load->view('statistics/qsltable', $total_qsos);
 		$this->load->view('interface_assets/footer');
 	}


### PR DESCRIPTION
Bug: In `/statistics/qslstats` page, the page title is broken. It shows ` - Wavelog`.

This PR makes the code to pass the data value to the header component. 