### PR TITLE
Use PK as secondary sorting criteria after time

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -643,6 +643,7 @@ class Logbook_model extends CI_Model {
 			$this->db->group_end();
 		}
 		$this->db->order_by("COL_TIME_ON", "desc");
+		$this->db->order_by("COL_PRIMARY_KEY", "desc");
 
 		$this->db->limit(500);
 
@@ -1983,6 +1984,7 @@ class Logbook_model extends CI_Model {
 
 		$this->db->where_in($this->config->item('table_name') . '.station_id', $logbooks_locations_array);
 		$this->db->order_by('' . $this->config->item('table_name') . '.COL_TIME_ON', "desc");
+		$this->db->order_by('' . $this->config->item('table_name') . '.COL_PRIMARY_KEY', "desc");
 
 		$this->db->limit($num);
 		$this->db->offset($offset);
@@ -2199,13 +2201,13 @@ class Logbook_model extends CI_Model {
 		if ($logbooks_locations_array) {
 			$location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 
-			$sql = "SELECT * FROM ( select * from " . $this->config->item('table_name') . "
+			$sql = "SELECT * FROM ( SELECT * FROM " . $this->config->item('table_name') . "
 			    WHERE station_id IN(" . $location_list . ")
-			    order by col_time_on desc
-			    limit ?) hrd
+			    ORDER BY col_time_on DESC, col_primary_key DESC
+			    LIMIT ?) hrd
 			    JOIN station_profile ON station_profile.station_id = hrd.station_id
 			    LEFT JOIN dxcc_entities ON hrd.col_dxcc = dxcc_entities.adif
-			    order by col_time_on desc";
+			    ORDER BY col_time_on DESC";
 			$binding[] = $num * 1;
 			$query = $this->db->query($sql, $binding);
 


### PR DESCRIPTION
For post-logging satellite QSOs (transcribing recordings) it often happens that users use the same timestamp for all QSOs of a SAT pass (LoTW matches QSOs on a +- 15 min basis). The current state uses different sorting criteria for listing QSOs.

Dashboard:

![dashboard](https://github.com/user-attachments/assets/05b20a12-8df3-4688-8cc7-35f4c3d2ee07)

Logbook:

![logbook](https://github.com/user-attachments/assets/2445cbff-4dff-4d80-89d2-f4be24fb4cec)

Logbook Advanced:

![lba](https://github.com/user-attachments/assets/939ef0e7-3145-4b52-aa7b-74fd3859a9f4)

The LBA order is correct. It uses time as first and primary key as second sorting criteria. This should be used in the other places as well. Fixes: Logbook view, Dashboard view and QSO lists popup (for example Activated Gridsquares).