### PR TITLE
Individual CAT URL

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 225;
+$config['migration_version'] = 226;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -116,10 +116,10 @@ class Radio extends CI_Controller {
 	}
 
 	public function saveCatUrl() {
-		$name = xss_clean($this->input->post('name', true));
+		$url = xss_clean($this->input->post('caturl', true));
 		$id = xss_clean($this->input->post('id', true));
 		$this->load->model('cat');
-		$this->cat->updateCatUrl($id,$name);
+		$this->cat->updateCatUrl($id,$url);
 	}
 
 	public function editCatUrl() {

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -50,6 +50,7 @@ class Radio extends CI_Controller {
 			echo "<th>" . __("Timestamp") . "</th>";
 			echo "<th></th>";
 			echo "<th>" . __("Options") . "</th>";
+			echo "<th>" . __("CAT-URL") . "</th>";
 			echo "<th></th>";
 			echo "</tr></thead><tbody>";
 			foreach ($query->result() as $row) {
@@ -102,6 +103,7 @@ class Radio extends CI_Controller {
 						echo '<td><button id="default_radio_btn_' . $row->id . '" class="btn btn-sm btn-primary ld-ext-right" onclick="release_default_radio(' . $row->id . ')">' . __("Default (click to release)") . '<div class="ld ld-ring ld-spin"></div></button</td>';
 					}
 				}
+				echo "<td><button id='".$row->id."' \" class=\"editCatUrl btn btn-sm btn-primary\"> " . __("Edit") . "</button></td>";
 				echo "<td><a href=\"" . site_url('radio/delete') . "/" . $row->id . "\" class=\"btn btn-sm btn-danger\"> <i class=\"fas fa-trash-alt\"></i> " . __("Delete") . "</a></td>";
 				echo "</tr>";
 			}
@@ -111,6 +113,20 @@ class Radio extends CI_Controller {
 			echo "<td colspan=\"6\"><div class=\"alert alert-info text-center\">" . __("No CAT interfaced radios found.") . "</div></td>";
 			echo "</tr></thead>";
 		}
+	}
+
+	public function saveCatUrl() {
+		$name = xss_clean($this->input->post('name', true));
+		$id = xss_clean($this->input->post('id', true));
+		$this->load->model('cat');
+		$this->cat->updateCatUrl($id,$name);
+	}
+
+	public function editCatUrl() {
+		$this->load->model('cat');
+		$data['container'] = $this->cat->radio_status(xss_clean($this->input->post('id', true)))->row();
+		$data['page_title'] = __("Edit container name");
+		$this->load->view('radio/edit', $data);
 	}
 
 	function json($id) {
@@ -147,6 +163,8 @@ class Radio extends CI_Controller {
 					$power = $row->power;
 
 					$prop_mode = $row->prop_mode;
+
+					$cat_url = $row->cat_url;;
 
 					// Check Mode
 					if (isset($row->mode) && ($row->mode != null)) {
@@ -216,6 +234,9 @@ class Radio extends CI_Controller {
 					}
 					if (isset($prop_mode) && ($prop_mode != null)) {
 						$a_ret['prop_mode'] = $prop_mode;
+					}
+					if (isset($cat_url) && ($cat_url != null)) {
+						$a_ret['cat_url'] = $cat_url;
 					}
 					$a_ret['update_minutes_ago'] = $updated_at;
 					echo json_encode($a_ret, JSON_PRETTY_PRINT);

--- a/application/migrations/226_add_cat_url.php
+++ b/application/migrations/226_add_cat_url.php
@@ -1,0 +1,26 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_add_cat_url extends CI_Migration {
+
+	public function up() {
+		$fields = array(
+			'cat_url' => array(
+				'type' => 'TEXT',
+				'null' => FALSE,
+				'default' => 'http://127.0.0.1:54321'
+			),
+		);
+
+		if (!$this->db->field_exists('cat_url', 'cat')) {
+			$this->dbforge->add_column('cat', $fields);
+		}
+	}
+
+	public function down() {
+		if ($this->db->field_exists('cat_url', 'cat')) {
+			$this->dbforge->drop_column('cat', 'cat_url');
+		}
+	}
+}

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -121,5 +121,13 @@
 
 			return true;
 		}
+
+		function updateCatUrl($id,$caturl) {
+			$this->db->where('id', $id);
+			$this->db->where('user_id', $this->session->userdata('user_id'));
+			$this->db->update('cat',array('cat_url' => $caturl));
+
+			return true;
+		}
 	}
 ?>

--- a/application/views/radio/edit.php
+++ b/application/views/radio/edit.php
@@ -1,0 +1,24 @@
+<div class="container" id="editCatUrl">
+
+<br>
+		<!-- Display Message -->
+		<div id="flashdata" class="alert-message error">
+		</div>
+
+		<?php if($this->session->flashdata('notice')) { ?>
+			<div id="message" >
+			<?php echo $this->session->flashdata('notice'); ?>
+			</div>
+		<?php } ?>
+
+		<?php $this->load->helper('form'); ?>
+		<input type="hidden" id="catid" name="id" value="<?php echo $container->id; ?>">
+
+		<div class="mb-3">
+			<label for="CatUrlInput"><?= __("CAT URL"); ?></label>
+			<input type="text" class="form-control" name="CatUrlInput" id="CatUrlInput" aria-describedby="CatUrlHelp" placeholder="http://127.0.0.1:54321" required value="<?php echo $container->cat_url; ?>">
+			<small id="CatUrlHelp" class="form-text text-muted"><?= __("Called URL when a spot at DXCluster is clicked. Notice: The slash (/) and QRG is added automatically"); ?></small>
+		</div>
+
+
+</div>

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -216,7 +216,7 @@ $(function() {
 		}
 
 		try {
-			irrelevant=fetch('http://127.0.0.1:54321/'+qrg);
+			irrelevant=fetch(CatCallbackURL + '/'+qrg);
 		} finally {}
 
 		let check_pong = setInterval(function() {
@@ -269,7 +269,9 @@ $(function() {
 		}
 	});
 	
+	var CatCallbackURL = "http://127.0.0.1:54321";
 	var updateFromCAT = function() {
+
 	if($('select.radios option:selected').val() != '0') {
 		radioID = $('select.radios option:selected').val();
 		$.getJSON( base_url+"index.php/radio/json/" + radioID, function( data ) {
@@ -287,7 +289,7 @@ $(function() {
 					$(".radio_login_error" ).remove();
 				}
 				var band = frequencyToBand(data.frequency);
-
+				CatCallbackURL=data.cat_url;
 				if (band !== $("#band").val()) {
 					$("#band").val(band);
 					$("#band").trigger("change");

--- a/assets/js/sections/radio.js
+++ b/assets/js/sections/radio.js
@@ -14,6 +14,66 @@ $(document).ready(function () {
 
 });
 
+$(document).on('click', '.editCatUrl', async function (e) {	// Dynamic binding, since element doesn't exists when loading this JS
+	editCatUrlDialog(e);
+});
+
+function editCatUrlDialog(e) {
+	$.ajax({
+		url: base_url + 'index.php/radio/editCatUrl',
+		type: 'post',
+		data: {
+			id: e.currentTarget.id,
+		},
+		success: function (data) {
+			BootstrapDialog.show({
+				title: 'Edit Callback-URL for CAT',
+				size: BootstrapDialog.SIZE_NORMAL,
+				cssClass: 'options',
+				id: "CatUrlModal",
+				nl2br: false,
+				message: data,
+				onshown: function(dialog) {
+				},
+				buttons: [{
+					label: 'Save',
+					cssClass: 'btn-primary btn-sm saveContainerName',
+					action: function (dialogItself) {
+						saveCatUrl();
+						dialogItself.close();
+					}
+				},
+					{
+						label: lang_admin_close,
+						cssClass: 'btn-sm',
+						id: 'closeButton',
+						action: function (dialogItself) {
+							dialogItself.close();
+						}
+					}],
+			});
+		},
+		error: function (data) {
+
+		},
+	});
+	return false;
+}
+
+function saveCatUrl() {
+	$.ajax({
+		url: base_url + 'index.php/radio/saveCatUrl',
+		type: 'post',
+		data: {
+			id: $('#catid').val(),
+			caturl: $('#CatUrlInput').val()
+		},
+		error: function (data) {
+
+		},
+	});
+}
+
 function set_default_radio(radio_id) {
     $('#default_radio_btn_' + radio_id).addClass('running').prop('disable', true);
     $('#default_radio_btn_' + radio_id).removeClass('btn-outline-primary').addClass('btn-primary');


### PR DESCRIPTION
Added the ability to set a different CAT-Callback-URL for the dxcluster for each radio.

![telegram-cloud-photo-size-2-5292044692957032404-y](https://github.com/user-attachments/assets/ea5057ca-0a7e-438b-baae-28d0b4d82e05)

Old behaviour: Click on a Call at Bandmap-list, and the browser requested a QSY via http://127.0.0.1:54321/QRG to WaveLogGate

New behaviour: 
- One can set individual URLs for each radio. So it is - e.g. - possible to run WavelogGate (or other tools) on different machines than the Browser. 
- A click on a Call at Bandmap-list, and the browser requested a QSY via the configured URL (at HW-Interfaces) to WaveLogGate.
- The default-URL is set to http://127.0.0.1:54321 to ensure all standard-installations are still running