### PR TITLE
Enable at least the manual uploading of a file for LoTW

### DIFF
--- a/application/views/lotw/import.php
+++ b/application/views/lotw/import.php
@@ -18,7 +18,7 @@
       <?php echo form_open_multipart('lotw/import'); ?>
 
       <div class="form-check">
-        <input type="radio" id="lotwimport" name="lotwimport" class="form-check-input">
+        <input type="radio" id="lotwimport" name="lotwimport" class="form-check-input"<?php if ($this->config->item('disable_manual_lotw')) { echo ' checked="checked"'; } ?>>
         <label class="form-check-label" for="lotwimport"><?= __("Upload a File"); ?></label>
         <br><br>
         <p><?= sprintf(__("Upload the Exported ADIF file from LoTW from the %s Area, to mark QSOs as confirmed on LoTW."), "<a href='https://p1k.arrl.org/lotwuser/qsos?qsoscmd=adif' target='_blank'>".__("Download Report")."</a>"); ?></p>
@@ -30,6 +30,7 @@
 
       <br><br>
 
+<?php if (!$this->config->item('disable_manual_lotw')) { ?>
       <div>
         <div class="form-check">
           <input type="radio" name="lotwimport" id="fetch" class="form-check-input" value="fetch" checked="checked" />
@@ -60,6 +61,7 @@
 
           <p class="form-text text-muted"><?= __("Wavelog will use the LoTW username and password stored in your user profile to download a report from LoTW for you. The report Wavelog downloads will have all confirmations since chosen date, or since your last LoTW confirmation (fetched from your log), up until now."); ?></p>
         </div>
+<?php } ?>
 
         <input class="btn btn-primary" type="submit" value="<?= __("Import LoTW Matches"); ?>" />
 

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -5,10 +5,7 @@
 	</div>
 <?php } ?>
 <br>
-	<?php
-	if (!($this->config->item('disable_manual_lotw'))) { ?>
 	<a class="btn btn-outline-primary btn-sm float-end" href="<?php echo site_url('/lotw/import'); ?>" role="button"><i class="fas fa-cloud-download-alt"></i> <?= __("LoTW Import"); ?></a>
-	<?php } ?>
 	<h2><?= __("Logbook of the World"); ?></h2>
 
 	<!-- Card Starts -->


### PR DESCRIPTION
Disabling the LoTW-Userimport (at config.php) can cause a problem.

E.g.:
- A User uploads/logs QSOs (via ADIF/logging) for today
- Cron syncs with LoTW
- QSOs will (perhaps) be confirmed
- Last-QSL-Date has the value of today.

Now User likes Wavelog and uploads his history.
The LoTW-QSLs will never be confirmed via cron, because they're all older than today.

This one re-enables the ability to manual-upload the LoTW-Report to Wavelog. So there's a chance to "heal" those QSOs.

@Reviewers: Check with "ignore whitespace" - it isn't that much