### PR TITLE
[WAC Award] Added a check before unset

### DIFF
--- a/application/models/Wac.php
+++ b/application/models/Wac.php
@@ -57,7 +57,9 @@ class Wac extends CI_Model{
 		if ($postdata['notworked'] == NULL) {
 			foreach ($this->validContinents as $cont) {
 				if ($wac[$cont]['count'] == 0) {
-					unset($bandWac[$cont]);
+					if (isset($bandWac)) {
+						unset($bandWac[$cont]);
+					}
 				};
 			}
 		}


### PR DESCRIPTION
If you unchecked "Show not worked" while your log was empty, you would get some errors.
By adding this check, no error.