### PR TITLE
Refactor sattimers

### DIFF
--- a/application/views/sattimers/index.php
+++ b/application/views/sattimers/index.php
@@ -57,10 +57,10 @@ var custom_date_format = "<?php echo $custom_date_format ?>";
                 <td><span id="tevel<?php echo $i; ?>Timeout">...</span></td>
                 <td><span id="tevel<?php echo $i; ?>AosTime"><?php echo date('H:i:s', $activation['aos_time']); ?></span></td>
                 <td><span id="tevel<?php echo $i; ?>LosTime"><?php echo date('H:i:s', $activation['los_time']); ?></span></td>
-                <td align="right"><span id="tevel<?php echo $i; ?>Aos"><?php echo $activation['aos']; ?>°</span><span style="margin-left: 10px; display: inline-block; transform: rotate(<?php echo (-45+$activation['aos']); ?>deg);"><i class="fas fa-location-arrow fa-xs"></i></span></td>
-                <td align="right"><span id="tevel<?php echo $i; ?>Los"><?php echo $activation['los']; ?>°</span><span style="margin-left: 10px; display: inline-block; transform: rotate(<?php echo (-45+$activation['los']); ?>deg);"><i class="fas fa-location-arrow fa-xs"></i></span></td>
-                <td align="right"><span id="tevel<?php echo $i; ?>MaxEl"><?php echo $activation['max_elev']; ?>°</span><span style="margin-left: 10px; display: inline-block; transform: rotate(-<?php echo ($activation['max_elev']); ?>deg);"><i class="fas fa-arrow-right fa-xs"></i></span></td>
-                <td align="right"><span id="tevel<?php echo $i; ?>Duration"><?php echo $activation['duration_min']; ?> min</span></td>
+                <td align="right"><span id="tevel<?php echo $i; ?>Aos"><?php echo $activation['aos'] ? $activation['aos']."°" : ''; ?></span><?php echo $activation['aos'] ? "<span style=\"margin-left: 10px; display: inline-block; transform: rotate(<?php echo (-45+".$activation['aos'].")deg);\"><i class=\"fas fa-location-arrow fa-xs\"></i></span>" : ''; ?></td>
+                <td align="right"><span id="tevel<?php echo $i; ?>Los"><?php echo $activation['los'] ? $activation['los']."°" : ''; ?></span><?php echo $activation['los'] ? "<span style=\"margin-left: 10px; display: inline-block; transform: rotate(<?php echo (-45+".$activation['los'].")deg);\"><i class=\"fas fa-location-arrow fa-xs\"></i></span>" : ''; ?></td>
+                <td align="right"><span id="tevel<?php echo $i; ?>MaxEl"><?php echo $activation['max_elev'] ? $activation['max_elev']."°" : ''; ?></span><?php echo $activation['max_elev'] ? "<span style=\"margin-left: 10px; display: inline-block; transform: rotate(-".$activation['max_elev'].")deg);\"><i class=\"fas fa-arrow-right fa-xs\"></i></span>" : ''; ?></td>
+                <td align="right"><span id="tevel<?php echo $i; ?>Duration"><?php echo $activation['duration_min'] ? $activation['duration_min']." min" : ''; ?></span></td>
                 <td>
                 <?php
                    if (strpos($activation['sat'], 'TEVEL') !== false) {

--- a/application/views/sattimers/index.php
+++ b/application/views/sattimers/index.php
@@ -55,8 +55,8 @@ var custom_date_format = "<?php echo $custom_date_format ?>";
                 <td><span class="emoji" id="emoji<?php echo $i; ?>">n/a</span></td>
                 <td><span id="tevel<?php echo $i; ?>Timer"></span></td>
                 <td><span id="tevel<?php echo $i; ?>Timeout">...</span></td>
-                <td><span id="tevel<?php echo $i; ?>AosTime"><?php echo date('H:i:s', $activation['aos_time']); ?></span></td>
-                <td><span id="tevel<?php echo $i; ?>LosTime"><?php echo date('H:i:s', $activation['los_time']); ?></span></td>
+                <td><span id="tevel<?php echo $i; ?>AosTime"><?php echo $activation['aos_time'] ? date('H:i:s', $activation['aos_time']) : ''; ?></span></td>
+                <td><span id="tevel<?php echo $i; ?>LosTime"><?php echo $activation['los_time'] ? date('H:i:s', $activation['los_time']) : ''; ?></span></td>
                 <td align="right"><span id="tevel<?php echo $i; ?>Aos"><?php echo $activation['aos'] ? $activation['aos']."°" : ''; ?></span><?php echo $activation['aos'] ? "<span style=\"margin-left: 10px; display: inline-block; transform: rotate(<?php echo (-45+".$activation['aos'].")deg);\"><i class=\"fas fa-location-arrow fa-xs\"></i></span>" : ''; ?></td>
                 <td align="right"><span id="tevel<?php echo $i; ?>Los"><?php echo $activation['los'] ? $activation['los']."°" : ''; ?></span><?php echo $activation['los'] ? "<span style=\"margin-left: 10px; display: inline-block; transform: rotate(<?php echo (-45+".$activation['los'].")deg);\"><i class=\"fas fa-location-arrow fa-xs\"></i></span>" : ''; ?></td>
                 <td align="right"><span id="tevel<?php echo $i; ?>MaxEl"><?php echo $activation['max_elev'] ? $activation['max_elev']."°" : ''; ?></span><?php echo $activation['max_elev'] ? "<span style=\"margin-left: 10px; display: inline-block; transform: rotate(-".$activation['max_elev'].")deg);\"><i class=\"fas fa-arrow-right fa-xs\"></i></span>" : ''; ?></td>


### PR DESCRIPTION
Empty values lead to arbitrary AOS/LOS times as well as az/el max el and duration data for inactive satellites. We need to catch those and hide the columns instead of displaying garbage.