### PR TITLE
views: debug: add System Time

### DIFF
--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -64,6 +64,10 @@
                             <td><?= __("Environment"); ?></td>
                             <td><?php echo ENVIRONMENT; ?></td>
                         </tr>
+                        <tr>
+                            <td><?= __("System Time"); ?></td>
+                            <td><?php echo(date("Y-m-d H:i:s", time())); ?></td>
+                        </tr>
                         <tr class="blank-row">
                             <td> </td>
                             <td> </td>


### PR DESCRIPTION
Added system time column to debug page. Useful in debugging system time information and contextualizing cron jobs.

Fixes: https://github.com/wavelog/wavelog/issues/1381