### PR TITLE
Add QSOs per operator to statistics view

### DIFF
--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -110,6 +110,35 @@ class Statistics extends CI_Controller {
 		echo json_encode($bandstats);
 	}
 
+	public function get_operators() {
+
+		//load logbook model
+		$this->load->model('logbook_model');
+
+		//define stats array
+		$operatorstats = array();
+
+		//get year if present
+		$yr = xss_clean($this->input->post('yr')) ?? 'All';
+		
+		//load stats
+		$total_operators = $this->logbook_model->total_operators($yr);
+
+		$i = 0;
+
+		//convert to final form
+		if ($total_operators) {
+			foreach($total_operators->result() as $qso_numbers) {
+				$operatorstats[$i]['operator'] = $qso_numbers->operator;
+				$operatorstats[$i++]['count'] = $qso_numbers->count;
+			}
+		}
+
+		//return as json
+		header('Content-Type: application/json');
+		echo json_encode($operatorstats);
+	}
+
 	public function get_sat() {
 		$this->load->model('logbook_model');
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3190,7 +3190,7 @@ class Logbook_model extends CI_Model {
 		}
 
 		//get statistics from database
-		$this->db->select('IFNULL(IF(COL_OPERATOR = "", TABLE_HRD_CONTACTS_V01.COL_STATION_CALLSIGN, COL_OPERATOR), TABLE_HRD_CONTACTS_V01.COL_STATION_CALLSIGN) AS operator, count( * ) AS count', FALSE);
+		$this->db->select('IFNULL(IF(COL_OPERATOR = "", COL_STATION_CALLSIGN, COL_OPERATOR), COL_STATION_CALLSIGN) AS operator, count( * ) AS count', FALSE);
 		$this->db->where_in('station_id', $logbooks_locations_array);
 		$this->where_year($yr);
 		$this->db->group_by('operator');

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3178,6 +3178,30 @@ class Logbook_model extends CI_Model {
 		return $query;
 	}
 
+	/* Return total number of QSOs per operator */
+	function total_operators($yr = 'All') {
+		
+		//Load logbook model and get station locations
+		$this->load->model('logbooks_model');
+		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+		if (!$logbooks_locations_array) {
+			return null;
+		}
+
+		//get statistics from database
+		$this->db->select('IFNULL(IF(COL_OPERATOR = "", TABLE_HRD_CONTACTS_V01.COL_STATION_CALLSIGN, COL_OPERATOR), TABLE_HRD_CONTACTS_V01.COL_STATION_CALLSIGN) AS operator, count( * ) AS count', FALSE);
+		$this->db->where_in('station_id', $logbooks_locations_array);
+		$this->where_year($yr);
+		$this->db->group_by('operator');
+		$this->db->order_by('count', 'DESC');
+
+		$query = $this->db->get($this->config->item('table_name'));
+
+		//return result
+		return $query;
+	}
+
 	function get_QSLStats($StationLocationsArray = null) {
 
 		if ($StationLocationsArray == null) {

--- a/application/views/statistics/index.php
+++ b/application/views/statistics/index.php
@@ -14,11 +14,13 @@
 		var lang_statistics_years = "<?= __("Years")?>";
 		var lang_statistics_modes = "<?= __("Mode")?>";
 		var lang_statistics_bands = "<?= __("Bands")?>";
+		var lang_statistics_operators = "<?= __("Operators")?>";
 		var lang_statistics_number_of_qso_worked_each_year = "<?= __("Number of QSOs worked each year")?>";
 		var lang_statistics_year = "<?= __("Year")?>";
 		var lang_statistics_number_of_qso_worked = "<?= __("# of QSO's worked")?>";
 		var lang_gen_hamradio_mode = "<?= __("Mode")?>";
 		var lang_gen_hamradio_band = "<?= __("Band")?>";
+		var lang_gen_hamradio_operator = "<?= __("Operator")?>";
 		var lang_gen_satellite = "<?= __("Satellite")?>";
 </script>
 
@@ -68,6 +70,9 @@
 							<a class="nav-link" id="qso-tab" data-bs-toggle="tab" href="#qsotab" role="tab" aria-controls="bandtab" aria-selected="false"><?= __("QSOs"); ?></a>
 						</li>
 						<li class="nav-item">
+							<a class="nav-link" id="operators-tab" data-bs-toggle="tab" href="#operatorstab" role="tab" aria-controls="operatorstab" aria-selected="false"><?= __("Operators"); ?></a>
+						</li>
+						<li class="nav-item">
 							<a class="nav-link" id="unique-tab" data-bs-toggle="tab" href="#uniquetab" role="tab" aria-controls="uniquetab" aria-selected="false"><?= __("Unique callsigns"); ?></a>
 						</li>
 					</ul>
@@ -86,6 +91,10 @@
 					</div>
 					<div class="tab-pane fade" id="qsotab" role="tabpanel" aria-labelledby="qso-tab">
 							<div class="qsos">
+							</div>
+					</div>
+					<div class="tab-pane fade" id="operatorstab" role="tabpanel" aria-labelledby="operators-tab">
+							<div class="operators">
 							</div>
 					</div>
 					<div class="tab-pane fade" id="uniquetab" role="tabpanel" aria-labelledby="unique-tab">

--- a/assets/js/sections/statistics.js
+++ b/assets/js/sections/statistics.js
@@ -46,6 +46,12 @@ $("a[href='#qsotab']").on('shown.bs.tab', function(e) {
 	$("#yr").show();
 });
 
+$("a[href='#operatorstab']").on('shown.bs.tab', function(e) {
+	totalOperatorQsos();
+	activeTab='totalOperatorQsos()'
+	$("#yr").show();
+});
+
 $("a[href='#satqsostab']").on('shown.bs.tab', function(e) {
 	totalSatQsosC();
 	activeTab='totalSatQsosC()'
@@ -494,6 +500,149 @@ function totalBandQsos() {
 					responsive: false,
 					ordering: false,
 					"scrollY": "330px",
+					"scrollCollapse": true,
+					"paging": false,
+					"scrollX": true,
+					"language": {
+						url: getDataTablesLanguageUrl(),
+					},
+					bFilter: false,
+					bInfo: false,
+				});
+
+				// using this to change color of csv-button if dark mode is chosen
+				var background = $('body').css("background-color");
+
+				if (background != ('rgb(255, 255, 255)')) {
+					$(".buttons-csv").css("color", "white");
+				}
+			}
+		}
+	});
+}
+
+function totalOperatorQsos() {
+	// using this to change color of legend and label according to background color
+	var color = ifDarkModeThemeReturn('white', 'grey');
+
+	$.ajax({
+		url: base_url+'index.php/statistics/get_operators',
+		type: 'post',
+		data: { yr: $("#yr option:selected").val() },
+		success: function (data) {
+			if (data.length > 0) {
+				$(".operators").html('');
+				$(".operators").append('<br /><div style="display: flex;" id="operatorContainer"><h2>' + lang_statistics_operators + '</h2><div style="flex: 1;"><canvas id="operatorChart" width="500" height="500"></canvas></div><div style="flex: 1;" id="operatorTable"></div></div><br />');
+
+				// appending table to hold the data
+				$("#operatorTable").append('<table style="width:100%" class="operatorTable table table-sm table-bordered table-hover table-striped table-condensed text-center"><thead>' +
+					'<tr>' +
+					'<td>#</td>' +
+					'<td>' + lang_gen_hamradio_operator + '</td>' +
+					'<td>' + lang_statistics_number_of_qso_worked + ' </td>' +
+					'</tr>' +
+					'</thead>' +
+					'<tbody></tbody></table>');
+				var labels = [];
+				var dataQso = [];
+				var totalQso = Number(0);
+
+				var $myTable = $('.operatorTable');
+				var i = 1;
+
+				// building the rows in the table
+				var rowElements = data.map(function (row) {
+
+					var $row = $('<tr></tr>');
+
+					var $iterator = $('<td></td>').html(i++);
+					var $type = $('<td></td>').html(row.operator);
+					var $content = $('<td></td>').html(row.count);
+
+					$row.append($iterator, $type, $content);
+
+					return $row;
+				});
+
+				// finally inserting the rows
+				$myTable.append(rowElements);
+
+				$.each(data, function () {
+					labels.push(this.operator);
+					dataQso.push(this.count);
+					totalQso = Number(totalQso) + Number(this.count);
+				});
+
+				const COLORS = ["#3366cc", "#dc3912", "#ff9900", "#109618", "#990099", "#0099c6", "#dd4477", "#66aa00", "#b82e2e", "#316395", "#994499"]
+				var ctx = document.getElementById("operatorChart").getContext('2d');
+				var myChart = new Chart(ctx, {
+					plugins: [ChartPieChartOutlabels],
+					type: 'doughnut',
+					data: {
+						labels: labels,
+						datasets: [{
+							label: 'Number of QSO\'s worked',
+							data: dataQso,
+							borderColor: 'rgba(54, 162, 235, 1)',
+							backgroundColor: ["#3366cc", "#dc3912", "#ff9900", "#109618", "#990099", "#0099c6", "#dd4477", "#66aa00", "#b82e2e", "#316395", "#994499"],
+							borderWidth: 1,
+						}]
+					},
+					options: {
+						layout: {
+							padding: 100
+						},
+						title: {
+							fontColor: color,
+							fullSize: true,
+						},
+						responsive: true,
+						maintainAspectRatio: true,
+						plugins: {
+							legend: {
+								display: false,
+								labels: {
+									boxWidth: 15,
+									color: color,
+									font: {
+										size: 14,
+									}
+								},
+								position: 'right',
+								align: "middle"
+							},
+							outlabels: {
+								display: function(context) { // Hide labels with low percentage
+									return ((context.dataset.data[context.dataIndex] / totalQso * 100) > 1)
+								},
+								backgroundColor: COLORS,
+								borderColor: COLORS,
+								borderRadius: 2, // Border radius of Label
+								borderWidth: 2, // Thickness of border
+								color: 'white',
+								stretch: 10,
+								padding: 0,
+								font: {
+									resizable: true,
+									minSize: 12,
+									maxSize: 25,
+									family: Chart.defaults.font.family,
+									size: Chart.defaults.font.size,
+									style: Chart.defaults.font.style,
+									lineHeight: Chart.defaults.font.lineHeight,
+								},
+								zoomOutPercentage: 100,
+								textAlign: 'start',
+								backgroundColor: COLORS,
+							}
+						}
+					}
+				});
+
+				$('.operatorTable').DataTable({
+					responsive: false,
+					ordering: false,
+					"scrollY": "400px",
 					"scrollCollapse": true,
 					"paging": false,
 					"scrollX": true,


### PR DESCRIPTION
In light of the addition of club stations to wavelog and my own experiences running event callsigns, a piece of data that is highly requested most of the time is "QSOs per Operator".

I added this stat with supporting visualization to the statistics view.

There are 2 decisions I made which maybe are debatable:

1. Display this stat even for "non-clubstation" users
Of course, this stat is only hugely interesting for club stations with multiple operators. But there are some edge cases like training calls where the callsign itself does not use the club station feature (because all operators must be supervised by the callsign holder so they may not have their own login), but because of the trainer/trainee setup, there are still different operators for each QSO.

2. Handling of empty COL_OPERATOR column
I decided to set an empty or NULL operator column to the corresponding station callsign of the QSO, mostly because an empty row in the data and on the tooltips of the chart looked "wrong". Furthermore, on callsigns which are strictly personal calls and do not log operator, this strat will display the station callsign and thus, the reality of the operation.

How to test: Have QSOs in your data with at least 2 different operators (or change at least one QSO to have a different operator call to the station callsign), then click on the operators tab in the statistics view