### PR TITLE
Make column rename failsafe

### DIFF
--- a/application/migrations/228_rename_satellites.php
+++ b/application/migrations/228_rename_satellites.php
@@ -156,14 +156,16 @@ class Migration_rename_satellites extends CI_Migration {
 			$this->insert_sat("AO-123", "ASRTU-1", "LEO", "V/U", "FM", "145850000", "FM", "435400000", "N");
 			$this->update_log_table("ASRTU-1", "AO-123");
 
-			$fields = array(
-				'exportname' => array(
-					'name' => 'displayname',
-					'type' => 'VARCHAR',
-					'constraint' => 255,
-				),
-			);
-			$this->dbforge->modify_column('satellite', $fields);
+			if ($this->db->field_exists('exportname', 'satellite')) {
+				$fields = array(
+					'exportname' => array(
+						'name' => 'displayname',
+						'type' => 'VARCHAR',
+						'constraint' => 255,
+					),
+				);
+				$this->dbforge->modify_column('satellite', $fields);
+			}
 		}
 		$this->rm_ix('TMP_HRD_IDX_COL_SAT_NAME');
 	}

--- a/application/migrations/228_rename_satellites.php
+++ b/application/migrations/228_rename_satellites.php
@@ -174,6 +174,7 @@ class Migration_rename_satellites extends CI_Migration {
 		$this->add_ix('TMP_HRD_IDX_COL_SAT_NAME','`COL_SAT_NAME`');
 		if ($this->db->table_exists('satellite')) {
 
+			if ($this->db->field_exists('displayname', 'satellite')) {
 			$fields = array(
 				'displayname' => array(
 					'name' => 'exportname',
@@ -181,6 +182,7 @@ class Migration_rename_satellites extends CI_Migration {
 					'constraint' => 255,
 				),
 			);
+		}
 
 			$this->dbforge->modify_column('satellite', $fields);
 

--- a/application/migrations/228_rename_satellites.php
+++ b/application/migrations/228_rename_satellites.php
@@ -175,14 +175,14 @@ class Migration_rename_satellites extends CI_Migration {
 		if ($this->db->table_exists('satellite')) {
 
 			if ($this->db->field_exists('displayname', 'satellite')) {
-			$fields = array(
-				'displayname' => array(
-					'name' => 'exportname',
-					'type' => 'VARCHAR',
-					'constraint' => 255,
-				),
-			);
-		}
+				$fields = array(
+					'displayname' => array(
+						'name' => 'exportname',
+						'type' => 'VARCHAR',
+						'constraint' => 255,
+					),
+				);
+			}
 
 			$this->dbforge->modify_column('satellite', $fields);
 


### PR DESCRIPTION
Migration 228 fails in some cases. We should fix this to make it more failsafe.

Repro:

- Checkout earlier version tag 1.8.8
- Checkout version tag 1.9
- Open Wavelog
- Migration 228 will fail

The reason is that on checking out earlier tags the downgrade migrations do not run but on checking out the later tag the migs are applied again. In this special case the renaming of column is tried again and fails as it is renamed already. Fixed by a check if the old name exists and skip the rename in case it does.
