### PR TITLE
show hint about qrz.com login credentials. QRZ.com needs your callsig…

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -37,7 +37,7 @@ $config['display_freq'] = true;
 | QRZ Login Options
 |--------------------------------------------------------------------------
 |
-| 	'qrz_username'	QRZ.com user login
+| 	'qrz_username'	QRZ.com user login (callsign, not email)
 |	'qrz_password'	QRZ.com user password
 |	'use_fullname'  Get full names from QRZ, may not be GDPR compliant
 */

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -37,7 +37,7 @@ $config['display_freq'] = true;
 | QRZ Login Options
 |--------------------------------------------------------------------------
 |
-| 	'qrz_username'	QRZ.com user login
+| 	'qrz_username'	QRZ.com user login (callsign, not email)
 |	'qrz_password'	QRZ.com user password
 |	'use_fullname'  Get full names from QRZ, may not be GDPR compliant
 */

--- a/install/index.php
+++ b/install/index.php
@@ -391,6 +391,10 @@ if (!file_exists('.lock')) {
 														</div>
 													</div>
 												</div>
+												<div class="alert alert-info" id="qrz_hint" style="display: none; margin-top: 10px;">
+													<p><i class="fas fa-lightbulb"></i> <?= __("Good to know:"); ?></p>
+													<?= __("Use your callsign as your username for QRZ.com. The XML API does not support email addresses."); ?>
+												</div>
 											</div>
 											<a class="btn btn-sm btn-secondary" id="advancedSettingsButton"><?= __("Advanced Settings"); ?></a>
 											<div class="modal fade" id="advancedSettingsModal" tabindex="-1" aria-labelledby="advancedSettingsModalLabel" aria-hidden="true">
@@ -1405,11 +1409,24 @@ if (!file_exists('.lock')) {
 
 				let directory = $('#directory');
 				let websiteurl = $('#websiteurl');
+				let callbook_type = $('#global_call_lookup');
 				let callbook_username = $('#callbook_username');
 				let callbook_password = $('#callbook_password');
 
 				// On Page Load
 				$(document).ready(function() {
+
+					if (callbook_type.val() === 'qrz') {
+						$('#qrz_hint').show();
+					}
+
+					callbook_type.on('change', function() {
+						if (callbook_type.val() === 'qrz') {
+							$('#qrz_hint').show();
+						} else {
+							$('#qrz_hint').hide();
+						}
+					});
 
 					$('#advancedSettingsButton').click(function() {
 						$('#advancedSettingsModal').modal('show');


### PR DESCRIPTION
QRZ XML seems not working properly with email address as username, which is kind of confusing for a user since the regular qrz login does work with the email. 

Let's place a hint in the installer and in the config.php to avoid confusion here:

![image](https://github.com/user-attachments/assets/3f6e39ee-d2ab-4b83-b672-581ff6a2eafd)

The hint is only shown if QRZ.com is selected

This is a small addition for #1505  reported by @WEKarnesky