### PR TITLE
Fixes Bug where Modes are not shown correct

### DIFF
--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -122,8 +122,8 @@ class Statistics extends CI_Controller {
 		$modestats[$i++]['total'] = $this->logbook_model->total_cw($yr);
 		$modestats[$i]['mode'] = 'fm';
 		$modestats[$i++]['total'] = $this->logbook_model->total_fm($yr);
-		$modestats[$i]['mode'] = 'others';
-		$modestats[$i++]['total'] = $this->logbook_model->total_others($yr);
+		$modestats[$i]['mode'] = 'am';
+		$modestats[$i++]['total'] = $this->logbook_model->total_am($yr);
 		$modestats[$i]['mode'] = 'digi';
 		$modestats[$i]['total'] = $this->logbook_model->total_digi($yr);
 		usort($modestats, fn($a, $b) => $b['total'] <=> $a['total']);

--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -122,6 +122,8 @@ class Statistics extends CI_Controller {
 		$modestats[$i++]['total'] = $this->logbook_model->total_cw($yr);
 		$modestats[$i]['mode'] = 'fm';
 		$modestats[$i++]['total'] = $this->logbook_model->total_fm($yr);
+		$modestats[$i]['mode'] = 'others';
+		$modestats[$i++]['total'] = $this->logbook_model->total_others($yr);
 		$modestats[$i]['mode'] = 'digi';
 		$modestats[$i]['total'] = $this->logbook_model->total_digi($yr);
 		usort($modestats, fn($a, $b) => $b['total'] <=> $a['total']);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3002,7 +3002,7 @@ class Logbook_model extends CI_Model {
 	}
 
 	/* Return total number of FM QSOs */
-	function total_others($yr = 'All') {
+	function total_am($yr = 'All') {
 
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
@@ -3013,7 +3013,7 @@ class Logbook_model extends CI_Model {
 
 		$this->db->select('COUNT( * ) as count', FALSE);
 		$this->db->where_in('station_id', $logbooks_locations_array);
-		$this->db->where_not_in('COL_MODE', array('FM','CW','DIGI','SSB','LSB','USB'));
+		$this->db->where('COL_MODE', 'AM');
 		$this->where_year($yr);
 		$query = $this->db->get($this->config->item('table_name'));
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3002,6 +3002,28 @@ class Logbook_model extends CI_Model {
 	}
 
 	/* Return total number of FM QSOs */
+	function total_others($yr = 'All') {
+
+		$this->load->model('logbooks_model');
+		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+		if (!$logbooks_locations_array) {
+			return null;
+		}
+
+		$this->db->select('COUNT( * ) as count', FALSE);
+		$this->db->where_in('station_id', $logbooks_locations_array);
+		$this->db->where_not_in('COL_MODE', array('FM','CW','DIGI','SSB','LSB','USB'));
+		$this->where_year($yr);
+		$query = $this->db->get($this->config->item('table_name'));
+
+		if ($query->num_rows() > 0) {
+			foreach ($query->result() as $row) {
+				return $row->count;
+			}
+		}
+	}
+
 	function total_fm($yr = 'All') {
 
 		$this->load->model('logbooks_model');


### PR DESCRIPTION
e.g.: A year (or whole logbook) where only a AM-QSO exists.
Stats-page (Modes) fails with NaN (see picture)

![image](https://github.com/user-attachments/assets/530cc6cb-f6ac-4875-913f-cb58a0abc0d1)

This was because AM was never reported.