### PR TITLE
If there was an error at inserting QSO via API, return 400

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -240,7 +240,7 @@ class API extends CI_Controller {
 			} else {
 				$return_msg[]=$custom_errors;
 				http_response_code(400);
-				echo json_encode(['status' => 'created', 'type' => $obj['type'], 'string' => $obj['string'], 'adif_count' => $adif_count, 'adif_errors' => $adif_errors, 'messages' => $return_msg ]);
+				echo json_encode(['status' => 'abort', 'type' => $obj['type'], 'string' => $obj['string'], 'adif_count' => $adif_count, 'adif_errors' => $adif_errors, 'messages' => $return_msg ]);
 			}
 
 

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -234,8 +234,15 @@ class API extends CI_Controller {
 				$return_msg[]='Dryrun works';
 			}
 
-			http_response_code(201);
-			echo json_encode(['status' => 'created', 'type' => $obj['type'], 'string' => $obj['string'], 'adif_count' => $adif_count, 'adif_errors' => $adif_errors, 'messages' => $return_msg ]);
+			if ($adif_errors == 0) {
+				http_response_code(201);
+				echo json_encode(['status' => 'created', 'type' => $obj['type'], 'string' => $obj['string'], 'adif_count' => $adif_count, 'adif_errors' => $adif_errors, 'messages' => $return_msg ]);
+			} else {
+				$return_msg[]=$custom_errors;
+				http_response_code(400);
+				echo json_encode(['status' => 'created', 'type' => $obj['type'], 'string' => $obj['string'], 'adif_count' => $adif_count, 'adif_errors' => $adif_errors, 'messages' => $return_msg ]);
+			}
+
 
 		}
 


### PR DESCRIPTION
Reproduce:

insert a QSO with a different station_callsign than at station_profile. This one returns (in latest master/dev) a 201 (insert) but with "adif_error"-count > 0. And QSO wasn't inserted!!

With this PR a 400 would be returned and the messages-object will contain further information.

Part of resolving https://github.com/wavelog/WaveLogGate/issues/26


Testing: Try to log a QSO with the API as described here: https://github.com/wavelog/wavelog/wiki/API#apiqso
Vary the station_callsign within the payload