### PR TITLE
Catch undefined club operators

### DIFF
--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -77,7 +77,7 @@
                         </select>
                         <?php
                         $show_operator_question = true;
-                        if ($this->config->item('special_callsign') && $club_operators != false) {
+                        if ($this->config->item('special_callsign') && (!empty($club_operators))) {
                             $show_operator_question = false; ?>
                             <div class="small form-text text-muted"><?= __("Select the operator of the imported QSOs") ?></div>
                             <select name="club_operator" class="form-select mb-2 me-sm-2 w-50 w-lg-100">


### PR DESCRIPTION
If switching back to ADIF tab after a failed import for example on DCL upload there is an error because $club_operators is not defined:

![image](https://github.com/user-attachments/assets/33dd4be4-ab5e-4b25-8b17-2362808db5a4)

We should catch this situation.