### PR TITLE
Use QSLRDATE provided by eqsl.cc (current date only as fallback)

### DIFF
--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -163,6 +163,13 @@ class EqslImporter
 				$record['qsl_sent'] = $config['eqsl_rcvd_mark'];
 			}
 
+			// eQSL now provides EQSL_QSLRDATE so we can use it if it is present
+			if ((array_key_exists('eqsl_qslrdate', $record)) && ($record['eqsl_qslrdate'] != '')) {
+				$eqsl_qslrdate = $record['eqsl_qslrdate'];
+			} else {
+				$eqsl_qslrdate = date('Y-m-d');
+			}
+
 			$status = $this->CI->logbook_model->import_check($time_on, $record['call'], $record['band'], $record['mode'], $station_callsign, $station_id);
 			$qsoid = 0;
 			if ($status[0] == "Found") {
@@ -170,7 +177,7 @@ class EqslImporter
 				$dupe = $this->CI->eqslmethods_model->eqsl_dupe_check($time_on, $record['call'], $record['band'], $record['mode'], $config['eqsl_rcvd_mark'], $station_callsign, $station_id);
 				if ($dupe == false) {
 					$updated += 1;
-					$eqsl_status = $this->CI->eqslmethods_model->eqsl_update($time_on, $record['call'], $record['band'], $record['mode'], $config['eqsl_rcvd_mark'], $station_callsign, $station_id);
+					$eqsl_status = $this->CI->eqslmethods_model->eqsl_update($time_on, $record['call'], $record['band'], $record['mode'], $config['eqsl_rcvd_mark'], $station_callsign, $station_id, $eqsl_qslrdate);
 				} else {
 					$dupes += 1;
 					$eqsl_status = "Already received an eQSL for this QSO.";

--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -192,6 +192,7 @@ class EqslImporter
 				'call' => str_replace("0", "&Oslash;", $record['call']),
 				'mode' => $record['mode'],
 				'submode' => $record['submode'] ?? null,
+				'eqsl_qslrdate' => $eqsl_qslrdate ?? null,
 				'status' => $status[0],
 				'eqsl_status' => $eqsl_status,
 				'qsoid' => $qsoid,

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -505,9 +505,9 @@ class Eqslmethods_model extends CI_Model {
 	// We could also probably use this:
 	// https://eqsl.cc/qslcard/VerifyQSO.txt
 	// https://www.eqsl.cc/qslcard/ImportADIF.txt
-	function eqsl_update($datetime, $callsign, $band, $mode, $qsl_status, $station_callsign, $station_id) {
+	function eqsl_update($datetime, $callsign, $band, $mode, $qsl_status, $station_callsign, $station_id, $eqsl_qslrdate = null) {
 		$data = array(
-			'COL_EQSL_QSLRDATE' => date('Y-m-d H:i:s'), // eQSL doesn't give us a date, so let's use current
+			'COL_EQSL_QSLRDATE' => $eqsl_qslrdate ?? date('Y-m-d'), // eQSL gives a date now. Use current date as fallback only
 			'COL_EQSL_QSL_RCVD' => $qsl_status
 		);
 

--- a/application/views/eqsl/analysis.php
+++ b/application/views/eqsl/analysis.php
@@ -38,6 +38,7 @@ $custom_date_format = $this->session->userdata('user_date_format');
 						<td><?= __("Call"); ?></td>
 						<td><?= __("Mode"); ?></td>
 						<td><?= __("Submode"); ?></td>
+						<td><?= __("eQSL Receive Date"); ?></td>
 						<td><?= __("Log Status"); ?></td>
 						<td><?= __("eQSL Status"); ?></td>
 					</tr>
@@ -53,6 +54,7 @@ $custom_date_format = $this->session->userdata('user_date_format');
 							<?php } ?>
 							<td><?php echo $qso['mode']; ?></td>
 							<td><?php echo $qso['submode']; ?></td>
+							<td><?php echo date ($custom_date_format, strtotime($qso['eqsl_qslrdate'])); ?></td>
 							<td><?php echo $qso['status']; ?></td>
 							<td><?php echo $qso['eqsl_status']; ?></td>
 						</tr>


### PR DESCRIPTION
eQSL does now provide the EQSL_QSLRDATE field as date when the eQSL card was received. So we should use this date instead of the current date (at the time we are importing).