### PR TITLE
Add  previous contacts count setting for QSO Page

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -48,6 +48,9 @@ define('OK',									'OK');
 define('DASHBOARD_DEFAULT_QSOS_COUNT',          20);
 define('DASHBOARD_QSOS_COUNT_LIMIT',            50);
 
+define('QSO_PAGE_DEFAULT_QSOS_COUNT',           5);
+define('QSO_PAGE_QSOS_COUNT_LIMIT',             20);
+
 
 /* End of file constants.php */
 /* Location: ./application/config/constants.php */

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -2,14 +2,14 @@
 
 class QSO extends CI_Controller {
 
-	const LAST_QSOS_COUNT = 5; // max number of most recent qsos to be displayed on a qso page
-
 	function __construct()
 	{
 		parent::__construct();
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
-		$this->session->set_userdata('last_qsos_count', self::LAST_QSOS_COUNT);
+        
+        $last_qso_count = empty($this->session->userdata('qso_page_last_qso_count')) ? QSO_PAGE_DEFAULT_QSOS_COUNT : $this->session->userdata('qso_page_last_qso_count');
+		$this->session->set_userdata('qso_page_last_qso_count', $last_qso_count);
 	}
 
 	public function index() {
@@ -37,7 +37,7 @@ class QSO extends CI_Controller {
 		$data['stations'] = $this->stations->all_of_user();
 		$data['radios'] = $this->cat->radios(true);
 		$data['radio_last_updated'] = $this->cat->last_updated()->row();
-		$data['query'] = $this->logbook_model->last_custom($this->session->userdata('last_qsos_count'));
+		$data['query'] = $this->logbook_model->last_custom($this->session->userdata('qso_page_last_qso_count'));
 		$data['dxcc'] = $this->logbook_model->fetchDxcc();
 		$data['iota'] = $this->logbook_model->fetchIota();
 		$data['modes'] = $this->modes->active();
@@ -87,7 +87,7 @@ class QSO extends CI_Controller {
 			$data['user_dok_to_qso_tab'] = 0;
 		}
 
-		$data['qso_count'] = $this->session->userdata('last_qsos_count');
+		$data['qso_count'] = $this->session->userdata('qso_page_last_qso_count');
 
 		$this->load->library('form_validation');
 
@@ -606,7 +606,7 @@ class QSO extends CI_Controller {
       $this->load->model('logbook_model');
       session_write_close();
 
-      $data['query'] = $this->logbook_model->last_custom($this->session->userdata('last_qsos_count'));
+      $data['query'] = $this->logbook_model->last_custom($this->session->userdata('qso_page_last_qso_count'));
 
       // Load view
       $this->load->view('qso/components/previous_contacts', $data);

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -181,6 +181,10 @@ class User extends CI_Controller {
 		$data['dashboard_last_qso_count_limit'] = DASHBOARD_QSOS_COUNT_LIMIT;
 		$data['user_dashboard_last_qso_count'] = DASHBOARD_DEFAULT_QSOS_COUNT;
 
+		// Values for the "QSO page last QSO count" selectbox
+		$data['qso_page_last_qso_count_limit'] = QSO_PAGE_QSOS_COUNT_LIMIT;
+		$data['user_qso_page_last_qso_count'] = QSO_PAGE_DEFAULT_QSOS_COUNT;
+
 		if ($this->form_validation->run() == FALSE) {
 			$data['page_title'] = __("Add User");
 			$data['measurement_base'] = $this->config->item('measurement_base');
@@ -377,6 +381,9 @@ class User extends CI_Controller {
 
 		// Max value to be present in the "dashboard last QSO count" selectbox
 		$data['dashboard_last_qso_count_limit'] = DASHBOARD_QSOS_COUNT_LIMIT;
+
+		// Max value to be present in the "QSO page last QSO count" selectbox
+		$data['qso_page_last_qso_count_limit'] = QSO_PAGE_QSOS_COUNT_LIMIT;
 
 		$data['page_title'] = __("Edit User");
 
@@ -758,6 +765,7 @@ class User extends CI_Controller {
 			$data['user_locations_quickswitch'] = ($this->user_options_model->get_options('header_menu', array('option_name'=>'locations_quickswitch'), $this->uri->segment(3))->row()->option_value ?? 'false');
 			$data['user_utc_headermenu'] = ($this->user_options_model->get_options('header_menu', array('option_name'=>'utc_headermenu'), $this->uri->segment(3))->row()->option_value ?? 'false');
 			$data['user_dashboard_last_qso_count'] = ($this->user_options_model->get_options('dashboard', array('option_name'=>'last_qso_count', 'option_key' => 'count'), $this->uri->segment(3))->row()->option_value ?? DASHBOARD_DEFAULT_QSOS_COUNT);
+			$data['user_qso_page_last_qso_count'] = ($this->user_options_model->get_options('qso_tab', array('option_name'=>'last_qso_count', 'option_key' => 'count'), $this->uri->segment(3))->row()->option_value ?? QSO_PAGE_DEFAULT_QSOS_COUNT);
 
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('user/edit', $data);
@@ -855,6 +863,8 @@ class User extends CI_Controller {
 			$data['user_hamsat_key'] = $this->input->post('user_hamsat_key');
 			$data['user_hamsat_workable_only'] = $this->input->post('user_hamsat_workable_only');
 			$data['user_dashboard_last_qso_count'] = $this->input->post('user_dashboard_last_qso_count', true);
+			$data['user_qso_page_last_qso_count'] = $this->input->post('user_qso_page_last_qso_count', true);
+
 			$this->load->view('user/edit');
 			$this->load->view('interface_assets/footer');
 		}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -325,9 +325,11 @@ class User_Model extends CI_Model {
 					'winkey' => xss_clean($fields['user_winkey']),
 				);
 
-				// Hard limit safety check for last (recent) QSO count setting
+				// Hard limit safety check for last (recent) QSO count settings
 				$dashboard_last_qso_count = xss_clean($fields['user_dashboard_last_qso_count']);
 				$dashboard_last_qso_count = $dashboard_last_qso_count > DASHBOARD_QSOS_COUNT_LIMIT ? DASHBOARD_QSOS_COUNT_LIMIT : $dashboard_last_qso_count;
+				$qso_page_last_qso_count = xss_clean($fields['user_qso_page_last_qso_count']);
+				$qso_page_last_qso_count = $qso_page_last_qso_count > QSO_PAGE_QSOS_COUNT_LIMIT ? QSO_PAGE_QSOS_COUNT_LIMIT : $qso_page_last_qso_count;
 
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','api','".xss_clean($fields['user_hamsat_key'])."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'hamsat','hamsat_key','workable','".xss_clean($fields['user_hamsat_workable_only'])."');");
@@ -338,7 +340,9 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','sig','show',".(xss_clean($fields['user_sig_to_qso_tab'] ?? 'off') == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','dok','show',".(xss_clean($fields['user_dok_to_qso_tab'] ?? 'off') == "on" ? 1 : 0).");");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'dashboard','last_qso_count','count','".$dashboard_last_qso_count."');");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','last_qso_count','count','".$qso_page_last_qso_count."');");
 				$this->session->set_userdata('dashboard_last_qso_count', $dashboard_last_qso_count);
+				$this->session->set_userdata('qso_page_last_qso_count', $qso_page_last_qso_count);				
 
 				// Check to see if the user is allowed to change user levels
 				if($this->session->userdata('user_type') == 99) {
@@ -523,6 +527,7 @@ class User_Model extends CI_Model {
 			'impersonate' => $this->session->userdata('impersonate') ?? false,
 			'clubstation' => $u->row()->clubstation,
 			'dashboard_last_qso_count' => ($this->session->userdata('dashboard_last_qso_count') ?? '') == '' ? ($this->user_options_model->get_options('dashboard', array('option_name' => 'last_qso_count', 'option_key' => 'count'))->row()->option_value ?? '') : $this->session->userdata('dashboard_last_qso_count'),
+			'qso_page_last_qso_count' => ($this->session->userdata('qso_page_last_qso_count') ?? '') == '' ? ($this->user_options_model->get_options('qso_tab', array('option_name' => 'last_qso_count', 'option_key' => 'count'))->row()->option_value ?? '') : $this->session->userdata('qso_page_last_qso_count'),
 			'source_uid' => $this->session->userdata('source_uid') ?? ''
 		);
 

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -63,7 +63,7 @@
                 	$profile_info = $this->stations->profile($actstation)->row();
                 	echo "var activeStationTXPower = '".xss_clean($profile_info->station_power ?? 0)."';\n";
                 	echo "var activeStationOP = '".xss_clean($this->session->userdata('operator_callsign'))."';\n";
-                	echo "var last_qsos_count = ".$this->session->userdata('last_qsos_count')."\n";
+                	echo "var last_qsos_count = ".$this->session->userdata('qso_page_last_qso_count')."\n";
 		}
                 ?>
 	</script>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -421,6 +421,15 @@
 										</select>
 										<small class="form-text text-muted"><?= __("If set, name and gridsquare is fetched from the API and filled in location and locator."); ?></small>
 									</div>
+									<div class="mb-3">
+										<label for="qso-page-last-qso-count"><?= __("Number of previous contacts displayed on QSO page."); ?></label>
+										<select class="form-select" id="qso-page-last-qso-count" name="user_qso_page_last_qso_count">
+											<?php for ($i = 5 ; $i <= $qso_page_last_qso_count_limit; $i += 5) {
+												$selected_attribute_value = $user_qso_page_last_qso_count == $i ? " selected =\"selected\"" : "";
+												printf("<option value=\"{$i}\"{$selected_attribute_value}>{$i}</option>");
+											} ?>
+										</select>
+									</div>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
As promised [here](https://github.com/wavelog/wavelog/pull/1571#issuecomment-2621433290). Now we should avoid potential questions why dashboard count is configurable but QSO page count not 😊  .

I was not quite sure if the place in Settings UI is the right one, but I dod not want to introduce another tab related to QSO page settings (currently there are two, this would be third). So I put it under QSO logging settings group. Feel free to suggest something better if you do not agree 😊 