### PR TITLE
Replace 0 by Ø in awards table search input

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2385,6 +2385,11 @@ function viewEqsl(picture, callsign) {
                         $('.table-responsive .dropdown-toggle').off('mouseenter').on('mouseenter', function () {
                             showQsoActionsMenu($(this).closest('.dropdown'));
                         });
+                        $('#contacttable_filter input').on('keyup', function() {
+                           tocrappyzero = $(this).val().toUpperCase().replaceAll(/0/g, 'Ø');
+                           $('#contacttable_filter label input').val(tocrappyzero);
+                           $('#contacttable_filter label input').trigger('input');
+                        });
                     },
                     buttons: [{
                         label: lang_admin_close,
@@ -2393,6 +2398,7 @@ function viewEqsl(picture, callsign) {
                         }
                     }]
                 });
+
             }
         });
     }

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -117,7 +117,7 @@ function echoQrbCalcLink($mygrid, $grid, $vucc, $isVisitor = false) {
 <?php if ($results) { ?>
 
 <div class="table-responsive">
-    <table style="width:100%" class="table contacttable table-striped table-hover">
+    <table style="width:100%" id="contacttable" class="table contacttable table-striped table-hover">
         <thead>
             <tr class="titles">
                 <th><?= __("Date"); ?></th>


### PR DESCRIPTION
Makes searching for slashed zero callsign in awards tables work again. Identified by @dg2ron in DXCC table on QSO logging showing worked slots for DXCC.