### PR TITLE
Ignore country-column since dxcc is joined

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -592,7 +592,13 @@ class Lotw extends CI_Controller {
 					$dxcc = "";
 				}
 
-				$lotw_status = $this->logbook_model->lotw_update($time_on, $record['call'], $record['band'], $qsl_date, $record['qsl_rcvd'], $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $record['station_callsign'],$qso_id4lotw, $station_ids, $dxcc, $ant_path);
+				if (isset($record['country'])) {
+					$country = $record['country'];
+				} else {
+					$country = "";
+				}
+
+				$lotw_status = $this->logbook_model->lotw_update($time_on, $record['call'], $record['band'], $qsl_date, $record['qsl_rcvd'], $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $record['station_callsign'],$qso_id4lotw, $station_ids, $dxcc, $country, $ant_path);
 
 				$table .= "<tr>";
 				$table .= "<td>".$record['station_callsign']."</td>";

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3727,7 +3727,7 @@ class Logbook_model extends CI_Model {
 		}
 	}
 
-	function lotw_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $station_callsign, $qsoid, $station_ids, $dxcc = null, $ant_path = null) {
+	function lotw_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $station_callsign, $qsoid, $station_ids, $country = null, $dxcc = null, $ant_path = null) {
 
 		$data = array(
 			'COL_LOTW_QSLRDATE' => $qsl_date,
@@ -3751,6 +3751,10 @@ class Logbook_model extends CI_Model {
 
 		if (($dxcc ?? '') != '') {
 			$data['COL_DXCC'] = $dxcc;
+		}
+
+		if (($country ?? '') != '') {
+			$data['COL_COUNTRY'] = $country;
 		}
 
 		if ($ituz != "") {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3727,7 +3727,7 @@ class Logbook_model extends CI_Model {
 		}
 	}
 
-	function lotw_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $station_callsign, $qsoid, $station_ids, $country = null, $dxcc = null, $ant_path = null) {
+	function lotw_update($datetime, $callsign, $band, $qsl_date, $qsl_status, $state, $qsl_gridsquare, $qsl_vucc_grids, $iota, $cnty, $cqz, $ituz, $station_callsign, $qsoid, $station_ids, $dxcc = null, $country = null, $ant_path = null) {
 
 		$data = array(
 			'COL_LOTW_QSLRDATE' => $qsl_date,

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -63,11 +63,11 @@ class Timeline_model extends CI_Model {
 
 		$sql .= $this->addQslToQuery($qsl, $lotw, $eqsl, $clublog, $qrz);
 
-		$sql .= " group by col_dxcc, col_country
+		$sql .= " group by col_dxcc
 			order by date desc";
 
 		$query = $this->db->query($sql, $binding);
-
+		log_message("Error",$this->db->last_query());
 		return $query->result();
 	}
 

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -67,7 +67,6 @@ class Timeline_model extends CI_Model {
 			order by date desc";
 
 		$query = $this->db->query($sql, $binding);
-		log_message("Error",$this->db->last_query());
 		return $query->result();
 	}
 


### PR DESCRIPTION
i accidently logged a US Station with a wrong DXCC. At Country there was "Alaska" in it (But DXCC was "291" and not "6" - explanation at repro)
result was this at timeline:

<img width="1342" alt="image" src="https://github.com/user-attachments/assets/15c5494f-3091-4e12-a72b-f275d07a1c28" />

Repro with example (Not easy to repro):
- log KL3R - DXCC will be 6 and Country Alaska
- correct the call (only the call) to K3LR (misheard during contest and in hurry)
- wait for LoTW-Confirm. LoTW changes DXCC to 291 but won't touch country-field

however: the patch fixes:
- the report (only adif-dxcc tells the DXCC)
- the LoTW-Importer (if dxcc is provided and updated, take the country as well)