### PR TITLE
Trigger recheck work/cnf state on modechange

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -905,6 +905,7 @@ $('#band').on('change', function () {
 	$("#sat_name").val("");
 	$("#sat_mode").val("");
 	set_qrg();
+	$("#callsign").blur();
 });
 
 /* On Key up Calculate Bearing and Distance */

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -888,6 +888,7 @@ $('.mode').on('change', function () {
 		});
 	}
 	$('#frequency_rx').val("");
+	$("#callsign").blur();
 });
 
 /* Calculate Frequency */


### PR DESCRIPTION
Bug at Worked/Confirm-check.

Example:

- Go to live-QSO
- Set Mode manual to LSB and Band to 40m
- Enter DJ7NT
- save it
- do the same - Callframe becomes yellow/orange because worked.
- Enter DJ7NT
- Set Mode manual to CW and Band to 40m
- Callframe stays orange, even if DJ7NT was never worked in CW on that band.

This one fixes it.
