### PR TITLE
Restore uppercase transformation for inputs

### DIFF
--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -39,7 +39,7 @@
 
                             <label class="col-auto control-label" for="operatorcall"><?= __("Operator Callsign"); ?></label>
                             <div class="col-auto">
-                                <input type="text" class="form-control form-control-sm" id="operator_callsign" name="operator_callsign" value='<?php echo $this->session->userdata('operator_callsign'); ?>' required>
+                                <input type="text" class="form-control form-control-sm uppercase" id="operator_callsign" name="operator_callsign" value='<?php echo $this->session->userdata('operator_callsign'); ?>' required>
                             </div>
                             <div class="col-auto">
                                 <a class="btn btn-sm btn-primary" id="moreSettingsButton"><i class="fas fa-wrench"></i> <?= __("More Settings"); ?></a>
@@ -163,7 +163,7 @@
                             <div class="col-md-2">
                                 <div>
                                     <label for="callsign"><?= __("Callsign"); ?></label>
-                                    <input type="text" class="form-control form-control-sm" id="callsign" name="callsign" autocomplete="off" required>
+                                    <input type="text" class="form-control form-control-sm uppercase" id="callsign" name="callsign" autocomplete="off" required>
                                     <small id="callsign_info" class="badge text-bg-danger"></small><br/>
                                     <small id="bearing_info" class="form-text text-muted"></small>
                                 </div>
@@ -184,12 +184,12 @@
 
                                 <div style="display:none" class="gridsquares">
                                     <label for="exch_gridsquare_s"><?= __("Gridsquare (S)"); ?></label>
-                                    <input disabled type="text" class="form-control form-control-sm" name="exch_gridsquare_s" id="exch_gridsquare_s" value="<?php echo $my_gridsquare;?>">
+                                    <input disabled type="text" class="form-control form-control-sm uppercase" name="exch_gridsquare_s" id="exch_gridsquare_s" value="<?php echo $my_gridsquare;?>">
                                 </div>
 
                                 <div style="display:none" class="exchanges">
                                     <label for="exch_sent"><?= __("Exch (S)"); ?></label>
-                                    <input type="text" class="form-control form-control-sm" name="exch_sent" id="exch_sent" value="">
+                                    <input type="text" class="form-control form-control-sm uppercase" name="exch_sent" id="exch_sent" value="">
                                 </div>
                             </div>
 
@@ -208,12 +208,12 @@
 
                                 <div style="display:none" class="gridsquarer">
                                     <label for="exch_gridsquare_r"><?= __("Gridsquare (R)"); ?></label>
-                                    <input type="text" class="form-control form-control-sm" name="locator" id="exch_gridsquare_r" value="">
+                                    <input type="text" class="form-control form-control-sm uppercase" name="locator" id="exch_gridsquare_r" value="">
                                 </div>
 
                                 <div style="display:none" class="exchanger">
                                     <label for="exch_rcvd"><?= __("Exch (R)"); ?></label>
-                                    <input type="text" class="form-control form-control-sm" name="exch_rcvd" id="exch_rcvd" value="">
+                                    <input type="text" class="form-control form-control-sm uppercase" name="exch_rcvd" id="exch_rcvd" value="">
                                 </div>
                             </div>
                         </div>

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -60,7 +60,7 @@
                                     <div class="row">
                                         <div class="mb-3 col-sm-6">
                                             <label for="callsign"><?= __("Callsign"); ?></label>
-                                            <input type="text" class="form-control" id="edit_callsign" name="callsign" value="<?php echo $qso->COL_CALL; ?>">
+                                            <input type="text" class="form-control uppercase" id="edit_callsign" name="callsign" value="<?php echo $qso->COL_CALL; ?>">
                                         </div>
 
                                         <div class="mb-3 col-sm-6">
@@ -153,7 +153,7 @@
                                     <div class="row">
                                         <div class="mb-3 col-sm-6">
                                             <label for="locator"><?= __("Gridsquare"); ?></label>
-                                            <input type="text" class="form-control" id="locator_edit" name="locator" value="<?php echo $qso->COL_GRIDSQUARE; ?>">
+                                            <input type="text" class="form-control uppercase" id="locator_edit" name="locator" value="<?php echo $qso->COL_GRIDSQUARE; ?>">
                                             <small id="locator_info_edit" class="form-text text-muted"><?php if ($qso->COL_DISTANCE != "") echo $qso->COL_DISTANCE . " km"; ?></small>
                                         </div>
 
@@ -161,7 +161,7 @@
 
                                         <div class="mb-3 col-sm-6">
                                             <label for="vucc_grids"><?= __("VUCC Gridsquare"); ?> <i id="vucc_grid_tooltip" data-bs-toggle="tooltip" data-bs-placement="right" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Used for VUCC MultiGrids"); ?>"></i></label>
-                                            <input type="text" class="form-control" id="vucc_grids" name="vucc_grids" value="<?php echo $qso->COL_VUCC_GRIDS; ?>">
+                                            <input type="text" class="form-control uppercase" id="vucc_grids" name="vucc_grids" value="<?php echo $qso->COL_VUCC_GRIDS; ?>">
                                         </div>
                                     </div>
 
@@ -592,7 +592,7 @@
 
                                     <div class="mb-3">
                                         <label for="operatorCallsign"><?= __("Operator Callsign"); ?></label>
-                                        <input type="text" id="operatorCallsign" class="form-control" name="operator_callsign" value="<?php echo $qso->COL_OPERATOR; ?>" />
+                                        <input type="text" id="operatorCallsign" class="form-control uppercase" name="operator_callsign" value="<?php echo $qso->COL_OPERATOR; ?>" />
                                     </div>
 
 
@@ -621,12 +621,12 @@
 
                                         <div class="mb-3 col-sm-3">
                                             <label for="srx_string"><?= __("Exchange (R)"); ?></label>
-                                            <input type="text" id="srx_string" class="form-control" name="srx_string" value="<?php echo $qso->COL_SRX_STRING; ?>" />
+                                            <input type="text" id="srx_string" class="form-control uppercase" name="srx_string" value="<?php echo $qso->COL_SRX_STRING; ?>" />
                                         </div>
 
                                         <div class="mb-3 col-sm-3">
                                             <label for="stx_string"><?= __("Exchange (S)"); ?></label>
-                                            <input type="text" id="stx_string" class="form-control" name="stx_string" value="<?php echo $qso->COL_STX_STRING; ?>" />
+                                            <input type="text" id="stx_string" class="form-control uppercase" name="stx_string" value="<?php echo $qso->COL_STX_STRING; ?>" />
                                         </div>
                                     </div>
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -126,7 +126,7 @@
                 <div class="mb-3 col-md-12">
                   <label for="callsign"><?= __("Callsign"); ?></label>&nbsp;<i id="check_cluster" data-bs-toggle="tooltip" title="<?= __("Search DXCluster for latest Spot"); ?>" class="fas fa-search"></i>
                   <div class="input-group">
-                    <input tabindex="7" type="text" class="form-control" id="callsign" name="callsign" autocomplete="off" required>
+                    <input tabindex="7" type="text" class="form-control uppercase" id="callsign" name="callsign" autocomplete="off" required>
                     <span id="qrz_info" class="input-group-text btn-included-on-field d-none py-0"></span>
                     <span id="hamqth_info" class="input-group-text btn-included-on-field d-none py-0"></span>
                   </div>
@@ -285,7 +285,7 @@
               <div class="mb-3 row">
                   <label for="locator" class="col-sm-3 col-form-label"><?= __("Gridsquare"); ?></label>
                   <div class="col-sm-9">
-                    <input tabindex="19" type="text" class="form-control form-control-sm" name="locator" id="locator" value="">
+                    <input tabindex="19" type="text" class="form-control form-control-sm uppercase" name="locator" id="locator" value="">
                     <small id="locator_info" class="form-text text-muted"></small>
                 </div>
               </div>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -230,14 +230,6 @@ thead > tr > td {
 	padding-top: 25px;
 }
 
-.qso_panel #callsign {
-	text-transform: uppercase;
-}
-
-.qso_panel #locator {
-	text-transform: uppercase;
-}
-
 .qso_panel .iota_ref {
 	text-transform: uppercase;
 }
@@ -258,18 +250,6 @@ thead > tr > td {
 	text-transform: uppercase;
 }
 
-.card-body #callsign {
-	text-transform: uppercase;
-}
-
-.card-body #locator {
-	text-transform: uppercase;
-}
-
-.card-body #vucc_grids {
-	text-transform: uppercase;
-}
-
 .card-body #sota_ref_edit-selectized {
 	text-transform: uppercase;
 }
@@ -283,18 +263,6 @@ thead > tr > td {
 }
 
 .card-body #darc_dok_edit-selectized {
-	text-transform: uppercase;
-}
-
-.card-body #exch_rcvd {
-	text-transform: uppercase;
-}
-
-.card-body #exch_sent {
-	text-transform: uppercase;
-}
-
-.card-body #exch_gridsquare_r {
 	text-transform: uppercase;
 }
 


### PR DESCRIPTION
In https://github.com/wavelog/wavelog/pull/1162 we broke CSS text-transformation to upper case for inputs like grid, VUCC grids, callsign and some more. Example:

![image](https://github.com/user-attachments/assets/2c5b041b-c81f-41e5-abf9-2d64cfe20a82)

This restores the text-transformation by adding class "uppercase". On the pro side we can get rid of various id-based CSS styles in general.css.