### PR TITLE
TX Power at QSO import

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3981,7 +3981,7 @@ class Logbook_model extends CI_Model {
 			if (isset($record['tx_pwr'])) {
 				$tx_pwr = filter_var($record['tx_pwr'], FILTER_VALIDATE_FLOAT);
 			} else {
-				$tx_pwr = NULL;
+				$tx_pwr = $station_profile->station_power ?? NULL;
 			}
 
 			// Sanitise RX Power


### PR DESCRIPTION
When importing QSOs via ADIF or SFLE we do not set the used TX Power if not set in the imported data. We should use the default value of the station location. 

Affects for example SFLE and ADIF import