### PR TITLE
Fix number of US counties

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -194,8 +194,9 @@ class Lookup extends CI_Controller {
                 $i = 0;
                 foreach ($result as &$value) {
                     $county = explode(',', $value);
-                    // Limit to 100 as to not slowdown browser too much
-                    if (count($json) <= 100) {
+                    // Limit to 254 as to not slowdown browser too much
+					// Texas has 254 counties so we need this number
+                    if (count($json) <= 254) {
                         $json[] = ["name"=>$county[1]];
                     }
                 }


### PR DESCRIPTION
fixes the available numbers of US counties in the dropdowns. 

Texas has 254 counties and with this the most counties of the US states. Therefore we have to show the all. 

https://en.wikipedia.org/wiki/County_statistics_of_the_United_States

`fixes #971`