### PR TITLE
QSO widget remix

### DIFF
--- a/application/config/constants.php
+++ b/application/config/constants.php
@@ -53,6 +53,9 @@ define('QSO_PAGE_QSOS_COUNT_LIMIT',             20);
 
 define('USER_SLUG_LENGTH',                      10);
 
+define('QSO_WIDGET_DEFAULT_QSO_LIMIT',          15);
+define('QSO_WIDGET_MAX_QSO_LIMIT',              50);
+
 
 /* End of file constants.php */
 /* Location: ./application/config/constants.php */

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -288,6 +288,7 @@ class User extends CI_Controller {
 				$this->input->post('on_air_widget_enabled'),
 				$this->input->post('on_air_widget_display_last_seen'),
 				$this->input->post('on_air_widget_show_only_most_recent_radio'),
+				$this->input->post('qso_widget_display_qso_time'),
 				$this->input->post('clubstation') == '1' ? true : false
 				)) {
 				// Check for errors
@@ -786,6 +787,7 @@ class User extends CI_Controller {
 			$data['on_air_widget_display_last_seen'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'display_last_seen'), $this->uri->segment(3))->row()->option_value ?? "false");
 			$data['on_air_widget_show_only_most_recent_radio'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'display_only_most_recent_radio'), $this->uri->segment(3))->row()->option_value ?? "true");
 			$data['on_air_widget_url'] = site_url('widgets/on_air/' . $q->slug);
+			$data['qso_widget_display_qso_time'] = ($this->user_options_model->get_options('widget', array('option_name'=>'qso', 'option_key' => 'display_qso_time'), $this->uri->segment(3))->row()->option_value ?? "false");
 
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('user/edit', $data);
@@ -887,6 +889,7 @@ class User extends CI_Controller {
 			$data['on_air_widget_enabled'] = $this->input->post('on_air_widget_enabled', true);
 			$data['on_air_widget_display_last_seen'] = $this->input->post('on_air_widget_display_last_seen', true);
 			$data['on_air_widget_show_only_most_recent_radio'] = $this->input->post('on_air_widget_show_only_most_recent_radio', true);
+			$data['qso_widget_display_qso_time'] = $this->input->post('qso_widget_display_qso_time', true);
 
 			$this->load->view('user/edit');
 			$this->load->view('interface_assets/footer');

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -34,11 +34,6 @@ class Widgets extends CI_Controller {
 			$data['theme'] = "default";
 		}
 
-		// should we show time?
-		// TODO
-		$data['show_time'] = (($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE || ($this->config->item('show_time')));
-		$data['show_time'] = true;
-
 		// determine text size
 		$text_size = $this->input->get('text_size', true) ?? 1;
 		$data['text_size_class'] = $this->prepare_text_size_css_class($text_size);
@@ -57,7 +52,6 @@ class Widgets extends CI_Controller {
 		$this->load->model('logbook_model');
 		$this->load->model('logbooks_model');
 		if($this->logbooks_model->public_slug_exists($logbook_slug)) {
-			// Load the public view
 
 			$logbook_id = $this->logbooks_model->public_slug_exists_logbook_id($logbook_slug);
 			if($logbook_id != false)
@@ -73,6 +67,11 @@ class Widgets extends CI_Controller {
 				show_404(__("Unknown Public Page."));
 			}
 
+			// Get widget settings
+			$user_id = $this->logbooks_model->user_id_from_logbook_slug($logbook_slug);
+			$widget_options = $this->get_qso_widget_options($user_id);
+
+			$data['show_time'] = $widget_options->display_qso_time;			
 			$data['last_qsos_list'] = $this->logbook_model->get_last_qsos($qso_count, $logbooks_locations_array);
 
 			$this->load->view('widgets/qsos', $data);
@@ -219,6 +218,38 @@ class Widgets extends CI_Controller {
 			$this->load->view('widgets/on_air', $data);
 			return;
 		}
+	}
+
+	/**
+	 * Fetch and prepare user options for QSO widget
+	 *
+	 * @return stdClass
+	 */
+	private function get_qso_widget_options($user_id) {
+		$raw_widget_options = $this->user_options_model->get_options('widget', null, $user_id)->result_array();
+
+		// default values
+		$options = new \stdClass();
+		$options->display_qso_time = false;
+
+		if ($raw_widget_options === null) {
+			return $options;
+		}
+
+		foreach ($raw_widget_options as $opt_data) {
+			if ($opt_data["option_name"] !== 'qso') {
+				continue;
+			}
+
+			$key = $opt_data["option_key"];
+			$value = $opt_data["option_value"];
+
+			if ($key === "display_qso_time") {
+				$options->display_qso_time = $value === "true";
+			}
+		}
+
+		return $options;
 	}
 
 	/**

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -40,10 +40,10 @@ class Widgets extends CI_Controller {
 
 		// number of QSOs shown
 		$qso_count_param = $this->input->get('qso_count', TRUE);
-		if ($qso_count_param != null) {
-			$qso_count = min($qso_count_param, QSO_WIDGET_MAX_QSO_LIMIT);
-		} else {
+		if ($qso_count_param === null || !is_numeric($qso_count_param)) {
 			$qso_count = QSO_WIDGET_DEFAULT_QSO_LIMIT;
+		} else {
+			$qso_count = min($qso_count_param, QSO_WIDGET_MAX_QSO_LIMIT);
 		}
 
 		// date format

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -51,6 +51,7 @@ class Widgets extends CI_Controller {
 		
 		$this->load->model('logbook_model');
 		$this->load->model('logbooks_model');
+		$this->load->model('stationsetup_model');
 		if($this->logbooks_model->public_slug_exists($logbook_slug)) {
 
 			$logbook_id = $this->logbooks_model->public_slug_exists_logbook_id($logbook_slug);
@@ -68,7 +69,7 @@ class Widgets extends CI_Controller {
 			}
 
 			// Get widget settings
-			$user_id = $this->logbooks_model->user_id_from_logbook_slug($logbook_slug);
+			$user_id = $this->stationsetup_model->public_slug_exists_userid($logbook_slug);
 			$widget_options = $this->get_qso_widget_options($user_id);
 
 			$data['show_time'] = $widget_options->display_qso_time;			

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -188,6 +188,19 @@ class Logbooks_model extends CI_Model {
 		}
 	}
 
+	function user_id_from_logbook_slug($slug) {
+		$this->db->where('public_slug', $this->security->xss_clean($slug));
+		$query = $this->db->get('station_logbooks');
+
+		if ($query->num_rows() > 0){
+			foreach ($query->result() as $row) {
+				return $row->user_id;
+			}
+		} else {
+			return null;
+		}
+	}
+
 	function is_public_slug_available($slug) {
 		// Clean public_slug
 		$clean_slug = $this->security->xss_clean($slug);

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -188,19 +188,6 @@ class Logbooks_model extends CI_Model {
 		}
 	}
 
-	function user_id_from_logbook_slug($slug) {
-		$this->db->where('public_slug', $this->security->xss_clean($slug));
-		$query = $this->db->get('station_logbooks');
-
-		if ($query->num_rows() > 0){
-			foreach ($query->result() as $row) {
-				return $row->user_id;
-			}
-		} else {
-			return null;
-		}
-	}
-
 	function is_public_slug_available($slug) {
 		// Clean public_slug
 		$clean_slug = $this->security->xss_clean($slug);

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -215,7 +215,7 @@ class User_Model extends CI_Model {
 		$user_wwff_to_qso_tab, $user_pota_to_qso_tab, $user_sig_to_qso_tab, $user_dok_to_qso_tab,
 		$user_lotw_name, $user_lotw_password, $user_eqsl_name, $user_eqsl_password, $user_clublog_name, $user_clublog_password,
 		$user_winkey, $on_air_widget_enabled, $on_air_widget_display_last_seen, $on_air_widget_show_only_most_recent_radio,
-		$clubstation = 0) {
+		$qso_widget_display_qso_time, $clubstation = 0) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -301,6 +301,7 @@ class User_Model extends CI_Model {
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'widget','on_air','enabled','".(xss_clean($on_air_widget_enabled ?? 'false'))."');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'widget','on_air','display_last_seen','".(xss_clean($on_air_widget_display_last_seen ?? 'false'))."');");
 			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'widget','on_air','display_only_most_recent_radio','".(xss_clean($on_air_widget_show_only_most_recent_radio ?? 'true'))."');");
+			$this->db->query("insert into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $insert_id . ", 'widget','qso','display_qso_time','".(xss_clean($qso_widget_display_qso_time ?? 'false'))."');");
 
 			return OK;
 		} else {
@@ -369,6 +370,7 @@ class User_Model extends CI_Model {
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'widget','on_air','enabled','".(xss_clean($fields['on_air_widget_enabled'] ?? 'false'))."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'widget','on_air','display_last_seen','".(xss_clean($fields['on_air_widget_display_last_seen'] ?? 'false'))."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'widget','on_air','display_only_most_recent_radio','".(xss_clean($fields['on_air_widget_show_only_most_recent_radio'] ?? 'true'))."');");
+				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'widget','qso','display_qso_time','".(xss_clean($fields['qso_widget_display_qso_time'] ?? 'false'))."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'dashboard','last_qso_count','count','".$dashboard_last_qso_count."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'qso_tab','last_qso_count','count','".$qso_page_last_qso_count."');");
 				$this->db->query("replace into user_options (user_id, option_type, option_name, option_key, option_value) values (" . $fields['id'] . ", 'dashboard','show_map','boolean','".xss_clean($fields['user_dashboard_map'] ?? 'Y')."');");

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -892,6 +892,25 @@
 							</div>
 						</div>
 					</div>
+					<div class="row">
+						<!-- QSOs Widget Settings -->
+						<div class="col-md">
+							<div class="card">
+								<div class="card-header"><?= __("QSOs widget"); ?></div>
+								<div class="card-body">
+									<div class="mb-3">
+										<label><?= __('Display exact QSO time'); ?></label>
+										<?php if(!isset($qso_widget_display_qso_time)) { $qso_widget_display_qso_time='false'; }?>
+										<select class="form-select" name="qso_widget_display_qso_time" id="qso_widget_display_qso_time">
+											<option value="false" <?php if ($qso_widget_display_qso_time == "false") { echo 'selected="selected"'; } ?>><?= __("No"); ?></option>
+											<option value="true" <?php if ($qso_widget_display_qso_time == "true") { echo 'selected="selected"'; } ?>><?= __("Yes"); ?></option>
+										</select>
+										<small class="form-text text-muted"><?= __("This setting control whether exact QSO time should displayed in the QSO widget or not."); ?></small>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/application/views/widgets/qsos.php
+++ b/application/views/widgets/qsos.php
@@ -1,64 +1,45 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
-	<title><?= __("QSOs"); ?></title>
-	<style type="text/css" media="screen">
-		body {
-			font-family: Arial, "MS Trebuchet", sans-serif;
-		}
-		.titles th {
-			font-weight: bold;
-			text-align: left;
-		}
-	</style>
+	<meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/bootstrap.min.css">
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/overrides.css">
+    <link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
+
+    <title><?= "QSOs"; ?></title>
 </head>
 
-<?php if (($this->config->item('use_auth') && ($this->session->userdata('user_type') >= 2)) || $this->config->item('use_auth') === FALSE || ($this->config->item('show_time'))) {
-	$show_time = true;
-} else {
-	$show_time = false;
-} ?>
-
-
 <body>
-	   <table width="100%" class="zebra-striped">
+	   <table width="100%" class="table table-striped">
 			<tr class="titles">
-				<th><?= __("Date"); ?></th>
-				<?php if ($show_time) { ?>
-					<th><?= __("Time"); ?></th>
-				<?php } ?>
-				<th><?= __("Call"); ?></th>
-				<th><?= __("Mode"); ?></th>
-				<th><?= __("Sent"); ?></th>
-				<th><?= __("Rcvd"); ?></th>
-				<th><?= __("Band"); ?></th>
+				<th class="<?= $text_size_class ?>"><?= __("Date"); ?></th>
+				<th class="<?= $text_size_class ?>"><?= __("Call"); ?></th>
+				<th class="<?= $text_size_class ?>"><?= __("Mode"); ?></th>
+				<th class="<?= $text_size_class ?>"><?= __("Sent"); ?></th>
+				<th class="<?= $text_size_class ?>"><?= __("Rcvd"); ?></th>
+				<th class="<?= $text_size_class ?>"><?= __("Band"); ?></th>
 			</tr>
 
 			<?php
 
-			// Get Date format
-			if($this->session->userdata('user_date_format')) {
-				// If Logged in and session exists
-				$custom_date_format = $this->session->userdata('user_date_format');
-			} else {
-				// Get Default date format from /config/wavelog.php
-				$custom_date_format = $this->config->item('qso_date_format');
-			}
-
 			$i = 0;
 			foreach ($last_qsos_list->result() as $row) { ?>
 				<?php  echo '<tr class="tr'.($i & 1).'">'; ?>
-					<td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date($custom_date_format, $timestamp); ?></td>
-					<?php if ($show_time) { ?>
-						<td><?php $timestamp = strtotime($row->COL_TIME_ON); echo date('H:i', $timestamp); ?></td>
-					<?php } ?>
-					<td><?php echo str_replace("0","&Oslash;",strtoupper($row->COL_CALL)); ?></td>
-					<td><?php echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; ?></td>
-					<td><?php echo $row->COL_RST_SENT; ?> <?php if ($row->COL_STX_STRING) { ?>(<?php echo $row->COL_STX_STRING;?>)<?php } ?></td>
-					<td><?php echo $row->COL_RST_RCVD; ?> <?php if ($row->COL_SRX_STRING) { ?>(<?php echo $row->COL_SRX_STRING;?>)<?php } ?></td>
+					<td class="<?= $text_size_class ?>">
+						<?php $timestamp = strtotime($row->COL_TIME_ON); echo date($date_format, $timestamp); ?>
+						<?php if ($show_time) { ?>
+							<?php $timestamp = strtotime($row->COL_TIME_ON); echo date('H:i', $timestamp); ?>
+						<?php } ?>
+					</td>
+					<td class="<?= $text_size_class ?>"><?php echo str_replace("0","&Oslash;",strtoupper($row->COL_CALL)); ?></td>
+					<td class="<?= $text_size_class ?>"><?php echo $row->COL_SUBMODE==null?$row->COL_MODE:$row->COL_SUBMODE; ?></td>
+					<td class="<?= $text_size_class ?>"><?php echo $row->COL_RST_SENT; ?> <?php if ($row->COL_STX_STRING) { ?>(<?php echo $row->COL_STX_STRING;?>)<?php } ?></td>
+					<td class="<?= $text_size_class ?>"><?php echo $row->COL_RST_RCVD; ?> <?php if ($row->COL_SRX_STRING) { ?>(<?php echo $row->COL_SRX_STRING;?>)<?php } ?></td>
 					<?php if($row->COL_SAT_NAME != null) { ?>
-					<td><?php echo $row->COL_SAT_NAME; ?></td>
+					<td class="<?= $text_size_class ?>"><?php echo $row->COL_SAT_NAME; ?></td>
 					<?php } else { ?>
-					<td><?php echo $row->COL_BAND; ?></td>
+					<td class="<?= $text_size_class ?>"><?php echo $row->COL_BAND; ?></td>
 					<?php } ?>
 				</tr>
 			<?php $i++; } ?>


### PR DESCRIPTION
Attempt to make QSO widget more configurable and better looking. It adds option to configure number of QSOs show, text size, theme and option to display or hide QSO times.

Since I am modifying already existing widget, the design will differ a little from what is it now. I do not know if this is an issue. If it is, one option is to create something like "qso widget new" with its own widget logic and template.  let me know what you think. 

Default designs shown here:

BEFORE:
<img width="1439" alt="Screenshot 2025-02-27 at 22 02 33" src="https://github.com/user-attachments/assets/b247ed2d-2d7c-462c-a120-6260f4460bb0" />


AFTER:
<img width="1436" alt="Screenshot 2025-02-27 at 22 00 13" src="https://github.com/user-attachments/assets/004d7acd-92d8-4850-88d0-24fdb336747d" />
