### PR TITLE
fix lotw upload: unnecessary column

### DIFF
--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -48,12 +48,12 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 
 <?php if($qso->COL_FREQ_RX != "" && $qso->COL_FREQ_RX != "0") { $freq_in_mhz_rx = $qso->COL_FREQ_RX / 1000000; ?><FREQ_RX:<?php echo strlen($freq_in_mhz_rx); ?>><?php echo $freq_in_mhz_rx; } ?>
 
-<?php if(isset($qso->COL_PROP_MODE)) { ?><PROP_MODE:<?php echo strlen($qso->COL_PROP_MODE); ?>><?php echo strtoupper($qso->COL_PROP_MODE); } ?>
+<?php if($qso->COL_PROP_MODE) { ?><PROP_MODE:<?php echo strlen($qso->COL_PROP_MODE); ?>><?php echo strtoupper($qso->COL_PROP_MODE); } ?>
 
-<?php if(isset($qso->COL_SAT_NAME)) { $satellite_name_check = $CI->lotw_satellite_map(strtoupper($qso->COL_SAT_NAME)); if($satellite_name_check != FALSE) { $satname = $satellite_name_check; } else { $satname = $qso->COL_SAT_NAME; } ?>
+<?php if($qso->COL_SAT_NAME) { $satellite_name_check = $CI->lotw_satellite_map(strtoupper($qso->COL_SAT_NAME)); if($satellite_name_check != FALSE) { $satname = $satellite_name_check; } else { $satname = $qso->COL_SAT_NAME; } ?>
 <SAT_NAME:<?php echo strlen($satname); ?>><?php echo strtoupper($satname); } ?>
 
-<?php if(isset($qso->COL_BAND_RX)) { ?><BAND_RX:<?php echo strlen($qso->COL_BAND_RX); ?>><?php echo strtoupper($qso->COL_BAND_RX); } ?>
+<?php if($qso->COL_BAND_RX) { ?><BAND_RX:<?php echo strlen($qso->COL_BAND_RX); ?>><?php echo strtoupper($qso->COL_BAND_RX); } ?>
 
 <?php $date_on = strtotime($qso->COL_TIME_ON); $new_date = date('Y-m-d', $date_on); ?>
 <QSO_DATE:<?php echo strlen($new_date); ?>><?php echo $new_date; ?>
@@ -163,4 +163,3 @@ if(isset($qso->COL_SAT_NAME)) {
 <EOR>
 
 <?php } ?>
-


### PR DESCRIPTION
### Wavelog version: 1.8.3

Bug description: LoTW throws error after uploading from Wavelog.

Step to reproduce: Create a QSO and try to upload to LoTW from Wavelog.

---

LoTW output:

```
2024-09-05 01:44:05 LOTW_QSO: Error in record 3: SAT_NAME: Invalid value in field ()
2024-09-05 01:44:05 LOTW_QSO: Error in record 3: BAND_RX: Invalid value in field ()
```

In the tq8 file generated by Wavelog, there are three empty columns which should not be printed: `PROP_MODE, SAT_NAME, BAND_RX`.

```
<EOR>

<Rec_Type:8>tCONTACT
<STATION_UID:1>1
<CALL:7>BG2TEST
<BAND:4>160M
<MODE:2>CW
<FREQ:4>1.83

<PROP_MODE:0>
<SAT_NAME:0>
<BAND_RX:0>
<QSO_DATE:10>2024-09-05
<QSO_TIME:9>01:24:00Z
<SIGN_LOTW_V2.0:174:6>/*redundant*/

<SIGNDATA:46>/*redundant*/
<EOR>
```

After diving deeper into the code, I think that the `isset()` is unnecessary for these 3 attributes. Since they are fetched directly from DB, they will be always set.

If one of these attributes isn't used, it will be a empty string, which turns out as a falsy value in PHP.

Any thoughts?