### PR TITLE
Clear distance (and bearing display) if grid is empty(ed)

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1004,6 +1004,13 @@ $("#locator").on("input focus", function () {
 	}
 });
 
+$("#locator").on("focusout", function () {
+	if ($(this).val().length == 0) {
+		$('#locator_info').text("");
+		document.getElementById("distance").value = null;
+	}
+});
+
 // Change report based on mode
 $('.mode').on('change', function () {
 	setRst($('.mode').val());


### PR DESCRIPTION
If a callsign is entered and (wrong) grid info is fetched from callbook the op would delete the grid data from the input field. But the bearing and distance is already calculated based on the (wrong) callbook grid. Even with empty grid the wrong distance is then stored in the QSO:

https://github.com/user-attachments/assets/ac1889a4-44f2-4ba0-ad17-c060587914b5

Result:

![Screenshot from 2024-11-03 14-28-00](https://github.com/user-attachments/assets/31115216-f522-44ce-824d-db62ae0817f1)

With this PR the bearing and distance info is cleared if the grid locator field is empty and the op tabs out. Now no distance/bearing is displayed and no distance is stored along with the QSO.
