### PR TITLE
Qso edit gui button move

### DIFF
--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -694,8 +694,8 @@
 
                                 <div class="actions">
                                     <a class="btn btn-danger" href="javascript:qso_delete(<?php echo $qso->COL_PRIMARY_KEY; ?>, '<?php echo $qso->COL_CALL; ?>')"><i class="fas fa-trash-alt"></i> <?= __("Delete QSO"); ?></a>
+									<button id="update_from_callbook" type="button" class="btn btn-warning ld-ext-right" onclick="single_callbook_update();"><i class="fas fa-book"></i> <?= __("Update from Callbook"); ?><div class="ld ld-ring ld-spin"></div></button>
                                     <div class="float-end">
-                                        <button id="update_from_callbook" type="button" class="btn btn-warning ld-ext-right" onclick="single_callbook_update();"><i class="fas fa-book"></i> <?= __("Update from Callbook"); ?><div class="ld ld-ring ld-spin"></div></button>
                                         <button id="show" type="button" name="download" class="btn btn-primary" onclick="qso_save();"><i class="fas fa-save"></i> <?= __("Save changes"); ?></button>
                                     </div>
                                 </div>


### PR DESCRIPTION
Moved the update from callbook button.
Before:
![image](https://github.com/user-attachments/assets/82ecc885-fa2d-4a3b-bfe7-e036dbba1858)

After:
![image](https://github.com/user-attachments/assets/c490e839-29ba-41b9-b38b-3a48bb3d8477)


Reason:
3 people reported on discord that they managed to wrongfully click it.