### PR TITLE
Staticmap - Options for Contest and Date Range

### DIFF
--- a/application/controllers/Staticmap.php
+++ b/application/controllers/Staticmap.php
@@ -31,6 +31,7 @@ class Staticmap extends CI_Controller {
         $continent = $this->input->get('continent', TRUE) ?? 'nC';
         $thememode = $this->input->get('theme', TRUE) ?? null;
         $hide_home = $this->input->get('hide_home', TRUE) == 1 ? true : false;
+        $contest = $this->input->get('contest', TRUE) ?? 'nContest';
 
         // if the user defines an Satellite Orbit, we need to set the band to SAT
         if ($orbit != 'nOrb') {
@@ -44,7 +45,7 @@ class Staticmap extends CI_Controller {
         $qsocount = $this->input->get('qsocount', TRUE) ?? '';
         // if the qso count is not a number, set it to the user option or 250 per default (same as used in stationsetup)
         $uid = $this->stationsetup_model->getContainer($logbook_id, false)->row()->user_id;
-        if ($qsocount == 0 || !is_numeric($qsocount)) {
+        if ($qsocount == 0 || (!is_numeric($qsocount) && $qsocount != 'all')) {
             $qsocount = $this->user_options_model->get_options('ExportMapOptions', array('option_name' => 'qsocount', 'option_key' => $slug), $uid)->row()->option_value ?? 250;
         }
 
@@ -94,7 +95,7 @@ class Staticmap extends CI_Controller {
         $cacheDir = realpath($cachepath . "staticmap_images/");
 
         // create a unique filename for the cache
-        $filenameRaw = $uid . $logbook_id . $qsocount . $band . $thememode . $continent . $hide_home . ($night_shadow == false ? 0 : 1) . ($pathlines == false ? 0 : 1) . ($cqzones == false ? 0 : 1) . ($ituzones == false ? 0 : 1) . $orbit;
+        $filenameRaw = $uid . $logbook_id . $qsocount . $band . $thememode . $continent . $hide_home . ($night_shadow == false ? 0 : 1) . ($pathlines == false ? 0 : 1) . ($cqzones == false ? 0 : 1) . ($ituzones == false ? 0 : 1) . $orbit . $contest;   
         $filename = crc32('staticmap_' . $slug) . '_' . substr(md5($filenameRaw), 0, 12) . '.png';
         $filepath = $cacheDir . '/' . $filename;
 
@@ -148,7 +149,7 @@ class Staticmap extends CI_Controller {
                 }
                 $centerMap = $this->qra->getCenterLatLng($coordinates);
 
-                $qsos = $this->visitor_model->get_qsos($qsocount, $logbooks_locations_array, $band == 'nbf' ? '' : $band, $continent == 'nC' ? '' : $continent, $orbit == 'nOrb' ? '' : $orbit); // TODO: Allow 'all' option
+                $qsos = $this->visitor_model->get_qsos($qsocount, $logbooks_locations_array, $band == 'nbf' ? '' : $band, $continent == 'nC' ? '' : $continent, $orbit == 'nOrb' ? '' : $orbit, $contest == 'nContest' ? '' : $contest);
 
                 $image = $this->staticmap_model->render_static_map($qsos, $uid, $centerMap, $coordinates, $filepath, $continent, $thememode, $hide_home, $night_shadow, $pathlines, $cqzones, $ituzones);
 

--- a/application/controllers/Staticmap.php
+++ b/application/controllers/Staticmap.php
@@ -33,6 +33,9 @@ class Staticmap extends CI_Controller {
         $hide_home = $this->input->get('hide_home', TRUE) == 1 ? true : false;
         $contest = $this->input->get('contest', TRUE) ?? 'nContest';
 
+        $start_date = $this->input->get('start_date', TRUE) ?? 'noStart';   // Format YYYY-MM-DD
+        $end_date = $this->input->get('end_date', TRUE) ?? 'noEnd';          // Format YYYY-MM-DD
+
         // if the user defines an Satellite Orbit, we need to set the band to SAT
         if ($orbit != 'nOrb') {
             $band = 'SAT';
@@ -95,7 +98,7 @@ class Staticmap extends CI_Controller {
         $cacheDir = realpath($cachepath . "staticmap_images/");
 
         // create a unique filename for the cache
-        $filenameRaw = $uid . $logbook_id . $qsocount . $band . $thememode . $continent . $hide_home . ($night_shadow == false ? 0 : 1) . ($pathlines == false ? 0 : 1) . ($cqzones == false ? 0 : 1) . ($ituzones == false ? 0 : 1) . $orbit . $contest;   
+        $filenameRaw = $uid . $logbook_id . $qsocount . $band . $thememode . $continent . $hide_home . ($night_shadow == false ? 0 : 1) . ($pathlines == false ? 0 : 1) . ($cqzones == false ? 0 : 1) . ($ituzones == false ? 0 : 1) . $orbit . $contest . $start_date . $end_date;   
         $filename = crc32('staticmap_' . $slug) . '_' . substr(md5($filenameRaw), 0, 12) . '.png';
         $filepath = $cacheDir . '/' . $filename;
 
@@ -149,7 +152,16 @@ class Staticmap extends CI_Controller {
                 }
                 $centerMap = $this->qra->getCenterLatLng($coordinates);
 
-                $qsos = $this->visitor_model->get_qsos($qsocount, $logbooks_locations_array, $band == 'nbf' ? '' : $band, $continent == 'nC' ? '' : $continent, $orbit == 'nOrb' ? '' : $orbit, $contest == 'nContest' ? '' : $contest);
+                $qsos = $this->visitor_model->get_qsos(
+                    $qsocount, 
+                    $logbooks_locations_array, 
+                    $band == 'nbf' ? '' : $band, 
+                    $continent == 'nC' ? '' : $continent, 
+                    $orbit == 'nOrb' ? '' : $orbit, 
+                    $contest == 'nContest' ? '' : $contest,
+                    $start_date == 'noStart' ? '' : $start_date,
+                    $end_date == 'noEnd' ? '' : $end_date
+                );
 
                 $image = $this->staticmap_model->render_static_map($qsos, $uid, $centerMap, $coordinates, $filepath, $continent, $thememode, $hide_home, $night_shadow, $pathlines, $cqzones, $ituzones);
 

--- a/application/models/Visitor_model.php
+++ b/application/models/Visitor_model.php
@@ -2,13 +2,22 @@
 
 class Visitor_model extends CI_Model {
 
-	function get_qsos($num, $StationLocationsArray, $band = '', $continent = '', $orbit = '', $contest = '') {
+	function get_qsos($num, $StationLocationsArray, $band = '', $continent = '', $orbit = '', $contest = '', $start_date = '', $end_date = '') {
 		$this->db->select($this->config->item('table_name').'.*, station_profile.*');
 		$this->db->from($this->config->item('table_name'));
 
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		if ($band == 'SAT') {
 			$this->db->join('satellite', 'satellite.name = '.$this->config->item('table_name').'.COL_SAT_NAME', 'left');
+		}
+
+		if ($start_date != '') {
+			$start_date = date('Y-m-d', strtotime($start_date));
+			$this->db->where($this->config->item('table_name').'.COL_TIME_ON >=', $start_date);
+		}
+		if ($end_date != '') {
+			$end_date = date('Y-m-d', strtotime($end_date));
+			$this->db->where($this->config->item('table_name').'.COL_TIME_ON <=', $end_date);
 		}
 
 		if ($band != '') {

--- a/application/models/Visitor_model.php
+++ b/application/models/Visitor_model.php
@@ -2,7 +2,7 @@
 
 class Visitor_model extends CI_Model {
 
-	function get_qsos($num, $StationLocationsArray, $band = '', $continent = '', $orbit = '') {
+	function get_qsos($num, $StationLocationsArray, $band = '', $continent = '', $orbit = '', $contest = '') {
 		$this->db->select($this->config->item('table_name').'.*, station_profile.*');
 		$this->db->from($this->config->item('table_name'));
 
@@ -31,6 +31,10 @@ class Visitor_model extends CI_Model {
 			$this->db->where($this->config->item('table_name').'.COL_CONT', $continent);
 		}
 
+		if ($contest != '') {
+			$this->db->where($this->config->item('table_name').'.COL_CONTEST_ID', $contest);
+		}
+
 		$this->db->group_start();
 		$this->db->where("(" . $this->config->item('table_name') . ".COL_GRIDSQUARE != '' AND " . $this->config->item('table_name') . ".COL_GRIDSQUARE IS NOT NULL)");
 		$this->db->or_where("(" . $this->config->item('table_name') . ".COL_VUCC_GRIDS != '' AND " . $this->config->item('table_name') . ".COL_VUCC_GRIDS IS NOT NULL)");
@@ -39,9 +43,12 @@ class Visitor_model extends CI_Model {
 		$this->db->where_in($this->config->item('table_name').'.station_id', $StationLocationsArray);
 		$this->db->order_by(''.$this->config->item('table_name').'.COL_TIME_ON', "desc");
 
-		$this->db->limit($num);
-
-		return $this->db->get();
+		if ($num == 'all') {
+			return $this->db->get();
+		} else {
+			$this->db->limit($num);
+			return $this->db->get();
+		}
 	}
 
 	function getlastqsodate ($slug) {


### PR DESCRIPTION
Added these options to staticmap:

`contest` 
Ability to filter for a contest. Use Contest ID (Adif Name)

`start_date`
Shows only QSOs from a certain date

`end_date`
Shows only QSOs to a certain date

`qsocount=all`
Shows all available QSOs in Database