### PR TITLE
Prevent endless looping in case of br0ken ADIFs

### DIFF
--- a/application/libraries/Adif_parser.php
+++ b/application/libraries/Adif_parser.php
@@ -149,7 +149,7 @@ class ADIF_Parser
 				$len_str = "";
 				$len = 0;
 				$a++; //go past the <
-				while(mb_substr($record, $a, 1, "UTF-8") != ':') //get the tag
+				while((mb_substr($record, $a, 1, "UTF-8") != ':') && ($a<=mb_strlen($record, "UTF-8"))) //get the tag
 				{
 					$tag_name = $tag_name.mb_substr($record, $a, 1, "UTF-8"); //append this char to the tag name
 					$a++;
@@ -159,14 +159,14 @@ class ADIF_Parser
 					}
 				};
 				$a++; //iterate past the colon
-				while(mb_substr($record, $a, 1, "UTF-8") != '>' && mb_substr($record, $a, 1, "UTF-8") != ':')
+				while(mb_substr($record, $a, 1, "UTF-8") != '>' && mb_substr($record, $a, 1, "UTF-8") != ':' && ($a<=mb_strlen($record, "UTF-8")))
 				{
 					$len_str = $len_str.mb_substr($record, $a, 1, "UTF-8");
 					$a++;
 				};
 				if(mb_substr($record, $a, 1, "UTF-8") == ':')
 				{
-					while(mb_substr($record, $a, 1, "UTF-8") != '>')
+					while((mb_substr($record, $a, 1, "UTF-8") != '>') && ($a<=mb_strlen($record, "UTF-8")))
 					{
 						$a++;
 					};

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3647,7 +3647,7 @@ class Logbook_model extends CI_Model {
 			if (isset($record['date_off'])) {
 				// date_off and time_off set
 				$time_off = date('Y-m-d', strtotime($record['date_off'] ?? '1970-01-01 00:00:00')) . ' ' . date('H:i:s', strtotime($record['time_off'] ?? '1970-01-01 00:00:00'));
-			} elseif (strtotime($record['time_off']) < strtotime($record['time_on'])) {
+			} elseif (strtotime($record['time_off']) < strtotime($record['time_on'] ?? '00:00:00')) {
 				// date_off is not set, QSO ends next day
 				$time_off = date('Y-m-d', strtotime(($record['qso_date']  ?? '1970-01-01 00:00:00') . ' + 1 day')) . ' ' . date('H:i:s', strtotime($record['time_off'] ?? '1970-01-01 00:00:00'));
 			} else {


### PR DESCRIPTION
In some cases ADIFs aren't complete (User provided or from 3rd-party-services).
A bug in our parser produced an endless loop in this case.

this one prevents the endless-loop