### PR TITLE
Fix correct check for empty date

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3718,7 +3718,7 @@ class Logbook_model extends CI_Model {
 		$query = $this->db->query($sql);
 		$row = $query->row();
 
-		if (isset($row)) {
+		if ($row->MAXDATE != null) {
 			return $row->MAXDATE;
 		}
 


### PR DESCRIPTION
Check for last LoTW date fails if none can be found. $row is set in any case and `$row->MAXDATE`  is NULL. So `isset($row)` will always be true.

Added debug output shows:

```
object(stdClass)#47 (1) { ["MAXDATE"]=> NULL }
```

![image](https://github.com/user-attachments/assets/4cbde4d1-8d37-4dd6-b105-c34af6a676e1)

So we need to check `$row->MAXDATE` for being != NULL.