### PR TITLE
Fixes issue, where browser sends an empty string instead of null

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -21,7 +21,7 @@ class Logbook_model extends CI_Model {
     $callsign = str_replace('Ø', '0', $this->input->post('callsign'));
     // Join date+time
     $datetime = date("Y-m-d",strtotime($this->input->post('start_date')))." ". $this->input->post('start_time');
-    if ($this->input->post('end_time') != null) {
+    if ( ($this->input->post('end_time') ?? '') != '') {
         $datetime_off = date("Y-m-d",strtotime($this->input->post('start_date')))." ". $this->input->post('end_time');
         // if time off < time on, and time off is on 00:xx >> add 1 day (concidering start and end are between 23:00 and 00:59) //
         $_tmp_datetime_off = strtotime($datetime_off);


### PR DESCRIPTION
Avoids such things:

```
ERROR - 2024-09-14 14:57:54 --> Severity: error --> Exception: Incorrect datetime value: '' for column `wavelog`.`TABLE_HRD_CONTACTS_V01`.`COL_TIME_OFF` at row 1 /var/www/html/system/database/drivers/mysqli/mysqli_driver.php 301
ERROR - 2024-09-14 14:57:56 --> Severity: error --> Exception: Incorrect datetime value: '' for column `wavelog`.`TABLE_HRD_CONTACTS_V01`.`COL_TIME_OFF` at row 1 /var/www/html/system/database/drivers/mysqli/mysqli_driver.php 301
```