### PR TITLE
Fix time reset functions in post QSO

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -158,11 +158,19 @@ $('#reset_start_time').on("click", function () {
 	var now = new Date();
 	$('#start_time').attr('value', ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2));
 	$("[id='start_time']").each(function () {
-		$(this).attr("value", ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2) + ':' + ("0" + now.getUTCSeconds()).slice(-2));
+		$starttime = ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2);
+		if (qso_manual != 1) {
+			$starttime += ':' + ("0" + now.getUTCSeconds()).slice(-2);
+		}
+		$(this).attr("value", $starttime);
 	});
 	$('#end_time').attr('value', ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2));
 	$("[id='end_time']").each(function () {
-		$(this).attr("value", ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2) + ':' + ("0" + now.getUTCSeconds()).slice(-2));
+		$endtime = ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2);
+		if (qso_manual != 1) {
+			$endtime += ':' + ("0" + now.getUTCSeconds()).slice(-2);
+		}
+		$(this).attr($stoptime);
 	});
 	// update date (today, for "post qso") //
 	$('#start_date').attr('value', ("0" + now.getUTCDate()).slice(-2) + '-' + ("0" + (now.getUTCMonth() + 1)).slice(-2) + '-' + now.getUTCFullYear());
@@ -172,7 +180,11 @@ $('#reset_end_time').on("click", function () {
 	var now = new Date();
 	$('#end_time').attr('value', ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2));
 	$("[id='end_time']").each(function () {
-		$(this).attr("value", ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2) + ':' + ("0" + now.getUTCSeconds()).slice(-2));
+		$endtime = ("0" + now.getUTCHours()).slice(-2) + ':' + ("0" + now.getUTCMinutes()).slice(-2);
+		if (qso_manual != 1) {
+			$endtime += ':' + ("0" + now.getUTCSeconds()).slice(-2);
+		}
+		$(this).attr($stoptime);
 	});
 });
 


### PR DESCRIPTION
In https://github.com/wavelog/wavelog/pull/1190 the reset functions were reafactored. This left the reset functions in post QSO with a bug that seconds were inserted upon reset of the timers. This leads to incorrect format for the input field and needs manual correction before saving the QSO:

![Screenshot 2024-11-26 112620](https://github.com/user-attachments/assets/430ab795-92a3-458d-a01e-5616d41a1ef2)

![Screenshot 2024-11-26 112626](https://github.com/user-attachments/assets/ab17e5e8-65bb-4bc3-a0a6-e42b39b91fe1)

So we need to add a differentiation here for live and post QSO and only add seconds if were are logging live.