### PR TITLE
Fix LBA issue with CQZ 0 and remove some ucwords from DXCC NONE

### DIFF
--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -71,7 +71,11 @@ class DXCC extends CI_Model {
 
 		foreach ($bands as $band) {             	// Looping through bands and entities to generate the array needed for display
 			foreach ($dxccArray as $dxcc) {
-				$dxccMatrix[$dxcc->adif]['name'] = ucwords(strtolower($dxcc->name), "- (/");
+				if ($dxcc->adif == '0') {
+					$dxccMatrix[$dxcc->adif]['name'] = $dxcc->name;
+				} else {
+					$dxccMatrix[$dxcc->adif]['name'] = ucwords(strtolower($dxcc->name), "- (/");
+				}
 				$dxccMatrix[$dxcc->adif]['Dxccprefix'] = $dxcc->prefix;
 				if ($postdata['includedeleted'])
 					$dxccMatrix[$dxcc->adif]['Deleted'] = isset($dxcc->Enddate) ? 1 : 0;

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -170,12 +170,17 @@ $options = json_decode($options);
                                 <option value="">-</option>
                                 <?php
                                 foreach ($dxccarray as $dxcc) {
-                                    echo '<option value=' . $dxcc->adif;
-                                    echo '>' . $dxcc->prefix . ' - ' . ucwords(strtolower($dxcc->name), "- (/");
-                                    if ($dxcc->Enddate != null) {
-                                        echo ' - (' . __("Deleted DXCC") . ')';
+                                    if ($dxcc->adif == '0') {
+                                        echo '<option value='.$dxcc->adif.'>';
+                                        echo $dxcc->name;
+                                        echo '</option>';
+                                    } else {
+                                        echo '<option value=' . $dxcc->adif;
+                                        echo '>' . $dxcc->prefix . ' - ' . ucwords(strtolower($dxcc->name), "- (/");
+                                        if ($dxcc->Enddate != null) {
+                                            echo ' - (' . __("Deleted DXCC") . ')';
+                                        }
                                     }
-                                    echo '</option>';
                                 }
                                 ?>
                             </select>

--- a/application/views/lookup/index.php
+++ b/application/views/lookup/index.php
@@ -26,11 +26,15 @@
 
 			<?php
 			foreach ($dxcc as $d) {
-				echo '<option value=' . $d->adif . '>' . $d->prefix . ' - ' . ucwords(strtolower($d->name), "- (/");
-				if ($d->Enddate != null) {
-					echo ' (' . __("Deleted DXCC") . ')';
+				if ($d->adif == '0') {
+					echo '<option value='.$d->adif.'>'.$d->name.'</option>';
+				} else {
+					echo '<option value=' . $d->adif . '>' . $d->prefix . ' - ' . ucwords(strtolower($d->name), "- (/");
+					if ($d->Enddate != null) {
+						echo ' (' . __("Deleted DXCC") . ')';
+					}
+					echo '</option>';
 				}
-				echo '</option>';
 			}
 			?>
 

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -220,16 +220,24 @@
                                         <select class="form-select" id="dxcc_id" name="dxcc_id" required>
                                             <option value=""><?= __("Please select one"); ?></option>
                                             <?php
-                                            foreach($dxcc as $d){
-                                                echo '<option value=' . $d->adif;
-                                                if ($qso->COL_DXCC == $d->adif) {
-                                                    echo " selected=\"selected\"";
+                                            foreach($dxcc as $d) {
+                                                if ($d->adif == '0') {
+                                                    echo '<option value='.$d->adif;
+                                                    if ($qso->COL_DXCC == $d->adif) {
+                                                        echo " selected=\"selected\"";
+                                                    }
+                                                    echo '>'.$d->name.'</option>';
+                                                } else {
+                                                    echo '<option value=' . $d->adif;
+                                                    if ($qso->COL_DXCC == $d->adif) {
+                                                        echo " selected=\"selected\"";
+                                                    }
+                                                    echo '>' . $d->prefix . ' - ' . ucwords(strtolower(($d->name)));
+                                                    if ($d->Enddate != null) {
+                                                        echo ' ('.__("Deleted DXCC").')';
+                                                    }
+                                                    echo '</option>';
                                                 }
-                                                echo '>' . $d->prefix . ' - ' . ucwords(strtolower(($d->name)));
-                                                if ($d->Enddate != null) {
-                                                    echo ' ('.__("Deleted DXCC").')';
-                                                }
-                                                echo '</option>';
                                             }
                                             ?>
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -364,12 +364,16 @@
                   <label for="dxcc_id"><?= __("DXCC"); ?></label>
                   <select class="form-control" id="dxcc_id" name="dxcc_id" required>
                       <?php
-                      foreach($dxcc as $d){
-                          echo '<option value=' . $d->adif . '>' . $d->prefix . ' - ' . ucwords(strtolower(($d->name)));
-                          if ($d->Enddate != null) {
-                              echo ' ('.__("Deleted DXCC").')';
+                      foreach($dxcc as $d) {
+                          if ($d->adif == '0') {
+                              echo '<option value='.$d->adif.'>'.$d->name.'</option>';
+                          } else {
+                              echo '<option value=' . $d->adif . '>' . $d->prefix . ' - ' . ucwords(strtolower(($d->name)));
+                              if ($d->Enddate != null) {
+                                  echo ' ('.__("Deleted DXCC").')';
+                              }
+                              echo '</option>';
                           }
-                          echo '</option>';
                       }
                       ?>
 

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -236,7 +236,11 @@
                     <?php if($row->name != null) { ?>
                     <tr>
                         <td><?= __("Country"); ?></td>
-                        <td><?php echo ucwords(strtolower(($row->name)), "- (/"); if ($dxccFlag != null) { echo " ".$dxccFlag; } if ($row->end != null) { echo ' <span class="badge text-bg-danger">'.__("Deleted DXCC").'</span>'; } ?></td>
+                        <td><?php if ($row->adif == '0') {
+                                     echo $row->name;
+                                  } else {
+                                     echo ucwords(strtolower(($row->name)), "- (/"); if ($dxccFlag != null) { echo " ".$dxccFlag; } if ($row->end != null) { echo ' <span class="badge text-bg-danger">'.__("Deleted DXCC").'</span>'; }
+                                  } ?></td>
                     </tr>
                     <?php } ?>
 

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -234,7 +234,7 @@ class QSO
 	function geCqLink($cqz): string
 	{
 		$cqz_link = '';
-		if ($cqz <= '40') {
+		if ($cqz > '0' && $cqz <= '40') {
 			return '<a href="javascript:spawnLookupModal('.$cqz.',\'cq\');">'.$cqz.'</a>';
 		}
 		return $cqz;

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -204,7 +204,7 @@ class QSO
 		$this->clublog = $this->getClublogString($data, $custom_date_format);
 		$this->qrz = $this->getQrzString($data, $custom_date_format);
 
-		$this->cqzone = ($data['COL_CQZ'] === null || $data['COL_CQZ'] == '0') ? '' : $this->getCqLink($data['COL_CQZ']);
+		$this->cqzone = $data['COL_CQZ'] === null ? '' : $this->getCqLink($data['COL_CQZ']);
 		$this->ituzone = $data['COL_ITUZ'] ?? '';
 		$this->state = ($data['COL_STATE'] === null) ? '' :$data['COL_STATE'];
 		if ($data['adif'] == '0') {

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -207,7 +207,11 @@ class QSO
 		$this->cqzone = ($data['COL_CQZ'] === null || $data['COL_CQZ'] == '0') ? '' : $this->getCqLink($data['COL_CQZ']);
 		$this->ituzone = $data['COL_ITUZ'] ?? '';
 		$this->state = ($data['COL_STATE'] === null) ? '' :$data['COL_STATE'];
-		$this->dxcc = (($data['dxccname'] ?? null) === null) ? '- NONE -' : '<a href="javascript:spawnLookupModal('.$data['COL_DXCC'].',\'dxcc\');">'.ucwords(strtolower($data['dxccname']), "- (/").'</a>';
+		if ($data['adif'] == '0') {
+			$this->dxcc = '<a href="javascript:spawnLookupModal('.$data['COL_DXCC'].',\'dxcc\');">'.$data['dxccname'].'</a>';
+		} else {
+			$this->dxcc = (($data['dxccname'] ?? null) === null) ? '- NONE -' : '<a href="javascript:spawnLookupModal('.$data['COL_DXCC'].',\'dxcc\');">'.ucwords(strtolower($data['dxccname']), "- (/").'</a>';
+		}
 		$this->iota = ($data['COL_IOTA'] === null) ? '' : $this->getIotaLink($data['COL_IOTA']);
 		if (array_key_exists('end', $data)) {
 			$this->end = ($data['end'] === null) ? null : DateTime::createFromFormat("Y-m-d", $data['end'], new DateTimeZone('UTC'));

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -204,7 +204,7 @@ class QSO
 		$this->clublog = $this->getClublogString($data, $custom_date_format);
 		$this->qrz = $this->getQrzString($data, $custom_date_format);
 
-		$this->cqzone = ($data['COL_CQZ'] === null) ? '' : $this->getCqLink($data['COL_CQZ']);
+		$this->cqzone = ($data['COL_CQZ'] === null || $data['COL_CQZ'] == '0') ? '' : $this->getCqLink($data['COL_CQZ']);
 		$this->ituzone = $data['COL_ITUZ'] ?? '';
 		$this->state = ($data['COL_STATE'] === null) ? '' :$data['COL_STATE'];
 		$this->dxcc = (($data['dxccname'] ?? null) === null) ? '- NONE -' : '<a href="javascript:spawnLookupModal('.$data['COL_DXCC'].',\'dxcc\');">'.ucwords(strtolower($data['dxccname']), "- (/").'</a>';

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -204,7 +204,7 @@ class QSO
 		$this->clublog = $this->getClublogString($data, $custom_date_format);
 		$this->qrz = $this->getQrzString($data, $custom_date_format);
 
-		$this->cqzone = ($data['COL_CQZ'] === null) ? '' : $this->geCqLink($data['COL_CQZ']);
+		$this->cqzone = ($data['COL_CQZ'] === null) ? '' : $this->getCqLink($data['COL_CQZ']);
 		$this->ituzone = $data['COL_ITUZ'] ?? '';
 		$this->state = ($data['COL_STATE'] === null) ? '' :$data['COL_STATE'];
 		$this->dxcc = (($data['dxccname'] ?? null) === null) ? '- NONE -' : '<a href="javascript:spawnLookupModal('.$data['COL_DXCC'].',\'dxcc\');">'.ucwords(strtolower($data['dxccname']), "- (/").'</a>';
@@ -231,7 +231,7 @@ class QSO
 	/**
 	 * @return string
 	 */
-	function geCqLink($cqz): string
+	function getCqLink($cqz): string
 	{
 		$cqz_link = '';
 		if ($cqz > '0' && $cqz <= '40') {

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -237,7 +237,6 @@ class QSO
 	 */
 	function getCqLink($cqz): string
 	{
-		$cqz_link = '';
 		if ($cqz > '0' && $cqz <= '40') {
 			return '<a href="javascript:spawnLookupModal('.$cqz.',\'cq\');">'.$cqz.'</a>';
 		}


### PR DESCRIPTION
This fixes and issue with CQ zone 0 leaving the quicklookupmodal unresponsive and all spinners rotating. Fixed by hiding zone if 0.

![Screenshot from 2024-10-23 14-09-51](https://github.com/user-attachments/assets/fcd5ae20-c53a-4b55-bc44-38358f5911ef)

Also fixes a few issues with DXCC NONE in various places. The uclower etc. does not make sense here. See screenshots belows.

![Screenshot from 2024-10-23 14-16-20](https://github.com/user-attachments/assets/139400a0-b4c9-4668-a570-e8c7edb2f0f0)

![Screenshot from 2024-10-23 14-16-26](https://github.com/user-attachments/assets/8db40af0-bf40-4e15-b631-5943ef162ec5)

![Screenshot from 2024-10-23 14-27-54](https://github.com/user-attachments/assets/e8d081e1-ce93-463a-888f-e96e419279b3)

![Screenshot from 2024-10-23 14-35-35](https://github.com/user-attachments/assets/d170015e-c656-4997-a91c-b257ddf19c94)

![Screenshot from 2024-10-23 14-43-21](https://github.com/user-attachments/assets/7adf2f30-72f7-45c9-8298-cac5716e0ce6)

![Screenshot from 2024-10-23 14-46-56](https://github.com/user-attachments/assets/07d2463d-346f-4c4b-ab6e-d9330efc3bae)

