### PR TITLE
Fix radio value = 0

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -314,6 +314,7 @@
             <div class="mb-3">
               <label for="radio"><?= __("Radio"); ?></label>
               <select class="form-select radios" id="radio" name="radio">
+                <option value="0" selected="selected"><?= __("None"); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
                   <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "(".__("last updated").")"; } else { echo ''; } ?></option>
                 <?php } ?>


### PR DESCRIPTION
Fixes a bad bug which was introduced in #1060 and caused another issue which was solved in #1095 

Bug caused the whole CAT, Band.on(change) and QRG stuff to fail as there was no value for the radio.