### PR TITLE
LoTW Tooltip Bug in QSO logging

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -6,6 +6,8 @@
   var lang_qso_title_times_worked_before = "<?= __("times worked before"); ?>";
   var lang_qso_title_not_worked_before = "<?= __("Not worked before"); ?>";
   var lang_dxccsummary_for = "<?= __("DXCC Summary for "); ?>";
+  var lang_lotw_upload_day_ago = "<?= __("LoTW User. Last upload was 1 day ago."); ?>";
+  var lang_lotw_upload_days_ago = "<?= __("LoTW User. Last upload was %x% days ago."); ?>"; // due to the way the string is built (PHP to JS), %x% is replaced with the number of days
 </script>
 
 <div class="row qsopane">

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -661,7 +661,11 @@ $("#callsign").focusout(function () {
 					$('#lotw_link').attr('href', "https://lotw.arrl.org/lotwuser/act?act=" + callsign);
 					$('#lotw_link').attr('target', "_blank");
 					$('#lotw_info').attr('data-bs-toggle', "tooltip");
-					$('#lotw_info').attr('data-bs-original-title', "LoTW User. Last upload was " + result.lotw_days + " days ago");
+					if (result.lotw_days == 1) { 
+						$('#lotw_info').attr('data-bs-original-title', lang_lotw_upload_day_ago);
+					} else {
+						$('#lotw_info').attr('data-bs-original-title', lang_lotw_upload_days_ago.replace('%x%', result.lotw_days));
+					}
 					$('[data-bs-toggle="tooltip"]').tooltip();
 				}
 				$('#qrz_info').html('<a target="_blank" href="https://www.qrz.com/db/' + callsign + '"><img width="30" height="30" src="' + base_url + 'images/icons/qrz.com.png"></a>');

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -494,6 +494,7 @@ function reset_fields() {
 	$('#country').val("");
 	$('#continent').val("");
 	$('#lotw_info').text("");
+	$('#lotw_info').attr('data-bs-original-title', "");
 	$('#lotw_info').removeClass("lotw_info_red");
 	$('#lotw_info').removeClass("lotw_info_yellow");
 	$('#lotw_info').removeClass("lotw_info_orange");
@@ -660,7 +661,7 @@ $("#callsign").focusout(function () {
 					$('#lotw_link').attr('href', "https://lotw.arrl.org/lotwuser/act?act=" + callsign);
 					$('#lotw_link').attr('target', "_blank");
 					$('#lotw_info').attr('data-bs-toggle', "tooltip");
-					$('#lotw_info').attr('title', "LoTW User. Last upload was " + result.lotw_days + " days ago");
+					$('#lotw_info').attr('data-bs-original-title', "LoTW User. Last upload was " + result.lotw_days + " days ago");
 					$('[data-bs-toggle="tooltip"]').tooltip();
 				}
 				$('#qrz_info').html('<a target="_blank" href="https://www.qrz.com/db/' + callsign + '"><img width="30" height="30" src="' + base_url + 'images/icons/qrz.com.png"></a>');


### PR DESCRIPTION
There was a little frontend bug in the QSO logging which only seems to appear in Firefox Browsers.

![image](https://github.com/user-attachments/assets/01f78c87-dbee-403c-878c-db0df576a695)

This fixes this and also adds translations for this text.

`Fixes #1030`
