### PR TITLE
Also search display contest name from contest table

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -319,7 +319,8 @@ class Logbookadvanced_model extends CI_Model {
 		}
 
 		if ($searchCriteria['contest'] !== '*' && $searchCriteria['contest'] !== '') {
-			$conditions[] = "COL_CONTEST_ID like ?";
+			$conditions[] = "(COL_CONTEST_ID like ? OR contest.name like ?)";
+			$binding[] = '%'.$searchCriteria['contest'].'%';
 			$binding[] = '%'.$searchCriteria['contest'].'%';
 		}
 


### PR DESCRIPTION
Fixes https://github.com/wavelog/wavelog/issues/1722

We also need to search the contest table name for the search criteria here as this is what is displayed in the result table.