### PR TITLE
Remove DXCC NONE from DXCC award

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -165,6 +165,9 @@ class Awards extends CI_Controller {
 		}
 
 		$dxcclist = $this->dxcc->fetchdxcc($postdata);
+		if ($dxcclist[0]->adif == "0") {
+			unset($dxcclist[0]);
+		}
 		$data['dxcc_array'] = $this->dxcc->get_dxcc_array($dxcclist, $bands, $postdata);
 		$data['dxcc_summary'] = $this->dxcc->get_dxcc_summary($bands, $postdata);
 
@@ -1485,6 +1488,9 @@ class Awards extends CI_Controller {
         $postdata['orbit'] = $this->security->xss_clean($this->input->post('orbit'));
 
         $dxcclist = $this->dxcc->fetchdxcc($postdata);
+        if ($dxcclist[0]->adif == "0") {
+            unset($dxcclist[0]);
+        }
 
         $dxcc_array = $this->dxcc->get_dxcc_array($dxcclist, $bands, $postdata);
 


### PR DESCRIPTION
As "NONE" is not valid for DXCC award we remove it from the list.

Note: The fetchdxcc function was not changed as it is used in other places as well where NONE should be included. So 0/NONE is removed from the result array of that function only for the DXCC award and its map.