### PR TITLE
add .user.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ sync.sh
 .maintenance
 .demo
 .htaccess
+.user.ini


### PR DESCRIPTION
Some hosters require a ".user.ini" file to store differing php settings usually found in .htaccess like memory_limit or max_execution_time.

To prevent this file from being overwritten on update or creating error messages, this should be included in .gitignore.
There is a possibility for each individual user to add this to the local ".git/info/exclude" file on every install to get the same result, but I think the global .gitignore makes more sense.

I can't think of any blockers, but if someone can think of some, happy to discuss and change.