### PR TITLE
Disable HRDLog-Upload if credentials are obviously wrong

### DIFF
--- a/application/models/Hrdlog_model.php
+++ b/application/models/Hrdlog_model.php
@@ -2,124 +2,132 @@
 
 class Hrdlog_model extends CI_Model {
 
-    function upload() {
-        $this->setOptions();
+	function upload() {
+		$this->setOptions();
 
-        // set the last run in cron table for the correct cron id
-        $this->load->model('cron_model');
-        $this->cron_model->set_last_run($this->router->class . '_' . $this->router->method);
+		// set the last run in cron table for the correct cron id
+		$this->load->model('cron_model');
+		$this->cron_model->set_last_run($this->router->class . '_' . $this->router->method);
 
-        $this->load->model('logbook_model');
+		$this->load->model('logbook_model');
 
-        $station_ids = $this->logbook_model->get_station_id_with_hrdlog_code();
+		$station_ids = $this->logbook_model->get_station_id_with_hrdlog_code();
 
-        if ($station_ids) {
-            foreach ($station_ids as $station) {
-                $hrdlog_username = $station->hrdlog_username;
-                $hrdlog_code = $station->hrdlog_code;
-                $u_result = $this->mass_upload_qsos($station->station_id, $hrdlog_username, $hrdlog_code);
-                if ($u_result['count'] > 0) {
-                    $msg = __("HRDlog: QSOs have been uploaded to hrdlog.net for the station callsign: ").$station->station_callsign." (ID: ".$station->station_id.")";
-                    echo $msg;
-                } else {
-                    $msg = __("HRDlog: No QSOs found to upload for the station callsign: ").$station->station_callsign." (ID: ".$station->station_id.")";
-                    echo $msg;
-                }
-                log_message('debug', $msg);
-            }
-        } else {
-            $msg = __("HRDlog: No station profiles with HRDlog Credentials found.");
-            echo $msg;
-            log_message('debug', $msg);
-        }
-    }
+		if ($station_ids) {
+			foreach ($station_ids as $station) {
+				$hrdlog_username = $station->hrdlog_username;
+				$hrdlog_code = $station->hrdlog_code;
+				$u_result = $this->mass_upload_qsos($station->station_id, $hrdlog_username, $hrdlog_code);
+				if ($u_result['count'] > 0) {
+					$msg = __("HRDlog: QSOs have been uploaded to hrdlog.net for the station callsign: ").$station->station_callsign." (ID: ".$station->station_id.")";
+					echo $msg;
+				} else {
+					$msg = __("HRDlog: No QSOs found to upload for the station callsign: ").$station->station_callsign." (ID: ".$station->station_id.")";
+					echo $msg;
+				}
+				log_message('debug', $msg);
+			}
+		} else {
+			$msg = __("HRDlog: No station profiles with HRDlog Credentials found.");
+			echo $msg;
+			log_message('debug', $msg);
+		}
+	}
 
-    function setOptions() {
-        $this->config->load('config');
-        ini_set('memory_limit', '-1');
-        ini_set('display_errors', 1);
-        ini_set('display_startup_errors', 1);
-        error_reporting(E_ALL);
-    }
+	function setOptions() {
+		$this->config->load('config');
+		ini_set('memory_limit', '-1');
+		ini_set('display_errors', 1);
+		ini_set('display_startup_errors', 1);
+		error_reporting(E_ALL);
+	}
 
-    /*
-     * Function gets all QSOs from given station_id, that are not previously uploaded to hrdlog.
-     * Adif is build for each qso, and then uploaded, one at a time
-     */
-    function mass_upload_qsos($station_id, $hrdlog_username, $hrdlog_code) {
-        $i = 0;
-        $data['qsos'] = $this->logbook_model->get_hrdlog_qsos($station_id);
-        $errormessages = array();
+	/*
+	 * Function gets all QSOs from given station_id, that are not previously uploaded to hrdlog.
+	 * Adif is build for each qso, and then uploaded, one at a time
+	 */
+	function mass_upload_qsos($station_id, $hrdlog_username, $hrdlog_code) {
+		$i = 0;
+		$data['qsos'] = $this->logbook_model->get_hrdlog_qsos($station_id);
+		$errormessages = array();
 
-        if (!$this->load->is_loaded('AdifHelper')) {
+		if (!$this->load->is_loaded('AdifHelper')) {
 			$this->load->library('AdifHelper');
 		}
 
-        if ($data['qsos']) {
-            foreach ($data['qsos']->result() as $qso) {
-                $adif = $this->adifhelper->getAdifLine($qso);
+		if ($data['qsos']) {
+			foreach ($data['qsos']->result() as $qso) {
+				$adif = $this->adifhelper->getAdifLine($qso);
 
-                if ($qso->COL_HRDLOG_QSO_UPLOAD_STATUS == 'M') {
-                    $result = $this->logbook_model->push_qso_to_hrdlog($hrdlog_username, $hrdlog_code, $adif, true);
-                } else {
-                    $result = $this->logbook_model->push_qso_to_hrdlog($hrdlog_username, $hrdlog_code, $adif);
-                }
+				if ($qso->COL_HRDLOG_QSO_UPLOAD_STATUS == 'M') {
+					$result = $this->logbook_model->push_qso_to_hrdlog($hrdlog_username, $hrdlog_code, $adif, true);
+				} else {
+					$result = $this->logbook_model->push_qso_to_hrdlog($hrdlog_username, $hrdlog_code, $adif);
+				}
 
-                if (($result['status'] == 'OK') || (($result['status'] == 'error') || ($result['status'] == 'duplicate'))) {
-                    $this->markqso($qso->COL_PRIMARY_KEY);
-                    $i++;
-                    $result['status'] = 'OK';
-                } elseif ((substr($result['status'], 0, 11)  == 'auth_error')) {
-                    log_message('error', 'hrdlog upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
-                    log_message('error', 'hrdlog upload failed with the following message: ' . $result['message']);
-                    log_message('error', 'hrdlog upload stopped for Station_ID: ' . $station_id);
-                    $errormessages[] = $result['message'] . 'Invalid HRDLog-Code, stopped at Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-                    $result['status'] = 'Error';
-                    break; /* If key is invalid, immediate stop syncing for more QSOs of this station */
-                } else {
-                    log_message('error', 'hrdlog upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
-                    log_message('error', 'hrdlog upload failed with the following message: ' . $result['message']);
-                    $result['status'] = 'Error';
-                    $errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-                }
-            }
-            if ($i == 0) {
-                $result['status'] = 'Error';
-            }
-            $result['count'] = $i;
-            $result['errormessages'] = $errormessages;
-        } else {
-            $result['status'] = 'Error';
-            $result['count'] = $i;
-            $result['errormessages'] = $errormessages;
-        }
-        return $result;
-    }
+				if (($result['status'] == 'OK') || (($result['status'] == 'error') || ($result['status'] == 'duplicate'))) {
+					$this->markqso($qso->COL_PRIMARY_KEY);
+					$i++;
+					$result['status'] = 'OK';
+				} elseif ((substr($result['status'], 0, 11)  == 'auth_error')) {
+					log_message('error', 'hrdlog upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
+					log_message('error', 'hrdlog upload failed with the following message: ' . $result['message']);
+					log_message('error', 'hrdlog upload stopped and disabled for Station_ID: ' . $station_id);
+					$errormessages[] = $result['message'] . 'Invalid HRDLog-Code, stopped at Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					$this->disable_hrdlog_station($station_id);
+					$result['status'] = 'Error';
+					break; /* If key is invalid, immediate stop syncing for more QSOs of this station */
+				} else {
+					log_message('error', 'hrdlog upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
+					log_message('error', 'hrdlog upload failed with the following message: ' . $result['message']);
+					$result['status'] = 'Error';
+					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+				}
+			}
+			if ($i == 0) {
+				$result['status'] = 'Error';
+			}
+			$result['count'] = $i;
+			$result['errormessages'] = $errormessages;
+		} else {
+			$result['status'] = 'Error';
+			$result['count'] = $i;
+			$result['errormessages'] = $errormessages;
+		}
+		return $result;
+	}
 
-    function mass_mark_hrdlog_sent($station_id, $from, $till) {
-	    // Set memory limit to unlimited to allow heavy usage
-	    ini_set('memory_limit', '-1');
+	function mass_mark_hrdlog_sent($station_id, $from, $till) {
+		// Set memory limit to unlimited to allow heavy usage
+		ini_set('memory_limit', '-1');
 
-	    $this->load->model('adif_data');
-	    $this->load->model('logbook_model');
+		$this->load->model('adif_data');
+		$this->load->model('logbook_model');
 
-	    $qsos = $this->adif_data->export_custom($from, $till, $station_id);
+		$qsos = $this->adif_data->export_custom($from, $till, $station_id);
 
-	    if (isset($qsos)) {
-		    foreach ($qsos->result() as $qso) {
-			    $mark_them[]=$qso->COL_PRIMARY_KEY;
-		    }
-		    $sql="update ".$this->config->item('table_name')." set COL_HRDLOG_QSO_UPLOAD_DATE='".date("Y-m-d H:i:s", strtotime("now"))."', COL_HRDLOG_QSO_UPLOAD_STATUS='Y'  where COL_HRDLOG_QSO_UPLOAD_STATUS != 'Y' and col_primary_key in (".implode(',', array_values($mark_them)).") and station_id=".$station_id;
-		    $query = $this->db->query($sql);
-		    return $this->db->affected_rows();
-	    }
-	    return 0;
-    }
+		if (isset($qsos)) {
+			foreach ($qsos->result() as $qso) {
+				$mark_them[]=$qso->COL_PRIMARY_KEY;
+			}
+			$sql="update ".$this->config->item('table_name')." set COL_HRDLOG_QSO_UPLOAD_DATE='".date("Y-m-d H:i:s", strtotime("now"))."', COL_HRDLOG_QSO_UPLOAD_STATUS='Y'  where COL_HRDLOG_QSO_UPLOAD_STATUS != 'Y' and col_primary_key in (".implode(',', array_values($mark_them)).") and station_id=".$station_id;
+			$query = $this->db->query($sql);
+			return $this->db->affected_rows();
+		}
+		return 0;
+	}
 
-    /*
-     * Function marks QSO with given primarykey as uploaded to hrdlog
-     */
-    function markqso($primarykey) {
-        $this->logbook_model->mark_hrdlog_qsos_sent($primarykey);
-    }
+	function disable_hrdlog_station($station_id) {
+		$sql='update station_profile set hrdlogrealtime=-1 where station_id=?';
+		$bindings=[$station_id];
+		$this->db->query($sql,$bindings);
+		return;
+	}
+
+	/*
+	 * Function marks QSO with given primarykey as uploaded to hrdlog
+	 */
+	function markqso($primarykey) {
+		$this->logbook_model->mark_hrdlog_qsos_sent($primarykey);
+	}
 }

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -815,7 +815,7 @@ class Logbook_model extends CI_Model {
    */
 	function exists_hrdlog_credentials($station_id) {
 		$sql = 'select hrdlog_username, hrdlog_code, hrdlogrealtime from station_profile
-		  where station_id = ?';
+		  where station_id = ? and hrdlogrealtime>=0';
 
 		$query = $this->db->query($sql, $station_id);
 
@@ -1922,7 +1922,8 @@ class Logbook_model extends CI_Model {
 			' left join station_profile on thcv.station_id = station_profile.station_id' .
 			' left outer join dxcc_entities on thcv.col_my_dxcc = dxcc_entities.adif' .
 			' where thcv.station_id = ?' .
-			' and (COL_HRDLOG_QSO_UPLOAD_STATUS is NULL
+			' and station_profile.hrdlogrealtime>=0
+			  and (COL_HRDLOG_QSO_UPLOAD_STATUS is NULL
 		  or COL_HRDLOG_QSO_UPLOAD_STATUS = ""
 		  or COL_HRDLOG_QSO_UPLOAD_STATUS = "M"
 		  or COL_HRDLOG_QSO_UPLOAD_STATUS = "N")';
@@ -2034,6 +2035,7 @@ class Logbook_model extends CI_Model {
 		$sql = 'SELECT station_id, hrdlog_username, hrdlog_code, station_callsign
                 FROM station_profile
                 WHERE coalesce(hrdlog_username, "") <> ""
+		AND hrdlogrealtime>=0
                 AND coalesce(hrdlog_code, "") <> ""';
 
 		$query = $this->db->query($sql);

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -242,6 +242,7 @@ if ($dxcc_list->result() > 0) {
 					<select class="form-select" id="hrdlogrealtime" name="hrdlogrealtime">
                         <option value="1"><?= __("Yes"); ?></option>
                         <option value="0" selected><?= __("No"); ?></option>
+                        <option value="-1" selected><?= __("Disabled"); ?></option>
                     </select>
                 </div>
             </div>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -390,6 +390,7 @@ if ($dxcc_list->result() > 0) {
 						<select class="form-select" id="hrdlogrealtime" name="hrdlogrealtime">
 							<option value="1" <?php if ($my_station_profile->hrdlogrealtime == 1) { echo " selected =\"selected\""; } ?>><?= __("Yes"); ?></option>
 							<option value="0" <?php if ($my_station_profile->hrdlogrealtime == 0) { echo " selected =\"selected\""; } ?>><?= __("No"); ?></option>
+							<option value="0" <?php if ($my_station_profile->hrdlogrealtime == -1) { echo " selected =\"selected\""; } ?>><?= __("Disabled"); ?></option>
 						</select>
 					</div>
 				</div>


### PR DESCRIPTION
old behaviour:
- Try to upload to HRDLog, if auth fails skip the station (for this loop)

new behaviour:
- Try to upload to HRDLog, if auth fails skip the station and disable further uploads (New option at station_setup)

Reviewers: Add "Hide whitespace" to comparison. it's not that much as it seems