### PR TITLE
Added a new api: /api/private_lookup

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -592,11 +592,216 @@ class API extends CI_Controller {
 
 	}
 
-	function lookup() {
+	function private_lookup() {
 		/*
 		 *
 		 *	Callsign lookup function for Wavelogs logging page or thirdparty systems
 		 *	which want to show previous QSO data on their system.
+		 *	This endpoint returns detailled data about your personal log!
+		 *
+		 */
+
+		// Make sure users logged in
+		$raw_input = json_decode(file_get_contents("php://input"), true);
+		$user_id='';
+		$this->load->model('user_model');
+		if (!( $this->user_model->authorize($this->config->item('auth_mode') ))) {				// User not authorized?
+			$no_auth=true;
+			$this->load->model('api_model');
+			if (!( ((isset($raw_input['key'])) && ($this->api_model->authorize($raw_input['key']) > 0) ))) {			// Key invalid?
+				$no_auth=true;
+			} else {
+				$no_auth=false;
+				$user_id=$this->api_model->key_userid($raw_input['key']);
+			}
+			if ($no_auth) {
+				http_response_code(401);
+				echo json_encode(['status' => 'failed', 'reason' => "missing api key or session"]);
+				die();
+			}
+		} else {
+			$user_id=$this->session->userdata('user_id');
+		}
+
+		$this->load->model('stations');
+		$all_station_ids=$this->stations->all_station_ids_of_user($user_id);
+		
+		if ((array_key_exists('station_ids',$raw_input)) && (is_array($raw_input['station_ids']))) {		// Special station_ids needed and it is an array?
+			$a_station_ids=[];
+			foreach ($raw_input['station_ids'] as $stationid) {	// Check for grants to given station_id
+				if ($this->stations->check_station_against_user($stationid, $user_id)) {
+					$a_station_ids[]=$stationid;
+				}
+			}
+			$station_ids=implode(', ', $a_station_ids);
+		} else {
+			$station_ids=$all_station_ids;				// Take all of user if no station_ids were given
+		}
+
+		if ($station_ids == '') {					// No station_ids found for user or no station_id of given ones were granted? exit!
+			http_response_code(200);
+			echo json_encode(['status' => 'failed', 'reason' => "no station_profiles are matching the User with this API-Key"]);
+			die();
+		}
+
+		if (array_key_exists('band',$raw_input)) {
+			$band=$raw_input['band'];
+		} else {
+			$band='NO_BAND';
+		}
+		if (array_key_exists('mode',$raw_input)) {
+			$mode=$raw_input['mode'];
+		} else {
+			$mode='NO_MODE';
+		}
+
+		$lookup_callsign = strtoupper($raw_input['callsign'] ?? '');
+		if ($lookup_callsign ?? '' != '') {
+
+
+			$this->load->model("logbook_model");
+			$date = date("Y-m-d");
+
+			// Return Array
+			$return = [
+				"callsign" => "",
+				"dxcc" => false,
+				"dxcc_id" => -1,
+				"dxcc_lat" => "",
+				"dxcc_long" => "",
+				"dxcc_cqz" => "",
+				"dxcc_flag" => "",
+				"cont" => "",
+				"name" => "",
+				"gridsquare"  => "",
+				"location"  => "",
+				"iota_ref" => "",
+				"state" => "",
+				"us_county" => "",
+				"qsl_manager" => "",
+				"bearing" 		=> "",
+				"workedBefore" => false,
+				"lotw_member" => false,
+				"dxcc_confirmed_on_band" => false,
+				"dxcc_confirmed_on_band_mode" => false,
+				"dxcc_confirmed" => false,
+				"suffix_slash" => "", // Suffix Slash aka Portable
+			];
+
+
+			/*
+			 *
+			 *	Handle Callsign field
+			 *
+			 */
+			$return['callsign'] = $lookup_callsign;
+
+			/*
+			 *
+			 *	Lookup DXCC and Suffix information
+			 *
+			 */
+
+			$callsign_dxcc_lookup = $this->logbook_model->dxcc_lookup($lookup_callsign, $date);
+
+			$last_slash_pos = strrpos($lookup_callsign, '/');
+
+			if(isset($last_slash_pos) && $last_slash_pos > 4) {
+				$suffix_slash = $last_slash_pos === false ? $lookup_callsign : substr($lookup_callsign, $last_slash_pos + 1);
+				switch ($suffix_slash) {
+				case "P":
+					$suffix_slash_item = "Portable";
+					break;
+				case "M":
+					$suffix_slash_item = "Mobile";
+				case "MM":
+					$suffix_slash_item =  "Maritime Mobile";
+					break;
+				default:
+					// If its not one of the above suffix slashes its likely dxcc
+					$ans2 = $this->logbook_model->dxcc_lookup($suffix_slash, $date);
+					$suffix_slash_item = null;
+				}
+
+				$return['suffix_slash'] = $suffix_slash_item;
+			}
+
+			// If the final slash is a DXCC then find it!
+			if (isset($ans2['call'])) {
+				$return['dxcc_id'] = $ans2['adif'];
+				$return['dxcc'] = $ans2['entity'];
+				$return['dxcc_lat'] = $ans2['lat'];
+				$return['dxcc_long'] = $ans2['long'];
+				$return['dxcc_cqz'] = $ans2['cqz'];
+				$return['cont'] = $ans2['cont'];
+			} else {
+				$return['dxcc_id'] = $callsign_dxcc_lookup['adif'] ?? '';
+				$return['dxcc'] = $callsign_dxcc_lookup['entity'] ?? '';
+				$return['dxcc_lat'] = $callsign_dxcc_lookup['lat'] ?? '';
+				$return['dxcc_long'] = $callsign_dxcc_lookup['long'] ?? '';
+				$return['dxcc_cqz'] = $callsign_dxcc_lookup['cqz'] ?? '';
+				$return['cont'] = $callsign_dxcc_lookup['cont'] ?? '';
+			}
+
+			/*
+			 *
+			 *	Pool any local data we have for a callsign
+			 *
+			 */
+			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids);
+
+			if($call_lookup_results != null) {
+				$return['name'] = $call_lookup_results->COL_NAME;
+				$return['gridsquare'] = $call_lookup_results->COL_GRIDSQUARE;
+				$return['location'] = $call_lookup_results->COL_QTH;
+				$return['iota_ref'] = $call_lookup_results->COL_IOTA;
+				$return['qsl_manager'] = $call_lookup_results->COL_QSL_VIA;
+				$return['state'] = $call_lookup_results->COL_STATE;
+				$return['us_county'] = $call_lookup_results->COL_CNTY;
+				$return['dxcc_id'] = $call_lookup_results->COL_DXCC;
+				$return['cont'] = $call_lookup_results->COL_CONT;
+				$return['workedBefore'] = true;
+
+				if ($return['gridsquare'] != "") {
+					$return['latlng'] = $this->qralatlng($return['gridsquare']);
+				}
+
+			}
+
+			if ($return['dxcc'] ?? '' != '') {
+				$this->load->library('DxccFlag');
+				$return['dxcc_flag']=$this->dxccflag->get($return['dxcc_id']);
+			}
+
+			$lotw_days=$this->logbook_model->check_last_lotw($lookup_callsign);
+			if ($lotw_days != null) {
+				$return['lotw_member']=$lotw_days;
+			} else {
+				$lotw_member="";
+			}
+			/*
+			 *
+			 *	Output Returned data
+			 *
+			 */
+			$userdata=$this->user_model->get_by_id($user_id);
+
+			if ($return['dxcc_id'] ?? '' != '') {	// DXCC derivated before?
+				$return['dxcc_confirmed']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, null, null)>0) ? true : false;
+				$return['dxcc_confirmed_on_band']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, $band, null)>0) ? true : false;
+				$return['dxcc_confirmed_on_band_mode']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, $band, $mode)>0) ? true : false;
+			}
+			echo json_encode($return, JSON_PRETTY_PRINT);
+		} else {
+			echo '{"error":"callsign to lookup not given"}';
+		}
+		return;
+	}
+
+	function lookup() {
+		/*
+		 *
+		 *	This API provides NO information about previous QSOs. It just derivates DXCC, Lat, Long
 		 *
 		 */
 

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -745,10 +745,11 @@ class API extends CI_Controller {
 
 			/*
 			 *
-			 *	Pool any local data we have for a callsign
+			 *	Pool stations local data we have for a callsign
 			 *
 			 */
-			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids);
+			$userdata=$this->user_model->get_by_id($user_id);
+			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids,$userdata->row()->user_default_confirmation,$band,$mode);
 
 			if($call_lookup_results != null) {
 				$return['name'] = $call_lookup_results->COL_NAME;
@@ -761,6 +762,9 @@ class API extends CI_Controller {
 				$return['dxcc_id'] = $call_lookup_results->COL_DXCC;
 				$return['cont'] = $call_lookup_results->COL_CONT;
 				$return['workedBefore'] = true;
+				$return['call_confirmed'] = ($call_lookup_results->CALL_CNF==1) ? true : false;
+				$return['call_confirmed_band'] = ($call_lookup_results->CALL_CNF_BAND==1) ? true : false;
+				$return['call_confirmed_band_mode'] = ($call_lookup_results->CALL_CNF_BAND_MODE==1) ? true : false;
 
 				if ($return['gridsquare'] != "") {
 					$return['latlng'] = $this->qralatlng($return['gridsquare']);
@@ -784,7 +788,6 @@ class API extends CI_Controller {
 			 *	Output Returned data
 			 *
 			 */
-			$userdata=$this->user_model->get_by_id($user_id);
 
 			if ($return['dxcc_id'] ?? '' != '') {	// DXCC derivated before?
 				$return['dxcc_confirmed']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, null, null)>0) ? true : false;
@@ -922,7 +925,7 @@ class API extends CI_Controller {
 			 *	Pool any local data we have for a callsign
 			 *
 			 */
-			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids);
+			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids,'','NO BAND','NO MODE');
 
 			if($call_lookup_results != null)
 			{

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -593,15 +593,7 @@ class API extends CI_Controller {
 	}
 
 	function private_lookup() {
-		/*
-		 *
-		 *	Callsign lookup function for Wavelogs logging page or thirdparty systems
-		 *	which want to show previous QSO data on their system.
-		 *	This endpoint returns detailled data about your personal log!
-		 *
-		 */
-
-		// Make sure users logged in
+		// Lookup Callsign and dxcc for further informations. UseCase: e.g. external Application which checks calls like FlexRadio-Overlay
 		$raw_input = json_decode(file_get_contents("php://input"), true);
 		$user_id='';
 		$this->load->model('user_model');
@@ -691,19 +683,7 @@ class API extends CI_Controller {
 				"suffix_slash" => "", // Suffix Slash aka Portable
 			];
 
-
-			/*
-			 *
-			 *	Handle Callsign field
-			 *
-			 */
 			$return['callsign'] = $lookup_callsign;
-
-			/*
-			 *
-			 *	Lookup DXCC and Suffix information
-			 *
-			 */
 
 			$callsign_dxcc_lookup = $this->logbook_model->dxcc_lookup($lookup_callsign, $date);
 
@@ -746,11 +726,7 @@ class API extends CI_Controller {
 				$return['cont'] = $callsign_dxcc_lookup['cont'] ?? '';
 			}
 
-			/*
-			 *
-			 *	Pool stations local data we have for a callsign
-			 *
-			 */
+			// Query stations of KeyOwner for an already worked call
 			$userdata=$this->user_model->get_by_id($user_id);
 			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids,$userdata->row()->user_default_confirmation,$band,$mode);
 
@@ -786,13 +762,8 @@ class API extends CI_Controller {
 			} else {
 				$lotw_member="";
 			}
-			/*
-			 *
-			 *	Output Returned data
-			 *
-			 */
 
-			if ($return['dxcc_id'] ?? '' != '') {	// DXCC derivated before?
+			if ($return['dxcc_id'] ?? '' != '') {	// DXCC derivated before? if yes: check cnf-states
 				$return['dxcc_confirmed']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, null, null)>0) ? true : false;
 				$return['dxcc_confirmed_on_band']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, $band, null)>0) ? true : false;
 				$return['dxcc_confirmed_on_band_mode']=($this->logbook_model->check_if_dxcc_cnfmd_in_logbook_api($userdata->row()->user_default_confirmation,$return['dxcc_id'], $station_ids, $band, $mode)>0) ? true : false;
@@ -805,15 +776,7 @@ class API extends CI_Controller {
 	}
 
 	function lookup() {
-		/*
-		 *
-		 *	This API provides NO information about previous QSOs. It just derivates DXCC, Lat, Long
-		 *
-		 */
-
-
-
-		// Make sure users logged in
+		// This API provides NO information about previous QSOs. It just derivates DXCC, Lat, Long. It is used by the DXClusterAPI
 		$raw_input = json_decode(file_get_contents("php://input"), true);
 		$user_id='';
 		$this->load->model('user_model');
@@ -869,18 +832,7 @@ class API extends CI_Controller {
 			];
 
 
-			/*
-			 *
-			 *	Handle Callsign field
-			 *
-			 */
 			$return['callsign'] = $lookup_callsign;
-
-			/*
-			 *
-			 *	Lookup DXCC and Suffix information
-			 *
-			 */
 
 			$callsign_dxcc_lookup = $this->logbook_model->dxcc_lookup($lookup_callsign, $date);
 
@@ -924,9 +876,7 @@ class API extends CI_Controller {
 			}
 
 			/*
-			 *
-			 *	Pool any local data we have for a callsign
-			 *
+			 *	Query Data of API-Key-Owner for further informations
 			 */
 			$call_lookup_results = $this->logbook_model->call_lookup_result($lookup_callsign, $station_ids,'','NO BAND','NO MODE');
 
@@ -960,11 +910,6 @@ class API extends CI_Controller {
 			} else {
 				$lotw_member="";
 			}
-			/*
-			 *
-			 *	Output Returned data
-			 *
-			 */
 			echo json_encode($return, JSON_PRETTY_PRINT);
 		} else {
 			echo '{"error":"callsign to lookup not given"}';

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -672,7 +672,9 @@ class API extends CI_Controller {
 				"us_county" => "",
 				"qsl_manager" => "",
 				"bearing" 		=> "",
-				"workedBefore" => false,
+				"call_worked" => false,
+				"call_worked_band" => false,
+				"call_worked_band_mode" => false,
 				"lotw_member" => false,
 				"dxcc_confirmed_on_band" => false,
 				"dxcc_confirmed_on_band_mode" => false,
@@ -740,7 +742,9 @@ class API extends CI_Controller {
 				$return['us_county'] = $call_lookup_results->COL_CNTY;
 				$return['dxcc_id'] = $call_lookup_results->COL_DXCC;
 				$return['cont'] = $call_lookup_results->COL_CONT;
-				$return['workedBefore'] = true;
+				$return['call_worked'] = true;
+				$return['call_worked_band'] = ($call_lookup_results->CALL_WORKED_BAND==1) ? true : false;
+				$return['call_worked_band_mode'] = ($call_lookup_results->CALL_WORKED_BAND_MODE==1) ? true : false;
 				$return['call_confirmed'] = ($call_lookup_results->CALL_CNF==1) ? true : false;
 				$return['call_confirmed_band'] = ($call_lookup_results->CALL_CNF_BAND==1) ? true : false;
 				$return['call_confirmed_band_mode'] = ($call_lookup_results->CALL_CNF_BAND_MODE==1) ? true : false;

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -685,6 +685,9 @@ class API extends CI_Controller {
 				"dxcc_confirmed_on_band" => false,
 				"dxcc_confirmed_on_band_mode" => false,
 				"dxcc_confirmed" => false,
+				"call_confirmed" => false,
+				"call_confirmed_band" => false,
+				"call_confirmed_band_mode" => false,
 				"suffix_slash" => "", // Suffix Slash aka Portable
 			];
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1463,9 +1463,14 @@ class Logbook_model extends CI_Model {
 		$sql="SELECT COL_CALL, COL_NAME, COL_QSL_VIA, COL_GRIDSQUARE, COL_QTH, COL_IOTA, COL_TIME_ON, COL_STATE, COL_CNTY, COL_DXCC, COL_CONT,
 			CASE WHEN ( (".$qsl_where.") ) THEN 1  ELSE 0 END AS CALL_CNF,
 			CASE WHEN ( (".$qsl_where.") AND ".$band_addon.") THEN 1  ELSE 0 END AS CALL_CNF_BAND,
-			CASE WHEN ( (".$qsl_where.") AND ".$band_addon." AND COL_MODE=?) THEN 1  ELSE 0 END AS CALL_CNF_BAND_MODE
-			FROM ".$this->config->item('table_name')." WHERE ";
-		$sql.="station_id IN (".$station_ids.") AND COL_CALL = ?  ORDER BY call_cnf desc, call_cnf_band desc, call_cnf_band_mode desc limit 1";
+			CASE WHEN ( (".$qsl_where.") AND ".$band_addon." AND COL_MODE=?) THEN 1  ELSE 0 END AS CALL_CNF_BAND_MODE,
+			CASE WHEN ( ".$band_addon.") THEN 1  ELSE 0 END AS CALL_WORKED_BAND,
+			CASE WHEN ( ".$band_addon." AND COL_MODE=?) THEN 1  ELSE 0 END AS CALL_WORKED_BAND_MODE
+		FROM ".$this->config->item('table_name')." WHERE ";
+		$sql.="station_id IN (".$station_ids.") AND COL_CALL = ? ORDER BY call_cnf desc, call_worked_band desc, call_cnf_band desc, call_worked_band_mode desc, call_cnf_band_mode desc limit 1";
+		$binding[]=$band;
+		$binding[]=$band;
+		$binding[]=$mode;
 		$binding[]=$band;
 		$binding[]=$band;
 		$binding[]=$mode;

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2247,14 +2247,15 @@ class Logbook_model extends CI_Model {
 		$binding[]=$dxcc;
 
 		if ($band != null && $band != 'SAT') {
-			$sql.=" AND COL_BAND=?";
+			$sql.=" AND COL_BAND = ?";
 			$binding[]=$band;
 		} else if ($band == 'SAT') {
-			$sql.=" AND COL_SAT_NAME !=''";
+			$sql.=" AND COL_PROP_MODE = ?";
+			$binding[]=$band;
 		}
 
 		if ($mode != null) {
-			$sql.=" AND COL_MODE=?";
+			$sql.=" AND COL_MODE = ?";
 			$binding[]=$mode;
 		}
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1449,26 +1449,33 @@ class Logbook_model extends CI_Model {
   *
   * Function: call_lookup_result
   *
-  * Usage: Callsign lookup data for the QSO panel and API/callsign_lookup
+  * Usage: Callsign lookup data for API/callsign_lookup
   *
   */
-	function call_lookup_result($callsign, $station_ids) {
-		$this->db->select('COL_CALL, COL_NAME, COL_QSL_VIA, COL_GRIDSQUARE, COL_QTH, COL_IOTA, COL_TIME_ON, COL_STATE, COL_CNTY, COL_DXCC, COL_CONT');
-		$this->db->where('station_id in (' . $station_ids . ')');
-		$this->db->where('COL_CALL', $callsign);
-		$where = "COL_NAME != \"\"";
+	function call_lookup_result($callsign, $station_ids, $user_default_confirmation, $band, $mode) {
+		$binding=[];
+		$qsl_where = $this->qsl_default_where($user_default_confirmation);
+		$band_addon='COL_BAND=?';
+		if ($band == 'SAT') {
+			$band_addon="COL_PROP_MODE=?";
+		}
 
-		$this->db->where($where);
+		$sql="SELECT COL_CALL, COL_NAME, COL_QSL_VIA, COL_GRIDSQUARE, COL_QTH, COL_IOTA, COL_TIME_ON, COL_STATE, COL_CNTY, COL_DXCC, COL_CONT,
+			CASE WHEN ( (".$qsl_where.") ) THEN 1  ELSE 0 END AS CALL_CNF,
+			CASE WHEN ( (".$qsl_where.") AND ".$band_addon.") THEN 1  ELSE 0 END AS CALL_CNF_BAND,
+			CASE WHEN ( (".$qsl_where.") AND ".$band_addon." AND COL_MODE=?) THEN 1  ELSE 0 END AS CALL_CNF_BAND_MODE
+			FROM ".$this->config->item('table_name')." WHERE ";
+		$sql.="station_id IN (".$station_ids.") AND COL_CALL = ?  ORDER BY call_cnf desc, call_cnf_band desc, call_cnf_band_mode desc limit 1";
+		$binding[]=$band;
+		$binding[]=$band;
+		$binding[]=$mode;
+		$binding[]=$callsign;
 
-		$this->db->order_by("COL_TIME_ON", "desc");
-		$this->db->limit(1);
-		$query = $this->db->get($this->config->item('table_name'));
-		$name = "";
+		$query = $this->db->query($sql, $binding);
 		$data = [];
 		if ($query->num_rows() > 0) {
 			$data = $query->row();
 		}
-
 		return $data;
 	}
 
@@ -2198,13 +2205,8 @@ class Logbook_model extends CI_Model {
 		return $query->num_rows();
 	}
 
-	function check_if_dxcc_cnfmd_in_logbook_api($user_default_confirmation,$dxcc, $station_ids = null, $band = null, $mode = null) {
-		$binding=[];
-		if ($station_ids == null) {
-			return [];
-		} 
-
-		$extrawhere = '';
+	private function qsl_default_where($user_default_confirmation) {
+		$extrawhere='';
 		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'Q') !== false) {
 			$extrawhere = "COL_QSL_RCVD='Y'";
 		}
@@ -2227,11 +2229,19 @@ class Logbook_model extends CI_Model {
 			}
 			$extrawhere .= " COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
 		}
-
 		if ($extrawhere == '') {
 			$extrawhere='1=0';	// No default_confirmations set? in that case everything is false
 		}
+		return $extrawhere;
+	}
 
+	function check_if_dxcc_cnfmd_in_logbook_api($user_default_confirmation,$dxcc, $station_ids = null, $band = null, $mode = null) {
+		$binding=[];
+		if ($station_ids == null) {
+			return [];
+		} 
+
+		$extrawhere = $this->qsl_default_where($user_default_confirmation);
 
 		$sql="SELECT count(1) as CNT from ".$this->config->item('table_name')." where station_id in (".$station_ids.") and (".$extrawhere.") and COL_DXCC=?";
 		$binding[]=$dxcc;


### PR DESCRIPTION
This api checks the (API-)owners logbook for confirmations.
Difference between `/api/lookup` is the private-part. `/api/lookup` is used by other 3rd-party tools (like DXCluster) and cannot be changed.

The PR addresses #983 

Details:

`curl https://[URL]/api/private_lookup -X POST -d '{"key":"[key]","callsign":"VK4XY","band":"20m","mode":"SSB"}'`

returns:
```
{
    "callsign": "VK4XY",
    "dxcc": "AUSTRALIA",
    "dxcc_id": "150",
    "dxcc_lat": "-22",
    "dxcc_long": "135",
    "dxcc_cqz": "30",
    "dxcc_flag": "\ud83c\udde6\ud83c\uddfa",
    "cont": "OC",
    "name": "",
    "gridsquare": "",
    "location": "",
    "iota_ref": "",
    "state": "",
    "us_county": "",
    "qsl_manager": "",
    "bearing": "",
    "call_worked": true,
    "call_worked_band": true,
    "call_worked_band_mode": true,
    "lotw_member": false,
    "dxcc_confirmed_on_band": true,
    "dxcc_confirmed_on_band_mode": true,
    "dxcc_confirmed": true,
    "call_confirmed": true,
    "call_confirmed_band": true,
    "call_confirmed_band_mode": true,
    "suffix_slash": ""
}
```

Mandatory Fields within payload (api will be documented after merge):
* key (your API-Key from AccountSettings --> API)
* callsign (the Call you want to check)

Optional Fields:
* band
   * if given: api checks if the DXCC of the call was confirmed for this band
   * if not given: dxcc_confirmed_on_band and dxcc_confirmed_on_band_mode will be false
* mode
   * if given: api checks if the DXCC of the call was confirmed for this band/mode combination
   * if not given: dxcc_confirmed_on_band_mode will be false
* station_ids (array!)
   * if given: api checks QSOs within those station_profiles. If ommited: Every station_id of the key-owner will be checked.
   * if given but no given ID was granted: Every station_id of the key-owner will be checked.
   * if given but only a few IDs were granted: The granted IDs will be checked
   * if given as string and not array: Every station_id of the key-owner will be checked.

The old Fields work as before. so workedBefore represents if the explicit Call was worked before in general