### PR TITLE
sota: add link to sota.org reference page

### DIFF
--- a/application/views/awards/sota/index.php
+++ b/application/views/awards/sota/index.php
@@ -16,9 +16,9 @@
 	<?php
 		if ($sota_all) {
 	?>
-	
+
 	<table class="table table-sm table-striped table-hover">
-		
+
 	<tr>
 		<td><?= __("Reference"); ?></td>
 		<td><?= __("Date/Time"); ?></td>
@@ -27,16 +27,14 @@
 		<td><?= __("RST Sent"); ?></td>
 		<td><?= __("RST Received"); ?></td>
 	</tr>
-	
+
 	<?php
 		if ($sota_all->num_rows() > 0) {
 			foreach ($sota_all->result() as $row) {
 	?>
-	
+
 	<tr>
-		<td>	
-			<?php echo $row->COL_SOTA_REF; ?>
-		</td>
+		<td><a target="_blank" href="https://www.sotadata.org.uk/en/summit/<?php echo $row->COL_SOTA_REF; ?>"><?php echo $row->COL_SOTA_REF; ?></a></td>
 		<td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date('d/m/y', $timestamp); ?> - <?php $timestamp = strtotime($row->COL_TIME_ON); echo date('H:i', $timestamp); ?></td>
 		<td><?php echo $row->COL_CALL; ?></td>
 		<td><?php echo $row->COL_BAND; ?></td>
@@ -47,7 +45,7 @@
 		  }
 		}
 	?>
-	
+
 	</table>
 	<?php } else {
         echo '<div class="alert alert-danger" role="alert">' . __("Nothing found!") . '</div>';


### PR DESCRIPTION
This adds a link to the sota.org summit reference page, similar to how the POTA awards page works.