### PR TITLE
Fixes two issues at DOK-Lookup. Pre/Suffix and crappy Zero(tm)

### DIFF
--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -142,6 +142,7 @@ class Lookup extends CI_Controller {
 		session_write_close();
 
 		if($call) {
+			$call = str_replace("-","/",$call);
 			$uppercase_callsign = strtoupper($call);
 		}
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -713,7 +713,7 @@ $("#callsign").on("focusout", function () {
 				var $dok_select = $('#darc_dok').selectize();
 				var dok_selectize = $dok_select[0].selectize;
 				if ((result.dxcc.adif == '230') && (($("#callsign").val().trim().length) > 0)) {
-					$.get(base_url + 'index.php/lookup/dok/' + $('#callsign').val().toUpperCase(), function (result) {
+					$.get(base_url + 'index.php/lookup/dok/' + $('#callsign').val().toUpperCase().replaceAll('Ø', '0').replaceAll('/','-'), function (result) {
 						if (result) {
 							dok_selectize.addOption({ name: result });
 							dok_selectize.setValue(result, false);


### PR DESCRIPTION
Once a call has been logged  with its DOK the next time you work it the DOK is taken from the lastQSO.
this works in general.

But:
- If there was a Zero in the Call, it didn't work --> Fixed
- If the station had a pre- or suffix it didn't work --> Fixed.