### PR TITLE
Cabrillo Fix

### DIFF
--- a/application/controllers/Cabrillo.php
+++ b/application/controllers/Cabrillo.php
@@ -132,6 +132,7 @@ class Cabrillo extends CI_Controller {
 			$data['soapbox'] = $this->security->xss_clean($this->input->post('soapbox'));
 			$data['gridlocator'] = $station->station_gridsquare;
 			$data['certificate'] = $this->security->xss_clean($this->input->post('certificate'));
+			$data['grid_export'] = $this->security->xss_clean($this->input->post('grid_export')) == '1' ? true : false;
 
 			$this->load->view('cabrillo/export', $data);
 		}else {

--- a/application/libraries/Cabrilloformat.php
+++ b/application/libraries/Cabrilloformat.php
@@ -147,7 +147,7 @@ class Cabrilloformat {
       }
 
       if ($grid_export == true) {
-         $returnstring .= substr($qso->station_gridsquare, 0, 4) ." ";
+         $returnstring .= substr($qso->station_gridsquare, 0, 4) ?? '' ." ";
       }
 
       if ($qso->COL_STX_STRING != "") {
@@ -161,7 +161,7 @@ class Cabrilloformat {
       }  
 
       if ($grid_export == true) {
-         $returnstring .= substr($qso->COL_GRIDSQUARE, 0, 4) ." ";
+         $returnstring .= substr($qso->COL_GRIDSQUARE, 0, 4) ?? '' ." ";
       }
       
       if ($qso->COL_SRX_STRING != "") {

--- a/application/libraries/Cabrilloformat.php
+++ b/application/libraries/Cabrilloformat.php
@@ -62,7 +62,7 @@ class Cabrilloformat {
       return "END-OF-LOG:";
    }
 
-   public function qso($qso) {
+   public function qso($qso, $grid_export) {
       $freq =  substr($qso->COL_FREQ, 0, -3);
       if ($freq > 30000) {
          if ($freq > 250000000) {
@@ -123,7 +123,7 @@ class Cabrilloformat {
 
       // based on the official cabrillo documentation
       // https://wwrof.org/cabrillo/cabrillo-qso-data/
-      
+
       if($qso->COL_MODE == "CW") {
          $mode = "CW";
       } elseif($qso->COL_MODE == "SSB" || $qso->COL_MODE == "AM") {
@@ -146,6 +146,10 @@ class Cabrilloformat {
          $returnstring .= sprintf("%-6s", sprintf("%03d", $qso->COL_STX)) ." ";
       }
 
+      if ($grid_export == true) {
+         $returnstring .= substr($qso->station_gridsquare, 0, 4) ." ";
+      }
+
       if ($qso->COL_STX_STRING != "") {
          $returnstring .= $qso->COL_STX_STRING ." ";
       }
@@ -155,6 +159,10 @@ class Cabrilloformat {
       if ($qso->COL_SRX != NULL) {
          $returnstring .= sprintf("%-6s", sprintf("%03d", $qso->COL_SRX)) ." ";
       }  
+
+      if ($grid_export == true) {
+         $returnstring .= substr($qso->COL_GRIDSQUARE, 0, 4) ." ";
+      }
       
       if ($qso->COL_SRX_STRING != "") {
          $returnstring .= $qso->COL_SRX_STRING ." ";

--- a/application/libraries/Cabrilloformat.php
+++ b/application/libraries/Cabrilloformat.php
@@ -121,12 +121,19 @@ class Cabrilloformat {
          }
       }
 
-      if($qso->COL_MODE == "SSB") {
+      // based on the official cabrillo documentation
+      // https://wwrof.org/cabrillo/cabrillo-qso-data/
+      
+      if($qso->COL_MODE == "CW") {
+         $mode = "CW";
+      } elseif($qso->COL_MODE == "SSB" || $qso->COL_MODE == "AM") {
          $mode = "PH";
+      } elseif($qso->COL_MODE == "FM") {
+         $mode = "FM";
       } elseif($qso->COL_MODE == "RTTY") {
          $mode = "RY";
       } else {
-         $mode = $qso->COL_MODE;
+         $mode = "DG";
       }
 
       $time = substr($qso->COL_TIME_ON, 0, -3);

--- a/application/views/cabrillo/export.php
+++ b/application/views/cabrillo/export.php
@@ -9,6 +9,6 @@ echo $CI->cabrilloformat->header($contest_id, $callsign, $claimed_score,
 	$operators, $club, $location, $name, $address, $addresscity, $addressstateprovince, $addresspostalcode, $addresscountry, $soapbox, $gridlocator, 
 	$categoryoverlay, $categorytransmitter, $categorytime, $categorystation, $categorypower, $categorymode, $categoryband, $categoryassisted, $categoryoperator, $email, $certificate);
 foreach ($qsos->result() as $row) {
-	echo $CI->cabrilloformat->qso($row);
+	echo $CI->cabrilloformat->qso($row, $grid_export);
 }
 echo $CI->cabrilloformat->footer();

--- a/application/views/cabrillo/index.php
+++ b/application/views/cabrillo/index.php
@@ -198,6 +198,13 @@
 					</select>
 				</div>
 				<div hidden="true" class="mb-3 d-flex align-items-center row additionalinfo">
+					<div class="col-md-3 control-label" for="grid_export"><?= __("Include logged grids?") ?>: <i class="fas fa-question-circle col-md-1" data-bs-toggle="contestinfo" data-bs-placement="right" title="<?= __("If the gridsquare was part of the exchange, you should select YES.") ?>"></i></div>
+					<select class="form-select my-1 me-sm-2 col-md-4 w-auto" id="grid_export" name="grid_export">
+						<option value="0" selected><?= __("No"); ?></option>
+						<option value="1"><?= __("Yes"); ?></option>
+					</select>
+				</div>
+				<div hidden="true" class="mb-3 d-flex align-items-center row additionalinfo">
 					<div class="col-md-3 control-label" for="button1id"></div>
 					<button id="button1id" type="submit" name="button1id" class="btn btn-sm btn-primary w-auto"> <?= __("Export") ?></button>
 				</div>

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -675,7 +675,7 @@ function logQso() {
 				serialr = $("#exch_serial_r").val();
 			break;
 
-			case 'Serialgridsquare':
+			case 'SerialGridExchange':
 				gridr = gridsquare;
 				vuccr = vucc;
 				exchsent = $("#exch_sent").val();


### PR DESCRIPTION
There was an bug in the modes of cabrillo exports.

Additionally we had no possibility to include the gridsquares in the cabrillo file. Since Wavelog does not know that the grid was chosen as exchange type (we do not store this yet...), I had to add a little option in the export form. (Default: No)

<img width="616" alt="image" src="https://github.com/user-attachments/assets/deca7bbe-e4ea-486c-8ce7-dbf2441753b6">

 This affects for example the DARC FT4 contest.
 
 The sequence is 
 
 `QSO: [QRG in kHz]  [MODE*]   [DATE]   [TIME]  [MY_CALL]  [RSTs]  [SERIAL]  [GRID]  [EXCH]  [RSTr]  [SERIAL]  [GRID]  [EXCH] `
 
 Serial, Grid and Exchange: Each if not null / empty  and grid if option is true
 
 *Modes based on the official cabrillo documentation: https://wwrof.org/cabrillo/cabrillo-qso-data/