### PR TITLE
prevent http_state 500 if get-param wasn't provided

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -3,13 +3,11 @@
 class API extends CI_Controller {
 
 	// Do absolutely nothing
-	function index()
-	{
+	function index() {
 		echo "nothing to see";
 	}
 
-	function help()
-	{
+	function help() {
 		$this->load->model('user_model');
 
 		// Check if users logged in
@@ -112,7 +110,7 @@ class API extends CI_Controller {
 	}
 
 	// Example of authing
-	function auth($key) {
+	function auth($key = '') {
 		$this->load->model('api_model');
 			header("Content-type: text/xml");
 		if($this->api_model->access($key) == "No Key Found" || $this->api_model->access($key) == "Key Disabled") {

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -128,7 +128,7 @@ class API extends CI_Controller {
 		}
 	}
 
-	function station_info($key) {
+	function station_info($key = '') {
 		$this->load->model('api_model');
 		$this->load->model('stations');
 		header("Content-type: application/json");


### PR DESCRIPTION
when - e.g. - /api/station_info is called without a key it produces a 500.

This one fixes that