### PR TITLE
Take Lat/Long from exceptions if exceptions are taken

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4822,7 +4822,7 @@ class Logbook_model extends CI_Model {
 
 		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$/';
 
-		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`,`cont`')
+		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`,`cont`,`long`,`lat`')
 			->where('`call`', $call)
 			->where('(start <= ', $date)
 			->or_where('start is null)', NULL, false)


### PR DESCRIPTION
Bug: If a DXCC was derivated by its exception, lat/long were empty.
Result was: Wrong display for last-qsos / qrz-lookup to the right of QSO-Form

this one fixes it.

testcall: JD1/JG8NQJ

