### PR TITLE
Lotw update Fix

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3712,7 +3712,7 @@ class Logbook_model extends CI_Model {
 		}
 
 		// Check if QRZ or ClubLog is already uploaded. If so, set qso to reupload to qrz.com (M) or clublog
-		$qsql = "select COL_CLUBLOG_QSO_UPLOAD_STATUS as CL_STATE, COL_QRZCOM_QSO_UPLOAD_STATUS as QRZ_STATE from " . $this->config->item('table_name') . " where COL_BAND=? and COL_CALL=? and COL_STATION_CALLSIGN=? and date_format(COL_TIME_ON, '%Y-%m-%d %H:%i') = ? and COL_PRIMARY_KEY = ? and station_id in (" . $station_ids . ')';
+		$qsql = "SELECT COL_CLUBLOG_QSO_UPLOAD_STATUS as CL_STATE, COL_QRZCOM_QSO_UPLOAD_STATUS as QRZ_STATE FROM " . $this->config->item('table_name') . " WHERE COL_PRIMARY_KEY = ? AND station_id IN (" . $station_ids . ')';
 		$query = $this->db->query($qsql, array($band, $callsign, $station_callsign, $datetime, $qsoid));
 		$row = $query->row();
 		if (($row->QRZ_STATE ?? '') == 'Y') {
@@ -3722,14 +3722,6 @@ class Logbook_model extends CI_Model {
 			$data['COL_CLUBLOG_QSO_UPLOAD_STATUS'] = 'M';
 		}
 
-		$this->db->group_start();
-		$this->db->where('date_format(COL_LOTW_QSLRDATE, \'%Y-%m-%d %H:%i\') != ', $qsl_date);
-		$this->db->or_where('COL_LOTW_QSLRDATE is null');
-		$this->db->group_end();
-		$this->db->where('COL_CALL', $callsign);
-		$this->db->where('COL_BAND', $band);
-		$this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = ', $datetime);
-		$this->db->where('COL_STATION_CALLSIGN', $station_callsign);
 		$this->db->where('COL_PRIMARY_KEY', $qsoid);
 		$this->db->where('station_id in (' . $station_ids . ')');
 
@@ -3741,9 +3733,6 @@ class Logbook_model extends CI_Model {
 				'COL_DISTANCE' => 0
 			);
 			$this->db->select('station_profile.station_gridsquare as station_gridsquare');
-			$this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = ', $datetime);
-			$this->db->where('COL_CALL', $callsign);
-			$this->db->where('COL_BAND', $band);
 			$this->db->where('COL_PRIMARY_KEY', $qsoid);
 			$this->db->join('station_profile', $this->config->item('table_name') . '.station_id = station_profile.station_id', 'left outer');
 			$this->db->where('station_profile.station_id in (' . $station_ids . ')');
@@ -3765,9 +3754,6 @@ class Logbook_model extends CI_Model {
 				$data['COL_DISTANCE'] = $this->qra->distance($station_gridsquare, $qsl_vucc_grids, 'K', $ant_path);
 			}
 
-			$this->db->where('date_format(COL_TIME_ON, \'%Y-%m-%d %H:%i\') = ', $datetime);
-			$this->db->where('COL_CALL', $callsign);
-			$this->db->where('COL_BAND', $band);
 			$this->db->where('COL_PRIMARY_KEY', $qsoid);
 
 			$this->db->update($this->config->item('table_name'), $data);


### PR DESCRIPTION
Fixing the LoTW Update logic which updates the QSO in the database. 

Explaination:
In the `import_check()` we check for matching QSOs within an 15 Minute range. The LoTW Update Logic does the same check again but this time without the 15 Minute range and expects a strikt match of the Time ON. 

Since the method has the QSO ID (COL_PRIMARY_KEY) available , it's not necessary to query for the other parameters aswell. So we can get rid of them.

Smaller Code but better results :)