### PR TITLE
Fix footer quoting in JS

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1311,7 +1311,7 @@ $($('#callsign')).on('keypress',function(e) {
 						    if (data.error == 'not_logged_in') {
 							    $(".radio_cat_state" ).remove();
 							    if($('.radio_login_error').length == 0) {
-								    $('.qso_panel').prepend('<div class="alert alert-danger radio_login_error" role="alert"><i class="fas fa-broadcast-tower"></i> ' + '<?= sprintf(__("You're not logged in. Please %slogin%s"), '<a href="' . base_url() . '">', '</a>'); ?>' + '</div>');
+								    $('.qso_panel').prepend('<div class="alert alert-danger radio_login_error" role="alert"><i class="fas fa-broadcast-tower"></i> ' + "<?= sprintf(__("You're not logged in. Please %slogin%s"), '<a href=\"' . base_url() . '\">', '</a>'); ?>" + '</div>');
 							    }
 						    }
 						    // Put future Errorhandling here


### PR DESCRIPTION
This PR fixes a malformed quoting (… until someone uses double-quotes in a translation…) in the JS part of the footer.

If a translation uses a single-quote, that single quote ended the JS-string, giving an error.

This fix simply uses double quotes to circumvent the issue here, but further steps should be taken (escaped `__(...)`-variant maybe?).