### PR TITLE
Add None to DXCCs

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 221;
+$config['migration_version'] = 222;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -31,6 +31,7 @@ class Station extends CI_Controller
 		$this->load->library('form_validation');
 
 		$this->form_validation->set_rules('station_profile_name', 'Station Profile Name', 'required');
+		$this->form_validation->set_rules('dxcc', 'DXCC', 'required');
 
 		if ($this->form_validation->run() == FALSE) {
 			$data['page_title'] = __("Create Station Location");
@@ -50,6 +51,7 @@ class Station extends CI_Controller
 			$data = $this->load_station_for_editing($id);
 			$data['page_title'] = __("Edit Station Location: ") . $data['my_station_profile']->station_profile_name;
 
+			$this->form_validation->set_rules('dxcc', 'DXCC', 'required');
 			if ($this->form_validation->run() == FALSE) {
 				$this->load->view('interface_assets/header', $data);
 				$this->load->view('station_profile/edit');

--- a/application/controllers/Stationsetup.php
+++ b/application/controllers/Stationsetup.php
@@ -376,7 +376,7 @@ class Stationsetup extends CI_Controller {
 	}
 
 	private function stationcountry2html($station_country, $dxcc_end) {
-		$returntext = $station_country == '' ? _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)") : $station_country;
+		$returntext = $station_country == '' ? __("Please select one") : $station_country;
 		if ($dxcc_end != NULL) {
 			$returntext .= ' <span class="badge bg-danger">'.__("Deleted DXCC").'</span>';
 		}

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -77,6 +77,18 @@ class Update extends CI_Controller {
 			if ($count % 10  == 0)
 				$this->update_status(__("Preparing DXCC-Entries: ").$count);
 		}
+		array_push($a_data, array(
+					'adif' => 0,
+					'name' => '- NONE - (e.g. /MM, /AM)',
+					'prefix' => '',
+					'ituz' => 0,
+					'cqz' => 0,
+					'cont' => '',
+					'long' => 0,
+					'lat' => 0,
+					'start' => null,
+					'end' => null
+				));
 		$this->db->insert_batch('dxcc_entities', $a_data);
 
 		$this->update_status();

--- a/application/migrations/222_add_none_dxcc.php
+++ b/application/migrations/222_add_none_dxcc.php
@@ -1,0 +1,14 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_add_none_dxcc extends CI_Migration {
+
+	public function up() {
+		$this->db->query("insert ignore into dxcc_entities (adif,`name`,prefix,ituz,cqz,cont,`long`,lat,`start`,`end`) values (0,'- NONE - (e.g. /MM, /AM)','',0,0,'',0,0,null,null)");
+	}
+
+	public function down(){
+		$this->db->query("delete from dxcc_entities where adif=0");
+	}
+}

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -219,7 +219,7 @@ class Logbookadvanced_model extends CI_Model {
 			$binding[] = $searchCriteria['iota'];
 		}
 
-        if ($searchCriteria['dxcc'] !== '') {
+        if ($searchCriteria['dxcc'] ?? '' !== '') {
 			$conditions[] = "COL_DXCC = ?";
 			$binding[] = $searchCriteria['dxcc'];
 		}

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -219,7 +219,7 @@ class Logbookadvanced_model extends CI_Model {
 			$binding[] = $searchCriteria['iota'];
 		}
 
-        if ($searchCriteria['dxcc'] ?? '' !== '') {
+        if (($searchCriteria['dxcc'] ?? '') !== '') {
 			$conditions[] = "COL_DXCC = ?";
 			$binding[] = $searchCriteria['dxcc'];
 		}

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -162,7 +162,7 @@ $options = json_decode($options);
                         <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="dxcc"><?= __("DXCC"); ?></label>
                             <select class="form-control form-control-sm" id="dxcc" name="dxcc">
-                                <option value=""><?= __("Please select one"); ?></option>
+                                <option value="">-</option>
                                 <?php
                                 foreach ($dxccarray as $dxcc) {
                                     echo '<option value=' . $dxcc->adif;

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -162,8 +162,7 @@ $options = json_decode($options);
                         <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="dxcc"><?= __("DXCC"); ?></label>
                             <select class="form-control form-control-sm" id="dxcc" name="dxcc">
-                                <option value="">-</option>
-                                <option value="0"><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
+                                <option value=""><?= __("Please select one"); ?></option>
                                 <?php
                                 foreach ($dxccarray as $dxcc) {
                                     echo '<option value=' . $dxcc->adif;

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -218,7 +218,7 @@
                                     <div class="mb-3 col-sm-6">
                                         <label for="dxcc_id"><?= __("DXCC"); ?></label>
                                         <select class="form-select" id="dxcc_id" name="dxcc_id" required>
-                                            <option value="0"><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
+                                            <option value=""><?= __("Please select one"); ?></option>
                                             <?php
                                             foreach($dxcc as $d){
                                                 echo '<option value=' . $d->adif;

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -314,7 +314,6 @@
             <div class="mb-3">
               <label for="radio"><?= __("Radio"); ?></label>
               <select class="form-select radios" id="radio" name="radio">
-                <option value="0" selected="selected"><?= __("None"); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
                   <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "(".__("last updated").")"; } else { echo ''; } ?></option>
                 <?php } ?>
@@ -363,7 +362,6 @@
               <div class="mb-3">
                   <label for="dxcc_id"><?= __("DXCC"); ?></label>
                   <select class="form-control" id="dxcc_id" name="dxcc_id" required>
-                      <option value="0">- NONE -</option>
                       <?php
                       foreach($dxcc as $d){
                           echo '<option value=' . $d->adif . '>' . $d->prefix . ' - ' . ucwords(strtolower(($d->name)));

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -1,12 +1,5 @@
 <script>
 var dxccarray = [];
-dxccarray.push({
-	adif: 0,
-	name: '- None -',
-	cq: '',
-	itu: '',
-});
-
 
 <?php
 if ($dxcc_list->result() > 0) {
@@ -74,8 +67,8 @@ if ($dxcc_list->result() > 0) {
 		  <div class="mb-3">
 		    <label for="stationDXCCInput"><?= __("Station DXCC"); ?></label>
 				<?php if ($dxcc_list->num_rows() > 0) { ?>
-				<select class="form-control" id="dxcc_id" name="dxcc" aria-describedby="stationCallsignInputHelp">
-				<option value="0" selected><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
+				<select class="form-control" id="dxcc_id" name="dxcc" aria-describedby="stationCallsignInputHelp" required>
+				<option value="" selected><?= _("Please select one"); ?></option>
 				<?php foreach ($dxcc_list->result() as $dxcc) { ?>
 				<option value="<?php echo $dxcc->adif; ?>"><?php echo ucwords(strtolower($dxcc->name)) . ' - ' . $dxcc->prefix; if ($dxcc->end != NULL) echo ' ('.__("Deleted DXCC").')';?>
 				</option>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -1,8 +1,8 @@
 <script>
 var dxccarray = [];
 dxccarray.push({
-	adif: 0,
-	name: '- None -',
+	adif: null,
+	name: '-',
 	cq: '',
 	itu: '',
 });
@@ -95,8 +95,8 @@ if ($dxcc_list->result() > 0) {
 					<div class="mb-3">
 					    <label for="stationDXCCInput"><?= __("Station DXCC"); ?></label>
 					    <?php if ($dxcc_list->num_rows() > 0) { ?>
-					        <select class="form-control" id="dxcc_id" name="dxcc" aria-describedby="stationCallsignInputHelp">
-					            <option value="0" <?php if($my_station_profile->station_dxcc == "0") { ?>selected<?php } ?>><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
+					        <select class="form-control" id="dxcc_id" name="dxcc" aria-describedby="stationCallsignInputHelp" required>
+					            <option value="" <?php if($my_station_profile->station_dxcc ?? '' == "") { ?>selected<?php } ?>><?= __("Please select one"); ?></option>
 					            <?php foreach ($dxcc_list->result() as $dxcc) { ?>
 					                <?php $isDeleted = $dxcc->end !== NULL; ?>
 					                <option value="<?php echo $dxcc->adif; ?>" <?php if($my_station_profile->station_dxcc == $dxcc->adif) { ?>selected<?php } ?>>

--- a/application/views/stationsetup/stationsetup.php
+++ b/application/views/stationsetup/stationsetup.php
@@ -147,7 +147,7 @@
 				<?php echo $row->station_profile_name;?><br>
 			</td>
 			<td><?php echo $row->station_callsign;?></td>
-			<td><?php echo $row->station_country == '' ? _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)") : $row->station_country; if ($row->dxcc_end != NULL) { echo ' <span class="badge bg-danger">'.__("Deleted DXCC").'</span>'; } ?></td>
+			<td><?php echo $row->station_country == '' ? __("Please select one") : $row->station_country; if ($row->dxcc_end != NULL) { echo ' <span class="badge bg-danger">'.__("Deleted DXCC").'</span>'; } ?></td>
 			<td><?php echo $row->station_gridsquare;?></td>
 			<td>
 				<?php if($row->station_active != 1) { ?>

--- a/install/assets/css/installer.css
+++ b/install/assets/css/installer.css
@@ -248,6 +248,11 @@ div.alert-danger {
 	border-color: #ffc107;
 }
 
+#dxcc_button.is-invalid {
+	border: 1px solid;
+	border-color: red;
+}
+
 .uppercase {
 	text-transform: uppercase;
 }

--- a/install/index.php
+++ b/install/index.php
@@ -485,6 +485,7 @@ if (!file_exists('.lock')) {
 											<label for="dxcc" class="form-label"><?= __("DXCC"); ?></label>
 											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp" required>
 												<option value="" selected=""><?= __("Please select one"); ?></option>
+												<option value="0" selected="">- NONE - (e.g. /MM /AM)</option>
 												<option value="2">Abu Ail Is - A1 (<?= __("Deleted DXCC"); ?>)</option>
 												<option value="3">Afghanistan - YA</option>
 												<option value="4">Agalega &amp; St Brandon Islands - 3B7</option>

--- a/install/index.php
+++ b/install/index.php
@@ -483,9 +483,8 @@ if (!file_exists('.lock')) {
 										</div>
 										<div class="col-md-6 mb-2">
 											<label for="dxcc" class="form-label"><?= __("DXCC"); ?></label>
-											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp" required>
-												<option value="" selected=""><?= __("Please select one"); ?></option>
-												<option value="0">- NONE - (e.g. /MM /AM)</option>
+											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp">
+												<option value="0" selected=""><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
 												<option value="2">Abu Ail Is - A1 (<?= __("Deleted DXCC"); ?>)</option>
 												<option value="3">Afghanistan - YA</option>
 												<option value="4">Agalega &amp; St Brandon Islands - 3B7</option>

--- a/install/index.php
+++ b/install/index.php
@@ -485,7 +485,7 @@ if (!file_exists('.lock')) {
 											<label for="dxcc" class="form-label"><?= __("DXCC"); ?></label>
 											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp" required>
 												<option value="" selected=""><?= __("Please select one"); ?></option>
-												<option value="0" selected="">- NONE - (e.g. /MM /AM)</option>
+												<option value="0">- NONE - (e.g. /MM /AM)</option>
 												<option value="2">Abu Ail Is - A1 (<?= __("Deleted DXCC"); ?>)</option>
 												<option value="3">Afghanistan - YA</option>
 												<option value="4">Agalega &amp; St Brandon Islands - 3B7</option>

--- a/install/index.php
+++ b/install/index.php
@@ -484,7 +484,7 @@ if (!file_exists('.lock')) {
 										<div class="col-md-6 mb-2">
 											<label for="dxcc" class="form-label"><?= __("DXCC"); ?></label>
 											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp">
-												<option value="0" selected=""><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
+												<option value="" selected=""><?= __("Please select one"); ?></option>
 												<option value="2">Abu Ail Is - A1 (<?= __("Deleted DXCC"); ?>)</option>
 												<option value="3">Afghanistan - YA</option>
 												<option value="4">Agalega &amp; St Brandon Islands - 3B7</option>
@@ -1607,6 +1607,7 @@ if (!file_exists('.lock')) {
 					'#callsign',
 					'#city',
 					'#user_email',
+					'#dxcc_id',
 					'#userlocator'
 				];
 
@@ -1682,13 +1683,20 @@ if (!file_exists('.lock')) {
 					let check = true;
 					firstUserInputIDs.forEach(function(inputID) {
 						if ($(inputID).val() == '') {
-							input_is_valid($(inputID), 'is-invalid');
+							if (inputID == '#dxcc_id') {
+								input_is_valid($('#dxcc_button'), 'is-invalid');
+							} else {
+								input_is_valid($(inputID), 'is-invalid');
+							}
 							show_userformwarnings('danger', "<?= __("At least one field is empty."); ?>");
 							return check = false;
 						} else {
 							if ($(inputID).hasClass('is-invalid')) {
 								hide_userformwarnings();
 								input_is_valid($(inputID), 'is-valid');
+							}
+							if (inputID == '#dxcc_id') {
+								input_is_valid($('#dxcc_button'), 'is-valid');
 							}
 						}
 					});

--- a/install/index.php
+++ b/install/index.php
@@ -483,8 +483,8 @@ if (!file_exists('.lock')) {
 										</div>
 										<div class="col-md-6 mb-2">
 											<label for="dxcc" class="form-label"><?= __("DXCC"); ?></label>
-											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp">
-												<option value="0" selected=""><?= _pgettext("DXCC Select - No DXCC", "- NONE - (e.g. /MM, /AM)"); ?></option>
+											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp" required>
+												<option value="" selected=""><?= __("Please select one"); ?></option>
 												<option value="2">Abu Ail Is - A1 (<?= __("Deleted DXCC"); ?>)</option>
 												<option value="3">Afghanistan - YA</option>
 												<option value="4">Agalega &amp; St Brandon Islands - 3B7</option>

--- a/install/index.php
+++ b/install/index.php
@@ -484,7 +484,7 @@ if (!file_exists('.lock')) {
 										<div class="col-md-6 mb-2">
 											<label for="dxcc" class="form-label"><?= __("DXCC"); ?></label>
 											<select class="form-control" id="dxcc_id" name="dxcc" tabindex="7" aria-describedby="stationCallsignInputHelp">
-												<option value="" selected=""><?= __("Please select one"); ?></option>
+												<option value="" selected><?= __("Please select one"); ?></option>
 												<option value="2">Abu Ail Is - A1 (<?= __("Deleted DXCC"); ?>)</option>
 												<option value="3">Afghanistan - YA</option>
 												<option value="4">Agalega &amp; St Brandon Islands - 3B7</option>


### PR DESCRIPTION
ADIF_DXCC = 0 was not part of the dxcc_entities table.

So a lot of Users skipped the step to fill in their own DXCC. As a result some exports weren't working (That was a bug).

This one adds the dxcc "None" hard to the DXCC-Table and forces the User to chose it's own DXCC