### PR TITLE
Order same time QSOs by PK desc

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1983,6 +1983,7 @@ class Logbook_model extends CI_Model {
 
 		$this->db->where_in($this->config->item('table_name') . '.station_id', $logbooks_locations_array);
 		$this->db->order_by('' . $this->config->item('table_name') . '.COL_TIME_ON', "desc");
+		$this->db->order_by('' . $this->config->item('table_name') . '.COL_PRIMARY_KEY', "desc");
 
 		$this->db->limit($num);
 		$this->db->offset($offset);


### PR DESCRIPTION
For QSOs added with same time (e.g. SAT passes) there is a difference in sort order for those QSOs. Dashboard shows the correct order, i.e. same QSO sorted by PK desc:

![Screenshot 2024-11-13 172723](https://github.com/user-attachments/assets/c01afbfc-1907-400f-a242-8745a5b6259a)

The logbook overview however reverses these QSOs

![Screenshot 2024-11-13 172740](https://github.com/user-attachments/assets/a7a675c8-58e0-4663-a539-a24a233c82bf)

We should add a secondary sorting criteria to take PK into account also (supposed that SAT QSOs are logged in a timely order, i.e. increasing PK).