### PR TITLE
Fallback to empty string at RST

### DIFF
--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -166,8 +166,8 @@ class QSO
 		$this->submode = $data['COL_SUBMODE'] ?? '';
 		$this->band = $data['COL_BAND'];
 		$this->bandRX = $data['COL_BAND_RX'] ?? '';
-		$this->rstR = $data['COL_RST_RCVD'];
-		$this->rstS = $data['COL_RST_SENT'];
+		$this->rstR = $data['COL_RST_RCVD'] ?? '';
+		$this->rstS = $data['COL_RST_SENT'] ?? '';
 		$this->srx = $data['COL_SRX'] ?? '';
 		$this->srxstring = $data['COL_SRX_STRING'] ?? '';
 		$this->stx = $data['COL_STX'] ?? '';


### PR DESCRIPTION
If a user adds QSOs (via ADIF-Upload or other ways) and the RST is empty, the LBA fails with in an internal-Server-Error.

Reason: QSO-Class isn't able to parse nulls here.

This one fixes it.
