### PR TITLE
Fix CORS error with installer

### DIFF
--- a/install/run.php
+++ b/install/run.php
@@ -297,7 +297,7 @@
 
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: url: `${window.location.origin}/index.php/update/dxcc`,
+                url: `${window.location.origin}/index.php/update/dxcc`,
                 success: async function(response) {
                     if (response == 'success') {
                         running(field, false);

--- a/install/run.php
+++ b/install/run.php
@@ -268,7 +268,7 @@
 
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: "<?php echo $_POST['websiteurl'] ?? $websiteurl; ?>" + "index.php/migrate",
+                url: `${window.location.origin}/index.php/migrate`,
                 dataType: 'json',
                 success: async function(response) {
                     if (response.status == 'success') {
@@ -297,7 +297,7 @@
 
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: "<?php echo $_POST['websiteurl'] ?? $websiteurl; ?>" + "index.php/update/dxcc",
+                url: url: `${window.location.origin}/index.php/update/dxcc`,
                 success: async function(response) {
                     if (response == 'success') {
                         running(field, false);


### PR DESCRIPTION
Resolves #1376

Updated the migrate and dxcc urls in the installer to point to the same host that the user navigated to.  This keeps the user on the same URL/host/domain that the user originally navigated to, preventing the dreaded CORS error.

Original CORS error:

![image](https://github.com/user-attachments/assets/9f62e797-dfad-4d89-8f02-43a1cebc9b54)


Updated installer working

![2025-01-02 18 33 56](https://github.com/user-attachments/assets/efe610dd-d049-42fb-87fc-775a3a29204c)

