### PR TITLE
Make QRZ-Download threadsafe

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -345,7 +345,7 @@ class Qrz extends CI_Controller {
 
 	function mass_download_qsos($qrz_api_key = '', $lastqrz = '1900-01-01', $station_ids = '', $trusted = false) {
 		$config['upload_path'] = './uploads/';
-		$file = $config['upload_path'] . 'qrzcom_download_report.adi';
+		$file = $config['upload_path'] . 'qrzcom_download_report_'.md5($qrz_api_key).'.adi';
 		if (file_exists($file) && ! is_writable($file)) {
 			$result = "Temporary download file ".$file." is not writable. Aborting!";
 			return false;


### PR DESCRIPTION
Given an instance with multiple users, it may come to race-conditions, when downloading QRZ-QSLs.

e.g.:
User a starts/triggers QRZ-Download --> file qrzcom_download_report.adi is created and is going to be parsed
while this process runs, another User (b) comes around and is doing the same. qrzcom_download_report.adi (which is currently processed) will be overwritten or cause an error (best case).

this one avoids it by simply adding the hash of the qrz_api_key to the filename.

Added that as well to the cron-triggered importer.

See also #1243 