### PR TITLE
Add API Endpoint to retrieve the version of Wavelog running

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -970,4 +970,16 @@ class API extends CI_Controller {
 		$latlng = $this->qra->qra2latlong($qra);
 		return $latlng;
 	}
+	
+	function version($key = '') {
+		// This API endpoint provides the version of Wavelog if the provide key has at least read permissions
+		$this->load->model('api_model');
+		header("Content-type: application/json");
+		if(substr($this->api_model->access($key),0,1) == 'r') {
+			echo json_encode(['version' => $this->optionslib->get_option('version')]);
+		} else {
+			http_response_code(401);
+			echo json_encode(['status' => 'failed', 'reason' => "missing or invalid api key"]);
+		}
+	}
 }

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -973,11 +973,18 @@ class API extends CI_Controller {
 	
 	function version() {
 		// This API endpoint provides the version of Wavelog if the provide key has at least read permissions
-		$this->load->model('api_model');
-		$key = $this->input->post('key', TRUE);
-		
+		$data = json_decode(file_get_contents('php://input'), true);
+		$valid = false;
+	
+		if (!empty($data['key'])) {
+			$this->load->model('api_model');
+			if (substr($this->api_model->access($data['key']), 0, 1) == 'r') {
+				$valid = true;
+			}
+		}
+
 		header("Content-type: application/json");
-		if(substr($this->api_model->access($key),0,1) == 'r') {
+		if ($valid) {
 			echo json_encode(['status' => 'ok', 'version' => $this->optionslib->get_option('version')]);
 		} else {
 			http_response_code(401);

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -971,12 +971,14 @@ class API extends CI_Controller {
 		return $latlng;
 	}
 	
-	function version($key = '') {
+	function version() {
 		// This API endpoint provides the version of Wavelog if the provide key has at least read permissions
 		$this->load->model('api_model');
+		$key = $this->input->post('key', TRUE);
+		
 		header("Content-type: application/json");
 		if(substr($this->api_model->access($key),0,1) == 'r') {
-			echo json_encode(['version' => $this->optionslib->get_option('version')]);
+			echo json_encode(['status' => 'ok', 'version' => $this->optionslib->get_option('version')]);
 		} else {
 			http_response_code(401);
 			echo json_encode(['status' => 'failed', 'reason' => "missing or invalid api key"]);


### PR DESCRIPTION
Endpoint "/version" reports the current version of Wavelog running in JSON.
The intention was check for a certain version of Wavelog in an external tool to ensure compatibility.

Example Request:
```
curl -X "POST" "https://<WAVELOG_URL>/api/version" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d "{\"key\":\"<API_KEY>\"}"
```

Response if OK:
`{"status":"ok","version":"1.9.1"}`

Response if the key is missing or invalid:
`{"status":"failed","reason":"missing or invalid api key"}`

73 de HB9HJQ