### PR TITLE
Added safety-net if last_worked isn't filled yet

### DIFF
--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -111,7 +111,7 @@ $(function() {
 						data[0].push(continent_wked_info);
 						data[0].push(single.spotter);
 						data[0].push(single.message || '');
-						if ((single.worked_call) && ((single.last_wked.LAST_QSO || '') != '')) {
+						if ((single.worked_call) && ((single.last_wked || '') != '')) {
 							data[0].push(single.last_wked.LAST_QSO+' in '+single.last_wked.LAST_MODE);
 						} else {
 							data[0].push('');

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -111,7 +111,7 @@ $(function() {
 						data[0].push(continent_wked_info);
 						data[0].push(single.spotter);
 						data[0].push(single.message || '');
-						if (single.worked_call) {
+						if ((single.worked_call) && ((single.last_wked.LAST_QSO || '') != '')) {
 							data[0].push(single.last_wked.LAST_QSO+' in '+single.last_wked.LAST_MODE);
 						} else {
 							data[0].push('');


### PR DESCRIPTION
This one adds a "safety-net" if a station was worked, but the last-worked-info isn't already at cluster.


trying to mitigate https://github.com/wavelog/wavelog/issues/1683