### PR TITLE
Extend SIG-Cols in Database

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 226;
+$config['migration_version'] = 227;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/227_extend_sig_info.php
+++ b/application/migrations/227_extend_sig_info.php
@@ -1,0 +1,16 @@
+<?php
+
+class Migration_extend_sig_info  extends CI_Migration
+{
+
+	public function up() {
+		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_SIG_INFO COL_SIG_INFO VARCHAR(128) NULL DEFAULT NULL");
+		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_MY_SIG_INFO COL_MY_SIG_INFO VARCHAR(128) NULL DEFAULT NULL");
+		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_MY_SIG COL_MY_SIG VARCHAR(64) NULL DEFAULT NULL");
+		$this->db->query("ALTER TABLE station_profile CHANGE COLUMN station_sig_info station_sig_info vARCHAR(128) NULL DEFAULT NULL");
+		$this->db->query("ALTER TABLE station_profile CHANGE COLUMN station_sig station_sig vARCHAR(64) NULL DEFAULT NULL");
+	}
+
+	public function down() {
+	}
+}

--- a/application/migrations/227_extend_sig_info.php
+++ b/application/migrations/227_extend_sig_info.php
@@ -4,6 +4,7 @@ class Migration_extend_sig_info  extends CI_Migration
 {
 
 	public function up() {
+		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_SIG COL_SIG VARCHAR(64) NULL DEFAULT NULL");
 		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_SIG_INFO COL_SIG_INFO VARCHAR(128) NULL DEFAULT NULL");
 		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_MY_SIG_INFO COL_MY_SIG_INFO VARCHAR(128) NULL DEFAULT NULL");
 		$this->db->query("ALTER TABLE ".$this->config->item('table_name')." CHANGE COLUMN COL_MY_SIG COL_MY_SIG VARCHAR(64) NULL DEFAULT NULL");


### PR DESCRIPTION
In some very rare circumstances one can log - e.g. - a WCA-Station which has more castles nearby (allowed at WCA) than SIG_INFO can contain.

This one harmonizes the sig_info columns at station_profile as well as at logbook-table (Old: 50/64 chars, now 128)
Furthermore the sig-field is harmonized.
