### PR TITLE
[Advanced Logbook] Query fix for getting band/mode/sat to the dropdowns

### DIFF
--- a/application/controllers/Continents.php
+++ b/application/controllers/Continents.php
@@ -7,9 +7,10 @@ class Continents extends CI_Controller {
         $this->load->model('user_model');
         $this->load->model('bands');
         $this->load->model('logbookadvanced_model');
+		$this->load->model('gridmap_model');
 
         $data['bands'] = $this->bands->get_worked_bands();
-		$data['modes'] = $this->logbookadvanced_model->get_modes();
+		$data['modes'] = $this->gridmap_model->get_worked_modes();
 
         if(!$this->user_model->authorize($this->config->item('auth_mode'))) {
             if($this->user_model->validate_session()) {
@@ -18,7 +19,7 @@ class Continents extends CI_Controller {
             } else {
                 redirect('user/login');
             }
-        }	
+        }
 		// Render User Interface
 
 		// Set Page Title
@@ -29,7 +30,7 @@ class Continents extends CI_Controller {
 		$this->load->view('continents/index');
 		$this->load->view('interface_assets/footer');
 	}
-	
+
 
 	public function get_continents() {
 

--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -53,14 +53,14 @@ class Logbookadvanced extends CI_Controller {
 		$pageData['modes'] = $this->logbookadvanced_model->get_modes();
 		$pageData['dxccarray'] = $this->logbook_model->fetchDxcc();
 		$pageData['iotaarray'] = $this->logbook_model->fetchIota();
-		$pageData['sats'] = $this->bands->get_worked_sats();
+		$pageData['sats'] = $this->logbookadvanced_model->get_worked_sats();
 		$pageData['orbits'] = $this->bands->get_worked_orbits();
 		$pageData['station_profile'] = $this->stations->all_of_user();
 		$pageData['active_station_info'] = $station_profile->row();
 		$pageData['homegrid'] = explode(',', $this->stations->find_gridsquare());
 		$pageData['active_station_id'] = $active_station_id;
 
-		$pageData['bands'] = $this->bands->get_worked_bands();
+		$pageData['bands'] = $this->logbookadvanced_model->get_worked_bands();
 
 		// Get Date format
 		if($this->session->userdata('user_date_format')) {

--- a/application/views/continents/index.php
+++ b/application/views/continents/index.php
@@ -40,7 +40,7 @@
                         <select id="mode" name="mode" class="form-select form-select-sm">
                             <option value=""><?= __("All"); ?></option>
                             <?php foreach($modes as $modeId => $mode){ ?>
-								<option value="<?php echo htmlspecialchars($mode);?>"><?php echo htmlspecialchars($mode);?></option>
+								<option value="<?php echo htmlspecialchars(strtoupper($mode));?>"><?php echo htmlspecialchars(strtoupper($mode));?></option>
 							<?php } ?>
                         </select>
                     </div>

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -813,9 +813,18 @@ $(document).ready(function () {
 						action: function (dialogItself) {
 							$('#optionButton').prop("disabled", false);
 							$('#closeButton').prop("disabled", true);
-							saveOptions();
-							dialogItself.close();
-							location.reload();
+							saveOptions().then(() => {
+								dialogItself.close();
+								location.reload();
+							}).catch(error => {
+								BootstrapDialog.alert({
+									title: 'Error',
+									message: 'An error occurred while saving options: ' + error,
+									type: BootstrapDialog.TYPE_DANGER, // Sets the dialog style to "danger"
+									closable: true,
+									buttonLabel: 'Close'
+								});
+							});
 						}
 					},
 					{
@@ -1263,61 +1272,65 @@ function printlabel() {
 function saveOptions() {
 	$('#saveButton').prop("disabled", true);
 	$('#closeButton').prop("disabled", true);
-	$.ajax({
-		url: base_url + 'index.php/logbookadvanced/setUserOptions',
-		type: 'post',
-		data: {
-			datetime: $('input[name="datetime"]').is(':checked') ? true : false,
-			de: $('input[name="de"]').is(':checked') ? true : false,
-			dx: $('input[name="dx"]').is(':checked') ? true : false,
-			mode: $('input[name="mode"]').is(':checked') ? true : false,
-			rsts: $('input[name="rsts"]').is(':checked') ? true : false,
-			rstr: $('input[name="rstr"]').is(':checked') ? true : false,
-			band: $('input[name="band"]').is(':checked') ? true : false,
-			myrefs: $('input[name="myrefs"]').is(':checked') ? true : false,
-			name: $('input[name="name"]').is(':checked') ? true : false,
-			qslvia: $('input[name="qslvia"]').is(':checked') ? true : false,
-			qsl: $('input[name="qsl"]').is(':checked') ? true : false,
-			clublog: $('input[name="clublog"]').is(':checked') ? true : false,
-			lotw: $('input[name="lotw"]').is(':checked') ? true : false,
-			eqsl: $('input[name="eqsl"]').is(':checked') ? true : false,
-			qslmsgs: $('input[name="qslmsgs"]').is(':checked') ? true : false,
-			qslmsgr: $('input[name="qslmsgr"]').is(':checked') ? true : false,
-			dxcc: $('input[name="dxcc"]').is(':checked') ? true : false,
-			state: $('input[name="state"]').is(':checked') ? true : false,
-			cqzone: $('input[name="cqzone"]').is(':checked') ? true : false,
-			ituzone: $('input[name="ituzone"]').is(':checked') ? true : false,
-			iota: $('input[name="iota"]').is(':checked') ? true : false,
-			pota: $('input[name="pota"]').is(':checked') ? true : false,
-			operator: $('input[name="operator"]').is(':checked') ? true : false,
-			comment: $('input[name="comment"]').is(':checked') ? true : false,
-			propagation: $('input[name="propagation"]').is(':checked') ? true : false,
-			contest: $('input[name="contest"]').is(':checked') ? true : false,
-			gridsquare: $('input[name="gridsquare"]').is(':checked') ? true : false,
-			sota: $('input[name="sota"]').is(':checked') ? true : false,
-			dok: $('input[name="dok"]').is(':checked') ? true : false,
-			wwff: $('input[name="wwff"]').is(':checked') ? true : false,
-			sig: $('input[name="sig"]').is(':checked') ? true : false,
-			region: $('input[name="region"]').is(':checked') ? true : false,
-			continent: $('input[name="continent"]').is(':checked') ? true : false,
-			distance: $('input[name="distance"]').is(':checked') ? true : false,
-			antennaazimuth: $('input[name="antennaazimuth"]').is(':checked') ? true : false,
-			antennaelevation: $('input[name="antennaelevation"]').is(':checked') ? true : false,
-			qrz: $('input[name="qrz"]').is(':checked') ? true : false,
-			profilename: $('input[name="profilename"]').is(':checked') ? true : false,
-			stationpower: $('input[name="stationpower"]').is(':checked') ? true : false,
-			gridsquare_layer: $('input[name="gridsquareoverlay"]').is(':checked') ? true : false,
-			path_lines: $('input[name="pathlines"]').is(':checked') ? true : false,
-			cqzone_layer: $('input[name="cqzones"]').is(':checked') ? true : false,
-			ituzone_layer: $('input[name="ituzones"]').is(':checked') ? true : false,
-			nightshadow_layer: $('input[name="nightshadow"]').is(':checked') ? true : false,
-		},
-		success: function(data) {
-			$('#saveButton').prop("disabled", false);
-			$('#closeButton').prop("disabled", false);
-		},
-		error: function() {
-			$('#saveButton').prop("disabled", false);
-		},
+	return new Promise((resolve, reject) => {
+		$.ajax({
+			url: base_url + 'index.php/logbookadvanced/setUserOptions',
+			type: 'post',
+			data: {
+				datetime: $('input[name="datetime"]').is(':checked') ? true : false,
+				de: $('input[name="de"]').is(':checked') ? true : false,
+				dx: $('input[name="dx"]').is(':checked') ? true : false,
+				mode: $('input[name="mode"]').is(':checked') ? true : false,
+				rsts: $('input[name="rsts"]').is(':checked') ? true : false,
+				rstr: $('input[name="rstr"]').is(':checked') ? true : false,
+				band: $('input[name="band"]').is(':checked') ? true : false,
+				myrefs: $('input[name="myrefs"]').is(':checked') ? true : false,
+				name: $('input[name="name"]').is(':checked') ? true : false,
+				qslvia: $('input[name="qslvia"]').is(':checked') ? true : false,
+				qsl: $('input[name="qsl"]').is(':checked') ? true : false,
+				clublog: $('input[name="clublog"]').is(':checked') ? true : false,
+				lotw: $('input[name="lotw"]').is(':checked') ? true : false,
+				eqsl: $('input[name="eqsl"]').is(':checked') ? true : false,
+				qslmsgs: $('input[name="qslmsgs"]').is(':checked') ? true : false,
+				qslmsgr: $('input[name="qslmsgr"]').is(':checked') ? true : false,
+				dxcc: $('input[name="dxcc"]').is(':checked') ? true : false,
+				state: $('input[name="state"]').is(':checked') ? true : false,
+				cqzone: $('input[name="cqzone"]').is(':checked') ? true : false,
+				ituzone: $('input[name="ituzone"]').is(':checked') ? true : false,
+				iota: $('input[name="iota"]').is(':checked') ? true : false,
+				pota: $('input[name="pota"]').is(':checked') ? true : false,
+				operator: $('input[name="operator"]').is(':checked') ? true : false,
+				comment: $('input[name="comment"]').is(':checked') ? true : false,
+				propagation: $('input[name="propagation"]').is(':checked') ? true : false,
+				contest: $('input[name="contest"]').is(':checked') ? true : false,
+				gridsquare: $('input[name="gridsquare"]').is(':checked') ? true : false,
+				sota: $('input[name="sota"]').is(':checked') ? true : false,
+				dok: $('input[name="dok"]').is(':checked') ? true : false,
+				wwff: $('input[name="wwff"]').is(':checked') ? true : false,
+				sig: $('input[name="sig"]').is(':checked') ? true : false,
+				region: $('input[name="region"]').is(':checked') ? true : false,
+				continent: $('input[name="continent"]').is(':checked') ? true : false,
+				distance: $('input[name="distance"]').is(':checked') ? true : false,
+				antennaazimuth: $('input[name="antennaazimuth"]').is(':checked') ? true : false,
+				antennaelevation: $('input[name="antennaelevation"]').is(':checked') ? true : false,
+				qrz: $('input[name="qrz"]').is(':checked') ? true : false,
+				profilename: $('input[name="profilename"]').is(':checked') ? true : false,
+				stationpower: $('input[name="stationpower"]').is(':checked') ? true : false,
+				gridsquare_layer: $('input[name="gridsquareoverlay"]').is(':checked') ? true : false,
+				path_lines: $('input[name="pathlines"]').is(':checked') ? true : false,
+				cqzone_layer: $('input[name="cqzones"]').is(':checked') ? true : false,
+				ituzone_layer: $('input[name="ituzones"]').is(':checked') ? true : false,
+				nightshadow_layer: $('input[name="nightshadow"]').is(':checked') ? true : false,
+			},
+			success: function(data) {
+				$('#saveButton').prop("disabled", false);
+				$('#closeButton').prop("disabled", false);
+				resolve(data);
+			},
+			error: function(error) {
+				$('#saveButton').prop("disabled", false);
+				reject(error);
+			},
+		});
 	});
 }


### PR DESCRIPTION
This PR includes fixes for the following:
1. If your logbook did not contain any locations, BAND/MODE/SAT dropdown would be blank.
2. Since the advanced logbook can filter on locations, it could happen that you had a mode/band/sat in a location that would not be fetched, since the fetch only fetched in the active logbook. Queries now fetches from locations based on user_id instead.
3. Since continents stats used get_modes, I had to swap out the function from another place.
4. A few users reported that column/map options would not save. Probably because the nature of JS. The location.reload would trigger before the ajax call was finished. Reworked the JS to close the dialog and refresh the page once the ajax call is finished.