### PR TITLE
Disable map click if modal is shown

### DIFF
--- a/assets/js/leaflet/geocoding.js
+++ b/assets/js/leaflet/geocoding.js
@@ -95,6 +95,9 @@ function onMapMove(event) {
 };
 
 function onMapClick(event) {
+	if ($('.modal-dialog')[0]) {
+		return;
+	}
 	var LatLng = event.latlng;
 	var lat = LatLng.lat;
 	var lng = LatLng.lng;

--- a/assets/js/sections/gridmap.js
+++ b/assets/js/sections/gridmap.js
@@ -196,12 +196,14 @@ function spawnGridsquareModal(loc_4char) {
 						label: lang_admin_close,
 						action: function(dialogItself) {
 							dialogItself.close();
+							//map.on('click', onMapClick);
 						}
 					}]
 				});
 			    dialog.realize();
-		    		$("#gridsquare_map").append(dialog.getModal());
-		    		dialog.open();
+					$("#gridsquare_map").append(dialog.getModal());
+					map.off('click');
+					dialog.open();
 },
 			error: function(e) {
 				modalloading=false;

--- a/assets/js/sections/gridmap.js
+++ b/assets/js/sections/gridmap.js
@@ -196,13 +196,11 @@ function spawnGridsquareModal(loc_4char) {
 						label: lang_admin_close,
 						action: function(dialogItself) {
 							dialogItself.close();
-							//map.on('click', onMapClick);
 						}
 					}]
 				});
 			    dialog.realize();
 					$("#gridsquare_map").append(dialog.getModal());
-					map.off('click');
 					dialog.open();
 },
 			error: function(e) {


### PR DESCRIPTION
Disabling cklick input upon showing the modal works. But re-enabling it is still an issue. 