### PR TITLE
Only show the most critical warning and link to LoTW

### DIFF
--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -173,13 +173,11 @@ function getDistance($distance) {
 		<?php
 			if($lotw_cert_expired == true) { ?>
 			<div class="alert alert-danger" role="alert">
-				<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-hourglass-end"></i> <?= __("At least one of your LoTW certificates is expired!"); ?>
+				<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-hourglass-end"></i> <?= sprintf(_pgettext("LoTW Warning", "At least one of your %sLoTW certificates%s is expired!"), '<a href="' . site_url('lotw') . '">', "</a>"); ?>
 			</div>
-		<?php } ?>
-
-		<?php if($lotw_cert_expiring == true) { ?>
+		<?php } elseif($lotw_cert_expiring == true) { ?>
 			<div class="alert alert-warning" role="alert">
-				<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-hourglass-half"></i> <?= __("At least one of your LoTW certificates is about to expire!"); ?>
+				<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-hourglass-half"></i> <?= sprintf(_pgettext("LoTW Warning", "At least one of your %sLoTW certificates%s is about to expire!"), '<a href="' . site_url('lotw') . '">', "</a>"); ?>
 			</div>
 		<?php } ?>
 	<?php } ?>


### PR DESCRIPTION
Refactored the LoTW warnings on the dashboard page:
- Changed link so that only the most critical (i.e. one) warning is shown
- Added a link to the LoTW page

Before:

![image](https://github.com/user-attachments/assets/55e927e0-a5de-4a0b-920a-3f520df80aaf)

After:

![image](https://github.com/user-attachments/assets/d6808f06-a204-4a5d-b751-79f083f25741)
