### PR TITLE
Keep SAT frequencies on mode change

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -882,7 +882,7 @@ $('#start_date').on('change', function () {
 
 /* on mode change */
 $('.mode').on('change', function () {
-	if ($('#radio').val() == 0) {
+	if ($('#radio').val() == 0 && $('#sat_name').val() == '') {
 		$.get(base_url + 'index.php/qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function (result) {
 			$('#frequency').val(result).trigger("change");
 		});

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -886,8 +886,8 @@ $('.mode').on('change', function () {
 		$.get(base_url + 'index.php/qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val(), function (result) {
 			$('#frequency').val(result).trigger("change");
 		});
+		$('#frequency_rx').val("");
 	}
-	$('#frequency_rx').val("");
 	$("#callsign").blur();
 });
 


### PR DESCRIPTION
If we post log SAT QSOs and choose SAT and SAT_MODE and then change mode from SSB to CW the default SAT frequencies are overwritten by the default CW frequencies of the band plan. This should not happen if we have selected a satellite before (and use those frequencies). Demo:

https://github.com/user-attachments/assets/2fc39c24-ec65-4c1b-b162-a2d4fe3bc115

Fix: Trigger mode changing of frequencies only if SAT is not set aka. empty.
