### PR TITLE
change QSO format for REG1TEST - remove optional trailing semicolon

### DIFF
--- a/application/libraries/Reg1testformat.php
+++ b/application/libraries/Reg1testformat.php
@@ -111,7 +111,7 @@ class Reg1testformat {
                $newlocator = false;
                $distance = $locators[$row->COL_GRIDSQUARE];
             }
-         } else {
+         } else { 
             $distance = 0;
             $newlocator = false;
          }
@@ -143,7 +143,7 @@ class Reg1testformat {
 
          $qsorow .= ($newdxcc ? 'N' : '') . ';'; //flag if DXCC is new
 
-         $qsorow .= ";\r\n"; //flag for duplicate QSO. Leave empty as Wavelog does not have this.
+         $qsorow .= "\r\n"; //flag for duplicate QSO. Leave empty as Wavelog does not have this. Do not include a semicolon at the end as this is optional
 
          //add row to overall result
          $result['formatted_qso'] .= $qsorow;


### PR DESCRIPTION
After the last field of the QSO line in Reg1Test format, there is an optional semicolon.
Some parsers won't accept that, so I removed it for broader compatibility.

Fixes #1719 .