### PR TITLE
Check for wrong credentials when doing cron-download / LoTW

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -785,7 +785,7 @@ class Lotw extends CI_Controller {
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 				curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
 				$content = curl_exec($ch);
-				if(!curl_errno($ch)){
+				if(!curl_errno($ch) || str_contains($content,"Username/password incorrect</I>")){
 					file_put_contents($file, $content);
 
 					ini_set('memory_limit', '-1');

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -785,7 +785,7 @@ class Lotw extends CI_Controller {
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 				curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
 				$content = curl_exec($ch);
-				if(!curl_errno($ch) || str_contains($content,"Username/password incorrect</I>")){
+				if(!curl_errno($ch) && !str_contains($content,"Username/password incorrect</I>")){
 					file_put_contents($file, $content);
 
 					ini_set('memory_limit', '-1');


### PR DESCRIPTION
When invoking LoTW-Download via cron and wrong credentials were provided, the logic tries to parse the HTML returned by LoTW.
This one fixes it.