### PR TITLE
fix: globe map pathline #1046

### DIFF
--- a/assets/js/sections/logbookadvanced_map.js
+++ b/assets/js/sections/logbookadvanced_map.js
@@ -678,7 +678,7 @@ function renderGlobe(arcsData,labelData) {
 	.arcsData(arcsData)
 	.arcColor('color')
 	//.arcAltitude('altitude')
-	.arcAltitudeAutoScale(.3)
+	.arcAltitudeAutoScale(.35)
 	.arcStroke(.2)
 	.arcDashLength(() => .1)
 	.arcDashGap(() => 0.01)


### PR DESCRIPTION
#1046. Originally reported by @wafer-li.

According  to the Globe.gl [documentation](https://globe.gl/):

> `arcAltitudeAutoScale`: Arc object accessor function, attribute or a numeric constant for the scale of the arc’s automatic altitude, in terms of units of the great-arc distance between the two points. A value of `1` indicates the arc should be as high as its length on the ground. Only applicable if `arcAltitude` is not set.

A `0.35` should fix the bug.