### PR TITLE
Fixes a security-issue with the INTERNAL lookup-API

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -604,6 +604,7 @@ class API extends CI_Controller {
 
 		// Make sure users logged in
 		$raw_input = json_decode(file_get_contents("php://input"), true);
+		$user_id='';
 		$this->load->model('user_model');
 		if (!( $this->user_model->authorize($this->config->item('auth_mode') ))) {				// User not authorized?
 			$no_auth=true;
@@ -612,13 +613,19 @@ class API extends CI_Controller {
 				$no_auth=true;
 			} else {
 				$no_auth=false;
+				$user_id=$this->api_model->key_userid($raw_input['key']);
 			}
 			if ($no_auth) {
 				http_response_code(401);
 				echo json_encode(['status' => 'failed', 'reason' => "missing api key or session"]);
 				die();
 			}
+		} else {
+			$user_id=$this->session->userdata('user_id');
 		}
+
+		$this->load->model('stations');
+		$station_ids=$this->stations->all_station_ids_of_user($user_id);
 
 		$lookup_callsign = strtoupper($raw_input['callsign'] ?? '');
 		if ($lookup_callsign ?? '' != '') {
@@ -710,7 +717,7 @@ class API extends CI_Controller {
 			 *	Pool any local data we have for a callsign
 			 *
 			 */
-			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign);
+			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids);
 
 			if($call_lookup_results != null)
 			{
@@ -723,6 +730,7 @@ class API extends CI_Controller {
 				$return['us_county'] = $call_lookup_results->COL_CNTY;
 				$return['dxcc_id'] = $call_lookup_results->COL_DXCC;
 				$return['cont'] = $call_lookup_results->COL_CONT;
+				$return['wworked_before'] = true;
 
 				if ($return['gridsquare'] != "") {
 					$return['latlng'] = $this->qralatlng($return['gridsquare']);

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -730,7 +730,7 @@ class API extends CI_Controller {
 				$return['us_county'] = $call_lookup_results->COL_CNTY;
 				$return['dxcc_id'] = $call_lookup_results->COL_DXCC;
 				$return['cont'] = $call_lookup_results->COL_CONT;
-				$return['wworked_before'] = true;
+				$return['workedBefore'] = true;
 
 				if ($return['gridsquare'] != "") {
 					$return['latlng'] = $this->qralatlng($return['gridsquare']);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1460,8 +1460,9 @@ class Logbook_model extends CI_Model {
   * Usage: Callsign lookup data for the QSO panel and API/callsign_lookup
   *
   */
-  function call_lookup_result($callsign) {
+  function call_lookup_result($callsign, $station_ids) {
 	  $this->db->select('COL_CALL, COL_NAME, COL_QSL_VIA, COL_GRIDSQUARE, COL_QTH, COL_IOTA, COL_TIME_ON, COL_STATE, COL_CNTY, COL_DXCC, COL_CONT');
+	  $this->db->where('station_id', $station_ids);
 	  $this->db->where('COL_CALL', $callsign);
 	  $where = "COL_NAME != \"\"";
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1462,7 +1462,7 @@ class Logbook_model extends CI_Model {
   */
   function call_lookup_result($callsign, $station_ids) {
 	  $this->db->select('COL_CALL, COL_NAME, COL_QSL_VIA, COL_GRIDSQUARE, COL_QTH, COL_IOTA, COL_TIME_ON, COL_STATE, COL_CNTY, COL_DXCC, COL_CONT');
-	  $this->db->where('station_id', $station_ids);
+	  $this->db->where('station_id in ('.$station_ids.')');
 	  $this->db->where('COL_CALL', $callsign);
 	  $where = "COL_NAME != \"\"";
 


### PR DESCRIPTION
Old behaviour:

lookup-API (which is only used internal) checks ALL Logbooks for informations. This causes data-leaks.

New behaviour:

lookup-API (Still internal) uses ONLY the station_ids which belong to the user.

Side-Effect: The previous hard-coded `worked_before` could be derivated and set.

Check via curl:
```
curl https://=UR WL-URL]/index.php/api/lookup -X POST -d '{"key":"YOUR_WL_KEY","callsign":"DF2ET"}'
```