### PR TITLE
[QSO] Improvement and Bugfixes

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -66,73 +66,67 @@ class Lookup extends CI_Controller {
 	public function scp() {
 		session_write_close();
 		$uppercase_callsign = strtoupper($this->input->post('callsign', TRUE) ?? '');
-
+	
 		// SCP results from logbook
 		$this->load->model('logbook_model');
-
+	
 		$arCalls = array();
-
+	
 		$query = $this->logbook_model->get_callsigns($uppercase_callsign);
-
-		foreach ($query->result() as $row)
-	    {
-	    	if (in_array($row->COL_CALL, $arCalls) == false)
-			{
-					$arCalls[] = str_replace('0', 'Ø', $row->COL_CALL);
-			}
-	    }
-
+	
+		foreach ($query->result() as $row) {
+			$normalized_call = str_replace('0', 'Ø', $row->COL_CALL);
+			$arCalls[$normalized_call] = true;
+		}
+	
 		// SCP results from Club Log master scp db
 		$file = 'updates/clublog_scp.txt';
-
+	
 		if (is_readable($file)) {
 			$lines = file($file, FILE_IGNORE_NEW_LINES);
 			$input = preg_quote($uppercase_callsign, '~');
 			$result = preg_grep('~' . $input . '~', $lines, 0);
-			foreach ($result as &$value) {
-				if (in_array($value, $arCalls) == false)
-				{
-					$arCalls[] = str_replace('0', 'Ø', $value);
-				}
+			foreach ($result as $value) {
+				$normalized_call = str_replace('0', 'Ø', $value);
+				$arCalls[$normalized_call] = true;
 			}
 		} else {
 			$src = 'assets/resources/clublog_scp.txt';
 			if (copy($src, $file)) {
 				$this->scp();
+				return;
 			} else {
 				log_message('error', 'Failed to copy source file ('.$src.') to new location. Check if this path has the right permission: '.$file);
 			}
 		}
-
+	
 		// SCP results from master scp https://www.supercheckpartial.com
 		$file = 'updates/MASTER.SCP';
-
+	
 		if (is_readable($file)) {
 			$lines = file($file, FILE_IGNORE_NEW_LINES);
 			$input = preg_quote($uppercase_callsign, '~');
 			$result = preg_grep('~' . $input . '~', $lines, 0);
-			foreach ($result as &$value) {
-				if (in_array($value, $arCalls) == false)
-				{
-					$arCalls[] = str_replace('0', 'Ø', $value);
-				}
+			foreach ($result as $value) {
+				$normalized_call = str_replace('0', 'Ø', $value);
+				$arCalls[$normalized_call] = true;
 			}
 		} else {
 			$src = 'assets/resources/MASTER.SCP';
 			if (copy($src, $file)) {
 				$this->scp();
+				return;
 			} else {
 				log_message('error', 'Failed to copy source file ('.$src.') to new location. Check if this path has the right permission: '.$file);
 			}
 		}
-
-		sort($arCalls);
-
-		foreach ($arCalls as $strCall)
-		{
+	
+		// Sort and print unique calls
+		ksort($arCalls);
+	
+		foreach (array_keys($arCalls) as $strCall) {
 			echo " " . $strCall . " ";
 		}
-
 	}
 
 	public function dok($call) {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -4,7 +4,7 @@ var selected_sat_mode;
 var scps = [];
 
 // if the dxcc id changes we need to update the state dropdown and clear the county value to avoid wrong data
-$("#dxcc_id").change(function () {
+$("#dxcc_id").on('change', function () {
 	updateStateDropdown('#dxcc_id', '#stateInputLabel', '#location_us_county', '#stationCntyInputQso');
 	$('#stationCntyInputQso').val('');
 	$('#dxcc_id').multiselect('refresh');
@@ -33,7 +33,7 @@ function getUTCDateStamp(el) {
 }
 
 
-$('#stationProfile').change(function () {
+$('#stationProfile').on('change', function () {
 	var stationProfile = $('#stationProfile').val();
 	$.ajax({
 		url: base_url + 'index.php/qso/get_station_power',
@@ -56,22 +56,19 @@ $('.qso_panel .qso_eqsl_qslmsg_update').off('click').on('click', function () {
 	$('#charsLeft').text(" ");
 });
 
-$(document).keyup(function (e) {
-	if (e.charCode === 0) {
-		let fixedcall = $('#callsign').val();
-		$('#callsign').val(fixedcall.replace('Ø', '0'));
-	}
+$(document).on("keydown", function (e) {
 	if (e.key === "Escape") { // escape key maps to keycode `27`
 		reset_fields();
 		resetTimers(qso_manual)
 		$('#callsign').val("");
-		$("#callsign").focus();
+		$("#callsign").trigger("focus");
 	}
 });
 
 // Sanitize some input data
 $('#callsign').on('input', function () {
 	$(this).val($(this).val().replace(/\s/g, ''));
+	$(this).val($(this).val().replace(/0/g, 'Ø'));
 });
 
 $('#locator').on('input', function () {
@@ -93,7 +90,7 @@ function set_timers() {
 		var callsignValue = localStorage.getItem("quicklogCallsign");
 		if (callsignValue !== null && callsignValue !== undefined) {
 			$("#callsign").val(callsignValue);
-			$("#mode").focus();
+			$("#mode").trigger("focus");
 			localStorage.removeItem("quicklogCallsign");
 		}
 	}, 100);
@@ -131,7 +128,7 @@ $("#qso_input").off('submit').on('submit', function (e) {
 					$("#noticer").fadeOut(2000);
 					var triggerEl = document.querySelector('#myTab a[href="#qso"]')
 					bootstrap.Tab.getInstance(triggerEl).show() // Select tab by name
-					$("#callsign").focus();
+					$("#callsign").trigger("focus");
 				} else {
 					$("#noticer").removeClass("");
 					$("#noticer").addClass("alert alert-warning");
@@ -152,7 +149,7 @@ $("#qso_input").off('submit').on('submit', function (e) {
 	return false;
 });
 
-$('#reset_time').click(function () {
+$('#reset_time').on("click", function () {
 	var now = new Date();
 	var localTime = now.getTime();
 	var utc = localTime + (now.getTimezoneOffset() * 60000);
@@ -162,7 +159,7 @@ $('#reset_time').click(function () {
 	});
 });
 
-$('#reset_start_time').click(function () {
+$('#reset_start_time').on("click", function () {
 	var now = new Date();
 	var localTime = now.getTime();
 	var utc = localTime + (now.getTimezoneOffset() * 60000);
@@ -178,7 +175,7 @@ $('#reset_start_time').click(function () {
 	$('#start_date').val(("0" + now.getUTCDate()).slice(-2) + '-' + ("0" + (now.getUTCMonth() + 1)).slice(-2) + '-' + now.getUTCFullYear());
 });
 
-$('#reset_end_time').click(function () {
+$('#reset_end_time').on("click", function () {
 	var now = new Date();
 	var localTime = now.getTime();
 	var utc = localTime + (now.getTimezoneOffset() * 60000);
@@ -188,7 +185,7 @@ $('#reset_end_time').click(function () {
 	});
 });
 
-$('#fav_add').click(function (event) {
+$('#fav_add').on("click", function (event) {
 	save_fav();
 });
 
@@ -204,7 +201,7 @@ $(document).on("click", "#fav_recall", function (event) {
 	$('#frequency_rx').val(favs[this.innerText].frequency_rx);
 	$('#frequency').val(favs[this.innerText].frequency);
 	$('#selectPropagation').val(favs[this.innerText].prop_mode);
-	$('#mode').val(favs[this.innerText].mode).change();
+	$('#mode').val(favs[this.innerText].mode).on("change");
 });
 
 
@@ -300,7 +297,7 @@ bc.onmessage = function (ev) {
 	}
 } /* receive */
 
-$("#sat_name").change(function () {
+$("#sat_name").on('change', function () {
 	var sat = $("#sat_name").val();
 	if (sat == "") {
 		$("#sat_mode").val("");
@@ -308,7 +305,7 @@ $("#sat_name").change(function () {
 	}
 });
 
-$('#stateDropdown').change(function () {
+$('#stateDropdown').on('change', function () {
 	var state = $("#stateDropdown option:selected").text();
 	if (state != "") {
 		$("#stationCntyInputQso").prop('disabled', false);
@@ -466,11 +463,11 @@ function changebadge(entityname) {
 	}
 }
 
-$('#btn_reset').click(function () {
+$('#btn_reset').on("click", function () {
 	reset_fields();
 });
 
-$('#btn_fullreset').click(function () {
+$('#btn_fullreset').on("click", function () {
 	reset_to_default();
 });
 
@@ -566,7 +563,7 @@ function reset_fields() {
 	resetTimers(qso_manual);
 }
 
-$("#callsign").focusout(function () {
+$("#callsign").on("focusout", function () {
 	if ($(this).val().length >= 3) {
 
 		// Temp store the callsign
@@ -823,7 +820,7 @@ $("#callsign").focusout(function () {
 })
 
 /* time input shortcut */
-$('#start_time').change(function () {
+$('#start_time').on('change', function () {
 	var raw_time = $(this).val();
 	if (raw_time.match(/^\d\[0-6]d$/)) {
 		raw_time = "0" + raw_time;
@@ -834,7 +831,7 @@ $('#start_time').change(function () {
 	}
 });
 
-$('#end_time').change(function () {
+$('#end_time').on('change', function () {
 	var raw_time = $(this).val();
 	if (raw_time.match(/^\d\[0-6]d$/)) {
 		raw_time = "0" + raw_time;
@@ -846,7 +843,7 @@ $('#end_time').change(function () {
 });
 
 /* date input shortcut */
-$('#start_date').change(function () {
+$('#start_date').on('change', function () {
 	raw_date = $(this).val();
 	if (raw_date.match(/^[12]\d{3}[01]\d[0123]\d$/)) {
 		raw_date = raw_date.substring(0, 4) + "-" + raw_date.substring(4, 6) + "-" + raw_date.substring(6, 8);
@@ -855,7 +852,7 @@ $('#start_date').change(function () {
 });
 
 /* on mode change */
-$('.mode').change(function () {
+$('.mode').on('change', function () {
 	if ($('#radio').val() == 0) {
 		$.get(base_url + 'index.php/qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function (result) {
 			$('#frequency').val(result);
@@ -866,7 +863,7 @@ $('.mode').change(function () {
 
 /* Calculate Frequency */
 /* on band change */
-$('#band').change(function () {
+$('#band').on('change', function () {
 	if ($('#radio').val() == 0) {
 		$.get(base_url + 'index.php/qso/band_to_freq/' + $(this).val() + '/' + $('.mode').val(), function (result) {
 			$('#frequency').val(result);
@@ -880,7 +877,7 @@ $('#band').change(function () {
 });
 
 /* On Key up Calculate Bearing and Distance */
-$("#locator").keyup(function () {
+$("#locator").on("input focus", function () {
 	if ($(this).val()) {
 		var qra_input = $(this).val();
 
@@ -995,7 +992,7 @@ $("#locator").keyup(function () {
 });
 
 // Change report based on mode
-$('.mode').change(function () {
+$('.mode').on('change', function () {
 	setRst($('.mode').val());
 });
 
@@ -1040,16 +1037,15 @@ $('#dxcc_id').on('change', function () {
 
 //Spacebar moves to the name field when you're entering a callsign
 //Similar to contesting ux, good for pileups.
-$("#callsign").on("keypress", function (e) {
+$("#callsign").on("keydown", function (e) {
 	if (e.which == 32) {
-		$("#name").focus();
-		return false; //Eliminate space char
+		$("#name").trigger("focus");
+		e.preventDefault(); //Eliminate space char
 	}
 });
 
 
-// On Key up check and suggest callsigns
-$("#callsign").keyup(function () {
+$("#callsign").on("input focus", function () {
 	var ccall = $(this).val();
 	if ($(this).val().length >= 3) {
 		$('.callsign-suggest').show();
@@ -1217,7 +1213,7 @@ $(document).ready(function () {
 	};
 
 	// Callsign always has focus on load
-	$("#callsign").focus();
+	$("#callsign").trigger("focus");
 
 	// reset the timers on page load
 	resetTimers(qso_manual);

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -2,6 +2,8 @@ var favs = {};
 var selected_sat;
 var selected_sat_mode;
 var scps = [];
+let lookupCall = null;
+let preventLookup = false;
 
 // if the dxcc id changes we need to update the state dropdown and clear the county value to avoid wrong data
 $("#dxcc_id").on('change', function () {
@@ -464,7 +466,18 @@ function changebadge(entityname) {
 }
 
 $('#btn_reset').on("click", function () {
+	preventLookup = true;
+
+	if (lookupCall) {
+		lookupCall.abort();
+	}
+
 	reset_fields();
+
+	// make sure the focusout event is finished before we allow a new lookup
+	setTimeout(() => {
+		preventLookup = false;
+	}, 100);
 });
 
 $('#btn_fullreset').on("click", function () {
@@ -564,7 +577,7 @@ function reset_fields() {
 }
 
 $("#callsign").on("focusout", function () {
-	if ($(this).val().length >= 3) {
+	if ($(this).val().length >= 3 && preventLookup == false) {
 
 		// Temp store the callsign
 		var temp_callsign = $(this).val();
@@ -586,7 +599,7 @@ $("#callsign").on("focusout", function () {
 		find_callsign = find_callsign.replace('Ø', '0');
 
 		// Replace / in a callsign with - to stop urls breaking
-		$.getJSON(base_url + 'index.php/logbook/json/' + find_callsign + '/' + json_band + '/' + json_mode + '/' + $('#stationProfile').val() + '/' + $('#start_date').val(), async function (result) {
+		lookupCall = $.getJSON(base_url + 'index.php/logbook/json/' + find_callsign + '/' + json_band + '/' + json_mode + '/' + $('#stationProfile').val() + '/' + $('#start_date').val(), async function (result) {
 
 			// Make sure the typed callsign and json result match
 			if ($('#callsign').val = result.callsign) {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1064,12 +1064,12 @@ $("#callsign").keyup(function () {
 				success: function (result) {
 					$('.callsign-suggestions').text(result);
 					scps = result.split(" ");
-					highlight(ccall.toUpperCase());
+					highlightSCP(ccall.toUpperCase());
 				}
 			});
 		} else {
 			$('.callsign-suggestions').text(scps.filter((call) => call.includes($(this).val().toUpperCase())).join(' '));
-			highlight(ccall.toUpperCase());
+			highlightSCP(ccall.toUpperCase());
 		}
 	} else {
 		$('.callsign-suggest').hide();
@@ -1082,7 +1082,7 @@ RegExp.escape = function (text) {
 }
 
 
-function highlight(term, base) {
+function highlightSCP(term, base) {
 	if (!term) return;
 	base = base || document.body;
 	var re = new RegExp("(" + RegExp.escape(term) + ")", "gi");


### PR DESCRIPTION
This PR fixes some "microbugs" and brings some improvements to the QSO logging

## In Detail

### Standarize some functions

In some places we use `.change( function ( { } ) );` and in some places `.on(event, function ( { } ) );`. We should stick to the more modern one. `.change`, `click` and so on are deprecated.

### "Ø Problem"

As the replacement of 0 to Ø in the callsign input was broken, the callsign suggestion for these callsigns were broken aswell. Fixed that.

| Before Fix                                           | After Fix                                            |
|------------------------------------------------------|------------------------------------------------------|
| <img width="663" alt="image" src="https://github.com/user-attachments/assets/8bba70e8-3794-4258-8836-adfc5d404f0d"> | <img width="663" alt="image" src="https://github.com/user-attachments/assets/fd7a03c9-b18c-4907-9770-5a78e23f8059"> |

### Dupes returned in SCP result

As you can see in the screenshots of the "Ø Problem", the callsigns were returned twice. This happens because we use two different SCP sources to get as much results as possible. Due the fact we are handling two types of zeros (0 and Ø) it could happen that a callsign was returned twice. Using the callsign as array key with the value true solves this issue. 

| Before Fix                                           | After Fix                                            |
|------------------------------------------------------|------------------------------------------------------|
| <img width="663" alt="image" src="https://github.com/user-attachments/assets/fd7a03c9-b18c-4907-9770-5a78e23f8059"> | <img width="663" alt="image" src="https://github.com/user-attachments/assets/76e0c24d-7e09-4c0b-9add-22b29b573f6f"> |

### Fix highlighting in selectize dropdowns

After my qso.js restructuring all functions are now loaded correctly. But as this happens the `highlight()` function, which highlights parts of the callsigns in the callsign-suggestion is broken as this conflicts with the `highlight()` function of the selectize library. This results in a broken text-highlighting

| Before Fix                                           | After Fix                                            |
|------------------------------------------------------|------------------------------------------------------|
| <img width="175" alt="image" src="https://github.com/user-attachments/assets/56a41852-d644-447a-974e-8a5d21337170"> | <img width="175" alt="image" src="https://github.com/user-attachments/assets/1bf762d6-257b-4623-b41e-9ae9723447a4"> |

### Prevent lookups while resetting the fields

We have a racecondition here. It can happen, that the callsign lookup runs multiple times when switching between windows and/or try to reset the fields. Due the fact that the `reset_fields()` function is obviously much faster then a ajax call it happens that fields are getting filled after the reset was triggered. This is not really nice and is fixed with my last commit. 

https://github.com/user-attachments/assets/699229f5-8d1b-4729-a0c2-39003425f6c5

https://github.com/user-attachments/assets/cc8b0d4a-e260-4bb4-87da-ac708c13a459
