### PR TITLE
QSO Edit HTML ID's fix

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -173,8 +173,8 @@ class Logbook_model extends CI_Model {
 			$submode = $this->input->post('mode');
 		}
 
-		if ($this->input->post('county') && $this->input->post('input_state_edit')) {
-			$clean_county_input = trim($this->input->post('input_state_edit')) . "," . trim($this->input->post('county'));
+		if ($this->input->post('county') && $this->input->post('input_state')) {
+			$clean_county_input = trim($this->input->post('input_state')) . "," . trim($this->input->post('county'));
 		} else {
 			$clean_county_input = null;
 		}
@@ -204,7 +204,7 @@ class Logbook_model extends CI_Model {
 		$qso_qth = trim(xss_clean($this->input->post('qth')));
 		$qso_name = trim(xss_clean($this->input->post('name')));
 		$qso_age = null;
-		$qso_state = $this->input->post('input_state_edit') == null ? '' : trim(xss_clean($this->input->post('input_state_edit')));
+		$qso_state = $this->input->post('input_state') == null ? '' : trim(xss_clean($this->input->post('input_state')));
 		$qso_rx_power = null;
 
 		if ($this->input->post('copyexchangeto')) {

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -341,12 +341,10 @@
                                                 <?php } ?>
                                             </select>
                                         </div>
-                                        <?php if ($qso->COL_DXCC == '291' || $qso->COL_DXCC == '110'  || $qso->COL_DXCC == '006') { ?>
-                                            <div class="mb-3 col-sm-6" id="location_us_county">
-                                                <label for="stationCntyInput"><?= __("USA County"); ?></label>
-                                                <input class="form-control" id="stationCntyInputEdit" type="text" name="usa_county" value="<?php echo $qso->COL_CNTY; ?>" />
-                                            </div>
-                                        <?php } ?>
+                                        <div style="display: none;" class="mb-3 col-sm-6" id="location_us_county_edit">
+                                            <label for="stationCntyInput"><?= __("USA County"); ?></label>
+                                            <input class="form-control" id="stationCntyInputEdit" type="text" name="usa_county" value="<?php echo $qso->COL_CNTY; ?>" />
+                                        </div>
                                     </div>
                                     <div class="row">
                                         <div class="mb-3 col-sm-6">

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -168,12 +168,12 @@
                                     <div class="row">
                                         <div class="mb-3 col-sm-6">
                                             <label for="name"><?= __("Name"); ?></label>
-                                            <input type="text" class="form-control" id="name" name="name" value="<?php echo $qso->COL_NAME; ?>">
+                                            <input type="text" class="form-control" id="name_edit" name="name" value="<?php echo $qso->COL_NAME; ?>">
                                         </div>
 
                                         <div class="mb-3 col-sm-6">
                                             <label for="qth"><?= __("QTH"); ?></label>
-                                            <input type="text" class="form-control" id="qth" name="qth" value="<?php echo $qso->COL_QTH; ?>">
+                                            <input type="text" class="form-control" id="qth_edit" name="qth" value="<?php echo $qso->COL_QTH; ?>">
                                         </div>
                                     </div>
 
@@ -230,7 +230,7 @@
                                     <div class="row mb-3">
                                         <div class="mb-3 col-sm-6">
                                             <label for="dxcc_id"><?= __("DXCC"); ?></label>
-                                            <select class="form-select" id="dxcc_id" name="dxcc_id" required>
+                                            <select class="form-select" id="dxcc_id_edit" name="dxcc_id" required>
                                                 <option value=""><?= __("Please select one"); ?></option>
                                                 <?php
                                                 foreach ($dxcc as $d) {
@@ -258,7 +258,7 @@
                                         </div>
                                         <div class="mb-3 col-sm-6">
                                             <label for="continent"><?= __("Continent"); ?></label>
-                                            <select class="form-select" id="continent" name="continent">
+                                            <select class="form-select" id="continent_edit" name="continent">
                                                 <option value=""></option>
                                                 <option value="AF" <?php if ($qso->COL_CONT == "AF") { echo "selected=\"selected\""; } ?>><?= __("Africa"); ?></option>
                                                 <option value="AN" <?php if ($qso->COL_CONT == "AN") { echo "selected=\"selected\""; } ?>><?= __("Antarctica"); ?></option>
@@ -304,7 +304,7 @@
                                     <div class="row">
                                         <div class="mb-3 col-sm-6">
                                             <label for="cqz"><?= __("CQ Zone"); ?></label>
-                                            <select class="form-select" id="cqz" name="cqz" required>
+                                            <select class="form-select" id="cqz_edit" name="cqz" required>
                                                 <?php for ($i = 1; $i <= 40; $i++) { ?>
                                                     <option value="<?= $i; ?>" <?php if ($qso->COL_CQZ == $i) echo "selected=\"selected\""; ?>><?= $i; ?></option>
                                                 <?php } ?>
@@ -312,7 +312,7 @@
                                         </div>
                                         <div class="mb-3 col-sm-6">
                                             <label for="ituz"><?= __("ITU Zone"); ?></label>
-                                            <select class="form-select" id="ituz" name="ituz">
+                                            <select class="form-select" id="ituz_edit" name="ituz">
                                                 <option value=''></option>
                                                 <?php for ($i = 1; $i <= 90; $i++) { ?>
                                                     <option value="<?= $i; ?>" <?php if ($qso->COL_ITUZ == $i) echo "selected=\"selected\""; ?>><?= $i; ?></option>
@@ -331,7 +331,7 @@
                                             ?>
 
                                             <label for="stateDropdown" id="stateInputLabel"><?php echo $subdivision_name; ?></label>
-                                            <select class="form-select" id="stateDropdown" name="input_state_edit">
+                                            <select class="form-select" id="stateDropdownEdit" name="input_state_edit">
                                                 <option value=""></option>
                                                 <?php foreach ($state_list->result() as $state) {
                                                     $selected = ($qso->COL_STATE == $state->state) ? 'selected="selected"' : ''; ?>
@@ -351,7 +351,7 @@
                                     <div class="row">
                                         <div class="mb-3 col-sm-6">
                                             <label for="iota_ref"><?= __("IOTA"); ?></label>
-                                            <select class="form-select" id="iota_ref" name="iota_ref">
+                                            <select class="form-select" id="iota_ref_edit" name="iota_ref">
                                                 <option value=""></option>
                                                 <?php foreach ($iota as $i) { ?>
                                                     <option value="<?= $i->tag; ?>" <?php if ($qso->COL_IOTA == $i->tag) echo "selected=\"selected\""; ?>><?= $i->tag . ' - ' . $i->name; ?></option>

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -330,7 +330,7 @@
                                             $state_list = $CI->subdivisions->get_state_list($qso->COL_DXCC);
                                             ?>
 
-                                            <label for="stateDropdown" id="stateInputLabel"><?php echo $subdivision_name; ?></label>
+                                            <label for="stateDropdown" id="stateInputLabelEdit"><?php echo $subdivision_name; ?></label>
                                             <select class="form-select" id="stateDropdownEdit" name="input_state_edit">
                                                 <option value=""></option>
                                                 <?php foreach ($state_list->result() as $state) {

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -458,7 +458,7 @@
 
             <div class="mb-3">
               <label for="stateInput" id="stateInputLabel"></label>
-                <select class="form-select" name="input_state_edit" id="stateDropdown">
+                <select class="form-select" name="input_state" id="stateDropdown">
                   <option value=""></option>
                 </select>
             </div>

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -207,7 +207,7 @@ async function fill_if_empty(field, data) {
     }
 
     if (field == 'select[name="input_state_edit"]') {
-        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabel', '#location_us_county', '#stationCntyInputEdit', '#stateDropdownEdit');
+        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabel', '#location_us_county_edit', '#stationCntyInputEdit', '#stateDropdownEdit');
         $(field).val(data).css('border', border_color);
         return;
     }
@@ -272,7 +272,13 @@ function qso_edit(id) {
 
                     $('[data-bs-toggle="tooltip"]').tooltip();
 
-                    var state = $("#stateDropdown option:selected").text();
+                    if ($('#dxcc_id_edit').val() == '291' || $('#dxcc_id_edit').val() == '110' || $('#dxcc_id_edit').val() == '6') {
+                        $('#location_us_county_edit').show();
+                    } else {    
+                        $('#location_us_county_edit').hide();    
+                    }
+
+                    var state = $("#stateDropdownEdit option:selected").text();
                     if (state != "") {
                         $("#stationCntyInputEdit").prop('disabled', false);
                         selectize_usa_county('#stateDropdown', '#stationCntyInputEdit');
@@ -304,12 +310,12 @@ function qso_edit(id) {
                        }
                     });
 
-                    $('#stateDropdown').change(function(){
-                        var state = $("#stateDropdown option:selected").text();
+                    $('#stateDropdownEdit').change(function(){
+                        var state = $("#stateDropdownEdit option:selected").text();
                         if (state != "") {
                             $("#stationCntyInputEdit").prop('disabled', false);
 
-                            selectize_usa_county('#stateDropdown', '#stationCntyInputEdit');
+                            selectize_usa_county('#stateDropdownEdit', '#stationCntyInputEdit');
 
                         } else {
                             $("#stationCntyInputEdit").prop('disabled', true);
@@ -514,8 +520,8 @@ function qso_edit(id) {
                         calcRemainingChars(event, '.modal-content');
                     });
 
-                    $("#dxcc_id").change(async function () {
-                        await updateStateDropdown('#dxcc_id', '#stateInputLabel', '#location_us_county', '#stationCntyInputEdit');
+                    $("#dxcc_id_edit").change(async function () {
+                        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabel', '#location_us_county_edit', '#stationCntyInputEdit', '#stateDropdownEdit');
                     });
                 },
             });

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -170,22 +170,21 @@ function single_callbook_update() {
         dataType: 'json',
         success: function (data) {
             // console.log(data);
-            fill_if_empty('#qth', data.callsign_qth);
-            fill_if_empty('#dxcc_id', data.dxcc.adif);
-            fill_if_empty('#continent', data.dxcc.cont);
-            fill_if_empty('#cqz', data.dxcc.cqz);
+            fill_if_empty('#qth_edit', data.callsign_qth);
+            fill_if_empty('#dxcc_id_edit', data.dxcc.adif);
+            fill_if_empty('#continent_edit', data.dxcc.cont);
+            fill_if_empty('#cqz_edit', data.dxcc.cqz);
             if (data.callsign_ituz != '') {
-                fill_if_empty('#ituz', data.callsign_ituz);
+                fill_if_empty('#ituz_edit', data.callsign_ituz);
             } else {
-                fill_if_empty('#ituz', data.dxcc.ituz);
+                fill_if_empty('#ituz_edit', data.dxcc.ituz);
             }
-            fill_if_empty('#distance', data.callsign_distance);
-            fill_if_empty('#locator', data.callsign_qra);
+            fill_if_empty('#locator_edit', data.callsign_qra);
             // fill_if_empty('#image', data.image);  Not in use yet, but may in future
-            fill_if_empty('#iota_ref', data.callsign_iota);
-            fill_if_empty('#name', data.callsign_name);
+            fill_if_empty('#iota_ref_edit', data.callsign_iota);
+            fill_if_empty('#name_edit', data.callsign_name);
             fill_if_empty('#qsl-via', data.qsl_manager);
-            fill_if_empty('#stateDropdown', data.callsign_state);
+            fill_if_empty('select[name="input_state_edit"]', data.callsign_state);
             fill_if_empty('#stationCntyInputEdit', data.callsign_us_county);
 
             $('#update_from_callbook').prop("disabled", false).removeClass("running");
@@ -202,24 +201,26 @@ async function fill_if_empty(field, data) {
     var border_color = '2px solid green';
 
     // catch special case for dxcc
-    if (field == "#dxcc_id" && $(field).val() == 0) {
+    if (field == "#dxcc_id_edit" && $(field).val() == 0) {
         $(field).val(data).css('border', border_color);
+        return;
     }
 
-    // catch special case for state
-    if (field == '#stateDropdown') {
-        await updateStateDropdown('#dxcc_id', '#stateInputLabel', '#location_us_county', '#stationCntyInputEdit');
+    if (field == 'select[name="input_state_edit"]') {
+        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabel', '#location_us_county', '#stationCntyInputEdit', '#stateDropdownEdit');
         $(field).val(data).css('border', border_color);
+        return;
     }
 
-    // catch special case for distance
-    if (field == "#distance" && $(field).val() == 0) {
-        $(field).val(data).css('border', border_color);
-        // $('#locator_info_edit').html(data);
+    // catch special case for grid
+    if (field == "#locator_edit") {
+        $(field).val(data.toUpperCase()).css('border', border_color).trigger('change');
+        return;
     }
 
     if ($(field).val() == '' && data != '') {
         $(field).val(data).css('border', border_color);
+        return;
     }
 }
 
@@ -579,7 +580,7 @@ function selectize_usa_county(state_field, county_field) {
     });
 }
 
-async function updateStateDropdown(dxcc_field, state_label, county_div, county_input) {
+async function updateStateDropdown(dxcc_field, state_label, county_div, county_input, dropdown = '#stateDropdown') {
     var selectedDxcc = $(dxcc_field);
 
     if (selectedDxcc.val() !== "") {
@@ -589,7 +590,7 @@ async function updateStateDropdown(dxcc_field, state_label, county_div, county_i
             data: { dxcc: selectedDxcc.val() },
             success: function (response) {
                 if (response.status === "ok") {
-                    statesDropdown(response, set_state);
+                    statesDropdown(response, set_state, dropdown);
                     $(state_label).html(response.subdivision_name);
                 } else {
                     statesDropdown(response);
@@ -934,8 +935,8 @@ if ($('.table-responsive .dropdown-toggle').length>0) {
 }
 
 var set_state;
-function statesDropdown(states, set_state = null) {
-    var dropdown = $('#stateDropdown');
+function statesDropdown(states, set_state = null, dropdown = '#stateDropdown') {
+    var dropdown = $(dropdown);
     dropdown.empty();
     dropdown.append($('<option>', {
         value: ''

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -207,7 +207,7 @@ async function fill_if_empty(field, data) {
     }
 
     if (field == 'select[name="input_state_edit"]') {
-        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabel', '#location_us_county_edit', '#stationCntyInputEdit', '#stateDropdownEdit');
+        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabelEdit', '#location_us_county_edit', '#stationCntyInputEdit', '#stateDropdownEdit');
         $(field).val(data).css('border', border_color);
         return;
     }
@@ -521,7 +521,7 @@ function qso_edit(id) {
                     });
 
                     $("#dxcc_id_edit").change(async function () {
-                        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabel', '#location_us_county_edit', '#stationCntyInputEdit', '#stateDropdownEdit');
+                        await updateStateDropdown('#dxcc_id_edit', '#stateInputLabelEdit', '#location_us_county_edit', '#stationCntyInputEdit', '#stateDropdownEdit');
                     });
                 },
             });


### PR DESCRIPTION
Due the fact that in the QSO edit view the fields have the same ID like in QSO logging this causes a lot of issues. Noticed that while testing #1165 


https://github.com/user-attachments/assets/0259e29c-3a77-48e4-a87e-58864da8c13c



This PR fixes the HTML ID's in the edit_ajax.php view. Pleas test carefully. I tested everything but double check here is a good idea. If there would be a `bad bug` label this should be tagged to that...