### PR TITLE
[Advanced Logbook] Adjusted filters and column order

### DIFF
--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -152,19 +152,19 @@ $options = json_decode($options);
 				<input type="hidden" id="invalid" name="invalid" value="">
                 <div class="filterbody collapse">
                     <div class="row">
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->datetime->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="dateFrom"><?= __("From") . ": " ?></label>
                             <input name="dateFrom" id="dateFrom" type="date" class="form-control form-control-sm w-auto">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->datetime->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="dateTo"><?= __("To") . ": " ?></label>
                             <input name="dateTo" id="dateTo" type="date" class="form-control form-control-sm w-auto">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->dx->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="dx"><?= __("Dx"); ?></label>
                             <input type="text" name="dx" id="dx" class="form-control form-control-sm" value="">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->dxcc->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="dxcc"><?= __("DXCC"); ?></label>
                             <select class="form-control form-control-sm" id="dxcc" name="dxcc">
                                 <option value="">-</option>
@@ -185,15 +185,15 @@ $options = json_decode($options);
                                 ?>
                             </select>
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->state->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="state"><?= __("State"); ?></label>
                             <input type="text" name="state" id="state" class="form-control form-control-sm" value="">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->gridsquare->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="gridsquare"><?= __("Gridsquare"); ?></label>
                             <input type="text" name="gridsquare" id="gridsquare" class="form-control form-control-sm" value="">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->mode->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="mode"><?= __("Mode"); ?></label>
                             <select id="mode" name="mode" class="form-select form-select-sm">
                                 <option value=""><?= __("All"); ?></option>
@@ -204,7 +204,7 @@ $options = json_decode($options);
                                                                                                                                     ?>
                             </select>
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->band->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="band"><?= __("Band"); ?></label>
                             <select id="band" name="band" class="form-select form-select-sm">
                                 <option value=""><?= __("All"); ?></option>
@@ -233,7 +233,7 @@ $options = json_decode($options);
                                 } ?>
                             </select>
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->propagation->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="selectPropagation"><?= __("Propagation"); ?></label>
                             <select id="selectPropagation" class="form-select form-select-sm" name="propmode">
                                 <option value=""><?= __("All"); ?></option>
@@ -258,7 +258,7 @@ $options = json_decode($options);
                                 <option value="TR"><?= _pgettext("Propagation Mode", "Tropospheric ducting"); ?></option>
                             </select>
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->cqzone->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="cqzone"><?= __("CQ Zone"); ?></label>
                             <select id="cqzone" name="cqzone" class="form-select form-select-sm">
                                 <option value=""><?= __("All"); ?></option>
@@ -269,7 +269,7 @@ $options = json_decode($options);
                                 ?>
                             </select>
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->ituzone->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="ituzone"><?= __("ITU Zone"); ?></label>
                             <select id="ituzone" name="ituzone" class="form-select form-select-sm">
                                 <option value=""><?= __("All"); ?></option>
@@ -282,15 +282,15 @@ $options = json_decode($options);
                         </div>
                     </div>
                     <div class="row">
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->sota->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="sota"><?= __("SOTA"); ?></label>
                             <input type="text" name="sota" id="sota" class="form-control form-control-sm" value="">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->pota->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="pota"><?= __("POTA"); ?></label>
                             <input type="text" name="pota" id="pota" class="form-control form-control-sm" value="">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->iota->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="iota"><?= __("IOTA"); ?></label>
                             <select class="form-select form-select-sm" id="iota" name="iota">
                                 <option value="">-</option>
@@ -302,21 +302,21 @@ $options = json_decode($options);
                                 ?>
                             </select>
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->wwff->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="wwff"><?= __("WWFF"); ?></label>
                             <input type="text" name="wwff" id="wwff" class="form-control form-control-sm" value="">
                         </div>
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->operator->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="operator"><?= __("Operator"); ?></label>
                             <input type="text" name="operator" id="operator" class="form-control form-control-sm" value="">
                         </div>
 
-                        <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                        <div <?php if (($options->contest->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="contest"><?= __("Contest"); ?></label>
                             <input type="text" name="contest" id="contest" class="form-control form-control-sm" value="">
                         </div>
 
-						<div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+						<div <?php if (($options->continent->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                             <label class="form-label" for="continent"><?= __("Continent"); ?></label>
 							<select id="continent" name="continent" class="form-select form-select-sm">
 								<option value=""><?= __("All"); ?></option>
@@ -336,7 +336,7 @@ $options = json_decode($options);
         </div>
         <div class="qslfilterbody collapse">
             <div class="row">
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div  <?php if (($options->qsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="qslSent"><?= __("QSL sent"); ?></label>
                     <select id="qslSent" name="qslSent" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -347,7 +347,7 @@ $options = json_decode($options);
                         <option value="I"><?= __("Invalid (Ignore)"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div  <?php if (($options->qsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="qslReceived"><?= __("QSL received"); ?></label>
                     <select id="qslReceived" name="qslReceived" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -358,7 +358,7 @@ $options = json_decode($options);
                         <option value="V"><?= __("Verified"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->qsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="qslSentMethod"><?= __("QSL send. method"); ?></label>
                     <select id="qslSentMethod" name="qslSentMethod" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -368,7 +368,7 @@ $options = json_decode($options);
                         <option value="M"><?= __("Manager"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->qsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="qslReceivedMethod"><?= __("QSL recv. method"); ?></label>
                     <select id="qslReceivedMethod" name="qslReceivedMethod" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -378,7 +378,7 @@ $options = json_decode($options);
                         <option value="M"><?= __("Manager"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->lotw->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="lotwSent"><?= __("LoTW sent"); ?></label>
                     <select id="lotwSent" name="lotwSent" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -389,7 +389,7 @@ $options = json_decode($options);
                         <option value="I"><?= __("Invalid (Ignore)"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->lotw->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="lotwReceived"><?= __("LoTW received"); ?></label>
                     <select id="lotwReceived" name="lotwReceived" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -400,7 +400,7 @@ $options = json_decode($options);
                         <option value="V"><?= __("Verified"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->clublog->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="clublogSent"><?= __("Clublog sent"); ?></label>
                     <select id="clublogSent" name="clublogSent" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -411,7 +411,7 @@ $options = json_decode($options);
                         <option value="I"><?= __("Invalid (Ignore)"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->clublog->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="clublogReceived"><?= __("Clublog received"); ?></label>
                     <select id="clublogReceived" name="clublogReceived" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -422,7 +422,7 @@ $options = json_decode($options);
                         <option value="V"><?= __("Verified"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->eqsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="eqslSent"><?= __("eQSL sent"); ?></label>
                     <select id="eqslSent" name="eqslSent" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -433,7 +433,7 @@ $options = json_decode($options);
                         <option value="I"><?= __("Invalid (Ignore)"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->eqsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="eqslReceived"><?= __("eQSL received"); ?></label>
                     <select id="eqslReceived" name="eqslReceived" class="form-select form-select-sm">
                         <option value=""><?= __("All"); ?></option>
@@ -444,11 +444,11 @@ $options = json_decode($options);
                         <option value="V"><?= __("Verified"); ?></option>
                     </select>
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->qsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="qslvia"><?= __("QSL via"); ?></label>
                     <input type="search" name="qslvia" class="form-control form-control-sm">
                 </div>
-                <div class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
+                <div <?php if (($options->qsl->show ?? "true") == "false") { echo 'style="display:none"'; } ?> class="mb-3 col-lg-2 col-md-2 col-sm-3 col-xl">
                     <label for="qslimages"><?= __("QSL Images"); ?></label>
                     <select class="form-select form-select-sm" id="qslimages" name="qslimages">
                         <option value="">-</option>
@@ -641,6 +641,18 @@ $options = json_decode($options);
                     <?php if (($options->pota->show ?? "true") == "true") {
                         echo '<th>' . __("POTA") . '</th>';
                     } ?>
+					                    <?php if (($options->sota->show ?? "true") == "true") {
+                        echo '<th>SOTA</th>';
+                    } ?>
+                    <?php if (($options->dok->show ?? "true") == "true") {
+                        echo '<th>' . __("DOK") . '</th>';
+                    } ?>
+                    <?php if (($options->wwff->show ?? "true") == "true") {
+                        echo '<th>WWFF</th>';
+                    } ?>
+                    <?php if (($options->sig->show ?? "true") == "true") {
+                        echo '<th>SIG</th>';
+                    } ?>
                     <?php if (($options->operator->show ?? "true") == "true") {
                         echo '<th>' . __("Operator") . '</th>';
                     } ?>
@@ -652,18 +664,6 @@ $options = json_decode($options);
                     } ?>
                     <?php if (($options->contest->show ?? "true") == "true") {
                         echo '<th>' . __("Contest") . '</th>';
-                    } ?>
-                    <?php if (($options->sota->show ?? "true") == "true") {
-                        echo '<th>SOTA</th>';
-                    } ?>
-                    <?php if (($options->dok->show ?? "true") == "true") {
-                        echo '<th>' . __("DOK") . '</th>';
-                    } ?>
-                    <?php if (($options->wwff->show ?? "true") == "true") {
-                        echo '<th>WWFF</th>';
-                    } ?>
-                    <?php if (($options->sig->show ?? "true") == "true") {
-                        echo '<th>SIG</th>';
                     } ?>
                     <?php if (($options->myrefs->show ?? "true") == "true") {
                         echo '<th>' . __("My Refs") . '</th>';

--- a/application/views/logbookadvanced/useroptions.php
+++ b/application/views/logbookadvanced/useroptions.php
@@ -47,8 +47,8 @@
 			<td><div class="form-check"><input class="form-check-input" name="band" type="checkbox" <?php if (($options->band->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
-			<td><?= __("My Refs"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="myrefs" type="checkbox" <?php if (($options->myrefs->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+			<td><?= __("Gridsquare"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="gridsquare" type="checkbox" <?php if (($options->gridsquare->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("Name"); ?></td>
@@ -59,20 +59,24 @@
 			<td><div class="form-check"><input class="form-check-input" name="qslvia" type="checkbox" <?php if (($options->qslvia->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
-			<td><?= __("QSL"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="qsl" type="checkbox" <?php if (($options->qsl->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+			<td><?= __("Clublog"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="clublog" type="checkbox" <?php if (($options->clublog->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
-			<td><?= __("LoTW"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="lotw" type="checkbox" <?php if (($options->lotw->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+			<td><?= __("QSL"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="qsl" type="checkbox" <?php if (($options->qsl->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("eQSL"); ?></td>
 			<td><div class="form-check"><input class="form-check-input" name="eqsl" type="checkbox" <?php if (($options->eqsl->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
-			<td><?= __("Clublog"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="clublog" type="checkbox" <?php if (($options->clublog->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+			<td><?= __("LoTW"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="lotw" type="checkbox" <?php if (($options->lotw->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+		</tr>
+		<tr>
+			<td><?= __("QRZ"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="qrz" type="checkbox" <?php if (($options->qrz->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("QSL Msg"); ?></td>
@@ -95,16 +99,28 @@
 			<td><div class="form-check"><input class="form-check-input" name="ituzone" type="checkbox" <?php if (($options->ituzone->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
-			<td><?= __("SOTA"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="sota" type="checkbox" <?php if (($options->sota->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
-		</tr>
-		<tr>
 			<td><?= __("IOTA"); ?></td>
 			<td><div class="form-check"><input class="form-check-input" name="iota" type="checkbox" <?php if (($options->iota->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("POTA"); ?></td>
 			<td><div class="form-check"><input class="form-check-input" name="pota" type="checkbox" <?php if (($options->pota->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+		</tr>
+		<tr>
+			<td><?= __("SOTA"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="sota" type="checkbox" <?php if (($options->sota->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+		</tr>
+		<tr>
+			<td><?= __("DOK"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="dok" type="checkbox" <?php if (($options->dok->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+		</tr>
+		<tr>
+			<td><?= __("WWFF"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="wwff" type="checkbox" <?php if (($options->wwff->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+		</tr>
+		<tr>
+			<td><?= __("SIG"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="sig" type="checkbox" <?php if (($options->sig->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("Operator"); ?></td>
@@ -123,28 +139,12 @@
 			<td><div class="form-check"><input class="form-check-input" name="contest" type="checkbox" <?php if (($options->contest->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
-			<td><?= __("Gridsquare"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="gridsquare" type="checkbox" <?php if (($options->gridsquare->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
-		</tr>
-		<tr>
-			<td><?= __("DOK"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="dok" type="checkbox" <?php if (($options->dok->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
-		</tr>
-		<tr>
-			<td><?= __("WWFF"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="wwff" type="checkbox" <?php if (($options->wwff->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
-		</tr>
-		<tr>
-			<td><?= __("SIG"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="sig" type="checkbox" <?php if (($options->sig->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+			<td><?= __("My Refs"); ?></td>
+			<td><div class="form-check"><input class="form-check-input" name="myrefs" type="checkbox" <?php if (($options->myrefs->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("Continent"); ?></td>
 			<td><div class="form-check"><input class="form-check-input" name="continent" type="checkbox" <?php if (($options->continent->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
-		</tr>
-		<tr>
-			<td><?= __("QRZ"); ?></td>
-			<td><div class="form-check"><input class="form-check-input" name="qrz" type="checkbox" <?php if (($options->qrz->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 		<tr>
 			<td><?= __("Profile name"); ?></td>

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -97,18 +97,6 @@ function updateRow(qso) {
 	if (user_options.pota.show == "true"){
 		cells.eq(c++).html(qso.pota);
 	}
-	if ( (user_options.operator) && (user_options.operator.show == "true")){
-		cells.eq(c++).html(qso.operator);
-	}
-	if ( (user_options.comment) && (user_options.comment.show == "true")){
-		cells.eq(c++).html(qso.comment);
-	}
-	if ( (user_options.propagation) && (user_options.propagation.show == "true")){
-		cells.eq(c++).html(qso.propagation);
-	}
-	if ( (user_options.contest) && (user_options.contest.show == "true")){
-		cells.eq(c++).html(qso.contest);
-	}
 	if ( (user_options.sota) && (user_options.sota.show == "true")){
 		cells.eq(c++).html(qso.sota);
 	}
@@ -120,6 +108,18 @@ function updateRow(qso) {
 	}
 	if ( (user_options.sig) && (user_options.sig.show == "true")){
 		cells.eq(c++).html(qso.sig);
+	}
+	if ( (user_options.operator) && (user_options.operator.show == "true")){
+		cells.eq(c++).html(qso.operator);
+	}
+	if ( (user_options.comment) && (user_options.comment.show == "true")){
+		cells.eq(c++).html(qso.comment);
+	}
+	if ( (user_options.propagation) && (user_options.propagation.show == "true")){
+		cells.eq(c++).html(qso.propagation);
+	}
+	if ( (user_options.contest) && (user_options.contest.show == "true")){
+		cells.eq(c++).html(qso.contest);
 	}
 	if (user_options.myrefs.show == "true"){
 		cells.eq(c++).text(qso.deRefs);
@@ -251,18 +251,6 @@ function loadQSOTable(rows) {
 		if (user_options.pota.show == "true"){
 			data.push(qso.pota);
 		}
-		if (user_options.operator.show == "true"){
-			data.push(qso.operator);
-		}
-		if (user_options.comment.show == "true"){
-			data.push(qso.comment);
-		}
-		if (user_options.propagation.show == "true"){
-			data.push(qso.propagation);
-		}
-		if (user_options.contest.show == "true"){
-			data.push(qso.contest);
-		}
 		if (user_options.sota.show == "true"){
 			data.push(qso.sota);
 		}
@@ -274,6 +262,18 @@ function loadQSOTable(rows) {
 		}
 		if (user_options.sig.show == "true"){
 			data.push(qso.sig);
+		}
+		if (user_options.operator.show == "true"){
+			data.push(qso.operator);
+		}
+		if (user_options.comment.show == "true"){
+			data.push(qso.comment);
+		}
+		if (user_options.propagation.show == "true"){
+			data.push(qso.propagation);
+		}
+		if (user_options.contest.show == "true"){
+			data.push(qso.contest);
 		}
 		if (user_options.myrefs.show == "true"){
 			data.push(qso.deRefs);


### PR DESCRIPTION
I made the following changes in the advanced logbook:
1. Filters are hidden if the corresponding column is hidden
2. Same column order in the table as in the option to show/hide column
3. Moved SOTA, DOK, WWFF and SIG to be after IOTA, so that most of the award stuff is grouped.