### PR TITLE
Remove ambiguity for sat and country name from search results

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -918,7 +918,17 @@ class Logbook extends CI_Controller {
 	}
 
 	function querydb($id) {
-		$this->db->select('*, satellite.displayname AS sat_displayname');
+		$this->db->select('dxcc_entities.adif, lotw_users.callsign, COL_BAND, COL_CALL, COL_CLUBLOG_QSO_DOWNLOAD_DATE,
+			COL_CLUBLOG_QSO_DOWNLOAD_STATUS, COL_CLUBLOG_QSO_UPLOAD_DATE, COL_CLUBLOG_QSO_UPLOAD_STATUS,
+			COL_CONTEST_ID, COL_DISTANCE, COL_EQSL_QSL_RCVD, COL_EQSL_QSLRDATE, COL_EQSL_QSLSDATE, COL_EQSL_QSL_SENT,
+			COL_FREQ, COL_GRIDSQUARE, COL_IOTA, COL_LOTW_QSL_RCVD, COL_LOTW_QSLRDATE, COL_LOTW_QSLSDATE,
+			COL_LOTW_QSL_SENT, COL_MODE, COL_NAME, COL_OPERATOR, COL_POTA_REF, COL_PRIMARY_KEY,
+			COL_QRZCOM_QSO_DOWNLOAD_DATE, COL_QRZCOM_QSO_DOWNLOAD_STATUS, COL_QRZCOM_QSO_UPLOAD_DATE,
+			COL_QRZCOM_QSO_UPLOAD_STATUS, COL_QSL_RCVD, COL_QSL_RCVD_VIA, COL_QSLRDATE, COL_QSLSDATE, COL_QSL_SENT,
+			COL_QSL_SENT_VIA, COL_QSL_VIA, COL_RST_RCVD, COL_RST_SENT, COL_SAT_NAME, COL_SOTA_REF, COL_SRX,
+			COL_SRX_STRING, COL_STATE, COL_STX, COL_STX_STRING, COL_SUBMODE, COL_TIME_ON, COL_VUCC_GRIDS, COL_WWFF_REF,
+			dxcc_entities.end, lotw_users.lastupload, satellite.name AS sat_displayname, station_profile.station_callsign,
+			station_profile.station_gridsquare, station_profile.station_profile_name, dxcc_entities.name');
 		$this->db->from($this->config->item('table_name'));
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		$this->db->join('dxcc_entities', 'dxcc_entities.adif = '.$this->config->item('table_name').'.COL_DXCC', 'left outer');

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -927,7 +927,7 @@ class Logbook extends CI_Controller {
 			COL_QRZCOM_QSO_UPLOAD_STATUS, COL_QSL_RCVD, COL_QSL_RCVD_VIA, COL_QSLRDATE, COL_QSLSDATE, COL_QSL_SENT,
 			COL_QSL_SENT_VIA, COL_QSL_VIA, COL_RST_RCVD, COL_RST_SENT, COL_SAT_NAME, COL_SOTA_REF, COL_SRX,
 			COL_SRX_STRING, COL_STATE, COL_STX, COL_STX_STRING, COL_SUBMODE, COL_TIME_ON, COL_VUCC_GRIDS, COL_WWFF_REF,
-			dxcc_entities.end, lotw_users.lastupload, satellite.name AS sat_displayname, station_profile.station_callsign,
+			dxcc_entities.end, lotw_users.lastupload, satellite.displayname AS sat_displayname, station_profile.station_callsign,
 			station_profile.station_gridsquare, station_profile.station_profile_name, dxcc_entities.name');
 		$this->db->from($this->config->item('table_name'));
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');


### PR DESCRIPTION
User reported that search results country column lists false data:

![image](https://github.com/user-attachments/assets/a22662f1-1579-444c-a51e-e29f06c97e49)

Adding join satellite DB to display sat display name introduced an ambiguity between dxcc_entities.name and satellite.name leading to SAT name being shown as country name. B0rken in https://github.com/wavelog/wavelog/pull/996 with commmit https://github.com/wavelog/wavelog/pull/996/commits/c961926b05b00010f221a96e30c51f9d12f64fe4.

Reproduced by using country as one of the user columns and conducting a simple search.