### PR TITLE
Update/add MESAT and SONATE-2 and reset LoTW upload for those

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 224;
+$config['migration_version'] = 225;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/225_lotw_satupdate_mesat_sonate.php
+++ b/application/migrations/225_lotw_satupdate_mesat_sonate.php
@@ -1,0 +1,55 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+class Migration_lotw_satupdate_mesat_sonate extends CI_Migration
+{
+	public function up() {
+		$this->db->set('name', 'MO-122');
+		$this->db->where('name', 'MESAT1');
+		$this->db->or_where('name', 'MESAT-1');
+		$this->db->update('satellite');
+
+		$this->db->select('COUNT(name) AS count');
+		$this->db->where('name', 'MO-122');
+		$query = $this->db->get('satellite');
+		$row = $query->row();
+		if ($row->count == 0) {
+			$data = array('name' => 'MO-122', 'exportname' => '', 'orbit' => 'LEO');
+			$this->db->insert('satellite', $data);
+			$this->db->query("INSERT INTO satellitemode (name, satelliteid, uplink_mode, uplink_freq, downlink_mode, downlink_freq) SELECT 'V/U', id, 'LSB', '145925000', 'USB', '435825000' FROM satellite WHERE name = 'MO-122';");
+		}
+
+		$this->db->set('COL_SAT_NAME', 'MO-122');
+		$this->db->set('COL_LOTW_QSL_SENT', 'N');
+		$this->db->set('COL_LOTW_QSLSDATE', null);
+		$this->db->where('COL_SAT_NAME', 'MESAT1');
+		$this->db->or_where('COL_SAT_NAME', 'MESAT-1');
+		$this->db->update($this->config->item('table_name'));
+
+		$this->db->set('name', 'SONATE');
+		$this->db->where('name', 'SONATE-2');
+		$this->db->update('satellite');
+
+		$this->db->select('COUNT(name) AS count');
+		$this->db->where('name', 'SONATE');
+		$query = $this->db->get('satellite');
+		$row = $query->row();
+		if ($row->count == 0) {
+			$data = array('name' => 'SONATE', 'exportname' => '', 'orbit' => 'LEO');
+			$this->db->insert('satellite', $data);
+			$this->db->query("INSERT INTO satellitemode (name, satelliteid, uplink_mode, uplink_freq, downlink_mode, downlink_freq) SELECT 'V/V', id, 'PKT', '145825000', 'PKT', '145825000' FROM satellite WHERE name = 'SONATE';");
+		}
+
+		$this->db->set('COL_SAT_NAME', 'SONATE');
+		$this->db->set('COL_LOTW_QSL_SENT', 'N');
+		$this->db->set('COL_LOTW_QSLSDATE', null);
+		$this->db->where('COL_SAT_NAME', 'SONATE-2');
+		$this->db->update($this->config->item('table_name'));
+
+	}
+
+	public function down()
+	{
+		// Not Possible
+	}
+}


### PR DESCRIPTION
MESAT1 and SONATE-2 are now accepted on LoTW. This PR:

- Renames MESAT1/MESAT-1 to MO-122 in satellite table (if found)
- If not found adds that satellite to satellite table
- Renames SAT name in already logged QSOs
- Resets LoTW upload to N and LOTW upload date to empty (to enable re-upload with correct name)

Same goes for SONATE-2 (recognized as SONATE by LoTW).