### PR TITLE
[Advanced Logbook] Show name of region

### DIFF
--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -175,7 +175,7 @@ class QSO
 		$this->de = $data['station_callsign'];
 		$this->dx = $data['COL_CALL'];
 		$this->continent = $data['COL_CONT'] ?? '';
-		$this->region = $data['COL_REGION'] ?? '';
+		$this->region = $this->getRegionString(strtoupper($data['COL_REGION']));
 
 		$this->mode = $data['COL_MODE'] ?? '';
 		$this->submode = $data['COL_SUBMODE'] ?? '';
@@ -304,6 +304,39 @@ class QSO
 			return '<a href="javascript:spawnLookupModal('.$ituz.',\'itu\');">'.$ituz.'</a>';
 		}
 		return $ituz;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getRegionString($region): string
+	{
+		switch($region) {
+			case 'AI':
+				return 'African Italy ('.$region.')';
+				break;
+			case 'BI':
+				return 'Bear Island ('.$region.')';
+				break;
+			case 'ET':
+				return 'European Turkey ('.$region.')';
+				break;
+			case 'IV':
+				return 'ITU Vienna ('.$region.')';
+				break;
+			case 'KO':
+				return 'Kosovo ('.$region.')';
+				break;
+			case 'SY':
+				return 'Sicily ('.$region.')';
+				break;
+			case 'SI':
+				return 'Shetland Islands ('.$region.')';
+				break;
+			default:
+				return ($region ?? '');
+				break;
+			}
 	}
 
 	/**


### PR DESCRIPTION
Now shows name in LBA instead of just the region abbreviation.

![image](https://github.com/user-attachments/assets/1d42ccf8-4a48-4308-b665-e33065cf6ced)
