### PR TITLE
[Installer] Fixes

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -109,7 +109,7 @@ $config['auth_level'][99] = 'Administrator';
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['base_url'] = 'http://localhost/logbook';
+$config['base_url'] = 'http://localhost/logbook/';
 
 /*
 |--------------------------------------------------------------------------

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -13,7 +13,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 */
 
 $config['app_name'] = 'Wavelog';
-$config['directory'] = '/%directory%';
+$config['directory'] = '%directory%';
 $config['callbook'] = '%callbook%'; // Options are hamqth, qrz or qrzcq
 
 $config['datadir'] = null; // default to install directory

--- a/install/includes/interface_assets/footer.php
+++ b/install/includes/interface_assets/footer.php
@@ -3,8 +3,11 @@
 		// restore data from the localstorage if available
 		$('#install_form input').each(function() {
 			var inputId = $(this).attr('id');
-			if (localStorage.getItem(inputId)) {
-				$(this).val(localStorage.getItem(inputId));
+			if (inputId !== 'directory' && inputId !== 'websiteurl') { // do not restore directory and websiteurl for legacy reasons
+				console.log('Updated inputId: ', inputId);
+				if (localStorage.getItem(inputId)) {
+					$(this).val(localStorage.getItem(inputId));
+				}
 			}
 		});
 		$('#install_form select').each(function() {

--- a/install/index.php
+++ b/install/index.php
@@ -344,24 +344,14 @@ if (!file_exists('.lock')) {
 										<div class="col">
 											<p><?= __("Configure some basic parameters for your wavelog instance. You can change them later in 'application/config/config.php'"); ?></p>
 											<div class="mb-3">
-												<label for="directory" class="form-label"><?= __("Directory"); ?><i id="directory_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("The 'Directory' is basically your subfolder of the webroot In normal conditions the prefilled value is doing it's job. It also can be empty."); ?>"></i></label>
-												<div class="input-group">
-													<span class="input-group-text" id="main-url"><?php echo $http_scheme . '://' . $_SERVER['HTTP_HOST'] . "/"; ?></span>
-													<input type="text" id="directory" value="<?php echo substr(str_replace("index.php", "", str_replace("/install/", "", $_SERVER['REQUEST_URI'])), 1); ?>" class="form-control" name="directory" aria-describedby="main-url" />
-													<div class="invalid-tooltip">
-														<?= __("No slash before or after the directory. Just the name of the folder."); ?>
-													</div>
-												</div>
-											</div>
-											<div class="mb-3 position-relative">
-												<label for="websiteurl" class="form-label required"><?= __("Website URL"); ?></label><i id="websiteurl_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= sprintf(__("This is the complete URL where your Wavelog Instance will be available. If you run this installer locally but want to place Wavelog behind a Reverse Proxy with SSL you should type in the new URL here (e.g. %s instead of %s). Don't forget to include the directory from above."), "https://mywavelog.example.org/", "http://192.168.1.100/"); ?>"></i>
-												<input type="text" id="websiteurl" value="<?php echo $websiteurl; ?>" class="form-control" name="websiteurl" />
-												<div class="invalid-tooltip">
-													<?= __("This field<br>
-													- can't be empty<br>
-													- have to end with a slash 'example/'<br>
-													- have to start with 'http'"); ?>
-												</div>
+												<?php 
+													$directory = ltrim(str_replace('/install', '', dirname($_SERVER['SCRIPT_NAME'])), '/');
+													$base_url = $http_scheme . '://' . $_SERVER['HTTP_HOST'] . "/" . $directory . "/";
+												?>
+												<label for="directory" class="form-label"><?= __("Your final Wavelog URL"); ?><i id="directory_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("This is the URL where you can access this Wavelog instance after the installer has run. If this does not display what you expect, you may need to check your web server configuration. This is the base_url in your config.php, which can be edited after the installation."); ?>"></i></label>
+												<pre class="alert bg-secondary" id="main-url"><?php echo $base_url; ?></pre>
+												<input type="hidden" id="directory" name="directory" value="<?php echo $directory; ?>" />
+												<input type="hidden" id="websiteurl" name="websiteurl" value="<?php echo $base_url; ?>" />
 											</div>
 											<div class="mb-3">
 												<label for="global_call_lookup" class="form-label"><?= __("Optional: Global Callbook Lookup"); ?><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("This configuration is optional. The callsign lookup will be available for all users of this installation. You can choose between QRZ.com and HamQTH. While HamQTH also works without username and password, you will need credentials for QRZ.com. To also get the Call Locator in QRZ.com you'll need an XML subscription. HamQTH does not always provide the locator information."); ?>"></i></label>
@@ -1219,9 +1209,6 @@ if (!file_exists('.lock')) {
 
 					// Exit Tab 3 - Configuration
 					if (nextTab.attr('id') == fourthTabId) {
-						if (!directory_check() || !websiteurl_check()) {
-							return;
-						}
 						if (!callbook_combination()) {
 							return;
 						}
@@ -1895,14 +1882,6 @@ if (!file_exists('.lock')) {
 					var checklist_configuration = true;
 
 					if ($('#callbook_password').hasClass('is-invalid')) {
-						checklist_configuration = false;
-					}
-
-					if ($('#directory').hasClass('is-invalid')) {
-						checklist_configuration = false;
-					}
-
-					if ($('#websiteurl').val() == '' || $('#websiteurl').hasClass('is-invalid')) {
 						checklist_configuration = false;
 					}
 

--- a/install/index.php
+++ b/install/index.php
@@ -13,7 +13,7 @@ require_once('includes/install_config/install_lib.php');
 $http_scheme = is_https() ? "https" : "http";
 
 $directory = ltrim(str_replace('/install', '', dirname($_SERVER['SCRIPT_NAME'])), '/');
-$base_url = $http_scheme . '://' . $_SERVER['HTTP_HOST'] . "/" . $directory . "/";
+$base_url = $http_scheme . '://' . $_SERVER['HTTP_HOST'] . ($directory !== '' ? '/' . $directory : '') . '/';
 
 if (!file_exists('.lock') && !file_exists('../application/config/config.php') && !file_exists('../application/config/docker/config.php')) {
 
@@ -349,8 +349,8 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 										<div class="col">
 											<p><?= __("Configure some basic parameters for your wavelog instance. You can change them later in 'application/config/config.php'"); ?></p>
 											<div class="mb-3">
-												<label for="directory" class="form-label"><?= __("Your final Wavelog URL"); ?><i id="directory_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("This is the URL where you can access this Wavelog instance after the installer has run. If this does not display what you expect, you may need to check your web server configuration. This is the base_url in your config.php, which can be edited after the installation."); ?>"></i></label>
-												<pre class="alert bg-secondary" id="main-url"><?php echo $base_url; ?></pre>
+												<label for="main_url" class="form-label"><?= __("Your final Wavelog URL"); ?><i id="main_url_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("This is the URL where you can access this Wavelog instance after the installer has run. If this does not display what you expect, you may need to check your web server configuration. This is the base_url in your config.php, which can be edited after the installation."); ?>"></i></label>
+												<pre class="alert bg-secondary" id="main_url"><?php echo $base_url; ?></pre>
 												<input type="hidden" id="directory" name="directory" value="<?php echo $directory; ?>" />
 												<input type="hidden" id="websiteurl" name="websiteurl" value="<?php echo $base_url; ?>" />
 											</div>
@@ -434,23 +434,23 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 											<div class="row">
 												<div class="col">
 													<div class="mb-3">
-														<label for="db_hostname" class="form-label required"><?= __("Hostname or IP"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" title="Directory Hint" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Usually 'localhost'.<br>Optional with '[host]:[port]'. Default port: 3306.<br>In a docker compose install type 'wavelog-db'."); ?>"></i>
+														<label for="db_hostname" class="form-label required"><?= __("Hostname or IP"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Usually 'localhost'.<br>Optional with '[host]:[port]'. Default port: 3306.<br>In a docker compose install type 'wavelog-db'."); ?>"></i>
 														<input type="text" id="db_hostname" placeholder="localhost" class="form-control" name="db_hostname" />
 													</div>
 												</div>
 												<div class="col">
 													<div class="mb-3">
-														<label for="db_name" class="form-label required"><?= __("Database Name"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" title="Directory Hint" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Name of the Database"); ?>"></i>
+														<label for="db_name" class="form-label required"><?= __("Database Name"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Name of the Database"); ?>"></i>
 														<input type="text" id="db_name" placeholder="wavelog" class="form-control" name="db_name" />
 													</div>
 												</div>
 											</div>
 											<div class="mb-3">
-												<label for="db_username" class="form-label required"><?= __("Username"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" title="Directory Hint" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Username of the Database User which has full access to the database."); ?>"></i>
+												<label for="db_username" class="form-label required"><?= __("Username"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Username of the Database User which has full access to the database."); ?>"></i>
 												<input type="text" id="db_username" placeholder="waveloguser" class="form-control" name="db_username" />
 											</div>
 											<div class="mb-3">
-												<label for="db_password" class="form-label"><?= __("Password"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" title="Directory Hint" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Password of the Database User"); ?>"></i>
+												<label for="db_password" class="form-label"><?= __("Password"); ?></label><i id="callbook_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("Password of the Database User"); ?>"></i>
 												<input type="password" id="db_password" placeholder="supersecretpassword" class="form-control" name="db_password" />
 											</div>
 											<div class="col">
@@ -1380,23 +1380,14 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 				 * Tab 3 - Configuration
 				 * 
 				 * 		Rules:
-				 * 		Website-URL and Directory have to be green. No checks needed 'Advanced Settings'.
+				 * 		No checks needed 'Advanced Settings'.
 				 * 
 				 * 		Callbook Password:
 				 * 			- do not allow specialchars defined in stringForbiddenChars() (hard)
 				 * 
-				 * 		Directory:
-				 * 			- no slash allowed (hard)
-				 * 
-				 * 		Website-URL:
-				 *			- can't be empty (hard)
-				 *			- has to have a trailing slash (hard)
-				 *			- have to start with http (hard)
 				 * 
 				 */
 
-				let directory = $('#directory');
-				let websiteurl = $('#websiteurl');
 				let callbook_type = $('#global_call_lookup');
 				let callbook_username = $('#callbook_username');
 				let callbook_password = $('#callbook_password');
@@ -1420,14 +1411,6 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 						$('#advancedSettingsModal').modal('show');
 					});
 
-					directory.on('change', function() {
-						directory_check();
-					});
-
-					websiteurl.on('change', function() {
-						websiteurl_check();
-					});
-
 					callbook_username.on('change', function() {
 						if (callbook_username.val() == '') {
 							callbook_username.removeClass('is-valid is-invalid');
@@ -1447,38 +1430,6 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 						stringForbiddenChars(callbook_password);
 					});
 				});
-
-				function directory_check() {
-					var check = true;
-
-					if (directory.val().startsWith('/') || directory.val().endsWith('/')) {
-						check = false;
-					}
-
-					input_is_valid(directory, check ? 'is-valid' : 'is-invalid');
-
-					return check;
-				}
-
-				function websiteurl_check() {
-					var check = true;
-
-					if (websiteurl.val() == '') {
-						check = false;
-					} else if (!websiteurl.val().endsWith('/')) {
-						check = false;
-					} else if (!websiteurl.val().startsWith('http')) {
-						check = false;
-					}
-
-					if (check) {
-						input_is_valid(websiteurl, 'is-valid');
-					} else {
-						input_is_valid(websiteurl, 'is-invalid');
-					}
-
-					return check;
-				}
 
 				function callbook_combination() {
 					let check = true;

--- a/install/index.php
+++ b/install/index.php
@@ -9,8 +9,13 @@ HB9HIL - First refactoring - January 2024
 DJ7NT - Docker Readiness - April 2024
 HB9HIL - Big UX and backend upgrade - July 2024
 */
+require_once('includes/install_config/install_lib.php');
+$http_scheme = is_https() ? "https" : "http";
 
-if (!file_exists('.lock')) {
+$directory = ltrim(str_replace('/install', '', dirname($_SERVER['SCRIPT_NAME'])), '/');
+$base_url = $http_scheme . '://' . $_SERVER['HTTP_HOST'] . "/" . $directory . "/";
+
+if (!file_exists('.lock') && !file_exists('../application/config/config.php') && !file_exists('../application/config/docker/config.php')) {
 
 	include 'includes/interface_assets/header.php';
 
@@ -344,10 +349,6 @@ if (!file_exists('.lock')) {
 										<div class="col">
 											<p><?= __("Configure some basic parameters for your wavelog instance. You can change them later in 'application/config/config.php'"); ?></p>
 											<div class="mb-3">
-												<?php 
-													$directory = ltrim(str_replace('/install', '', dirname($_SERVER['SCRIPT_NAME'])), '/');
-													$base_url = $http_scheme . '://' . $_SERVER['HTTP_HOST'] . "/" . $directory . "/";
-												?>
 												<label for="directory" class="form-label"><?= __("Your final Wavelog URL"); ?><i id="directory_tooltip" data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-question-circle text-muted ms-2" data-bs-custom-class="custom-tooltip" data-bs-html="true" data-bs-title="<?= __("This is the URL where you can access this Wavelog instance after the installer has run. If this does not display what you expect, you may need to check your web server configuration. This is the base_url in your config.php, which can be edited after the installation."); ?>"></i></label>
 												<pre class="alert bg-secondary" id="main-url"><?php echo $base_url; ?></pre>
 												<input type="hidden" id="directory" name="directory" value="<?php echo $directory; ?>" />
@@ -1996,8 +1997,8 @@ if (!file_exists('.lock')) {
 	<?php } ?>
 
 <?php } else {
-
-	header("Location: $websiteurl");
+	header('Location: '.$base_url, true, 301);
+	die();
 } ?>
 
 </html>

--- a/install/run.php
+++ b/install/run.php
@@ -39,7 +39,7 @@
                     <p><?= sprintf(__("All install steps went through. Redirect to user login in %s seconds..."), "<span id='countdown'>4</span>"); ?></p>
                 </div>
                 <div class="mb-3" id="success_button" style="display: none;">
-                    <a class="btn btn-primary" href="<?php echo $_POST['websiteurl'] ?? $websiteurl; ?>index.php/user/login/1"><?= __("Done. Go to the user login ->"); ?></a>
+                    <a class="btn btn-primary" href="<?php echo $_POST['websiteurl']; ?>index.php/user/login/1"><?= __("Done. Go to the user login ->"); ?></a>
                 </div>
                 <div id="error_message"></div>
                 <div class="container mt-5">
@@ -268,7 +268,7 @@
 
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: `${window.location.origin}/index.php/migrate`,
+                url: "<?php echo $_POST['websiteurl']; ?>" + "index.php/migrate",
                 dataType: 'json',
                 success: async function(response) {
                     if (response.status == 'success') {
@@ -297,7 +297,7 @@
 
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: `${window.location.origin}/index.php/update/dxcc`,
+                url: "<?php echo $_POST['websiteurl']; ?>" + "index.php/update/dxcc",
                 success: async function(response) {
                     if (response == 'success') {
                         running(field, false);


### PR DESCRIPTION
Replaces #1533 

Thanks @AndreasK79 for your debugging. But it seems that get rid of the configurable directory in the installer is the more safe way since you can change that stuff afterwards in the config.php. The installer needs to be bullet proof in the context of URL and directory. 

Please also test this stuff against WAMP / XAMPP

I tested docker and it works

@int2001 I also adressed the `.lock` issue in this PR which was already mentioned. The check is now extended to also check for config files and if there is something existing the visitor gets redirected (which was also broken) :D