### PR TITLE
Fallback to short-living-popup if fetch fails (cors-workaround)

### DIFF
--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -221,7 +221,11 @@ $(function() {
 		}
 
 		try {
-			irrelevant=fetch(CatCallbackURL + '/'+qrg);
+			irrelevant=fetch(CatCallbackURL + '/'+qrg).catch(() => {
+				console.log("Fallback to ugly PopUp");
+				openedWindow = window.open(CatCallbackURL + '/' + qrg);
+				openedWindow.close();
+			});
 		} finally {}
 
 		let check_pong = setInterval(function() {

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -222,7 +222,6 @@ $(function() {
 
 		try {
 			irrelevant=fetch(CatCallbackURL + '/'+qrg).catch(() => {
-				console.log("Fallback to ugly PopUp");
 				openedWindow = window.open(CatCallbackURL + '/' + qrg);
 				openedWindow.close();
 			});


### PR DESCRIPTION
See https://github.com/wavelog/wavelog/discussions/1487

Under normal circumstances QSY is working as before.
If one has WavelogGate or sth. different (Microcontroller) somewhere else than on local computer, this one falls back to open a popup (and close it instantly) to push the QSY-Trigger to the service.