### PR TITLE
Fix accidently removed line for updating log when QSL was sent

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1930,6 +1930,8 @@ class Logbook_model extends CI_Model {
 			$this->db->where('COL_PRIMARY_KEY', $qso_id);
 			$this->db->where('COL_QSL_SENT !=', 'Y');
 
+			$this->db->update($this->config->item('table_name'), $data);
+
 			if ($this->db->affected_rows()>0) {	// Only set to modified if REALLY modified
 				$this->set_qrzcom_modified($qso_id);
 			}


### PR DESCRIPTION
Bug was introduced bymyself, while refactoring the qrz-logic.
the update was missing.

testing:
- add some QSO's to the QSL-Queue (direct / bureau)
- go to labels
- single mark them as sent (they disappear, but arent't be marked as sent)

this one fixes that. sri!