### PR TITLE
Fix for case when 'show confirmed' checkbox is unselected in WAE award page

### DIFF
--- a/application/models/Wae.php
+++ b/application/models/Wae.php
@@ -147,7 +147,7 @@ class WAE extends CI_Model {
 				}
 			}
 
-			$confirmedWae = $this->getDxccConfirmed($$this->location_list, $postdata, true);
+			$confirmedWae = $this->getDxccConfirmed($this->location_list, $postdata, true);
 			foreach ($confirmedWae as $cdxcc) {
 				if (array_key_exists($cdxcc->col_region, $dxccMatrix)) {
 					unset($dxccMatrix[$cdxcc->col_region]);


### PR DESCRIPTION
Looks like just a plain typo. Referenced here: #1585 