### PR TITLE
Very very strange bug. the ON-Clause for joining was wrong

### DIFF
--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -112,7 +112,8 @@ class User_Model extends CI_Model {
 	function hasQrzKey($user_id) {
 		$this->db->where('station_profile.qrzapikey is not null');
 		$this->db->where('station_profile.qrzapikey != ""');
-		$this->db->join('station_profile', 'station_profile.user_id = '.$user_id);
+		$this->db->where('station_profile.user_id',$user_id);
+		$this->db->join('station_profile', 'station_profile.user_id = '.$this->config->item('auth_table').'.user_id');
 		$query = $this->db->get($this->config->item('auth_table'));
 
 		$ret = $query->row();


### PR DESCRIPTION
this was for a long time in the code-Base.

Repro:
A lot of Users PLUS a lot of station_ids are causing a mem-exhaust, because the join NEVER took care about the binding-element - the user_id.

tnx for Co-investigating @phl0 