### PR TITLE
Added hint for next automatic syncs to eQSL, LoTW and QRZ

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -54,6 +54,9 @@ class eqsl extends CI_Controller {
 		$station_profile = $this->stations->profile($active_station_id);
 		$data['active_station_info'] = $station_profile->row();
 
+		$this->load->model('cron_model');
+		$data['next_run'] = $this->cron_model->get_next_run("eqsl_sync");
+
 		// Check if eQSL Nicknames have been defined
 		$this->load->model('eqslmethods_model');
 		$eqsl_locations = $this->eqslmethods_model->all_of_user_with_eqsl_nick_defined();

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -56,6 +56,9 @@ class Lotw extends CI_Controller {
 		$uploads_folder = $this->permissions->is_really_writable('uploads');
 		$data['uploads_folder'] = $uploads_folder;
 
+		$this->load->model('cron_model');
+		$data['next_run'] = $this->cron_model->get_next_run("lotw_lotw_download");
+
 		// Load Views
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('lotw_views/index');

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -199,6 +199,9 @@ class Qrz extends CI_Controller {
 		$data['station_profile'] = $this->stations->stations_with_qrz_api_key();
 		$this->load->model('Stations');
 		$data['callsigns'] = $this->Stations->callsigns_of_user($this->session->userdata('user_id'));
+		$this->load->model('cron_model');
+		$data['next_run_up'] = $this->cron_model->get_next_run("qrz_upload");
+		$data['next_run_down'] = $this->cron_model->get_next_run("qrz_download");
 
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('qrz/export');

--- a/application/models/Cron_model.php
+++ b/application/models/Cron_model.php
@@ -90,4 +90,14 @@ class Cron_model extends CI_Model
 		
 		$this->set_modified($id);
 	}
+
+	function get_next_run($what) {
+		$crons=$this->get_crons();
+		$one_cron = $crons[array_search($what,array_column($crons,'id'),true)];
+		if (property_exists($one_cron,'next_run')) {
+			return $one_cron->next_run;
+		} else {
+			return null;
+		}
+	}
 }

--- a/application/views/eqsl/import.php
+++ b/application/views/eqsl/import.php
@@ -25,6 +25,7 @@
 			<?php echo form_open_multipart('eqsl/import'); ?>
 
 			<div class="form-check">
+            			<?php if (($next_run ?? '') != '') { echo "<p>".__("The next automatic sync with eQSL will happen at: ").$next_run."</p>"; } ?>
 				<input class="form-check-input" type="radio" name="eqslimport" id="upload" value="upload" checked />
 				<label class="form-check-label" for="exampleRadios1">
 					<?= __("Import from file..."); ?>

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -141,6 +141,7 @@
 		</div>
 
 		<div class="card-body">
+            		<?php if (($next_run ?? '') != '') { echo "<p>".__("The next automatic sync with LoTW will happen at: ").$next_run."</p>"; } ?>
 			<button class="btn btn-outline-success" hx-get="<?php echo site_url('lotw/lotw_upload'); ?>"  hx-target="#lotw_manual_results">
 				<?= __("Manual Sync"); ?>
 			</button>

--- a/application/views/qrz/export.php
+++ b/application/views/qrz/export.php
@@ -24,6 +24,7 @@
         <div class="card-body">
 			<div class="tab-content">
 				<div class="tab-pane active" id="export" role="tabpanel" aria-labelledby="export-tab">
+            <?php if (($next_run_up ?? '') != '') { echo "<p>".__("The next automatic Upload to QRZ will happen at: ").$next_run_up."</p>"; } ?>
             <p><?= __("Here you can see all QSOs which have not been previously uploaded to a QRZ logbook."); ?></p>
             <p><?= __("You need to set a QRZ Logbook API key in your station profile. Only station profiles with an API Key set are displayed."); ?></p>
             <?php if (!($this->config->item('disable_manual_qrz'))) { echo '<p><span class="badge text-bg-warning">Warning</span> This might take a while as QSO uploads are processed sequentially.</p>'; } ?>
@@ -70,6 +71,7 @@
 			<div class="tab-pane fade" id="import" role="tabpanel" aria-labelledby="home-tab">
 
 				<form class="form" action="<?php echo site_url('qrz/import_qrz'); ?>" method="post" enctype="multipart/form-data">
+            				<?php if (($next_run_down ?? '') != '') { echo "<p>".__("The next automatic Download from QRZ-QSLs will happen at: ").$next_run_down."</p>"; } ?>
 					<p><span class="badge text-bg-warning"><?= __("Warning"); ?></span> <?= __("If no startdate is given then all QSOs after last confirmation will be downloaded/updated!"); ?></p>
 					<div class="row">
 						<div class="col-md-2">


### PR DESCRIPTION
Adds a note to the pages for QRZ, LoTW and QRZ that indicates the next sync start to the user.

Prerequisites: The cron manager must be activated and scheduled.