### PR TITLE
Fix "my_country" in ADIF export from advanced search

### DIFF
--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -104,7 +104,8 @@ class Search extends CI_Controller {
 	}
 
 	function export_to_adif() {
-		$data['qsos'] = $this->fetchQueryResult(($this->input->post('search', TRUE) ?? ''), FALSE);
+		$sstring = str_replace('Ø', "0", $this->input->post("search", TRUE) ?? '');
+		$data['qsos'] = $this->fetchQueryResult($sstring, FALSE);
 		$this->load->view('adif/data/exportall', $data);
 	}
 
@@ -304,7 +305,7 @@ class Search extends CI_Controller {
 
 		$this->db->order_by('COL_TIME_ON', 'DESC');
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
-		$this->db->join('dxcc_entities', $this->config->item('table_name').'.col_dxcc = dxcc_entities.adif', 'left');
+		$this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif', 'left');
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 		$this->db->limit(5000);
 


### PR DESCRIPTION
**Describe the bug**
Exporting ADIF from the "advanced search" leads to corrupted 'MY_COUNTRY'-data in the resulting ADIF-file.

**Version Information**
We need some information about your versions. You can get all Information in the Admin > Debug Menu
- OS: Linux
- PHP: PHP 7.4
- MySQL/MariaDB:  MariaDB 10.3
- Wavelog: 1.9.1 / current dev-Branch, 94821b7d0

**Steps to Reproduce**
1. Go to 'Advanced Search'
2. Click on 'Search' and 'Export to ADIF'
4. Open the ADIF
5. Look for the 'MY_COUNTRY'-Line of a QSO with some other country than yours

**Expected Behavior**
'MY_COUNTRY' should contain your (station's) country, aligning with 'MY_DXCC'.
Instead, 'MY_DXCC' shows the correct DXCC (in my case 230) and 'MY_COUNTRY' shows the QSO-partners country as well (i.e. uppercased form of 'COUNTRY').


**Additional Info**
This PR should fix the described bug.

As in Line 300 in `Search.php` the `dxcc_entities` column 'name' is explicitly aliased as 'station_country', the join of `dxcc_entities` in line 308 should reference `station_profile.station_dxcc`.

p.s. ... I took over the changes regarding the 0 here as well.