### PR TITLE
Add option to enable eqsl massdownload

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -762,3 +762,14 @@ $config['disable_version_check'] = false;
 // $config['trxd_connection_type'] = 'ws';
 // $config['trxd_ws_path'] = '/trx-control';
 // $config['trxd_timeout'] = 5;
+
+/*
+|--------------------------------------------------------------------------
+| eqsl.cc Massdownloa
+|--------------------------------------------------------------------------
+|
+| The eqsl.cc mass download function is not threadsafe. So it is disabled by default.
+| Please consider enabling this carefully. Not recommended for multi-user environments.
+ */
+
+$config['enable_eqsl_massdownload'] = false;

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -447,7 +447,7 @@ class eqsl extends CI_Controller {
 		$errors = 0;
 		$this->load->library('electronicqsl');
 
-		if ($this->input->post('eqsldownload') == 'download') {
+		if ($this->input->post('eqsldownload') == 'download' && $this->config->item('enable_eqsl_massdownload')) {
 			$i = 0;
 			$this->load->model('eqslmethods_model');
 			$qslsnotdownloaded = $this->eqslmethods_model->eqsl_not_yet_downloaded();

--- a/application/views/eqsl/download.php
+++ b/application/views/eqsl/download.php
@@ -65,7 +65,7 @@ foreach ($qslsnotdownloaded->result_array() as $qsl) {
 ?>
 		</tbody></table>
 		<br /><br />
-		<?php if (!($this->config->item('disable_manual_eqsl'))) {
+		<?php if ($this->config->item('enable_eqsl_massdownload') && !($this->config->item('disable_manual_eqsl'))) {
 			echo form_open_multipart('eqsl/download');?>
 
 			<div class="form-check">

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -762,3 +762,14 @@ $config['disable_version_check'] = false;
 // $config['trxd_connection_type'] = 'ws';
 // $config['trxd_ws_path'] = '/trx-control';
 // $config['trxd_timeout'] = 5;
+
+/*
+|--------------------------------------------------------------------------
+| eqsl.cc Massdownloa
+|--------------------------------------------------------------------------
+|
+| The eqsl.cc mass download function is not threadsafe. So it is disabled by default.
+| Please consider enabling this carefully. Not recommended for multi-user environments.
+ */
+
+$config['enable_eqsl_massdownload'] = false;


### PR DESCRIPTION
The eqsl.cc massdownload function is not thread safe. So we added a config switch to disabled it. Default setting is disabled. Should not be enabled on multi-user instances.