### PR TITLE
Fix advanced search

### DIFF
--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -98,7 +98,7 @@ class Search extends CI_Controller {
 	}
 
 	function search_result() {
-        	$sstring = str_replace('Ø', "0", $this->input->post("method", TRUE) ?? '');
+		$sstring = str_replace('Ø', "0", $this->input->post("search", TRUE) ?? '');
 		$data['results'] = $this->fetchQueryResult($sstring, FALSE);
 		$this->load->view('search/search_result_ajax', $data);
 	}

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -638,8 +638,7 @@ $(function () {
             $(".searchbutton").prop('disabled', true);
 
             $.post("<?php echo site_url('search/search_result'); ?>", {
-                    search: JSON.stringify(result, null, 2),
-                    temp: "testvar"
+                    search: JSON.stringify(result, null, 2)
                 })
                 .done(function(data) {
                     $('.exportbutton').html('<button class="btn btn-sm btn-primary" onclick="export_search_result();">'+"<?= __("Export to ADIF"); ?>"+'</button>');


### PR DESCRIPTION
Was b0rken in https://github.com/wavelog/wavelog/pull/1412/commits/37e05649a6d0f4a16b9ba00f00b5d9922f6760a1 resp. https://github.com/wavelog/wavelog/pull/1412 where the JSON parameter was renamed from "search" to "method" for some reason.