### PR TITLE
Show Update Results in Debug Page as Flash Messages

### DIFF
--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -360,8 +360,16 @@ class Update extends CI_Controller {
 
         $this->load->model('Update_model');
         $result = $this->Update_model->clublog_scp();
-        echo $result;
-
+        if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 4) == 'DONE') {
+				$this->session->set_flashdata('success', __("SCP Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("SCP Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     public function download_lotw_users() {
@@ -372,8 +380,16 @@ class Update extends CI_Controller {
 
         $this->load->model('Update_model');
         $result = $this->Update_model->lotw_users();
-        echo $result;
-
+        if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 7) == 'Records') {
+				$this->session->set_flashdata('success', __("LoTW Users Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("LoTW Users Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     /*
@@ -383,8 +399,16 @@ class Update extends CI_Controller {
 
         $this->load->model('Update_model');
         $result = $this->Update_model->dok();
-        echo $result;
-
+		if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 4) == 'DONE') {
+				$this->session->set_flashdata('success', __("DOK Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("DOK Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     /*
@@ -394,8 +418,16 @@ class Update extends CI_Controller {
 
         $this->load->model('Update_model');
         $result = $this->Update_model->sota();
-        echo $result;
-
+        if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 4) == 'DONE') {
+				$this->session->set_flashdata('success', __("SOTA Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("SOTA Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     /*
@@ -405,22 +437,47 @@ class Update extends CI_Controller {
 
         $this->load->model('Update_model');
         $result = $this->Update_model->wwff();
-        echo $result;
-
+        if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 4) == 'DONE') {
+				$this->session->set_flashdata('success', __("WWFF Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("WWFF Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     public function update_pota() {
 
         $this->load->model('Update_model');
         $result = $this->Update_model->pota();
-        echo $result;
-
+        if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 4) == 'DONE') {
+				$this->session->set_flashdata('success', __("POTA Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("POTA Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     public function update_tle() {
         $this->load->model('Update_model');
         $result = $this->Update_model->tle();
-        echo $result;
+        if($this->session->userdata('user_type') == '99') {
+			if (substr($result, 0, 4) == 'This') {
+				$this->session->set_flashdata('success', __("TLE Update complete. Result: ") . "'" . $result . "'");
+			} else {
+				$this->session->set_flashdata('error', __("TLE Update failed. Result: ") . "'" . $result . "'");
+			}
+			redirect('debug');
+		} else {
+        	echo $result;
+		}
     }
 
     public function update_lotw_sats() {

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -10,8 +10,11 @@ class Update_model extends CI_Model {
 
         $this->cron_model->set_last_run($this->router->class . '_' . $this->router->method);
 
-		$this->fetch_clublog_scp();
-		$this->fetch_supercheckpartial_master();
+        $result = '';
+		$result .= $this->fetch_clublog_scp();
+		$result .= $this->fetch_supercheckpartial_master();
+
+        return $result;
     }
 
 	function fetch_clublog_scp() {
@@ -30,15 +33,15 @@ class Update_model extends CI_Model {
             if (file_put_contents($strFile, $data) !== FALSE) {
                 $nCount = count(file($strFile));
                 if ($nCount > 0) {
-                    echo "DONE: " . number_format($nCount) . " callsigns loaded";
+                    return "DONE: " . number_format($nCount) . " callsigns loaded";
                 } else {
-                    echo "FAILED: Empty file";
+                    return "FAILED: Empty file";
                 }
             } else {
-                echo "FAILED: Could not write to Club Log SCP file";
+                return "FAILED: Could not write to Club Log SCP file";
             }
         } else {
-            echo "FAILED: Could not connect to Club Log";
+            return "FAILED: Could not connect to Club Log";
         }
 	}
 
@@ -46,19 +49,19 @@ class Update_model extends CI_Model {
 		$contents = file_get_contents('https://www.supercheckpartial.com/MASTER.SCP', true);
 
         if ($contents === FALSE) {
-            echo  "Something went wrong with fetching the MASTER.SCP file.";
+            return  "Something went wrong with fetching the MASTER.SCP file.";
         } else {
             $file = './updates/MASTER.SCP';
 
             if (file_put_contents($file, $contents) !== FALSE) {     // Save our content to the file.
                 $nCount = count(file($file));
                 if ($nCount > 0) {
-                    echo  "DONE: " . number_format($nCount) . " callsigns loaded";
+                    return  "DONE: " . number_format($nCount) . " callsigns loaded";
                 } else {
-                    echo "FAILED: Empty file";
+                    return "FAILED: Empty file";
                 }
             } else {
-                echo "FAILED: Could not write to Supercheckpartial MASTER.SCP file";
+                return "FAILED: Could not write to Supercheckpartial MASTER.SCP file";
             }
         }
 	}
@@ -258,7 +261,7 @@ class Update_model extends CI_Model {
         $mtime = $mtime[1] + $mtime[0];
         $endtime = $mtime;
         $totaltime = ($endtime - $starttime);
-        return "Records inserted: " . $i . " in " . $totaltime . " seconds <br />";
+        return "Records inserted: " . $i . " in " . $totaltime . " seconds";
     }
 
     function wavelog_latest_release() {
@@ -327,7 +330,7 @@ class Update_model extends CI_Model {
 		$count = 0;
 
 		if ($response === false) {
-			echo 'Error: ' . curl_error($curl);
+			return 'Error: ' . curl_error($curl);
 		} else {
 			// Split the response into an array of lines
 			$lines = explode("\n", $response);
@@ -364,8 +367,7 @@ class Update_model extends CI_Model {
 		$mtime = $mtime[1] + $mtime[0];
 		$endtime = $mtime;
 		$totaltime = ($endtime - $starttime);
-		echo "This page was created in ".$totaltime." seconds <br />";
-		echo "Records inserted: " . $count . " <br/>";
+		return "This page was created in ".$totaltime." seconds <br />Records inserted: " . $count;
 	}
 
 	 function lotw_sats() {


### PR DESCRIPTION
if there is a session available, we can show the results of the update buttons in the debug page as flash messages. This leads to a much better UX instead echoing out the plain result in a blank page. In CLI the results are still normally printed out. 

![image](https://github.com/user-attachments/assets/aa111570-37f4-4772-9dfc-a560ba2d54dc)
