### PR TITLE
Fix clublog upload error message

### DIFF
--- a/assets/js/sections/clublog.js
+++ b/assets/js/sections/clublog.js
@@ -24,25 +24,7 @@ function ExportClublog(station_id) {
 				$("#export").append('<div class="alert alert-success" role="alert">' + data.infomessage + '</div>');
 			}
 			else {
-				$("#export").append('<div class="alert alert-danger" role="alert">' + data.info + '</div>');
-			}
-
-			if (data.errormessages.length > 0) {
-				$("#export").append(
-					'<div class="errormessages">\n' +
-					'    <div class="card mt-2">\n' +
-					'        <div class="card-header bg-danger">\n' +
-					'            Error Message\n' +
-					'        </div>\n' +
-					'        <div class="card-body">\n' +
-					'            <div class="errors"></div>\n' +
-					'        </div>\n' +
-					'    </div>\n' +
-					'</div>'
-				);
-				$.each(data.errormessages, function (index, value) {
-					$(".errors").append('<li>' + value);
-				});
+				$("#export").append('<div class="alert alert-danger" role="alert">' + data.errormessages + '</div>');
 			}
 		}
 	});


### PR DESCRIPTION
Fixed the clublog error message in case no credentials are configured.
The errormessage is contained in data.errormessages.
As errormessages is a single string and the controller does not fill an array here the following loop going through errormessages does not work and can be removed.