### PR TITLE
Keep eQSL incoming QSL arrows green on selection

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -667,7 +667,7 @@ div#station_logbooks_linked_table_paginate {
 }
 
 .activeRow a {
-	color: #fff !important;
+	color: #fff;
 }
 
 .w-qsl {


### PR DESCRIPTION
Selecting a line in LBA with received eQSL changes the color of the arrow (at least in some themes):

![Screenshot from 2024-09-16 15-34-26](https://github.com/user-attachments/assets/aedb670d-61a6-431c-ad2e-5e7a9aeb33b4)

We should remove the overwriting of hyperinks in activeRow:

![Screenshot from 2024-09-16 15-34-38](https://github.com/user-attachments/assets/98069059-f6fc-4fe2-adc9-ddacfe99118c)
