### PR TITLE
Make LoTW-Downloads threadsafe

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -664,7 +664,7 @@ class Lotw extends CI_Controller {
 				}
 
 				$config['upload_path'] = './uploads/';
-				$file = $config['upload_path'] . 'lotwreport_download.adi';
+				$file = $config['upload_path'] . 'lotwreport_download_'.$sync_user_id.'_auto.adi';
 				if (file_exists($file) && ! is_writable($file)) {
 					$result = "Temporary download file ".$file." is not writable. Aborting!";
 					continue;
@@ -736,7 +736,7 @@ class Lotw extends CI_Controller {
 		$this->load->model('logbook_model');
 
 		if (($this->input->post('lotwimport') == 'fetch') && (!($this->config->item('disable_manual_lotw')))) {
-			$file = $config['upload_path'] . 'lotwreport_download.adi';
+			$file = $config['upload_path'] . 'lotwreport_download_'.$this->session->userdata('user_id').'.adi';
 
 			// Get credentials for LoTW
 			$query = $this->user_model->get_by_id($this->session->userdata('user_id'));


### PR DESCRIPTION
Given an instance with multiple users, it may come to race-conditions, when downloading lotw-QSLs.

e.g.:
User a starts/triggers LoTW-Sync --> file lotw_report.adi is created and is going to be parsed
while this process runs, another User (b) comes around and is doing the same. lotw_report.adi (which is currently processed) will be overwritten or cause an error (best case).

this one avoids it by simply addingh the user_id to the filename.

Added that as well to the cron-triggered importer.