### PR TITLE
Fix cat radio UI

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1238,24 +1238,28 @@ $($('#callsign')).on('keypress',function(e) {
 							    }
 						    } else {
 							    $(".radio_timeout_error" ).remove();
-							    text = '<i class="fas fa-broadcast-tower"></i><span style="margin-left:10px;"></span><b>TX:</b> ' + data.frequency_formatted;
+                                separator = '<span style="margin-left:10px"></span>';
+							    text = '<i class="fas fa-broadcast-tower"></i>' + separator + '<b>TX:</b> ' + data.frequency_formatted;
 							    if(data.mode != null) {
-								    text = text+'<span style="margin-left:10px"></span>'+data.mode;
+								    text = text + separator + data.mode;
 							    }
 							    if(data.power != null && data.power != 0) {
-								    text = text+'<span style="margin-left:10px"></span>'+data.power+' W';
+								    text = text + separator + data.power+' W';
 							    }
-							    ptext = '';
+                                complementary_info = []
 							    if(data.prop_mode != null && data.prop_mode != '') {
-								    ptext = ptext + data.prop_mode;
 								    if (data.prop_mode == 'SAT') {
-									    ptext = ptext + ' ' + data.satname;
-								    }
+									    complementary_info.push(data.prop_mode + ' ' + data.satname);
+								    } else {
+                                        complementary_info.push(data.prop_mode);
+                                    }
 							    }
 							    if(data.frequency_rx != null && data.frequency_rx != 0) {
-								    ptext = ptext + '<span style="margin-left:10px"></span><b>RX:</b> ' + data.frequency_rx_formatted;
+                                    complementary_info.push('<b>RX:</b> ' + data.frequency_rx_formatted);
 							    }
-							    if( ptext != '') { text = text + '<span style="margin-left:10px"></span>(' + ptext + ')';}
+							    if( complementary_info.length > 0) { 
+                                    text = text + separator + '(' + complementary_info.join(separator) + ')';
+                                }
 							    if (! $('#radio_cat_state').length) {
 								    $('#radio_status').prepend('<div aria-hidden="true"><div id="radio_cat_state" class="alert alert-success radio_cat_state" role="alert">'+text+'</div></div>');
 							    } else {


### PR DESCRIPTION
In case only some of the optional/complementary CAT information was displayed in the CAT alert, it might end up in extra spaces, because the JS code relied on fact, that all the previous properties will also be filled. This should fix the extra space and clean up the code little bit.

Before:
 
<img width="668" alt="Screenshot 2024-12-23 at 20 57 42" src="https://github.com/user-attachments/assets/5967f2f6-7654-4109-9b63-d4cd5e62e47f" />

After:

<img width="534" alt="Screenshot 2024-12-24 at 8 27 46" src="https://github.com/user-attachments/assets/6a6abd48-6151-4af6-b4e9-d547ac9c9db5" />
