### PR TITLE
Add a progress indicator to LoTW manual sync and clear results upon (re-)click

### DIFF
--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -139,9 +139,10 @@
 
 		<div class="card-body">
             		<?php if (($next_run ?? '') != '') { echo "<p>".__("The next automatic sync with LoTW will happen at: ").$next_run."</p>"; } ?>
-			<button class="btn btn-outline-success" hx-get="<?php echo site_url('lotw/lotw_upload'); ?>"  hx-target="#lotw_manual_results">
-				<?= __("Manual Sync"); ?>
+			<button class="btn btn-outline-success" hx-on:click="document.getElementById('lotw_manual_results').innerHTML = '';" hx-get="<?php echo site_url('lotw/lotw_upload'); ?>" hx-indicator="#lotw-sync-running" hx-target="#lotw_manual_results">
+            <?= __("Manual Sync"); ?>
 			</button>
+			<span style="margin-left: 10px;" id="lotw-sync-running" class="htmx-indicator"> <?php echo __("running..."); ?></span>
 
 			<div id="lotw_manual_results"></div>
 		</div>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1207,3 +1207,18 @@ svg text.month { fill: #AAA; }
     align-items: center; /* Vertically aligns the flag and callsign */
     gap: 0.5em; /* Adds space between the flag and callsign */
 }
+
+.htmx-indicator {
+   opacity: 0;
+   animation: blinker 2s linear infinite;
+}
+
+.htmx-request.htmx-indicator {
+   opacity: 1;
+}
+
+@keyframes blinker {
+   50% {
+      opacity: 0;
+   }
+}


### PR DESCRIPTION
Add a progress indicator to the manual LoTW sync and clear the results when re-clicked.