### PR TITLE
Fix inconsistent font family in grid activators page

### DIFF
--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -129,7 +129,7 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
                 <td>' . $i++ . '</td>
                 <td>' . $line[1] . '</td>
                 <td>' . $line[0] . '</td>
-                <td style="text-align: left; font-family: Consolas, monospace;">' . $line[2] . '</td>
+                <td style="text-align: left; font-family: Consolas, monospace; text-transform: full-width; letter-spacing: -.3em;">' . $line[2] . '</td>
                 <td><a href=javascript:displayActivatorsContacts("' . $line[1] . '","' . $band . '","' . $leogeo . '")><i class="fas fa-list"></i></a></td>
                 <td><a href=javascript:spawnActivatorsMap("' . $line[1] . '","' . $line[0] . '","' . str_replace(' ', '', $line[2]) . '")><i class="fas fa-globe"></i></a></td>
                </tr>';

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -129,7 +129,7 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
                 <td>' . $i++ . '</td>
                 <td>' . $line[1] . '</td>
                 <td>' . $line[0] . '</td>
-                <td style="text-align: left; font-family: Consolas, monospace; text-transform: full-width; letter-spacing: -.3em;">' . $line[2] . '</td>
+                <td style="text-align: left; font-family: Consolas, monospace; text-transform: full-width; letter-spacing: -.05em;">' . $line[2] . '</td>
                 <td><a href=javascript:displayActivatorsContacts("' . $line[1] . '","' . $band . '","' . $leogeo . '")><i class="fas fa-list"></i></a></td>
                 <td><a href=javascript:spawnActivatorsMap("' . $line[1] . '","' . $line[0] . '","' . str_replace(' ', '', $line[2]) . '")><i class="fas fa-globe"></i></a></td>
                </tr>';

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -129,7 +129,7 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
                 <td>' . $i++ . '</td>
                 <td>' . $line[1] . '</td>
                 <td>' . $line[0] . '</td>
-                <td style="text-align: left">' . $line[2] . '</td>
+                <td style="text-align: left; font-family: Consolas, monospace;">' . $line[2] . '</td>
                 <td><a href=javascript:displayActivatorsContacts("' . $line[1] . '","' . $band . '","' . $leogeo . '")><i class="fas fa-list"></i></a></td>
                 <td><a href=javascript:spawnActivatorsMap("' . $line[1] . '","' . $line[0] . '","' . str_replace(' ', '', $line[2]) . '")><i class="fas fa-globe"></i></a></td>
                </tr>';

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -129,7 +129,7 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
                 <td>' . $i++ . '</td>
                 <td>' . $line[1] . '</td>
                 <td>' . $line[0] . '</td>
-                <td style="text-align: left; font-family: Consolas, monospace; text-transform: full-width; letter-spacing: -.05em;">' . $line[2] . '</td>
+                <td style="text-align: left; font-family: Consolas, monospace; text-transform: full-width; letter-spacing: -.03em;">' . $line[2] . '</td>
                 <td><a href=javascript:displayActivatorsContacts("' . $line[1] . '","' . $band . '","' . $leogeo . '")><i class="fas fa-list"></i></a></td>
                 <td><a href=javascript:spawnActivatorsMap("' . $line[1] . '","' . $line[0] . '","' . str_replace(' ', '', $line[2]) . '")><i class="fas fa-globe"></i></a></td>
                </tr>';

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -129,7 +129,7 @@ function write_activators($activators_array, $vucc_grids, $custom_date_format, $
                 <td>' . $i++ . '</td>
                 <td>' . $line[1] . '</td>
                 <td>' . $line[0] . '</td>
-                <td style="text-align: left; font-family: monospace;">' . $line[2] . '</td>
+                <td style="text-align: left">' . $line[2] . '</td>
                 <td><a href=javascript:displayActivatorsContacts("' . $line[1] . '","' . $band . '","' . $leogeo . '")><i class="fas fa-list"></i></a></td>
                 <td><a href=javascript:spawnActivatorsMap("' . $line[1] . '","' . $line[0] . '","' . str_replace(' ', '', $line[2]) . '")><i class="fas fa-globe"></i></a></td>
                </tr>';


### PR DESCRIPTION
A minor bug: the grid column uses `monospace` font family (hard coded), while other columns don't.

I think it would be nicer to use the same font family in the whole table.

![Snipaste_2024-11-03_22-43-30](https://github.com/user-attachments/assets/8c6e9758-b3cf-46ad-aad6-ccfbbab84085)
