### PR TITLE
Adjust regex to accept VUCC grids (again)

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -419,7 +419,7 @@ class Logbookadvanced extends CI_Controller {
 		if (strlen($grid) == 6)  $grid .= "55";	// Only 6 Chars? Fill with center "55"
 		if (strlen($grid) == 8)  $grid .= "LL";	// Only 8 Chars? Fill with center "LL" as only A-R allowed
 		// Regex pattern to match a single valid Maidenhead grid square (with optional extensions)
-		$singleGridPattern = '[A-R]{2}[0-9]{2}[A-X]{2}[0-9]{2}[A-X]{2}';
+		$singleGridPattern = '[A-R]{2}[0-9]{2}([A-X]{2})?([0-9]{2})?([A-X]{2})?';
 
 		// Regex to match VUCC grids, allowing multiple grids separated by commas
 		$compoundPattern = '/^(' . $singleGridPattern . ')(,' . $singleGridPattern . ')*$/i';


### PR DESCRIPTION
In https://github.com/wavelog/wavelog/pull/1134 we changed the code to accept up to 10-char maidenhead grids but we crossed that station gridsquare can also be a VUCC gridsquare or gridline. So LBA would only map QSOs with a single station gridsquare or two or four 10-char grids (which is not what we want). So we need to make the 3rd to 5th pair of chars/numbers optional.