### PR TITLE
HotFix for broken QRZ-Confirmations

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -410,6 +410,9 @@ class Qrz extends CI_Controller {
 
 		$table = "";
 		while($record = $this->adif_parser->get_record()) {
+			if ((!(array_key_exists('time_on',$record))) || (!(array_key_exists('app_qrzlog_qsldate',$record))) || (!(array_key_exists('qso_date',$record))) || (!(array_key_exists('mode',$record))) || (!(array_key_exists('call',$record))) || (!(array_key_exists('band',$record))) ) {
+				continue;
+			}
 			if ((!(isset($record['app_qrzlog_qsldate']))) || (!(isset($record['qso_date'])))) {
 				continue;
 			}


### PR DESCRIPTION
Since QRZ delivers strange ADIFs, check at least for existance of mandatory keys before processing them.

If a tag is missing, the QSO will be skipped.

This doesn't solve the root-cause but handles the exception.

Root-Cause: https://forums.qrz.com/index.php?threads/xml-issue-when-downloading-qrz-logbook-via-api.931324/#post-6974257