### PR TITLE
CAT radio timeout alert fix

### DIFF
--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -238,7 +238,7 @@ class Radio extends CI_Controller {
 					if (isset($cat_url) && ($cat_url != null)) {
 						$a_ret['cat_url'] = $cat_url;
 					}
-					$a_ret['update_minutes_ago'] = $updated_at;
+					$a_ret['updated_minutes_ago'] = $updated_at;
 					echo json_encode($a_ret, JSON_PRETTY_PRINT);
 				}
 			}


### PR DESCRIPTION
Due to typo(?) in the /radio API response, the timeout alert was never displayed, as the JS code rely on `updated_minutes_ago` key instead of `update_minutes_ago`

Before fix:
<img width="668" alt="Screenshot 2024-12-23 at 20 57 42" src="https://github.com/user-attachments/assets/d5ace8b7-fdde-43ba-b632-2ec4d43f2b69" />

After the fix:
<img width="967" alt="Screenshot 2024-12-23 at 20 52 35" src="https://github.com/user-attachments/assets/eb6d2530-36a5-4443-8693-3004986d2b1a" />
