### PR TITLE
Implement contest srx/stx and comments in SimpleFLE

### DIFF
--- a/application/views/simplefle/index.php
+++ b/application/views/simplefle/index.php
@@ -32,6 +32,7 @@
 				var lang_qso_simplefle_warning_missing_band_mode = "<?= __("Warning! You can't log the QSO List, because some QSO don't have band and/or mode defined!"); ?>";
 				var lang_qso_simplefle_warning_missing_time = "<?= __("Warning! You can't log the QSO List, because some QSO don't have a time defined!"); ?>";
 				var lang_qso_simplefle_warning_example_data = "<?= __("Attention! The Data Field containes example data. First Clear Logging Session!"); ?>";
+				var lang_qso_simplefle_warning_missing_contestid = "<?= __("Attention! Either you have set a contest, but included no exchange, or you have logged contest-data but did not select a contest."); ?>";
 				var lang_qso_simplefle_confirm_save_to_log = "<?= __("Are you sure that you want to add these QSO to the Log and clear the session?"); ?>";
 				var lang_qso_simplefle_success_save_to_log_header = "<?= __("QSO Logged!"); ?>";
 				var lang_qso_simplefle_success_save_to_log = "<?= __("The QSO were successfully logged in the logbook! Dupes were skipped."); ?>";

--- a/application/views/simplefle/syntax_help.php
+++ b/application/views/simplefle/syntax_help.php
@@ -25,5 +25,41 @@
     day ++
     df3et
 </pre>
+<p><?= __("Additional informations can be submitted in the following way:") ?></p>
+<p><?= __("Notes:") ?></p>
+<pre>
+    2112 dj3ce < comment >
+</pre>
+<p><?= __("Operator Name:") ?></p>
+<pre>
+  2112 dj3ce @Cedric
+</pre>
+<p><?= __("QSL-message (Caution! Not visible in wavelog currently!):") ?></p>
+<pre>
+  2112 dj3ce [tnx qso]
+</pre>
+<p><?= __("Contest exchange; serials or other exchange - or even both:") ?></p>
+<pre>
+    2112 dj3ce ,1.12
+    2113 dj3ce ,LA.DL
+    2114 dj3ce ,12,LA.14.DL
+    2114 dj3ce .14 ,12 .DL ,LA
+</pre>
+<p><?= __("Received exchange has to be prefixed with a dot '.', sent exchange with a comma ','. The last to lines are equivalent - i.e. spaces don't matter as the order doesn't as well. Exchange you have sent will automatically be included in the next QSO, if it contains received exchange, or if you use a single comma ','. To automatically increment the sent serial, use ',++' and give an initial sent exchange. To deactivate, use ',+0':") ?></p>
+<pre>
+    ,++
+    2112 dj3ce ,1.12
+    2113 dk0mm .105
+</pre>
+<p><?= __("Here, the first qso uses the set serial 1, and the second will use 2 as the serial. If you want to wipe your sent exchange, use ',-':") ?></p>
+<pre>
+    2115 dj3ce ,15,D23.1.F39
+    2116 dk0mm ,-,16.1015
+</pre>
+<p><?= __("First, all previous exchange is wiped, then only a serial is set. Otherwise the previous exchange 'D23' would have been set also.") ?></p>
+<p><?= __("You may use the comment syntax, to fill adif-fields supported by the Wavelog-Import:") ?></p>
+<pre>
+    2119 dj3ce <tx_pwr:50> <rx_pwr:750> <darc_dok:F39> <sfi:210> <rig:QCX> <...>
+</pre>
 <p><?= sprintf(__("A full summary of all commands and the necessary syntax can be found in %sthis article%s of our Wiki."), '<a href="https://github.com/wavelog/wavelog/wiki/SimpleFLE" target="_blank">', '</a>'); ?></p>
 

--- a/application/views/simplefle/syntax_help.php
+++ b/application/views/simplefle/syntax_help.php
@@ -28,7 +28,7 @@
 <p><?= __("Additional informations can be submitted in the following way:") ?></p>
 <p><?= __("Notes:") ?></p>
 <pre>
-    2112 dj3ce < comment >
+    2112 dj3ce &lt; comment &gt;
 </pre>
 <p><?= __("Operator Name:") ?></p>
 <pre>
@@ -59,7 +59,7 @@
 <p><?= __("First, all previous exchange is wiped, then only a serial is set. Otherwise the previous exchange 'D23' would have been set also.") ?></p>
 <p><?= __("You may use the comment syntax, to fill adif-fields supported by the Wavelog-Import:") ?></p>
 <pre>
-    2119 dj3ce <tx_pwr:50> <rx_pwr:750> <darc_dok:F39> <sfi:210> <rig:QCX> <...>
+    2119 dj3ce &lt;tx_pwr:50&gt; &lt;rx_pwr:750&gt; &lt;darc_dok:F39&gt; &lt;sfi:210&gt; &lt;rig:QCX&gt; &lt;...&gt;
 </pre>
 <p><?= sprintf(__("A full summary of all commands and the necessary syntax can be found in %sthis article%s of our Wiki."), '<a href="https://github.com/wavelog/wavelog/wiki/SimpleFLE" target="_blank">', '</a>'); ?></p>
 

--- a/assets/js/sections/simplefle.js
+++ b/assets/js/sections/simplefle.js
@@ -470,8 +470,8 @@ function handleInput() {
 			<td>${callsign}</td>
 			<td><span data-bs-toggle="tooltip" data-placement="left" title="${freq}">${band}</span></td>
 			<td>${mode}</td>
-			<td>${rst_s}${stx_info}</td>
-			<td>${rst_r}${srx_info}</td>
+			<td>${rst_s} ${stx_info}</td>
+			<td>${rst_r} ${srx_info}</td>
 			<td>${gridsquare}</td>
 			<td>${sotaWwffText}</td>
 			</tr>`);

--- a/assets/js/sections/simplefle.js
+++ b/assets/js/sections/simplefle.js
@@ -242,15 +242,17 @@ function handleInput() {
 		var add_info = {};
 
 		// First, search for <...>-Patterns, which may contain comments (... or additional fields)
-		let addInfoMatches = row.matchAll(/<([^>]*)>/g);
+		let addInfoMatches = row.matchAll(/<([^>]*)>|\[([^\]]*)\]/g);
 		addInfoMatches.forEach((item) => {
-		  row = row.replace(item[0], "");
-		  let kv;
-		  if (kv = item[1].match(/^([a-z_]+): *(.*)$/)) {
-		    add_info[kv[1]] = kv[2];
-		  } else {
-		    add_info.comment = (('comment' in add_info)?add_info.comment+' ': '')+item[1];
-		  }
+			row = row.replace(item[0], "");
+			let kv;
+			if (item[0][0] == '<' && (kv = item[1].match(/^([a-z_]+): *(.*)$/))) {
+				add_info[kv[1]] = kv[2];
+			} else if (item[0][0] == '[') {
+				add_info.qslmsg = item[2];
+			} else {
+				add_info.comment = (('comment' in add_info)?add_info.comment+' ': '')+item[1];
+			}
 		});
 
 		// Now split the remaining line by spaces and match patterns on those
@@ -315,9 +317,9 @@ function handleInput() {
 				callsign = item.toUpperCase();
 				call_rec = true;
 			} else if (
-				item.match(/^[A-R]{2}[0-9]{2}([A-X]{2}([0-9]{2}([A-X]{2})?)?)?$/i)
+				parts = item.match(/(?<=^#?)[A-R]{2}[0-9]{2}([A-X]{2}([0-9]{2}([A-X]{2})?)?)?$/i)
 			) {
-				gridsquare = item.toUpperCase();
+				gridsquare = parts[0].toUpperCase();
 			} else if (itemNumber > 0 && item.match(/^[-+]\d{1,2}$|^\d{1,3}$|^\d{1,3}[-+]d{1,2}$/)) {
 				if (rst_s === null) {
 					rst_s = item;
@@ -339,6 +341,8 @@ function handleInput() {
 						srx = parts[5];
 					}
 				}
+			} else if (itemNumber > 0 && (parts = item.match(/(?<=^@)[A-Za-z]+/))) {
+				add_info.name = parts[0];
 			}
 
 			itemNumber = itemNumber + 1;


### PR DESCRIPTION
DF3CB has specified `,***` and `.***` for contest exchange-received and sent, as well as `<...>` for comments.

Comments may contain spaces and are handled ahead of splitting rows by spaces.

Additionally, you may enter an arbitrary ADIF-field(\*) in the form of '<tx_pwr: 50>' or '<notes: Uses a straight key>', as long as the key matches '[a-z_]*:' and is implemented in wavelog's 'import()' in the Logbook-Model.

I'd be happy, if you'd a look into, do some tests and give some feedback :). Thanks!