### PR TITLE
fix typo in CBR export and add WIRE-ONLY overlay

### DIFF
--- a/application/views/cabrillo/index.php
+++ b/application/views/cabrillo/index.php
@@ -60,7 +60,7 @@
 					<div class="col-md-3 control-label" for="categoryassisted"><?= __("Category Assisted") ?>: </div>
 					<select class="form-select my-1 me-sm-2 col-md-4 w-auto" id="categoryassisted" name="categoryassisted">
 						<option value="NON-ASSISTED">NON-ASSISTED</option>
-						<option value="ASSISTED">ASSISTED></option>
+						<option value="ASSISTED">ASSISTED</option>
 					</select>
 				</div>
 					<div hidden="true" class="mb-3 d-flex align-items-center row additionalinfo">
@@ -157,6 +157,7 @@
 						<option value="YOUTH">YOUTH</option>
 						<option value="NOVICE-TECH">NOVICE-TECH</option>
 						<option value="YL">YL</option>
+						<option value="WIRE-ONLY">WIRE-ONLY</option>
 					</select>
 				</div>
 				<div hidden="true" class="mb-3 d-flex align-items-center row additionalinfo">


### PR DESCRIPTION
this fixes a typo in the view for CBR export, as well as adds the WIRE-ONLY overlay used in the Scandinavian Activity Contest ([Source](https://www.sactest.net/blog/scandinavian-activity-contest-2024-rules/))