### PR TITLE
Take ONLY Datepart if looking up a DXCC

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4694,6 +4694,7 @@ class Logbook_model extends CI_Model {
      */
 	public function check_dxcc_table($call, $date) {
 
+		$date = date("Y-m-d", strtotime($date));
 		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$/';
 
 		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`, `cont`')
@@ -4785,6 +4786,7 @@ class Logbook_model extends CI_Model {
 
 	public function dxcc_lookup($call, $date) {
 
+		$date = date("Y-m-d", strtotime($date));
 		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$/';
 
 		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`,`cont`,`long`,`lat`')


### PR DESCRIPTION
e.g.: GB6WWA had an exception valid till 31-01-2025.
if one logs it in frontend (past-QSO) with 31-01-2025 the exception "Wales" is derivated correctly
if one uploads an ADIF, it fails, because the ADIF-/DXCC-Derivation logic takes the time aswell (which is wrong). Result was England. 

Example-ADIF to repro:

```
Wavelog ADIF export
<ADIF_VER:5>3.1.4
<PROGRAMID:7>Wavelog
<EOH>

<call:6>GB6WWA <gridsquare:0> <mode:4>MFSK <submode:3>FT4 <rst_sent:3>+18 <rst_rcvd:3>-01 <qso_date:8>20250127 <time_on:6>195740 <qso_date_off:8>20250127 <time_off:6>195759 <band:3>40m <freq:8>7.049400 <station_callsign:5>DJ7NT <my_gridsquare:6>JO30oo <eor>
<call:6>GB6WWA <gridsquare:4>IO81 <mode:4>MFSK <submode:3>FT4 <rst_sent:3>-14 <rst_rcvd:3>-05 <qso_date:8>20250131 <time_on:6>192107 <qso_date_off:8>20250131 <time_off:6>192144 <band:3>20m <freq:9>14.081800 <station_callsign:5>DJ7NT <my_gridsquare:6>JO30oo <eor>
```