### PR TITLE
Added QRZ-Tab to Edit-QSO/QSLs

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1265,6 +1265,18 @@ class Logbook_model extends CI_Model {
 			$eqsl_rcvd = 'N';
 		}
 
+		if ($this->input->post('qrz_sent')) {
+			$qrz_sent = $this->input->post('qrz_sent');
+		} else {
+			$qrz_sent = 'N';
+		}
+
+		if ($this->input->post('qrz_rcvd')) {
+			$qrz_rcvd = $this->input->post('qrz_rcvd');
+		} else {
+			$qrz_rcvd = 'N';
+		}
+
 		if (in_array($this->input->post('prop_mode'), $this->config->item('lotw_unsupported_prop_modes'))) {
 			$lotw_sent = 'I';
 		} elseif ($this->input->post('lotw_sent')) {
@@ -1329,6 +1341,27 @@ class Logbook_model extends CI_Model {
 			$lotwrdate = $qso->COL_LOTW_QSLRDATE;
 		}
 
+		$qrz_modified=false;
+		if ($qrz_sent == 'N' && $qso->COL_QRZCOM_QSO_UPLOAD_STATUS != $qrz_sent) {
+			$qrzsdate = null;
+			$qrz_modified=true;
+		} elseif (!$qso->COL_QRZCOM_QSO_UPLOAD_DATE || $qso->COL_QRZCOM_QSO_UPLOAD_STATUS != $qrz_sent) {
+			$qrzsdate = date('Y-m-d H:i:s');
+			$qrz_modified=true;
+		} else {
+			$qrzsdate = $qso->COL_QRZCOM_QSO_UPLOAD_DATE;
+		}
+
+		if ($qrz_rcvd == 'N' && $qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS != $qrz_rcvd) {
+			$qrzrdate = null;
+			$qrz_modified=true;
+		} elseif (!$qso->COL_QRZCOM_QSO_DOWNLOAD_DATE || $qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS != $qrz_rcvd) {
+			$qrzrdate = date('Y-m-d H:i:s');
+			$qrz_modified=true;
+		} else {
+			$qrzrdate = $qso->COL_QRZCOM_QSO_DOWNLOAD_DATE;
+		}
+
 		if (($this->input->post('distance')) && (is_numeric($this->input->post('distance')))) {
 			$distance = $this->input->post('distance');
 		} else {
@@ -1370,6 +1403,10 @@ class Logbook_model extends CI_Model {
 			'COL_EQSL_QSL_SENT' => $this->input->post('eqsl_sent'),
 			'COL_EQSL_QSL_RCVD' => $this->input->post('eqsl_rcvd'),
 			'COL_QSLMSG' => $this->input->post('qslmsg'),
+			'COL_QRZCOM_QSO_UPLOAD_DATE' => $qrzsdate,
+			'COL_QRZCOM_QSO_DOWNLOAD_DATE' => $qrzrdate,
+			'COL_QRZCOM_QSO_UPLOAD_STATUS' => $qrz_sent,
+			'COL_QRZCOM_QSO_DOWNLOAD_STATUS' => $qrz_rcvd,
 			'COL_LOTW_QSLSDATE' => $lotwsdate,
 			'COL_LOTW_QSLRDATE' => $lotwrdate,
 			'COL_LOTW_QSL_SENT' => $lotw_sent,
@@ -1406,11 +1443,11 @@ class Logbook_model extends CI_Model {
 			'COL_MY_SIG_INFO' => $sigInfo
 		);
 
-		if ($this->exists_hrdlog_credentials($data['station_id'])) {
+		if ($this->exists_hrdlog_credentials($data['station_id']) && !$qrz_modified) {
 			$data['COL_HRDLOG_QSO_UPLOAD_STATUS'] = 'M';
 		}
 
-		if ($this->exists_qrz_api_key($data['station_id'])) {
+		if ($this->exists_qrz_api_key($data['station_id']) && !$qrz_modified) {
 			$data['COL_QRZCOM_QSO_UPLOAD_STATUS'] = 'M';
 		}
 

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -540,7 +540,7 @@
                                             </div>
                                         </div>
                                     </div>
-				    <div class="tab-pane fade" id="qrz" role="tabpanel" aria-labelledby="qrz-tab">
+				                    <div class="tab-pane fade" id="qrz" role="tabpanel" aria-labelledby="qrz-tab">
                                         <div class="mb-3 row">
                                             <label for="sent" class="col-sm-3 col-form-label"><?= __("Sent"); ?></label>
                                             <div class="col-sm-9">

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -411,6 +411,9 @@
                                     <li class="nav-item">
                                         <a class="nav-link" id="contact-tab" data-bs-toggle="tab" href="#contact" role="tab" aria-controls="contact" aria-selected="false"><?= __("LoTW"); ?></a>
                                     </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link" id="contact-tab" data-bs-toggle="tab" href="#qrz" role="tab" aria-controls="qrz" aria-selected="false"><?= __("QRZ"); ?></a>
+                                    </li>
                                 </ul>
                                 <div class="tab-content" id="myTabContent">
                                     <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
@@ -534,6 +537,33 @@
                                                     <option value="V" <?php if($qso->COL_LOTW_QSL_RCVD == "V") { echo "selected=\"selected\""; } ?>><?= __("Verified (Match)"); ?></option>
                                                 </select>
                                                 <small id="lotw_propmode_hint" class="form-text text-muted"><?php if (in_array($qso->COL_PROP_MODE, $this->config->item('lotw_unsupported_prop_modes'))) { echo __("Propagation mode is not supported by LoTW. LoTW QSL fields disabled."); } else { echo "&nbsp;"; } ?></small>
+                                            </div>
+                                        </div>
+                                    </div>
+				    <div class="tab-pane fade" id="qrz" role="tabpanel" aria-labelledby="qrz-tab">
+                                        <div class="mb-3 row">
+                                            <label for="sent" class="col-sm-3 col-form-label"><?= __("Sent"); ?></label>
+                                            <div class="col-sm-9">
+                                                <select class="form-select" id="qrz_sent" name="qrz_sent">
+                                                    <option value="N" <?php if($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == "N") { echo "selected=\"selected\""; } ?>><?= __("No"); ?></option>
+                                                    <option value="Y" <?php if($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == "Y") { echo "selected=\"selected\""; } ?>><?= __("Yes"); ?></option>
+                                                    <option value="R" <?php if($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == "R") { echo "selected=\"selected\""; } ?>><?= __("Requested"); ?></option>
+                                                    <option value="Q" <?php if($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == "Q") { echo "selected=\"selected\""; } ?>><?= __("Queued"); ?></option>
+                                                    <option value="I" <?php if($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == "I") { echo "selected=\"selected\""; } ?>><?= __("Invalid (Ignore)"); ?></option>
+                                                    <option value="M" <?php if($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == "M") { echo "selected=\"selected\""; } ?>><?= __("Modified"); ?></option>
+                                                </select></div>
+                                        </div>
+
+                                        <div class="mb-3 row">
+                                            <label for="sent" class="col-sm-3 col-form-label"><?= __("Received"); ?></label>
+                                            <div class="col-sm-9">
+                                                <select class="form-select" id="qrz_rcvd" name="qrz_rcvd">
+                                                    <option value="N" <?php if($qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS == "N") { echo "selected=\"selected\""; } ?>><?= __("No"); ?></option>
+                                                    <option value="Y" <?php if($qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS == "Y") { echo "selected=\"selected\""; } ?>><?= __("Yes"); ?></option>
+                                                    <option value="R" <?php if($qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS == "R") { echo "selected=\"selected\""; } ?>><?= __("Requested"); ?></option>
+                                                    <option value="I" <?php if($qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS == "I") { echo "selected=\"selected\""; } ?>><?= __("Invalid (Ignore)"); ?></option>
+                                                    <option value="V" <?php if($qso->COL_QRZCOM_QSO_DOWNLOAD_STATUS == "V") { echo "selected=\"selected\""; } ?>><?= __("Verified (Match)"); ?></option>
+                                                </select>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Added QRZ-Tab to the QSO-Editor

<img width="902" alt="image" src="https://github.com/user-attachments/assets/98b8cddf-4f58-48cf-9183-deb06613f089">

Changes on this tab are processed as followed:
- A change for QRZ-SENT or RECVD is not triggering the "M"odified-Logic introduced by @HB9HIL at #954 
- All other changes are triggering that as before.