### PR TITLE
Display a numeric keyboard for number input fields

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -171,10 +171,10 @@
                 <div class="mb-3 col">
                   <label for="frequency"><?= __("Frequency"); ?></label>
                   <div class="input-group input-group-sm">
-                    <input type="number" inputmode="decimal" tabindex="3" class="form-control form-control-sm" id="freq_calculated" name="freq_calculated" value="0" />
+                    <input type="text" tabindex="3" class="form-control form-control-sm" id="freq_calculated" name="freq_calculated" value="0" />
                     <small class="input-group-text btn-included-on-field" id="qrg_unit">...</small>
                   </div>
-                  <input style="display: none;" type="number" inputmode="deciaml" class="form-control form-control-sm" id="frequency" name="freq_display" value="<?php echo $this->session->userdata('freq'); ?>" />
+                  <input style="display: none;" type="text" class="form-control form-control-sm" id="frequency" name="freq_display" value="<?php echo $this->session->userdata('freq'); ?>" />
                 </div>
               </div>
 
@@ -327,7 +327,7 @@
 
             <div class="mb-3">
               <label for="frequency_rx"><?= __("Frequency (RX)"); ?></label>
-              <input type="number" inputmode="decimal" class="form-control" id="frequency_rx" name="freq_display_rx" value="<?php echo $this->session->userdata('freq_rx'); ?>" />
+              <input type="text" class="form-control" id="frequency_rx" name="freq_display_rx" value="<?php echo $this->session->userdata('freq_rx'); ?>" />
             </div>
 
             <div class="mb-3">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -171,10 +171,10 @@
                 <div class="mb-3 col">
                   <label for="frequency"><?= __("Frequency"); ?></label>
                   <div class="input-group input-group-sm">
-                    <input type="text" tabindex="3" class="form-control form-control-sm" id="freq_calculated" name="freq_calculated" value="0" />
+                    <input type="number" inputmode="decimal" tabindex="3" class="form-control form-control-sm" id="freq_calculated" name="freq_calculated" value="0" />
                     <small class="input-group-text btn-included-on-field" id="qrg_unit">...</small>
                   </div>
-                  <input style="display: none;" type="text" class="form-control form-control-sm" id="frequency" name="freq_display" value="<?php echo $this->session->userdata('freq'); ?>" />
+                  <input style="display: none;" type="number" inputmode="deciaml" class="form-control form-control-sm" id="frequency" name="freq_display" value="<?php echo $this->session->userdata('freq'); ?>" />
                 </div>
               </div>
 
@@ -327,7 +327,7 @@
 
             <div class="mb-3">
               <label for="frequency_rx"><?= __("Frequency (RX)"); ?></label>
-              <input type="text" class="form-control" id="frequency_rx" name="freq_display_rx" value="<?php echo $this->session->userdata('freq_rx'); ?>" />
+              <input type="number" inputmode="decimal" class="form-control" id="frequency_rx" name="freq_display_rx" value="<?php echo $this->session->userdata('freq_rx'); ?>" />
             </div>
 
             <div class="mb-3">
@@ -351,7 +351,7 @@
 
             <div class="mb-3">
               <label for="transmit_power"><?= __("Transmit Power (W)"); ?></label>
-              <input type="number" step="0.001" class="form-control" id="transmit_power" name="transmit_power" value="<?php if ($this->session->userdata('transmit_power')) { echo $this->session->userdata('transmit_power'); } else { echo $power; } ?>" />
+              <input type="number" inputmode="decimal" step="0.001" pattern="[0-9]*" class="form-control" id="transmit_power" name="transmit_power" value="<?php if ($this->session->userdata('transmit_power')) { echo $this->session->userdata('transmit_power'); } else { echo $power; } ?>" />
               <small id="powerHelp" class="form-text text-muted"><?= __("Give power value in Watts. Include only numbers in the input."); ?></small>
             </div>
 
@@ -574,13 +574,13 @@
 
             <div class="mb-3">
               <label for="ant_az"><?= __("Antenna Azimuth (°)"); ?></label>
-              <input type="number" step="0.1" min="0" max="360" class="form-control" id="ant_az" name="ant_az" />
+              <input type="number" inputmode="decimal" step="0.1" min="0" max="359.9" class="form-control" id="ant_az" name="ant_az" />
               <small id="azHelp" class="form-text text-muted"><?= __("Antenna azimuth in decimal degrees."); ?></small>
             </div>
 
             <div class="mb-3">
               <label for="ant_el"><?= __("Antenna Elevation (°)"); ?></label>
-              <input type="number" step="0.1" min="0" max="90" class="form-control" id="ant_el" name="ant_el" />
+              <input type="number" inputmode="decimal" step="0.1" min="0" max="90" class="form-control" id="ant_el" name="ant_el" />
               <small id="elHelp" class="form-text text-muted"><?= __("Antenna elevation in decimal degrees."); ?></small>
             </div>
           </div>


### PR DESCRIPTION
This changes the numeric input fields so that on mobile / touch input platforms a simplified numeric keyboard is shown instead of a full blown text input one.

Before:

![20241126_215629000_iOS](https://github.com/user-attachments/assets/cfd79798-17ba-43ae-aef4-ebe8997aff58)

After:

![20241126_215557000_iOS](https://github.com/user-attachments/assets/8e7f1caf-0661-4539-8397-f6d14bc742fb)
