### PR TITLE
Use PK as secondary sorting criteria (as in other places)

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -640,6 +640,7 @@ class Logbook extends CI_Controller {
 			$this->db->group_end();
 
 			$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "desc");
+			$this->db->order_by($this->config->item('table_name').".COL_PRIMARY_KEY", "desc");
 			$this->db->limit($count);
 
 			$query = $this->db->get();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1539,6 +1539,7 @@ class Logbook_model extends CI_Model {
 			$this->db->join('dxcc_entities', $this->config->item('table_name') . '.col_dxcc = dxcc_entities.adif', 'left outer');
 			$this->db->where_in('station_id', $logbooks_locations_array);
 			$this->db->order_by("COL_TIME_ON", "desc");
+			$this->db->order_by("COL_PRIMARY_KEY", "desc");
 			$this->db->limit($num);
 
 			return $this->db->get($this->config->item('table_name'));
@@ -2246,7 +2247,7 @@ class Logbook_model extends CI_Model {
 			    LIMIT ?) hrd
 			    JOIN station_profile ON station_profile.station_id = hrd.station_id
 			    LEFT JOIN dxcc_entities ON hrd.col_dxcc = dxcc_entities.adif
-			    ORDER BY col_time_on DESC";
+			    ORDER BY col_time_on DESC, col_primary_key DESC";
 			$binding[] = $num * 1;
 			$query = $this->db->query($sql, $binding);
 


### PR DESCRIPTION
In https://github.com/wavelog/wavelog/pull/1205 we introduces PK as secondary sorting criteria so that QSOs get sorted by time desc and for same time use PK to sort. This has not been implemented in all views obviously. Especially the Dashboard and the last QSOs view showed the old behaviour. So we need to align here.

To test: Just create some QSOs with exactly same time (yes happens for SAT QSOs) and see the different views.