### PR TITLE
Trim \r\n\t on ADIF before parsing JSON

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -166,6 +166,7 @@ class API extends CI_Controller {
 
 		// Decode JSON and store
 		$raw = file_get_contents("php://input");
+		$raw = $raw = preg_replace('#[\r\n\t]+#', '', $raw);
 		$obj = json_decode($raw,true);
 		$raw='';
 		if ($obj === NULL) {

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -166,7 +166,7 @@ class API extends CI_Controller {
 
 		// Decode JSON and store
 		$raw = file_get_contents("php://input");
-		$raw = $raw = preg_replace('#[\r\n\t]+#', '', $raw);
+		$raw = $raw = preg_replace('#<([eE][oO][rR])>[\r\n\t]+#', '<$1>', $raw);
 		$obj = json_decode($raw,true);
 		$raw='';
 		if ($obj === NULL) {


### PR DESCRIPTION
I use the API from the command line and use an ADIF file within the curl call. This breaks the import because ADIF file contains newlines after each <eor>. So It would make sense to strip newlines before parsing JSON.

Example command:

```
curl -X POST https://<WAVELOG_URL>/index.php/api/qso -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\",\"station_profile_id\":\"<STATION_PROFILE_ID>\",\"type\":\"adif\",\"string\":\"$(tail -n27 some_log.adi)\"}"
```