### PR TITLE
Add a link to VUCC modal for worked grids

### DIFF
--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -139,7 +139,7 @@ function loadActivationsTable(rows, show_workable_only) {
 		for (var j=0; j < activation.grids_wkd.length; j++) {
 			if (!grids.some(str => str.includes(activation.grids[j].substring(0, 4)))) {
 				if (activation.grids_wkd[j] == 1) {
-					grids.push("<span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-success\">"+activation.grids[j].substring(0, 4)+"</span>")
+					grids.push("<a href=\"javascript:displayContacts('"+activation.grids[j].substring(0, 4)+"','SAT','All','All','All','VUCC','');\"><span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-success\">"+activation.grids[j].substring(0, 4)+"</span></a>")
 				} else {
 					grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+activation.grids[j].substring(0, 4)+"</span>")
 				}


### PR DESCRIPTION
This adds a link to the VUCC popup for worked grids on the hams.at page.