### PR TITLE
[Advanced Logbook] Defaults were mixed, would lead to columns showing wrong

### DIFF
--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -71,7 +71,7 @@
         echo "\nuser_options={...user_options, ...o_template};";
     }
     if (!isset($current_opts->qslmsgr)) {
-        echo "\nvar o_template = { qslmsgr: {show: 'true'}};";
+        echo "\nvar o_template = { qslmsgr: {show: 'false'}};";
         echo "\nuser_options={...user_options, ...o_template};";
     }
     if (!isset($current_opts->pota)) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/738f82a2-f0c8-46dc-ab2e-a95cc942b453)

Since the column was defaulted to false one place, it needs to be false here too.
