### PR TITLE
Invalid CQ Zone Value

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -690,7 +690,7 @@ $("#callsign").focusout(function () {
 
 				$('#dxcc_id').val(result.dxcc.adif).multiselect('refresh');
 				await updateStateDropdown('#dxcc_id', '#stateInputLabel', '#location_us_county', '#stationCntyInputEdit');
-				if (result.callsign_cqz != '') {
+				if (result.callsign_cqz != '' && (result.callsign_cqz >= 1 && result.callsign_cqz <= 40)) {
 					$('#cqz').val(result.callsign_cqz);
 				} else {
 					$('#cqz').val(result.dxcc.cqz);


### PR DESCRIPTION
If the CQ Zone is `(result.callsign_cqz >= 1 && result.callsign_cqz <= 40)` we can safely use it, otherwise we should use the DXCC data

Classic Shit-In / Shit-Out by callbook provider

