### PR TITLE
Allow freetext for operator

### DIFF
--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -79,7 +79,7 @@
                         $show_operator_question = true;
                         if ($this->config->item('special_callsign') && (!empty($club_operators))) {
                             $show_operator_question = false; ?>
-                            <div class="small form-text text-muted"><?= __("Type in the operator of the imported QSOs") ?></div>
+                            <div class="small form-text text-muted"><?= __("Type in the operators callsign of the imported QSOs") ?></div>
                             <input type="text"  name="club_operator" class="form-control mb-2 me-sm-2 w-50 w-lg-100" value="<?php echo ($this->session->userdata('cd_src_call') ?? ''); ?>">
                         <?php } ?>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -79,17 +79,8 @@
                         $show_operator_question = true;
                         if ($this->config->item('special_callsign') && (!empty($club_operators))) {
                             $show_operator_question = false; ?>
-                            <div class="small form-text text-muted"><?= __("Select the operator of the imported QSOs") ?></div>
-                            <select name="club_operator" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
-                                <?php foreach ($club_operators as $operator) { ?>
-                                    <option value="<?php echo $operator->user_callsign; ?>"
-                                        <?php if ($operator->user_callsign == $this->session->userdata('cd_src_call')) {
-                                            echo ' selected="selected"';
-                                        } ?>>
-                                        <?php echo $operator->user_callsign; ?>
-                                    </option>
-                                <?php } ?>
-                            </select>
+                            <div class="small form-text text-muted"><?= __("Type in the operator of the imported QSOs") ?></div>
+                            <input type="text"  name="club_operator" class="form-control mb-2 me-sm-2 w-50 w-lg-100" value="<?php echo ($this->session->userdata('cd_src_call') ?? ''); ?>">
                         <?php } ?>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>
                         <select name="contest" id="contest" class="form-select mb-2 me-sm-2 w-50 w-lg-100">


### PR DESCRIPTION
Allow Free-Text for Operator when importing for a clubcall.

Scenario: Clubofficer receives an ADIF from a station which doesn't log via Wavelog. The only chance to set the OP correctly is: mass- or single-edit the QSOs.

Since the Clubmanager knows who sent him the adif, he can simply type it in.

i thought as well about selectize, @HB9HIL but dropped it, because it'll be overengeneered here in my opinion.
Tried some other approach with "datalists" here too, but dropped them also