### PR TITLE
[Advanced Logbook] Removed the if check to merge USB/LSB/SSB

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -579,10 +579,7 @@ class Logbookadvanced_model extends CI_Model {
 			if ($mode->col_submode == null || $mode->col_submode == "") {
 				array_push($modes, $mode->col_mode);
 			} else {
-				// Make sure we don't add LSB or USB as submodes in the array list
-				if ($mode->col_mode != "SSB") {
-					array_push($modes, $mode->col_submode);
-				}
+				array_push($modes, $mode->col_submode);
 			}
 		}
 


### PR DESCRIPTION
To avoid USB/LSB/SSB not showing up in the filter dropdown, depending on how your mode/submode are logged.

This should fix #1213 