### PR TITLE
As shortcut replace dot by /P on callsign input

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -66,6 +66,7 @@ $(document).on("keydown", function (e) {
 $('#callsign').on('input', function () {
 	$(this).val($(this).val().replace(/\s/g, ''));
 	$(this).val($(this).val().replace(/0/g, 'Ø'));
+	$(this).val($(this).val().replace(/\./g, '/P'));
 });
 
 $('#locator').on('input', function () {


### PR DESCRIPTION
Noted by DJ9BX some loggers replace a dot by "/P" suffix on callsign input. This implements this behaviour in Wavelog for QSO callsign input.