### PR TITLE
Fix JS copy functions for API URL and KEY

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -331,7 +331,7 @@ $(function () {
 </script>
 <?php } ?>
 
-<?php if ($this->uri->segment(1) == "api"  && $this->uri->segment(2) == "help") { ?>
+<?php if ($this->uri->segment(1) == "api") { ?>
 <script type="text/javascript">
 function copyApiKey(apiKey) {
    var apiKeyField = $('#'+apiKey);


### PR DESCRIPTION
In PR https://github.com/wavelog/wavelog/pull/1334 the copy function for API keys and URL was b0rken since /api/help was moved to /api without reflecting the change in /application/view/interface_assets/footer.php. See https://github.com/wavelog/wavelog/commit/c70c2ec5cd829fe86c8a81ed36979ded7a9dc204 and https://github.com/wavelog/wavelog/pull/1334/files#diff-d874c84a992509e99f6c082a7f39a19be2cf7dab13b54e71db3b7a3de4542318R23.

This restores the initial behavior.

![Screenshot from 2025-02-10 08-56-23](https://github.com/user-attachments/assets/9f08adfd-f53d-4a3d-bb44-593667fbe80f)
