### PR TITLE
Handle empty grid while LoTW confirmations

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -534,7 +534,7 @@ class Lotw extends CI_Controller {
 					// Present only if the QSLing station specified a single valid grid square value in its station location uploaded to LoTW.
 					$qsl_gridsquare = "";
 					if (isset($record['gridsquare'])) {
-						if (strlen($record['gridsquare']) > strlen($status[2]) || substr(strtoupper($status[2]), 0, 4) != substr(strtoupper($record['gridsquare']), 0, 4)) {
+						if (strlen($record['gridsquare']) > strlen($status[2] ?? '') || substr(strtoupper($status[2] ?? ''), 0, 4) != substr(strtoupper($record['gridsquare']), 0, 4)) {
 							$qsl_gridsquare = $record['gridsquare'];
 						}
 					}


### PR DESCRIPTION
The LoTW import check fails if the incoming LoTW confirmation provides a grid but the QSO in our logbook does not:

![Screenshot from 2024-09-06 16-45-51](https://github.com/user-attachments/assets/1cedd29d-db23-40fb-8f72-74cf77dff047)
