### PR TITLE
List SATs with only displayname and prevent QSO being made via those from being uploaded to LoTW

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5375,7 +5375,10 @@ class Logbook_model extends CI_Model {
 		$this->db->where("station_id", $station_id);
 		$this->db->group_start();
 			$this->db->where_in('COL_PROP_MODE', $this->config->item('lotw_unsupported_prop_modes'));
-			$this->db->or_where_in('COL_SAT_NAME', $invalid_sats);
+			$this->db->or_group_start();
+				$this->db->where('COL_PROP_MODE', 'SAT');
+				$this->db->where_in('COL_SAT_NAME', $invalid_sats);
+			$this->db->group_end();
 			$this->db->or_group_start();
 				$this->db->where('COL_PROP_MODE', 'SAT');
 				$this->db->group_start();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5320,6 +5320,7 @@ class Logbook_model extends CI_Model {
 	function get_lotw_qsos_to_upload($station_id, $start_date, $end_date) {
 
 		$this->db->select('COL_PRIMARY_KEY,COL_CALL, COL_BAND, COL_BAND_RX, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_SUBMODE, COL_FREQ, COL_FREQ_RX, COL_GRIDSQUARE, COL_SAT_NAME, COL_PROP_MODE, COL_LOTW_QSL_SENT, station_id');
+		$this->db->join('satellite', 'satellite.name = ' . $this->config->item('table_name') . '.COL_SAT_NAME');
 
 		$this->db->where("station_id", $station_id);
 		$this->db->group_start();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5374,8 +5374,15 @@ class Logbook_model extends CI_Model {
 		);
 		$this->db->where("station_id", $station_id);
 		$this->db->group_start();
-		$this->db->where_in('COL_PROP_MODE', $this->config->item('lotw_unsupported_prop_modes'));
-		$this->db->or_where_in('COL_SAT_NAME', $invalid_sats);
+			$this->db->where_in('COL_PROP_MODE', $this->config->item('lotw_unsupported_prop_modes'));
+			$this->db->or_where_in('COL_SAT_NAME', $invalid_sats);
+			$this->db->or_group_start();
+				$this->db->where('COL_PROP_MODE', 'SAT');
+				$this->db->group_start();
+					$this->db->where('COL_SAT_NAME', '');
+					$this->db->or_where('COL_SAT_NAME', null);
+				$this->db->group_end();
+			$this->db->group_end();
 		$this->db->group_end();
 		$this->db->update($this->config->item('table_name'), $data);
 	}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5320,7 +5320,6 @@ class Logbook_model extends CI_Model {
 	function get_lotw_qsos_to_upload($station_id, $start_date, $end_date) {
 
 		$this->db->select('COL_PRIMARY_KEY,COL_CALL, COL_BAND, COL_BAND_RX, COL_TIME_ON, COL_RST_RCVD, COL_RST_SENT, COL_MODE, COL_SUBMODE, COL_FREQ, COL_FREQ_RX, COL_GRIDSQUARE, COL_SAT_NAME, COL_PROP_MODE, COL_LOTW_QSL_SENT, station_id');
-		$this->db->join('satellite', 'satellite.name = ' . $this->config->item('table_name') . '.COL_SAT_NAME');
 
 		$this->db->where("station_id", $station_id);
 		$this->db->group_start();

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5353,12 +5353,13 @@ class Logbook_model extends CI_Model {
 
 	function lotw_invalid_sats() {
 		$sats = array();
-		$this->db->select('COALESCE(NULLIF(name, \'\'), displayname) AS name');
+		$this->db->select('COALESCE(NULLIF(name, \'\'), NULLIF(displayname, \'\')) AS satname');
 		$this->db->where('lotw', 'N');
+		$this->db->having('satname !=', null);
 		$query = $this->db->get('satellite');
 		if ($query->num_rows() > 0){
 			foreach ($query->result() as $row) {
-				array_push($sats, $row->name);
+				array_push($sats, $row->satname);
 			}
 		}
 		return $sats;

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5354,7 +5354,7 @@ class Logbook_model extends CI_Model {
 
 	function lotw_invalid_sats() {
 		$sats = array();
-		$this->db->select('name');
+		$this->db->select('COALESCE(NULLIF(name, \'\'), displayname) AS name');
 		$this->db->where('lotw', 'N');
 		$query = $this->db->get('satellite');
 		if ($query->num_rows() > 0){

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -108,7 +108,7 @@ class Satellite_model extends CI_Model {
 	}
 
 	function satellite_data() {
-		$this->db->select('satellite.name AS satellite, satellitemode.name AS satmode, satellitemode.uplink_mode AS Uplink_Mode, satellitemode.uplink_freq AS Uplink_Freq, satellitemode.downlink_mode AS Downlink_Mode, satellitemode.downlink_freq AS Downlink_Freq');
+		$this->db->select('COALESCE(NULLIF(satellite.name, \'\'), satellite.displayname) AS satellite, satellitemode.name AS satmode, satellitemode.uplink_mode AS Uplink_Mode, satellitemode.uplink_freq AS Uplink_Freq, satellitemode.downlink_mode AS Downlink_Mode, satellitemode.downlink_freq AS Downlink_Freq');
 		$this->db->join('satellitemode', 'satellite.id = satellitemode.satelliteid', 'LEFT OUTER');
 		$query = $this->db->get('satellite');
 		return $query->result();


### PR DESCRIPTION
If we manually add a satellite that is not known to LoTW (yet) we cannot select it during logging a QSO because the list only contains satellites with their LoTW names. To work around this we show the displayname for those satellites which do not have a LoTW name (yet).