### PR TITLE
feat(lotw): support CN_PROVINCE on lotw adif export

### DIFF
--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -31,6 +31,8 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 
 <?php if($station_profile->state != "" && $station_profile->station_country == "UNITED STATES OF AMERICA") { ?><US_STATE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; } ?>
 
+<?php if($station_profile->state != "" && $station_profile->station_country == "CHINA") { ?><CN_PROVINCE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; } ?>
+
 <?php if($station_profile->station_cnty != ""  && $station_profile->station_country == "UNITED STATES OF AMERICA") { ?><US_COUNTY:<?php echo strlen($station_profile->station_cnty); ?>><?php echo $station_profile->station_cnty; } ?>
 
 <EOR>
@@ -72,6 +74,11 @@ $sign_string = "";
 // Adds CA Province
 if($station_profile->state != "" && $station_profile->station_country == "CANADA") {
 	$sign_string .= strtoupper($CI->lotw_ca_province_map($station_profile->state));
+}
+
+// Adds CN Province
+if($station_profile->state != "" && $station_profile->station_country == "CHINA") {
+	$sign_string .= strtoupper($station_profile->state);
 }
 
 // Add CQ Zone


### PR DESCRIPTION
There is a such field `CN_PROVINCE` for Chinese Province. Reference: https://www.rickmurphy.net/lotw/

We are already had those provinces in database.

https://github.com/wavelog/wavelog/blob/62b7e45a8c2c177eab759f65d0fd5a916c422a42/application/migrations/173_primary_subdivisions.php#L1721-L1754

Before:

![image](https://github.com/user-attachments/assets/acbda35a-ee34-4f32-be39-bd0faa9ae00d)

After:

![image](https://github.com/user-attachments/assets/00db25b8-2d4f-47d1-96b3-562e8cfce4da)

cc @violarulan can you help me to test it?