### PR TITLE
Add a version check

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -695,4 +695,16 @@ $config['disable_impersonate'] = false;
 | 
 */
 
-$config['cron_allow_insecure'] = false;   
+$config['cron_allow_insecure'] = false;
+
+/*
+|--------------------------------------------------------------------------
+| Update / version check
+|--------------------------------------------------------------------------
+
+| This config switch disables the check for newer releases on github and
+| hides the banner to admin users if a newer release as published.
+| Default ON.
+ */
+
+$config['disable_version_check'] = false;

--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 217;
+$config['migration_version'] = 219;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 218;
+$config['migration_version'] = 217;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -31,10 +31,11 @@ class Debug extends CI_Controller
 
 		$data['running_version'] = $this->optionslib->get_option('version');
 		$data['latest_release'] = $this->optionslib->get_option('latest_release');
-		if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
-			$data['newer_version_available'] = true;
-		} else {
-			$data['newer_version_available'] = false;
+		$data['newer_version_available'] = false;
+		if ($this->config->item('version_check')) {
+			if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
+				$data['newer_version_available'] = true;
+			}
 		}
 
 		$data['stations'] = $this->Stations->all();

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -28,8 +28,8 @@ class Debug extends CI_Controller
 		$footerData['scripts'] = ['assets/js/sections/debug.js'];
 
 		$data['running_version'] = $this->optionslib->get_option('version');
-		$data['latest_release'] = $this->Update_model->wavelog_latest_release();
-		if (version_compare($data['latest_release'], $data['running_version'], '>')) {
+		$data['latest_release'] = $this->optionslib->get_option('latest_release');
+		if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
 			$data['newer_version_available'] = true;
 		} else {
 			$data['newer_version_available'] = false;

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -31,7 +31,7 @@ class Debug extends CI_Controller
 		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 
 		$data['newer_version_available'] = false;
-		if ($this->config->item('version_check')) {
+		if (!$this->config->item('disable_version_check') ?? false) {
 			$this->Update_model->update_check(true);
 			if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
 				$data['newer_version_available'] = true;

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -27,6 +27,8 @@ class Debug extends CI_Controller
 		$footerData = [];
 		$footerData['scripts'] = ['assets/js/sections/debug.js'];
 
+		$data['running_version'] = $this->optionslib->get_option('version');
+		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 
 		$data['newer_version_available'] = false;
 		if ($this->config->item('version_check')) {
@@ -35,8 +37,6 @@ class Debug extends CI_Controller
 				$data['newer_version_available'] = true;
 			}
 		}
-		$data['running_version'] = $this->optionslib->get_option('version');
-		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 
 		$data['stations'] = $this->Stations->all();
 

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -27,16 +27,16 @@ class Debug extends CI_Controller
 		$footerData = [];
 		$footerData['scripts'] = ['assets/js/sections/debug.js'];
 
-		$this->Update_model->update_check(true);
 
-		$data['running_version'] = $this->optionslib->get_option('version');
-		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 		$data['newer_version_available'] = false;
 		if ($this->config->item('version_check')) {
+			$this->Update_model->update_check(true);
 			if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
 				$data['newer_version_available'] = true;
 			}
 		}
+		$data['running_version'] = $this->optionslib->get_option('version');
+		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 
 		$data['stations'] = $this->Stations->all();
 

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -22,9 +22,18 @@ class Debug extends CI_Controller
 		$this->load->model('Debug_model');
 		$this->load->model('Stations');
 		$this->load->model('cron_model');
+		$this->load->model('Update_model');
 
 		$footerData = [];
 		$footerData['scripts'] = ['assets/js/sections/debug.js'];
+
+		$data['running_version'] = $this->optionslib->get_option('version');
+		$data['latest_release'] = $this->Update_model->wavelog_latest_release();
+		if (version_compare($data['latest_release'], $data['running_version'], '>')) {
+			$data['newer_version_available'] = true;
+		} else {
+			$data['newer_version_available'] = false;
+		}
 
 		$data['stations'] = $this->Stations->all();
 

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -27,6 +27,8 @@ class Debug extends CI_Controller
 		$footerData = [];
 		$footerData['scripts'] = ['assets/js/sections/debug.js'];
 
+		$this->Update_model->update_check(true);
+
 		$data['running_version'] = $this->optionslib->get_option('version');
 		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 		if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -427,7 +427,11 @@ class Update extends CI_Controller {
         $this->optionslib->update('tle_update', $datetime , 'no');
 	}
 
-	function wavelog_update_check() {
+	function version_check() {
+		// set the last run in cron table for the correct cron id
+		$this->load->model('cron_model');
+		$this->cron_model->set_last_run($this->router->class . '_' . $this->router->method);
+		
 		$this->load->model('Update_model');
 		$this->Update_model->update_check();
 	}

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -427,5 +427,16 @@ class Update extends CI_Controller {
         $this->optionslib->update('tle_update', $datetime , 'no');
 	}
 
+	function wavelog_update_check() {
+		if ($this->config->item('version_check')) {
+			$this->load->model('Update_model');
+			$running_version = $this->optionslib->get_option('version');
+			$latest_release = $this->Update_model->wavelog_latest_release();
+			if (version_compare($latest_release, $running_version, '>')) {
+				print __("Newer release available:")." ".$latest_release;
+				$this->Update_model->set_latest_release($latest_release);
+			}
+		}
+	}
 }
 ?>

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -428,15 +428,8 @@ class Update extends CI_Controller {
 	}
 
 	function wavelog_update_check() {
-		if ($this->config->item('version_check')) {
-			$this->load->model('Update_model');
-			$running_version = $this->optionslib->get_option('version');
-			$latest_release = $this->Update_model->wavelog_latest_release();
-			if (version_compare($latest_release, $running_version, '>')) {
-				print __("Newer release available:")." ".$latest_release;
-				$this->Update_model->set_latest_release($latest_release);
-			}
-		}
+		$this->load->model('Update_model');
+		$this->Update_model->update_check();
 	}
 }
 ?>

--- a/application/migrations/219_add_version_check_to_cron.php
+++ b/application/migrations/219_add_version_check_to_cron.php
@@ -1,0 +1,33 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_add_version_check_to_cron extends CI_Migration {
+	public function up() {
+		if ($this->chk4cron('version_check') == 0) {
+			$data = array(
+				array(
+					'id' => 'version_check',
+					'enabled' => '0',
+					'status' => 'pending',
+					'description' => 'Check for new Wavelog releases',
+					'function' => 'index.php/update/wavelog_update_check',
+					'expression' => '45 4 * * *',
+					'last_run' => null,
+					'next_run' => null
+				));
+			$this->db->insert_batch('cron', $data);
+		}
+	}
+
+	public function down() {
+		if ($this->chk4cron('version_check') > 0) {
+			$this->db->query("delete from cron where id='version_check'");
+		}
+	}
+
+	function chk4cron($cronkey) {
+		$query = $this->db->query("select count(id) as cid from cron where id=?",$cronkey);
+		$row = $query->row();
+		return $row->cid ?? 0;
+	}
+}

--- a/application/migrations/219_add_version_check_to_cron.php
+++ b/application/migrations/219_add_version_check_to_cron.php
@@ -3,14 +3,14 @@ defined('BASEPATH') or exit('No direct script access allowed');
 
 class Migration_add_version_check_to_cron extends CI_Migration {
 	public function up() {
-		if ($this->chk4cron('version_check') == 0) {
+		if ($this->chk4cron('update_version_check') == 0) {
 			$data = array(
 				array(
-					'id' => 'version_check',
+					'id' => 'update_version_check',
 					'enabled' => '0',
 					'status' => 'pending',
 					'description' => 'Check for new Wavelog releases',
-					'function' => 'index.php/update/wavelog_update_check',
+					'function' => 'index.php/update/version_check',
 					'expression' => '45 4 * * *',
 					'last_run' => null,
 					'next_run' => null
@@ -20,8 +20,8 @@ class Migration_add_version_check_to_cron extends CI_Migration {
 	}
 
 	public function down() {
-		if ($this->chk4cron('version_check') > 0) {
-			$this->db->query("delete from cron where id='version_check'");
+		if ($this->chk4cron('update_version_check') > 0) {
+			$this->db->query("delete from cron where id='update_version_check'");
 		}
 	}
 

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -289,4 +289,18 @@ class Update_model extends CI_Model {
             $this->db->insert_batch('options', $data);
         }
     }
+
+    function update_check($silent = false) {
+        if ($this->config->item('version_check')) {
+            $this->load->model('Update_model');
+            $running_version = $this->optionslib->get_option('version');
+            $latest_release = $this->Update_model->wavelog_latest_release();
+            if (version_compare($latest_release, $running_version, '>')) {
+                if (!$silent) {
+                   print __("Newer release available:")." ".$latest_release;
+                }
+                $this->Update_model->set_latest_release($latest_release);
+            }
+        }
+    }
 }

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -292,14 +292,13 @@ class Update_model extends CI_Model {
 
     function update_check($silent = false) {
         if ($this->config->item('version_check')) {
-            $this->load->model('Update_model');
             $running_version = $this->optionslib->get_option('version');
-            $latest_release = $this->Update_model->wavelog_latest_release();
+            $latest_release = $this->wavelog_latest_release();
             if (version_compare($latest_release, $running_version, '>')) {
                 if (!$silent) {
                    print __("Newer release available:")." ".$latest_release;
                 }
-                $this->Update_model->set_latest_release($latest_release);
+                $this->set_latest_release($latest_release);
             }
         }
     }

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -260,4 +260,18 @@ class Update_model extends CI_Model {
         $totaltime = ($endtime - $starttime);
         return "Records inserted: " . $i . " in " . $totaltime . " seconds <br />";
     }
+
+    function wavelog_latest_release() {
+        $latest_tag = null;
+        $url = "https://api.github.com/repos/wavelog/wavelog/releases";
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
+        curl_setopt($ch, CURLOPT_URL,$url);
+        $result=curl_exec($ch);
+        curl_close($ch);
+        $json = json_decode($result, true);
+        $latest_tag = $json[0]['tag_name'];
+        return $latest_tag;
+    }
 }

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -274,4 +274,19 @@ class Update_model extends CI_Model {
         $latest_tag = $json[0]['tag_name'];
         return $latest_tag;
     }
+
+    function set_latest_release($release) {
+        $this->db->select('option_value');
+        $this->db->where('option_name', 'latest_release');
+        $query = $this->db->get('options');
+        if ($query->num_rows() > 0) {
+            $this->db->where('option_name', 'latest_release');
+            $this->db->update('options', array('option_value' => $release));
+        } else {
+            $data = array(
+                array('option_name' => "latest_release", 'option_value' => $release, 'autoload' => "yes"),
+            );
+            $this->db->insert_batch('options', $data);
+        }
+    }
 }

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -291,14 +291,18 @@ class Update_model extends CI_Model {
     }
 
     function update_check($silent = false) {
-        if ($this->config->item('version_check')) {
+        if (!$this->config->item('disable_version_check') ?? false) {
             $running_version = $this->optionslib->get_option('version');
             $latest_release = $this->wavelog_latest_release();
+            $this->set_latest_release($latest_release);
             if (version_compare($latest_release, $running_version, '>')) {
                 if (!$silent) {
                    print __("Newer release available:")." ".$latest_release;
                 }
-                $this->set_latest_release($latest_release);
+            } else {
+                if (!$silent) {
+                    print __("You are running the latest version.");
+                }
             }
         }
     }

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -58,6 +58,13 @@ function echo_table_col($row, $name) {
 		<?= __("You need to upgrade your PHP version. Minimum version is 7.4. Your version is") . ' ' . PHP_VERSION . '.';?>
 		</div>
 	<?php } ?>
+	<?php if(($this->session->userdata('user_type') == 99) && $this->config->item('version_check') && $this->optionslib->get_option('latest_release')) { ?>
+		<?php if (version_compare($this->optionslib->get_option('latest_release'), $this->optionslib->get_option('version'), '>')) { ?>
+			<div class="alert alert-success" role="alert" style="margin-top: 1rem;">
+				<?= sprintf(_pgettext("Dashboard Warning", "A new version of Wavelog has been published. See: %s."), "<a href=\"https://github.com/wavelog/wavelog/releases/tag/".$this->optionslib->get_option('latest_release')."\" target=\"_blank\">Release ".$this->optionslib->get_option('latest_release')."</a>"); ?>
+			</div>
+		<?php } ?>
+	<?php } ?>
 
 	<?php if ($countryCount == 0) { ?>
 		<div class="alert alert-danger mt-3" role="alert">

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -58,10 +58,10 @@ function echo_table_col($row, $name) {
 		<?= __("You need to upgrade your PHP version. Minimum version is 7.4. Your version is") . ' ' . PHP_VERSION . '.';?>
 		</div>
 	<?php } ?>
-	<?php if(($this->session->userdata('user_type') == 99) && $this->config->item('version_check') && $this->optionslib->get_option('latest_release')) { ?>
+	<?php if(($this->session->userdata('user_type') == 99) && !($this->config->item('disable_version_check') ?? false) && $this->optionslib->get_option('latest_release')) { ?>
 		<?php if (version_compare($this->optionslib->get_option('latest_release'), $this->optionslib->get_option('version'), '>')) { ?>
 			<div class="alert alert-success" role="alert" style="margin-top: 1rem;">
-				<?= sprintf(_pgettext("Dashboard Warning", "A new version of Wavelog has been published. See: %s."), "<a href=\"https://github.com/wavelog/wavelog/releases/tag/".$this->optionslib->get_option('latest_release')."\" target=\"_blank\">Release ".$this->optionslib->get_option('latest_release')."</a>"); ?>
+				<?= sprintf(_pgettext("Dashboard Warning", "A new version of Wavelog has been published. See: %s."), "<a href=\"https://github.com/wavelog/wavelog/releases/tag/".$this->optionslib->get_option('latest_release')."\" target=\"_blank\"><u>Release ".$this->optionslib->get_option('latest_release')."</u></a>"); ?>
 			</div>
 		<?php } ?>
 	<?php } ?>

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -25,7 +25,11 @@
                     <table width="100%">
                         <tr>
                             <td><?= __("Version"); ?></td>
-                            <td><?php echo $running_version."\n"; ?></td>
+                            <td><?php echo $running_version; ?>
+                                <?php if ($running_version == $latest_release) { ?>
+                                    <span class="badge text-bg-success"> <?= __("Latest Version"); ?></span>
+                                <?php } ?>
+                            </td>
                         </tr>
                         <?php if ($newer_version_available) { ?>
                         <tr>

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -25,8 +25,14 @@
                     <table width="100%">
                         <tr>
                             <td><?= __("Version"); ?></td>
-                            <td><?php echo $this->optionslib->get_option('version') . "\n"; ?></td>
+                            <td><?php echo $running_version."\n"; ?></td>
                         </tr>
+                        <?php if ($newer_version_available) { ?>
+                        <tr>
+                            <td><?= __("Latest Release"); ?></td>
+                            <td><a href="https://github.com/wavelog/wavelog/releases/tag/<?php echo $latest_release; ?>" target="_blank"><?php echo $latest_release."\n"; ?></a></td>
+                        </tr>
+                        <?php } ?>
                         <tr>
                             <td><?= __("Language"); ?></td>
                             <td><?php echo __(ucfirst($this->config->item('language'))) . "\n"; ?></td>

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -707,4 +707,4 @@ $config['cron_allow_insecure'] = false;
 | Default on.
  */
 
-$config['version_check'] = false;
+$config['version_check'] = true;

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -702,9 +702,9 @@ $config['cron_allow_insecure'] = false;
 | Update / version check
 |--------------------------------------------------------------------------
 
-| This config switch enabled the check for newer releases on github and
-| displays a banner to admin users if a newer release as published.
-| Default on.
+| This config switch disables the check for newer releases on github and
+| hides the banner to admin users if a newer release as published.
+| Default ON.
  */
 
-$config['version_check'] = true;
+$config['disable_version_check'] = false;

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -25,11 +25,11 @@ $config['datadir'] = null; // default to install directory
 |
 | 	'table_name'	SQL table where log can be found
 |	'locator'	Default locator used to calculate bearings/distance
-|	'display_freq'	Show or Hide frequnecy info 
+|	'display_freq'	Show or Hide frequnecy info
 */
 
-$config['table_name'] = 'TABLE_HRD_CONTACTS_V01'; 
-$config['locator'] = '%baselocator%'; 
+$config['table_name'] = 'TABLE_HRD_CONTACTS_V01';
+$config['locator'] = '%baselocator%';
 $config['display_freq'] = true;
 
 /*
@@ -64,7 +64,7 @@ $config['hamqth_password'] = '%hamqth_password%';
 |
 | 'use_auth'	False turns all authentication off, best used when setting up
 | 'auth_table'	MySQL Database Table defaults "users"
-| 'auth_mode'	Minimum user level required 0 = anonymous, 1 = viewer, 
+| 'auth_mode'	Minimum user level required 0 = anonymous, 1 = viewer,
 |				2 = editor, 3 = api user, 99 = owner
 | 'auth_level[]'	Defines level titles
 */
@@ -631,7 +631,7 @@ $config['disable_manual_qrz'] = false;
 | Disables QSL-Image-Feature
 |--------------------------------------------------------------------------
 |
-| This disabled the whole QSL image feature if you don't need it and want to hide it. 
+| This disabled the whole QSL image feature if you don't need it and want to hide it.
 | Set to true will hide all QSL image related stuff in Wavelog
 |
 */
@@ -643,7 +643,7 @@ $config['disable_qsl'] = false;
 | Disables OQRS-Feature
 |--------------------------------------------------------------------------
 |
-| This disabled the whole OQRS feature if you don't need it and want to hide it. 
+| This disabled the whole OQRS feature if you don't need it and want to hide it.
 | Set to true will hide all OQRS related stuff in Wavelog
 |
 */
@@ -658,18 +658,18 @@ $config['disable_oqrs'] = false;
 | This config switch is meant to use for Special Callsign operations in a dedicated Wavelog Installation
 | If this switch is set to true it will enable a dialog which pops up for each operator after login
 | to ask for his personal callsign. This causes the QSOs to get saved with the correct operator data.
-| Example:      Special Callsign:   DL250CDF 
+| Example:      Special Callsign:   DL250CDF
 |               Operator:           DF2TG
-| 
-| It is recommend to enable also "Disable Syncing to 3rd party-Services at UI" 
-| More Information about this feature and how to use it, you can find here: 
+|
+| It is recommend to enable also "Disable Syncing to 3rd party-Services at UI"
+| More Information about this feature and how to use it, you can find here:
 | https://github.com/wavelog/wavelog/wiki/Recommended-Setup-for-Special-Callsigns-and-Clubs
 */
 
 $config['special_callsign'] = false;
 
 // hides the usermenu; takes action only if "special_callsign" is true
-$config['sc_hide_usermenu'] = true;  
+$config['sc_hide_usermenu'] = true;
 
 
 /*
@@ -679,10 +679,10 @@ $config['sc_hide_usermenu'] = true;
 |
 | This config switch disables the impersonate feature. This feauture is used to impersonate another user.
 | Impersonate is enabled by default. To disable it, set the value to false.
-| 
+|
 */
 
-$config['disable_impersonate'] = false;   
+$config['disable_impersonate'] = false;
 
 
 /*
@@ -692,7 +692,19 @@ $config['disable_impersonate'] = false;
 |
 | The cronmanager needs http or https with a valid certificate to work.
 | If you want to use it with https and a self-signed certificate, you need to set this to true.
-| 
+|
 */
 
-$config['cron_allow_insecure'] = false;   
+$config['cron_allow_insecure'] = false;
+
+/*
+|--------------------------------------------------------------------------
+| Update / version check
+|--------------------------------------------------------------------------
+
+| This config switch enabled the check for newer releases on github and
+| displays a banner to admin users if a newer release as published.
+| Default on.
+ */
+
+$config['version_check'] = false;


### PR DESCRIPTION
This adds functionality to check if there is a newer release of Wavelog on github and displays a banner to admin users if that's the case. The update check should be triggered by cron so it is non-blocking and interval can be user-configured.
This addresses https://github.com/wavelog/wavelog/issues/712.