### PR TITLE
Fix Iota map, bring IOTA up to default standards

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -812,11 +812,11 @@ class Awards extends CI_Controller {
 	    $data['modes'] = $this->modes->active(); // Used in the view for mode select
 
 	    if($this->input->method() === 'post') {
-		    $postdata['qsl'] = 1;
-		    $postdata['lotw'] = 1;
-		    $postdata['eqsl'] = 0;
-		    $postdata['qrz'] = 0;
-		    $postdata['clublog'] = 0;
+		    $postdata['qsl'] = $this->security->xss_clean($this->input->post('qsl')) ?? NULL;
+		    $postdata['lotw'] = $this->security->xss_clean($this->input->post('lotw')) ?? NULL;
+		    $postdata['eqsl'] = $this->security->xss_clean($this->input->post('eqsl')) ?? NULL;
+		    $postdata['qrz'] = $this->security->xss_clean($this->input->post('qrz')) ?? NULL;
+		    $postdata['clublog'] = $this->security->xss_clean($this->input->post('qrz')) ?? NULL;
 		    $postdata['worked'] = $this->security->xss_clean($this->input->post('worked')) ?? NULL;
 		    $postdata['confirmed'] = $this->security->xss_clean($this->input->post('confirmed')) ?? NULL;
 		    $postdata['notworked'] = $this->security->xss_clean($this->input->post('notworked')) ?? NULL;
@@ -1569,11 +1569,14 @@ class Awards extends CI_Controller {
 
         $postdata['lotw'] = $this->input->post('lotw') == 0 ? NULL: 1;
         $postdata['qsl'] = $this->input->post('qsl') == 0 ? NULL: 1;
+        $postdata['eqsl'] = $this->input->post('eqsl') == 0 ? NULL: 1;
+        $postdata['qrz'] = $this->input->post('qrz') == 0 ? NULL: 1;
+        $postdata['clublog'] = $this->input->post('clublog') == 0 ? NULL: 1;
         $postdata['worked'] = $this->input->post('worked') == 0 ? NULL: 1;
         $postdata['confirmed'] = $this->input->post('confirmed')  == 0 ? NULL: 1;
         $postdata['notworked'] = $this->input->post('notworked')  == 0 ? NULL: 1;
         $postdata['band'] = $this->input->post('band');
-	$postdata['mode'] = $this->input->post('mode');
+        $postdata['mode'] = $this->input->post('mode');
         $postdata['includedeleted'] = $this->input->post('includedeleted') == 0 ? NULL: 1;
         $postdata['Africa'] = $this->input->post('Africa') == 0 ? NULL: 1;
         $postdata['Asia'] = $this->input->post('Asia') == 0 ? NULL: 1;

--- a/application/views/awards/iota/index.php
+++ b/application/views/awards/iota/index.php
@@ -54,6 +54,32 @@
             </div>
 
             <div class="mb-3 row">
+                <div class="col-md-2"><?= __("Show QSO with QSL Type"); ?></div>
+                <div class="col-md-10">
+                    <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="qsl" value="1" id="qsl" <?php if ($this->input->post('qsl') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
+                        <label class="form-check-label" for="qsl"><?= __("QSL Card"); ?></label>
+                    </div>
+                    <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="lotw" value="1" id="lotw" <?php if ($this->input->post('lotw') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
+                        <label class="form-check-label" for="lotw"><?= __("LoTW"); ?></label>
+                    </div>
+                   <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="eqsl" value="1" id="eqsl" <?php if ($this->input->post('eqsl')) echo ' checked="checked"'; ?> >
+                        <label class="form-check-label" for="eqsl"><?= __("eQSL"); ?></label>
+                    </div>
+                   <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="qrz" value="1" id="qrz" <?php if ($this->input->post('qrz')) echo ' checked="checked"'; ?> >
+                        <label class="form-check-label" for="qrz"><?= __("QRZ.com"); ?></label>
+                    </div>
+                     <div class="form-check-inline">
+                        <input class="form-check-input" type="checkbox" name="clublog" value="1" id="clublog" <?php if ($this->input->post('clublog')) echo ' checked="checked"'; ?> >
+                        <label class="form-check-label" for="clublog"><?= __("Clublog"); ?></label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mb-3 row">
                 <div class="col-md-2"><?= __("Continents"); ?></div>
                 <div class="col-md-10">
                     <div class="form-check-inline">

--- a/assets/js/sections/iotamap.js
+++ b/assets/js/sections/iotamap.js
@@ -26,7 +26,7 @@ function load_iota_map() {
             Antarctica: +$('#Antarctica').prop('checked'),
         },
         success: function(data) {
-            load_iota_map2(data, worked, confirmed, notworked);
+            load_iota_map2(data, +$('#worked').prop('checked'), +$('#confirmed').prop('checked'), +$('#notworked').prop('checked'));
         },
         error: function() {
             


### PR DESCRIPTION
Some additional work on the IOTA-Award page. Make considered qsl-method selectable (copied over from other award pages) and replace the hardwired qsl-method in the code. Fix the worked/confirmed part on the map.