### PR TITLE
Added exceptionhandling for QSOs with no Call

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -506,7 +506,9 @@ class Lotw extends CI_Controller {
 			if (!isset($record['app_lotw_rxqsl'])) {
 				continue;
 			}
-
+			if (($record['call'] ?? '') == '') {	// Failsafe if no call is given
+				continue;
+			}
 			$time_on = date('Y-m-d', strtotime($record['qso_date'])) ." ".date('H:i', strtotime($record['time_on']));
 
 			$qsl_date = date('Y-m-d H:i', strtotime($record['app_lotw_rxqsl']));

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -413,6 +413,9 @@ class Qrz extends CI_Controller {
 			if ((!(isset($record['app_qrzlog_qsldate']))) || (!(isset($record['qso_date'])))) {
 				continue;
 			}
+			if (($record['call'] ?? '') == '') { 	// Failsafe if no Call is giveb
+				continue;
+			}
 			$time_on = date('Y-m-d', strtotime($record['qso_date'])) ." ".date('H:i', strtotime($record['time_on']));
 
 			$qsl_date = date('Y-m-d', strtotime($record['app_qrzlog_qsldate']));
@@ -424,7 +427,7 @@ class Qrz extends CI_Controller {
 			}
 
 			// If we have a positive match from LoTW, record it in the DB according to the user's preferences
-			if ($record['app_qrzlog_status'] == "C") {
+			if (($record['app_qrzlog_status'] ?? '')== "C") {
 				$record['qsl_rcvd'] = $config['qrz_rcvd_mark'];
 			}
 
@@ -440,7 +443,7 @@ class Qrz extends CI_Controller {
 					$table .= "<td>".$record['station_callsign']."</td>";
 					$table .= "<td>".$time_on."</td>";
 					$table .= "<td>".$record['call']."</td>";
-					$table .= "<td>".$record['mode']."</td>";
+					$table .= "<td>".($record['mode'] ?? '')."</td>";
 					$table .= "<td>".$record['qsl_rcvd']."</td>";
 					$table .= "<td>".$qsl_date."</td>";
 					$table .= "<td>QSO Record: ".$status[0]."</td>";
@@ -450,7 +453,7 @@ class Qrz extends CI_Controller {
 					$table .= "<td>".$record['station_callsign']."</td>";
 					$table .= "<td>".$time_on."</td>";
 					$table .= "<td>".$record['call']."</td>";
-					$table .= "<td>".$record['mode']."</td>";
+					$table .= "<td>".($record['mode'] ?? '')."</td>";
 					$table .= "<td>".$record['qsl_rcvd']."</td>";
 					$table .= "<td>QSO Record: ".$status[0]."</td>";
 					$table .= "</tr>";

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -459,6 +459,7 @@ class Qrz extends CI_Controller {
 					$table .= "</tr>";
 				}
 			}
+			unset($record);
 		}
 
 		if ($table != "") {

--- a/application/libraries/Adif_parser.php
+++ b/application/libraries/Adif_parser.php
@@ -23,7 +23,7 @@ class ADIF_Parser
     var $currentarray = 0; // current place in the array
 	var $i = 0; //the iterator
 	var $headers = array();
-	
+
 	public function initialize() //this function locates the <EOH>
 	{
 
@@ -40,7 +40,7 @@ class ADIF_Parser
 			$pos = 0;
 			goto noheaders;
 		};
-			
+
 		while($this->i < $pos)
 		{
 			//skip comments
@@ -52,7 +52,7 @@ class ADIF_Parser
 					{
 						break;
 					}
-				
+
 					$this->i++;
 				}
 			}else{
@@ -66,19 +66,19 @@ class ADIF_Parser
 						$tag = $tag.mb_substr($this->data, $this->i, 1, "UTF-8");
 						$this->i++;
 					}
-					
+
 					$this->i++; //iterate past the :
-					
+
 					//find out how long the value is
-					
+
 					while($this->i < $pos && mb_substr($this->data, $this->i, 1, "UTF-8") != '>')
 					{
 						$value_length = $value_length.mb_substr($this->data, $this->i, 1, "UTF-8");
 						$this->i++;
 					}
-					
+
 					$this->i++; //iterate past the >
-					
+
 					$len = (int)$value_length;
 					//copy the value into the buffer
 
@@ -93,15 +93,15 @@ class ADIF_Parser
 					$tag = "";
 					$value_length = "";
 					$value = "";
-					
+
 				}
 			}
 
 			$this->i++;
-			
+
 		};
 
-		
+
 		$this->i = $pos+5; //iterate past the <eoh>
 
 		// Skip to here in case we did not find headers
@@ -116,10 +116,10 @@ class ADIF_Parser
 		$this->currentarray = 0;
 		return 1;
 	}
-	
+
 	public function feed($input_data) //allows the parser to be fed a string
 	{
-		
+
 		if (strpos($input_data, "<EOH>") !== false) {
 			$arr=explode("<EOH>",$input_data);
 			$newstring = $arr[1];
@@ -130,12 +130,12 @@ class ADIF_Parser
 
         $this->datasplit = preg_split("/<eor>/i", mb_substr($this->data, $this->i, NULL, "UTF-8"));
 	}
-	
+
 	public function load_from_file($fname) //allows the user to accept a filename as input
 	{
 		$this->data = $string = mb_convert_encoding(file_get_contents($fname), "UTF-8");
 	}
-	
+
 	//the following function does the processing of the array into its key and value pairs
 	public function record_to_array($record)
 	{
@@ -193,7 +193,7 @@ class ADIF_Parser
 		};
 		return $return;
 	}
-	
+
 	//finds the next record in the file
 	public function get_record()
 	{
@@ -201,16 +201,10 @@ class ADIF_Parser
         if($this->currentarray >= count($this->datasplit)) {
             return array(); //return nothing
         } else {
-            // Is this a valid QSO?
-            if (mb_stristr($this->datasplit[$this->currentarray], "<CALL:", false, "UTF-8")) {
-                return $this->record_to_array($this->datasplit[$this->currentarray++]); //process and return output
-            }
-            else {
-                return array();
-            }
+			return $this->record_to_array($this->datasplit[$this->currentarray++]); //process and return output
         }
  	}
-	
+
 	public function get_header($key)
 	{
 		if(array_key_exists(mb_strtolower($key, "UTF-8"), $this->headers))
@@ -220,6 +214,6 @@ class ADIF_Parser
 			return NULL;
 		}
 	}
-	
+
 }
 ?>

--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -149,6 +149,9 @@ class EqslImporter
 		$qsos = array();
 		$records = $updated = $not_found = $dupes = 0;
 		while ($record = $this->CI->adif_parser->get_record()) {
+			if (($record['call'] ?? '') == '') {	// Failsafe if no call was given
+				continue;
+			}
 			$records += 1;
 			$time_on = date('Y-m-d', strtotime($record['qso_date'])) . " " . date('H:i', strtotime($record['time_on']));
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3560,7 +3560,7 @@ class Logbook_model extends CI_Model {
 		$time_on = date('Y-m-d', strtotime($record['qso_date'] ?? '1970-01-01')) . " " . date('H:i:s', strtotime($record['time_on'] ?? '00:00:00'));
 
 		if (($record['call'] ?? '') == '') {
-			log_message("Error","Trying to import QSO without Call for station_id ".$station_id);
+			log_message("Error", "Trying to import QSO without Call for station_id " . $station_id . ". QSO Date/Time: " . $time_on . " Mode: " . ($record['mode'] ?? '') . " Band: " . ($record['band'] ?? ''));
 			$returner['error']=__("QSO on")." ".$time_on.": ".__("You tried to import a QSO without any given CALL. This QSO wasn't imported. It's invalid");
 			return($returner);
 		}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3294,7 +3294,7 @@ class Logbook_model extends CI_Model {
 
 		$binding[] = $datetime;
 		$binding[] = $datetime;
-		$binding[] = $callsign;
+		$binding[] = $callsign ?? '';
 		$binding[] = $station_callsign;
 		$binding[] = $band;
 		$binding[] = $mode;
@@ -3558,6 +3558,12 @@ class Logbook_model extends CI_Model {
 
 		// Join date+time
 		$time_on = date('Y-m-d', strtotime($record['qso_date'] ?? '1970-01-01')) . " " . date('H:i:s', strtotime($record['time_on'] ?? '00:00:00'));
+
+		if (($record['call'] ?? '') == '') {
+			log_message("Error","Trying to import QSO without Call for station_id ".$station_id);
+			$returner['error']=__("QSO on")." ".$time_on.": ".__("You tried to import a QSO without any given CALL. This QSO wasn't imported. It's invalid");
+			return($returner);
+		}
 
 		if (isset($record['time_off'])) {
 			if (isset($record['date_off'])) {


### PR DESCRIPTION
Sometimes a Logbook-Tool called "HamOffice" exports wrong ADIFs.
There are QSOs without a partner. This one fixes the issue (QSOs will be skipped during import)