### PR TITLE
perf(ux): use sans-serif as font

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1,5 +1,5 @@
 body {
-	font-family: "Twemoji Country Flags", "Helvetica", "Comic Sans", serif;
+	font-family: "Twemoji Country Flags", "Helvetica", "Comic Sans", sans-serif;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
The default font `serif` in Chinese look nightmare to me, especially on Windows.

So I proposed to change the fallback font to `sans-serif`, it is not the best but way better than `serif` I think.

![image](https://github.com/user-attachments/assets/c063d45f-907a-4cdb-94d7-1afd400a20d6)

![image](https://github.com/user-attachments/assets/ced16c62-08ed-451a-85b2-c98edd8bb20e)

![image](https://github.com/user-attachments/assets/c12cd047-4d40-4ce6-a515-7f6e060f2b4c)

![image](https://github.com/user-attachments/assets/60a029a1-bd3b-4408-b18c-02452458a103)
