### PR TITLE
views: eqslcard: add ability to navigate between eqsl cards

### DIFF
--- a/application/views/eqslcard/index.php
+++ b/application/views/eqslcard/index.php
@@ -57,7 +57,7 @@
          echo '<td style=\'text-align: center\'>';
          if ($qsl->COL_EQSL_QSLRDATE) { $timestamp = strtotime($qsl->COL_EQSL_QSLRDATE); echo date($custom_date_format, $timestamp); }
          echo '</td>';
-            echo '<td style=\'text-align: center\'><button onclick="viewEqsl(\''.$qsl->image_file.'\', \''. $qsl->COL_CALL . '\')" class="btn btn-sm btn-success">' . __("View") . '</button></td>';
+            echo '<td style=\'text-align: center\'><a href=\''.site_url('eqsl/image/'.$qsl->COL_PRIMARY_KEY).'\' data-fancybox=\'images\' data-width=\'528\' data-height=\'336\' class=\'btn btn-sm btn-success\'>' . __("View") . '</a></td>';
             echo '</tr>';
         }
 


### PR DESCRIPTION
Adds the ability to navigate between eQSL cards in the eQSL manager screen. This makes the page consistent with the rest of the application like the logbook and eQSL download page.

Fixes: https://github.com/wavelog/wavelog/issues/1417