### PR TITLE
Don't save and process empty files for QRZ

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -371,10 +371,10 @@ class Qrz extends CI_Controller {
 
 		$content = htmlspecialchars_decode(curl_exec($ch));
 		if (strlen($content)<100) {
-			file_put_contents($file, $content);
 			$result = "QRZ downloading failed, either due to it being down or incorrect logins.";
 			return "false";
 		}
+		file_put_contents($file, $content);
 
 		ini_set('memory_limit', '-1');
 		$result = $this->loadFromFile($file, $station_ids);

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -370,8 +370,8 @@ class Qrz extends CI_Controller {
 		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
 
 		$content = htmlspecialchars_decode(curl_exec($ch));
-		file_put_contents($file, $content);
-		if (strlen(file_get_contents($file, false, null, 0, 100))!=100) {
+		if (strlen($content)<100) {
+			file_put_contents($file, $content);
 			$result = "QRZ downloading failed, either due to it being down or incorrect logins.";
 			return "false";
 		}


### PR DESCRIPTION
observed hundreds of `qrzcom_download_report_[hash].adi`-Files which were in a "staled"-state and digged in.
Content: `RESULT=FAIL&COUNT=`. not more, not less.

this one prevents saving and parsing them.

Repro: Put in wrong creds for QRZ and let cron run for QRZ-download run.