### PR TITLE
Fix for Last-QRZ-QSL

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -312,7 +312,7 @@ class Qrz extends CI_Controller {
 				if ((($user_id_to_load != null) && ($user_id_to_load != $station->user_id))) {	// Skip User if we're called with a specific user_id
 					continue;
 				} 
-				if ($lastqrz == null) {
+				if (($lastqrz == null) || ($user_id_to_load == null)) {
 					$lastqrz = $this->logbook_model->qrz_last_qsl_date($station->user_id);
 				}
 				$qrz_api_key = $station->qrzapikey;

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -315,6 +315,9 @@ class Qrz extends CI_Controller {
 				if (($lastqrz == null) || ($user_id_to_load == null)) {
 					$lastqrz = $this->logbook_model->qrz_last_qsl_date($station->user_id);
 				}
+				if (($lastqrz ?? '') == '2999-12-31') {	// Nothing to do here, skip station
+					continue;
+				}
 				$qrz_api_key = $station->qrzapikey;
 				$result=($this->mass_download_qsos($qrz_api_key, $lastqrz, $station->station_ids));
 				if (isset($result['tableheaders'])) {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3754,12 +3754,15 @@ class Logbook_model extends CI_Model {
 	}
 
 	function qrz_last_qsl_date($user_id) {
-		$sql = "SELECT date_format(MAX(COALESCE(COL_QRZCOM_QSO_DOWNLOAD_DATE, str_to_date('1900-01-01','%Y-%m-%d'))),'%Y-%m-%d') MAXDATE
+		$sql = "SELECT date_format(MAX(COALESCE(COL_QRZCOM_QSO_DOWNLOAD_DATE, str_to_date('1900-01-01','%Y-%m-%d'))),'%Y-%m-%d') MAXDATE, COUNT(1) as QSOs
 		    FROM " . $this->config->item('table_name') . " INNER JOIN station_profile ON (" . $this->config->item('table_name') . ".station_id = station_profile.station_id)
 		    WHERE station_profile.user_id=? and station_profile.qrzapikey is not null and COL_QRZCOM_QSO_DOWNLOAD_DATE is not null";
-		$query = $this->db->query($sql, $user_id);
+		$query = $this->db->query($sql, array($user_id));
 		$row = $query->row();
-		if (isset($row) && ($row->MAXDATE ?? '' != '')) {
+		if (isset($row) && (($row->QSOS ?? 0) == 0)) {	// Abort / Set LASTQSO to future if no QSO is in Log to prevent processing QRZ-Data
+			return '2999-12-31';
+		}
+		if (isset($row) && (($row->MAXDATE ?? '') != '')) {
 			return $row->MAXDATE;
 		} else {
 			return '1900-01-01';

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3754,7 +3754,7 @@ class Logbook_model extends CI_Model {
 	}
 
 	function qrz_last_qsl_date($user_id) {
-		$sql = "SELECT date_format(MAX(COALESCE(COL_QRZCOM_QSO_DOWNLOAD_DATE, str_to_date('1900-01-01','%Y-%m-%d'))),'%Y-%m-%d') MAXDATE, COUNT(1) as QSOs
+		$sql = "SELECT date_format(MAX(COALESCE(COL_QRZCOM_QSO_DOWNLOAD_DATE, str_to_date('1900-01-01','%Y-%m-%d'))),'%Y-%m-%d') MAXDATE, COUNT(1) as QSOS
 		    FROM " . $this->config->item('table_name') . " INNER JOIN station_profile ON (" . $this->config->item('table_name') . ".station_id = station_profile.station_id)
 		    WHERE station_profile.user_id=? and station_profile.qrzapikey is not null and COL_QRZCOM_QSO_DOWNLOAD_DATE is not null";
 		$query = $this->db->query($sql, array($user_id));


### PR DESCRIPTION
before patch:
- if triggered by cron, every QSO will be fetched OR even worse: last-qsl stuck at first synced station/user

after patch:
- if triggered by cron the last received "QSL" from qrz will be taken for each user/sync