### PR TITLE
Fixes for Wamp server

### DIFF
--- a/application/migrations/134_create_label_paper_types_table.php
+++ b/application/migrations/134_create_label_paper_types_table.php
@@ -21,7 +21,7 @@ class Migration_create_label_paper_types_table extends CI_Migration {
 
 				'paper_name' => array(
 					'type' => 'VARCHAR',
-					'constraint' => '250',
+					'constraint' => '191',
 				),
 
 				'metric' => array(

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -271,7 +271,7 @@ class Update_model extends CI_Model {
         $result=curl_exec($ch);
         curl_close($ch);
         $json = json_decode($result, true);
-        $latest_tag = $json[0]['tag_name'];
+        $latest_tag = $json[0]['tag_name'] ?? 'Unknown';
         return $latest_tag;
     }
 


### PR DESCRIPTION
While troubleshooting WAMP server, I found these 2 issues.

The migration is probably related to the MySQL config. I don't see any harm in changing it.

The tag in the version gives an error. Seems to be some issues with permission, but I don't see the harm in defaulting to unknown if latest version can't be grabbed from Github. This also made the debug page crash without it.