### PR TITLE
Fix Reg1Test-Format

### DIFF
--- a/application/libraries/Reg1testformat.php
+++ b/application/libraries/Reg1testformat.php
@@ -11,7 +11,7 @@ class Reg1testformat {
       $edi_header = "[REG1TEST;1]" . "\r\n";
       $edi_header .= "TName=" . $contest_id ."\r\n";   //Contestname
       $edi_header .= "TDate=" . str_replace("-", "", $from) . ";" . str_replace("-", "", $to) . "\r\n"; //from and to date of contest, Ymd format, with semicolon
-      $edi_header .= "PCALL=" . strtoupper($callsign) . "\r\n"; //Station callsign during contest
+      $edi_header .= "PCall=" . strtoupper($callsign) . "\r\n"; //Station callsign during contest
       $edi_header .= "PWWLo=" . strtoupper($gridlocator) . "\r\n"; //Gridlocator during contest
       $edi_header .= "PExch=" . strtoupper(substr($sentexchange, 0, 6)) . "\r\n"; //Sent exchange, max 6 characters uppercase
       $edi_header .= "PAdr1=" . $contestaddress1 . "\r\n"; //Contest Address Line 1


### PR DESCRIPTION
According to a support case via DARC, a field in the header file was wrong. 

This PR fixes it.

PCALL -> PCall