### PR TITLE
Handle 2-char grids (prevent filling the error log)

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -313,6 +313,7 @@ function qra2latlong($strQRA) {
 
 	if ((strlen($strQRA) % 2 == 0) && (strlen($strQRA) <= 10)) {	// Check if QRA is EVEN (the % 2 does that) and smaller/equal 8
 		$strQRA = strtoupper($strQRA);
+		if (strlen($strQRA) == 2)  $strQRA .= "55";	// Only 2 Chars? Fill with center "55"
 		if (strlen($strQRA) == 4)  $strQRA .= "LL";	// Only 4 Chars? Fill with center "LL" as only A-R allowed
 		if (strlen($strQRA) == 6)  $strQRA .= "55";	// Only 6 Chars? Fill with center "55"
 		if (strlen($strQRA) == 8)  $strQRA .= "LL";	// Only 8 Chars? Fill with center "LL" as only A-R allowed


### PR DESCRIPTION
QSOs with only 2 chars as grid fill the error log:

![image](https://github.com/user-attachments/assets/8e6372e5-132c-4d7e-8584-48cec3d9b08b)

This fixes by filling the 3rd and 4th position with 55 (center of grid).