### PR TITLE
Fix: certain QSOs are not shown in gridmap QSO list

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -493,12 +493,10 @@ class Logbook_model extends CI_Model {
 					// see https://github.com/wavelog/wavelog/pull/992
 					$this->db->like("COL_GRIDSQUARE", $searchphrase, 'after');
 					$this->db->or_like("COL_VUCC_GRIDS", $searchphrase, 'after');
-					if (strlen($searchphrase) != 2) {
-						// in case of the CALL has more than one GL
-						// see https://github.com/wavelog/wavelog/issues/1055
-						$this->db->or_like("COL_GRIDSQUARE", ',' . $searchphrase);
-						$this->db->or_like("COL_VUCC_GRIDS", ',' . $searchphrase);
-					}
+					// in case of the CALL has more than one GL
+					// see https://github.com/wavelog/wavelog/issues/1055
+					$this->db->or_like("COL_GRIDSQUARE", ',' . $searchphrase);
+					$this->db->or_like("COL_VUCC_GRIDS", ',' . $searchphrase);
 					$this->db->group_end();
 					if ($band == 'SAT' && $type == 'VUCC') {
 						if ($sat != 'All' && $sat != null) {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -489,8 +489,16 @@ class Logbook_model extends CI_Model {
 					}
 				} else {
 					$this->db->group_start();
+					// to avoid unnecessary QSO are returned, when a 2-digit GL is provided
+					// see https://github.com/wavelog/wavelog/pull/992
 					$this->db->like("COL_GRIDSQUARE", $searchphrase, 'after');
 					$this->db->or_like("COL_VUCC_GRIDS", $searchphrase, 'after');
+					if (strlen($searchphrase) != 2) {
+						// in case of the CALL has more than one GL
+						// see https://github.com/wavelog/wavelog/issues/1055
+						$this->db->or_like("COL_GRIDSQUARE", ',' . $searchphrase);
+						$this->db->or_like("COL_VUCC_GRIDS", ',' . $searchphrase);
+					}
 					$this->db->group_end();
 					if ($band == 'SAT' && $type == 'VUCC') {
 						if ($sat != 'All' && $sat != null) {


### PR DESCRIPTION
Bug description: #1055 

Workaround: By adding a comma to the search pattern, we can search for QSOs with more than one grid locator.

i.e. There's a QSO logged as `PN17,PN27,PN16,PN26`, if we click:
- PN: search pattern: `PN%` or `%,PN%`, (we described it in #992) the first condition works
- PN17: search pattern: `PN17%` or `%,PN17%`, the first condition works
- PN27: search pattern: `PN27%` or `%,PN27%`, the second condition works
- PN16: search pattern: `PN16%` or `%,PN16%`, the second condition works
- PN26: search pattern: `PN26%` or `%,PN26%`, the second condition works

Can you guys help me to test it?