### PR TITLE
Remove doubling WWFF-Ref to SIG-Fields

### DIFF
--- a/application/libraries/AdifHelper.php
+++ b/application/libraries/AdifHelper.php
@@ -234,25 +234,11 @@ class AdifHelper {
 
 		$line .= $this->getAdifFieldLine("MY_CNTY", $county);
 
-		$stationsSig = $qso->station_sig;
-		// If MY_SIG is WWFF or "" and there's a station_wwff set, use data from station_wwff
-		if ((empty($stationsSig) || $stationsSig === "WWFF") && !empty($qso->station_wwff)) {
-			$line .= $this->getAdifFieldLine("MY_SIG", "WWFF");
-			$line .= $this->getAdifFieldLine("MY_SIG_INFO", $qso->station_wwff);
-		} else {
-			$line .= $this->getAdifFieldLine("MY_SIG", $stationsSig);
-			$line .= $this->getAdifFieldLine("MY_SIG_INFO", $qso->station_sig_info);
-		}
+		$line .= $this->getAdifFieldLine("MY_SIG", $qso->station_sig);
+		$line .= $this->getAdifFieldLine("MY_SIG_INFO", $qso->station_sig_info);
 
-		$sig = $qso->{'COL_SIG'};
-		// If SIG is WWFF or "" and there's a WWFF_REF set, use data from COL_WWFF_REF
-		if ((empty($sig) || $sig === "WWFF") && !empty($qso->{'COL_WWFF_REF'})) {
-			$line .= $this->getAdifFieldLine("SIG", "WWFF");
-			$line .= $this->getAdifFieldLine("SIG_INFO", $qso->{'COL_WWFF_REF'});
-		} else {
-			$line .= $this->getAdifFieldLine("SIG", $sig);
-			$line .= $this->getAdifFieldLine("SIG_INFO", $qso->{'COL_SIG_INFO'});
-		}
+		$line .= $this->getAdifFieldLine("SIG", $qso->{'COL_SIG'});
+		$line .= $this->getAdifFieldLine("SIG_INFO", $qso->{'COL_SIG_INFO'});
 
 	/*
 	    Missing:


### PR DESCRIPTION
Special-Treatment for WWFF-References has been introduced in 2022.
Reason was - according to the PR - "some third party tools need the WWFF-Information at SIG-Fields".

Since we try to be as near as possible to the ADIF-Standard, and WWFF itself uses its own fields, we should drop this treatment after 2 years.

Testing:
- log a QSO with WWFF-Reference
- Export it
- You'll see WWFF-Reference at WWFF-Field as well as at SIG_ Fields

after applying patch:
- log a QSO with WWFF-Reference
- Export it
- You'll see WWFF-Reference at WWFF-Field.
- No more redundancy with SIG-Field