### PR TITLE
Call CAT first, even if QSO-Window doesn't exist (yet)

### DIFF
--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -200,11 +200,13 @@ $(function() {
 		} else {
 			qrg=this.parentNode.parentNode.cells[1].textContent*1000;
 		}
+
+		try {
+			irrelevant=fetch('http://127.0.0.1:54321/'+qrg);
+		} finally {}
+
 		if (Date.now()-qso_window_last_seen < 2000) {
 			bc2qso.postMessage({ frequency: qrg, call: call });
-			try {
-				irrelevant=fetch('http://127.0.0.1:54321/'+qrg);
-			} finally {}
 		} else {
 			let cl={};
 			cl.call=call;


### PR DESCRIPTION
Old behaviour:
- if QSO-Window does not exist, the CAT-Call isn't made and the window will be opened.

New behaviour:
- CAT-Call is made first before QSO-Window-logic takes effect.