### PR TITLE
Fixes search for calls with 0 at eQSL and QSL Datatable

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -860,6 +860,13 @@ function findincorrectcqzones() {
         if (isDarkModeTheme()) {
             $(".buttons-csv").css("color", "white");
         }
+		$(document).ready(function() {
+		$("#DataTables_Table_0_filter label input").on('keyup', function (e) {
+			tocrappyzero=$(this).val().toUpperCase().replaceAll(/0/g, 'Ø');
+			$("#DataTables_Table_0_filter label input").val(tocrappyzero);
+			$("#DataTables_Table_0_filter label input").trigger("input");
+		});
+        });
     });
 }
 
@@ -886,6 +893,13 @@ function findincorrectituzones() {
         if (isDarkModeTheme()) {
             $(".buttons-csv").css("color", "white");
         }
+		$(document).ready(function() {
+		$("#DataTables_Table_0_filter label input").on('keyup', function (e) {
+			tocrappyzero=$(this).val().toUpperCase().replaceAll(/0/g, 'Ø');
+			$("#DataTables_Table_0_filter label input").val(tocrappyzero);
+			$("#DataTables_Table_0_filter label input").trigger("input");
+		});
+        });
     });
 }
 
@@ -1258,7 +1272,7 @@ $($('#callsign')).on('keypress',function(e) {
 							    if(data.frequency_rx != null && data.frequency_rx != 0) {
                                     complementary_info.push('<b>RX:</b> ' + data.frequency_rx_formatted);
 							    }
-							    if( complementary_info.length > 0) { 
+							    if( complementary_info.length > 0) {
                                     text = text + separator + '(' + complementary_info.join(separator) + ')';
                                 }
 							    if (! $('#radio_cat_state').length) {

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2167,6 +2167,14 @@ $('#sats').change(function(){
             $('[class*="buttons"]').css("color", "white");
         }
 
+	 $(document).ready(function() {
+		$("#DataTables_Table_0_filter label input").on('keyup', function (e) {
+			tocrappyzero=$(this).val().toUpperCase().replaceAll(/0/g, 'Ø');
+			$("#DataTables_Table_0_filter label input").val(tocrappyzero);
+			$("#DataTables_Table_0_filter label input").trigger("input");
+		});
+        });
+
     </script>
 <?php } ?>
 


### PR DESCRIPTION
Fixes https://github.com/wavelog/wavelog/issues/1396

If a call with a zero was searched the Datatable returned nothing.
Reason is the "other" Zero which is used for optical(?) Reasons.

This one replaces the normal zero on the fly and re-triggers the search.

Testing: Logbook -> (e)QSL -> Type in search-term.