### PR TITLE
Allow for export upon single QSO ADIF being sent to API

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -226,7 +226,7 @@ class API extends CI_Controller {
 				};
 				$record='';	// free memory
 				gc_collect_cycles();
-				$custom_errors = $this->logbook_model->import_bulk($alladif, $obj['station_profile_id'], false, false, false, false, false, false, false, true, false, true, false);
+				$custom_errors = $this->logbook_model->import_bulk($alladif, $obj['station_profile_id'], false, false, false, false, false, false, false, false, false, true, false);
 				if ($custom_errors) {
 					$adif_errors++;
 				}


### PR DESCRIPTION
(Working) implementation for https://github.com/wavelog/wavelog/pull/1112.

$user requested QO-100 Dx Club uploads for (single) QSOs being sent via API, e.g. Logging from WSJT-X improved. 

This disables skipExport for API calls and adds a distinction for number of ADIF records sent via API. If its only one QSO we insert directly (and this get the insert ID) instead of using batch mode. Getting the ID allows for exports like QO-100 Dx Club instant uploads for QSOs sent via API.

@int2001 @AndreasK79 @HB9HIL would like you to double check if we can invert skipExport here especially for multi-user envs like DCL.
