### PR TITLE
Don't disable button if no file was chosen

### DIFF
--- a/assets/js/sections/adif.js
+++ b/assets/js/sections/adif.js
@@ -3,6 +3,9 @@ $(document).ready(function(){
 		e.preventDefault();
 		var fi = document.getElementById("userfile");
 		var file = fi.files[0];;
+		if (!(file)) {
+			return;
+		}
 		$("#prepare_sub").prop("disabled",true);
 		if (JSZip.support.blob) {	// Check if Browser supports ZIP
 			var zip = new JSZip();


### PR DESCRIPTION
If no file was chosen at ADIF Upload, and User presses upload the button is disabled.
this one simply returns if no file was chosen, so user can try again.

