### PR TITLE
Fix: vucc grids in certain query

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -487,8 +487,8 @@ class Logbook_model extends CI_Model {
 			  }
 		  } else {
 			  $this->db->group_start();
-			  $this->db->like("COL_GRIDSQUARE", $searchphrase);
-			  $this->db->or_like("COL_VUCC_GRIDS", $searchphrase);
+			  $this->db->like("COL_GRIDSQUARE", $searchphrase, 'after');
+			  $this->db->or_like("COL_VUCC_GRIDS", $searchphrase, 'after');
 			  $this->db->group_end();
 			  if ($band == 'SAT' && $type == 'VUCC') {
 				  if ($sat != 'All' && $sat != null) {


### PR DESCRIPTION
### Bug description

In gridmap page, some unnecessary QSOs is shown when click on certain grids.

### Step to reproduce

Zoom out that only 2 digit grid codes is shown and click any grid code you want. You will see some QSOs in other grids in the popout list.

### How this happens

https://github.com/wavelog/wavelog/blob/724b7fe1af41123949bf69482b799411e22edc36/application/models/Logbook_model.php#L490

The query statement uses LIKE in argument. But by default it adds `%s` to both sides of the string.

Let's say if we have two QSOs, one is in `PN27jo`, the other is in `JO21`. If we click on the `JO` grid in gridmap, the first QSO will also occur in the result page.

I think we should only add `%s` to the end of the string.
