### PR TITLE
Add custom date format for system time display

### DIFF
--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -27,6 +27,14 @@ class Debug extends CI_Controller
 		$footerData = [];
 		$footerData['scripts'] = ['assets/js/sections/debug.js'];
 
+		// Get Custom Date format
+		if ($this->session->userdata('user_date_format')) {
+			$custom_date_format = $this->session->userdata('user_date_format');
+		} else {
+			$custom_date_format = $this->config->item('qso_date_format');
+		}
+		$data['system_time'] = date($custom_date_format . " H:i:s", time());
+
 		$data['running_version'] = $this->optionslib->get_option('version');
 		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -66,7 +66,7 @@
                         </tr>
                         <tr>
                             <td><?= __("System Time"); ?></td>
-                            <td><?php echo(date("Y-m-d H:i:s", time())); ?></td>
+                            <td><?php echo $system_time; ?></td>
                         </tr>
                         <tr class="blank-row">
                             <td> </td>


### PR DESCRIPTION
@ethancedwards8 added in https://github.com/wavelog/wavelog/pull/1382 the server system time to the debug view. This is great for debugging, but to be consistent we should show the date in the user's date format