### PR TITLE
Proposal for splitting SAT/HF at DXCC

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -1464,55 +1464,57 @@ class Awards extends CI_Controller {
         This displays the DXCC map
     */
     public function dxcc_map() {
-        $this->load->model('dxcc');
-        $this->load->model('bands');
+	    $this->load->model('dxcc');
+	    $this->load->model('bands');
 
-        $bands[] = $this->security->xss_clean($this->input->post('band'));
+	    $bands[] = $this->security->xss_clean($this->input->post('band'));
 
-        $postdata['qsl'] = $this->input->post('qsl') == 0 ? NULL: 1;
-        $postdata['lotw'] = $this->input->post('lotw') == 0 ? NULL: 1;
-        $postdata['eqsl'] = $this->input->post('eqsl') == 0 ? NULL: 1;
-        $postdata['qrz'] = $this->input->post('qrz') == 0 ? NULL: 1;
-        $postdata['clublog'] = $this->input->post('clublog') == 0 ? NULL: 1;
-        $postdata['worked'] = $this->input->post('worked') == 0 ? NULL: 1;
-        $postdata['confirmed'] = $this->input->post('confirmed')  == 0 ? NULL: 1;
-        $postdata['notworked'] = $this->input->post('notworked')  == 0 ? NULL: 1;
-        $postdata['band'] = $this->security->xss_clean($this->input->post('band'));
-        $postdata['mode'] = $this->security->xss_clean($this->input->post('mode'));
-        $postdata['includedeleted'] = $this->input->post('includedeleted') == 0 ? NULL: 1;
-        $postdata['Africa'] = $this->input->post('Africa') == 0 ? NULL: 1;
-        $postdata['Asia'] = $this->input->post('Asia') == 0 ? NULL: 1;
-        $postdata['Europe'] = $this->input->post('Europe') == 0 ? NULL: 1;
-        $postdata['NorthAmerica'] = $this->input->post('NorthAmerica') == 0 ? NULL: 1;
-        $postdata['SouthAmerica'] = $this->input->post('SouthAmerica') == 0 ? NULL: 1;
-        $postdata['Oceania'] = $this->input->post('Oceania') == 0 ? NULL: 1;
-        $postdata['Antarctica'] = $this->input->post('Antarctica') == 0 ? NULL: 1;
-        $postdata['sat'] = $this->security->xss_clean($this->input->post('sat'));
-        $postdata['orbit'] = $this->security->xss_clean($this->input->post('orbit'));
+	    $postdata['qsl'] = ($this->input->post('qsl',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['lotw'] = ($this->input->post('lotw',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['eqsl'] = ($this->input->post('eqsl',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['qrz'] = ($this->input->post('qrz',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['clublog'] = ($this->input->post('clublog',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['worked'] = ($this->input->post('worked',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['confirmed'] = ($this->input->post('confirmed',true) ?? 0)  == 0 ? NULL: 1;
+	    $postdata['notworked'] = ($this->input->post('notworked',true) ?? 0)  == 0 ? NULL: 1;
 
-        $dxcclist = $this->dxcc->fetchdxcc($postdata);
-        if ($dxcclist[0]->adif == "0") {
-            unset($dxcclist[0]);
-        }
+	    $postdata['includedeleted'] = ($this->input->post('includedeleted',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['Africa'] = ($this->input->post('Africa',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['Asia'] = ($this->input->post('Asia',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['Europe'] = ($this->input->post('Europe',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['NorthAmerica'] = ($this->input->post('NorthAmerica',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['SouthAmerica'] = ($this->input->post('SouthAmerica',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['Oceania'] = ($this->input->post('Oceania',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['Antarctica'] = ($this->input->post('Antarctica',true) ?? 0) == 0 ? NULL: 1;
+	    $postdata['band'] = $this->security->xss_clean($this->input->post('band'));
+	    $postdata['mode'] = $this->security->xss_clean($this->input->post('mode'));
+	    $postdata['sat'] = $this->security->xss_clean($this->input->post('sat'));
+	    $postdata['orbit'] = $this->security->xss_clean($this->input->post('orbit'));
 
-        $dxcc_array = $this->dxcc->get_dxcc_array($dxcclist, $bands, $postdata);
 
-        $i = 0;
+	    $dxcclist = $this->dxcc->fetchdxcc($postdata);
+	    if ($dxcclist[0]->adif == "0") {
+		    unset($dxcclist[0]);
+	    }
 
-        foreach ($dxcclist as $dxcc) {
-            $newdxcc[$i]['adif'] = $dxcc->adif;
-            $newdxcc[$i]['prefix'] = $dxcc->prefix;
-            $newdxcc[$i]['name'] = ucwords(strtolower($dxcc->name), "- (/");
-            if ($dxcc->Enddate!=null) {
-                $newdxcc[$i]['name'] .= ' (deleted)';
-            }
-            $newdxcc[$i]['lat'] = $dxcc->lat;
-            $newdxcc[$i]['long'] = $dxcc->long;
-            $newdxcc[$i++]['status'] = isset($dxcc_array[$dxcc->adif]) ? $this->returnStatus($dxcc_array[$dxcc->adif]) : 'x';
-        }
+	    $dxcc_array = $this->dxcc->get_dxcc_array($dxcclist, $bands, $postdata);
 
-        header('Content-Type: application/json');
-        echo json_encode($newdxcc);
+	    $i = 0;
+
+	    foreach ($dxcclist as $dxcc) {
+		    $newdxcc[$i]['adif'] = $dxcc->adif;
+		    $newdxcc[$i]['prefix'] = $dxcc->prefix;
+		    $newdxcc[$i]['name'] = ucwords(strtolower($dxcc->name), "- (/");
+		    if ($dxcc->Enddate!=null) {
+			    $newdxcc[$i]['name'] .= ' (deleted)';
+		    }
+		    $newdxcc[$i]['lat'] = $dxcc->lat;
+		    $newdxcc[$i]['long'] = $dxcc->long;
+		    $newdxcc[$i++]['status'] = isset($dxcc_array[$dxcc->adif]) ? $this->returnStatus($dxcc_array[$dxcc->adif]) : 'x';
+	    }
+
+	    header('Content-Type: application/json');
+	    echo json_encode($newdxcc);
     }
 
     /*

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -858,6 +858,7 @@ class Awards extends CI_Controller {
 	    $iotalist = $this->iota->fetchIota($postdata, $location_list);
 	    $data['iota_array'] = $this->iota->get_iota_array($iotalist, $bands, $postdata, $location_list);
 	    $data['iota_summary'] = $this->iota->get_iota_summary($bands, $postdata, $location_list);
+	    $data['posted_band']=$postdata['band'];
 
 	    // Render Page
 	    $data['page_title'] = sprintf(__("Awards - %s"), __("IOTA (Island On The Air)"));

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -174,6 +174,7 @@ class Awards extends CI_Controller {
 
 		// Render Page
 		$data['page_title'] = sprintf(__("Awards - %s"), __("DXCC"));
+		$data['posted_band']=$postdata['band'];
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('awards/dxcc/index');
 		$this->load->view('interface_assets/footer');

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -81,6 +81,9 @@ class DXCC extends CI_Model {
 					$dxccMatrix[$dxcc->adif]['Deleted'] = isset($dxcc->Enddate) ? 1 : 0;
 				$dxccMatrix[$dxcc->adif][$band] = '-';
 			}
+			if (($postdata['band'] != 'SAT') && ($band == 'SAT')) {
+				continue;
+			}
 
 			// If worked is checked, we add worked entities to the array
 			if ($postdata['worked'] != NULL) {

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -70,6 +70,9 @@ class DXCC extends CI_Model {
 		$qsl = $this->genfunctions->gen_qsl_from_postdata($postdata);
 
 		foreach ($bands as $band) {             	// Looping through bands and entities to generate the array needed for display
+			if (($postdata['band'] != 'SAT') && ($band == 'SAT')) {
+				continue;
+			}
 			foreach ($dxccArray as $dxcc) {
 				if ($dxcc->adif == '0') {
 					$dxccMatrix[$dxcc->adif]['name'] = $dxcc->name;
@@ -80,9 +83,6 @@ class DXCC extends CI_Model {
 				if ($postdata['includedeleted'])
 					$dxccMatrix[$dxcc->adif]['Deleted'] = isset($dxcc->Enddate) ? 1 : 0;
 				$dxccMatrix[$dxcc->adif][$band] = '-';
-			}
-			if (($postdata['band'] != 'SAT') && ($band == 'SAT')) {
-				continue;
 			}
 
 			// If worked is checked, we add worked entities to the array

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -284,11 +284,11 @@ class DXCC extends CI_Model {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+			$sql .= $this->addOrbitToQuery($postdata,$bindings);
 		} else {
 			$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 		}
 
-		$sql .= $this->addOrbitToQuery($postdata,$bindings);
 
 		if ($postdata['mode'] != 'All') {
 			$sql .= " and (col_mode = ? or col_submode = ?)";
@@ -304,11 +304,11 @@ class DXCC extends CI_Model {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+			$sql .= $this->addOrbitToQuery($postdata,$bindings);
 		} else {
 			$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 		}
 
-		$sql .= $this->addOrbitToQuery($postdata,$bindings);
 
 		if ($postdata['mode'] != 'All') {
 			$sql .= " and (col_mode = ? or col_submode = ?)";
@@ -327,7 +327,6 @@ class DXCC extends CI_Model {
 		}
 
 		$sql .= $this->addContinentsToQuery($postdata);
-
 		$query = $this->db->query($sql,$bindings);
 		return $query->result();
 	}

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -137,10 +137,13 @@ class DXCC extends CI_Model {
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$bindings);
 		if ($band == 'SAT') {
+			$sql .= " and col_prop_mode='SAT'";
 			if ($postdata['sat'] != 'All') {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+		} else {
+			$sql.=" and (col_prop_mode!='SAT' or col_prop_mode is null)";
 		}
 
 		if ($postdata['mode'] != 'All') {
@@ -177,11 +180,15 @@ class DXCC extends CI_Model {
 					") and col_dxcc > 0";
 		$sql .= $this->genfunctions->addBandToQuery($band,$bindings);
 		if ($band == 'SAT') {
+			$sql .= " and col_prop_mode ='SAT'";
 			if ($postdata['sat'] != 'All') {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+		} else {
+			$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 		}
+
 		if ($postdata['mode'] != 'All') {
 			$sql .= " and (col_mode = ? or col_submode = ?)";
 			$bindings[]=$postdata['mode'];
@@ -232,6 +239,8 @@ class DXCC extends CI_Model {
 					$sql .= " and col_band = ?";
 					$bindings[]=$postdata['band'];
 				}
+			} else {
+				$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 			}
 
 			if ($postdata['mode'] != 'All') {
@@ -270,10 +279,13 @@ class DXCC extends CI_Model {
 				") and col_dxcc > 0";
 		$sql .= $this->genfunctions->addBandToQuery($postdata['band'],$bindings);
 		if ($postdata['band'] == 'SAT') {
+			$sql .= " and col_prop_mode = 'SAT'";
 			if ($postdata['sat'] != 'All') {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+		} else {
+			$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 		}
 
 		$sql .= $this->addOrbitToQuery($postdata,$bindings);
@@ -287,11 +299,15 @@ class DXCC extends CI_Model {
 		$sql .= " and not exists (select 1 from ".$this->config->item('table_name')." where station_id in (". $location_list .") and col_dxcc = thcv.col_dxcc and col_dxcc > 0";
 		$sql .= $this->genfunctions->addBandToQuery($postdata['band'],$bindings);
 		if ($postdata['band'] == 'SAT') {
+			$sql .= " and col_prop_mode = 'SAT'";
 			if ($postdata['sat'] != 'All') {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+		} else {
+			$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 		}
+
 		$sql .= $this->addOrbitToQuery($postdata,$bindings);
 
 		if ($postdata['mode'] != 'All') {
@@ -328,10 +344,13 @@ class DXCC extends CI_Model {
 
 		$sql .= $this->genfunctions->addBandToQuery($postdata['band'],$bindings);
 		if ($postdata['band'] == 'SAT') {
+			$sql .= " and col_prop_mode = 'SAT'";
 			if ($postdata['sat'] != 'All') {
 				$sql .= " and col_sat_name = ?";
 				$bindings[]=$postdata['sat'];
 			}
+		} else {
+			$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 		}
 
 		if ($postdata['mode'] != 'All') {

--- a/application/models/Iota.php
+++ b/application/models/Iota.php
@@ -7,6 +7,9 @@ class IOTA extends CI_Model {
 
 	function get_iota_array($iotaArray, $bands, $postdata, $location_list) {
 		foreach ($bands as $band) {             	// Looping through bands and iota to generate the array needed for display
+			if (($postdata['band'] != 'SAT') && ($band == 'SAT')) {
+				continue;
+			}
 			foreach ($iotaArray as $iota) {
 				$iotaMatrix[$iota->tag]['prefix'] = $iota->prefix;
 				$iotaMatrix[$iota->tag]['name'] = $iota->name;

--- a/application/models/Iota.php
+++ b/application/models/Iota.php
@@ -71,6 +71,11 @@ class IOTA extends CI_Model {
 			$binding[] = $postdata['mode'];
 			$binding[] = $postdata['mode'];
 		}
+		if ($band == 'SAT') {
+			$sql .= " and col_prop_mode='SAT'";
+		} else {
+			$sql.=" and (col_prop_mode!='SAT' or col_prop_mode is null)";
+		}
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$binding);
 
@@ -98,6 +103,11 @@ class IOTA extends CI_Model {
 			$sql .= " and (col_mode = ? or col_submode = ?)";
 			$binding[] = $postdata['mode'];
 			$binding[] = $postdata['mode'];
+		}
+		if ($band == 'SAT') {
+			$sql .= " and col_prop_mode='SAT'";
+		} else {
+			$sql.=" and (col_prop_mode!='SAT' or col_prop_mode is null)";
 		}
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$binding);
@@ -142,6 +152,8 @@ class IOTA extends CI_Model {
 					$sql .= " and col_band = ?";
 					$binding[] = $postdata['band'];
 				}
+			} else {
+				$sql.=" and (col_prop_mode != 'SAT' or col_prop_mode is null)";
 			}
 			$sql .= ")";
 		}
@@ -164,6 +176,11 @@ class IOTA extends CI_Model {
 			$sql .= " and (col_mode = ? or col_submode = ?)";
 			$binding[] = $postdata['mode'];
 			$binding[] = $postdata['mode'];
+		}
+		if ($postdata['band'] == 'SAT') {
+			$sql .= " and col_prop_mode='SAT'";
+		} else {
+			$sql.=" and (col_prop_mode!='SAT' or col_prop_mode is null)";
 		}
 
 		$sql .= $this->genfunctions->addBandToQuery($postdata['band'],$binding);
@@ -197,6 +214,11 @@ class IOTA extends CI_Model {
 			$sql .= " and (col_mode = ? or col_submode = ?)";
 			$binding[] = $postdata['mode'];
 			$binding[] = $postdata['mode'];
+		}
+		if ($postdata['band'] == 'SAT') {
+			$sql .= " and col_prop_mode='SAT'";
+		} else {
+			$sql.=" and (col_prop_mode!='SAT' or col_prop_mode is null)";
 		}
 
 		if ($postdata['includedeleted'] == NULL) {

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -217,110 +217,109 @@
     <?php
     $i = 1;
     if ($dxcc_array) {
-        echo '
-                <table style="width:100%" class="table-sm table tabledxcc table-bordered table-hover table-striped table-condensed text-center">
-                    <thead>
-                    <tr>
-                        <td>#</td>
-                        <td>' . __("DXCC Name") . '</td>
-                        <td>' . __("Prefix") . '</td>';
-        foreach($bands as $band) {
-            echo '<td>' . $band . '</td>';
-        }
-        echo '</tr>
-                    </thead>
-                    <tbody>';
-        foreach ($dxcc_array as $dxcc => $value) {      // Fills the table with the data
-            echo '<tr>
-                        <td>'. $i++ .'</td>';
-            foreach ($value as $name => $key) {
-                if (isset($value['Deleted']) && $value['Deleted'] == 1 && $name == "name") {
-                   echo '<td style="text-align: center">' . $key . ' <span class="badge text-bg-danger">'.__("Deleted DXCC").'</span></td>';
-                } else if ($name == "Deleted") {
-                   continue;
-                } else {
-                   echo '<td style="text-align: center">' . $key . '</td>';
-                }
-            }
-            echo '</tr>';
-        }
-        echo '</table>
-        <h2>' . __("Summary") . '</h2>
-
-        <table class="table-sm tablesummary table table-bordered table-hover table-striped table-condensed text-center">
-        <thead>
-        <tr><td></td>';
-
-	$addsat='';
-        foreach($bands as $band) {
-	    if ($band != 'SAT') {
-            	echo '<td>' . $band . '</td>';
-	    } else {
-		$addsat='<td>' . $band . '</td>';
+	    echo '
+		<table style="width:100%" class="table-sm table tabledxcc table-bordered table-hover table-striped table-condensed text-center">
+		    <thead>
+		    <tr>
+			<td>#</td>
+			<td>' . __("DXCC Name") . '</td>
+			<td>' . __("Prefix") . '</td>';
+	    foreach($bands as $band) {
+		    echo '<td>' . $band . '</td>';
 	    }
-        }
-        echo '<td><b>' . __("Total") . '</b></td>';
-        if (count($bands) > 1) {
-           echo '<td class="spacingcell"></td>';
-        }
-	echo $addsat;
-	echo '
-        </tr>
-        </thead>
-        <tbody>
-
-        <tr><td>' . __("Total worked") . '</td>';
-	$addsat='';
-        foreach ($dxcc_summary['worked'] as $band => $dxcc) {      // Fills the table with the data
-	    if ($band != 'SAT') {
-          echo '<td style="text-align: center">';
-          if ($band == 'Total') {
-             echo '<b>'.$dxcc.'</b>';
-          } else {
-             echo $dxcc;
-          }
-          echo '</td>';
-	    } else {
-		$addsat='<td style="text-align: center">' . $dxcc . '</td>';
+	echo '</tr>
+		    </thead>
+		    <tbody>';
+	    foreach ($dxcc_array as $dxcc => $value) {      // Fills the table with the data
+		    echo '<tr>
+			    <td>'. $i++ .'</td>';
+		    foreach ($value as $name => $key) {
+			    if (isset($value['Deleted']) && $value['Deleted'] == 1 && $name == "name") {
+				    echo '<td style="text-align: center">' . $key . ' <span class="badge text-bg-danger">'.__("Deleted DXCC").'</span></td>';
+			    } else if ($name == "Deleted") {
+				    continue;
+			    } else {
+				    echo '<td style="text-align: center">' . $key . '</td>';
+			    }
+		    }
+		    echo '</tr>';
 	    }
-        }
+	    echo '</table>
+		    <h2>' . __("Summary") . '</h2>
+
+		    <table class="table-sm tablesummary table table-bordered table-hover table-striped table-condensed text-center">
+		    <thead>
+		    <tr><td></td>';
+
+				    $addsat='';
+				    foreach($bands as $band) {
+					    if ($band != 'SAT') {
+						    echo '<td>' . $band . '</td>';
+					    } else {
+						    $addsat='<td>' . $band . '</td>';
+					    }
+				    }
+				    echo '<td><b>' . __("Total") . '</b></td>';
+				    if (count($bands) > 1) {
+					    echo '<td class="spacingcell"></td>';
+				    }
+				    echo $addsat;
+				    echo '
+	</tr>
+	</thead>
+	<tbody>
+
+	<tr><td>' . __("Total worked") . '</td>';
+	$addsat='';
+	foreach ($dxcc_summary['worked'] as $band => $dxcc) {      // Fills the table with the data
+		if ($band != 'SAT') {
+			echo '<td style="text-align: center">';
+			if ($band == 'Total') {
+				echo '<b>'.$dxcc.'</b>';
+			} else {
+				echo $dxcc;
+			}
+			echo '</td>';
+		} else {
+			$addsat='<td style="text-align: center">' . $dxcc . '</td>';
+		}
+	}
 	if ($addsat != '' && count($dxcc_summary['worked']) > 1) {
-        if (count($bands) > 1) {
-		echo '<td class="spacingcell"></td>';
-        }
+		if (count($bands) > 1) {
+			echo '<td class="spacingcell"></td>';
+		}
 		echo $addsat;
 	}
 
-        echo '</tr><tr>
-        <td>' . __("Total confirmed") . '</td>';
+	echo '</tr><tr>
+	<td>' . __("Total confirmed") . '</td>';
 	$addsat='';
-        foreach ($dxcc_summary['confirmed'] as $band => $dxcc) {      // Fills the table with the data
-	    if ($band != 'SAT') {
-          echo '<td style="text-align: center">';
-          if ($band == 'Total') {
-             echo '<b>'.$dxcc.'</b>';
-          } else {
-             echo $dxcc;
-          }
-          echo '</td>';
-	    } else {
-		$addsat='<td style="text-align: center">' . $dxcc . '</td>';
-	    }
-        }
+	foreach ($dxcc_summary['confirmed'] as $band => $dxcc) {      // Fills the table with the data
+		if ($band != 'SAT') {
+			echo '<td style="text-align: center">';
+			if ($band == 'Total') {
+				echo '<b>'.$dxcc.'</b>';
+			} else {
+				echo $dxcc;
+			}
+			echo '</td>';
+		} else {
+			$addsat='<td style="text-align: center">' . $dxcc . '</td>';
+		}
+	}
 	if ($addsat != '' && count($dxcc_summary['confirmed']) > 1) {
-        if (count($bands) > 1) {
-		echo '<td class="spacingcell"></td>';
-        }
+		if (count($bands) > 1) {
+			echo '<td class="spacingcell"></td>';
+		}
 		echo $addsat;
 	}
 
-        echo '</tr>
-        </table>
-        </div>';
+	echo '</tr>
+	</table>
+	</div>';
 
-    }
-    else {
-        echo '<div class="alert alert-danger" role="alert">' . __("Nothing found!") . '</div>';
+    } else {
+	    echo '<div class="alert alert-danger" role="alert">' . __("Nothing found!") . '</div>';
     }
     ?>
                 </div>

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -117,7 +117,7 @@
                 <label class="col-md-2 control-label" for="band"><?= __("Band"); ?></label>
                 <div class="col-md-2">
                     <select id="band2" name="band" class="form-select form-select-sm">
-                        <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("Every band"); ?></option>
+                        <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("Every band (w/o SAT)"); ?></option>
                         <?php foreach($worked_bands as $band) {
                             echo '<option value="' . $band . '"';
                             if ($this->input->post('band') == $band) echo ' selected';
@@ -251,25 +251,47 @@
         <thead>
         <tr><td></td>';
 
+	$addsat='';
         foreach($bands as $band) {
-            echo '<td>' . $band . '</td>';
+	    if ($band != 'SAT') {
+            	echo '<td>' . $band . '</td>';
+	    } else {
+		$addsat='<td>' . $band . '</td>';
+	    }
         }
-        echo '<td>' . __("Total") . '</td>
+        echo '<td>' . __("Total") . '</td>';
+	echo $addsat;
+	echo '
         </tr>
         </thead>
         <tbody>
 
         <tr><td>' . __("Total worked") . '</td>';
-
-        foreach ($dxcc_summary['worked'] as $dxcc) {      // Fills the table with the data
-            echo '<td style="text-align: center">' . $dxcc . '</td>';
+	$addsat='';
+        foreach ($dxcc_summary['worked'] as $band => $dxcc) {      // Fills the table with the data
+	    if ($band != 'SAT') {
+            	echo '<td style="text-align: center">' . $dxcc . '</td>';
+	    } else {
+		$addsat='<td style="text-align: center">' . $dxcc . '</td>';
+	    }
         }
+	if ($addsat != '') {
+		echo $addsat;
+	}
 
         echo '</tr><tr>
         <td>' . __("Total confirmed") . '</td>';
-        foreach ($dxcc_summary['confirmed'] as $dxcc) {      // Fills the table with the data
-            echo '<td style="text-align: center">' . $dxcc . '</td>';
+	$addsat='';
+        foreach ($dxcc_summary['confirmed'] as $band => $dxcc) {      // Fills the table with the data
+	    if ($band != 'SAT') {
+            	echo '<td style="text-align: center">' . $dxcc . '</td>';
+	    } else {
+		$addsat='<td style="text-align: center">' . $dxcc . '</td>';
+	    }
         }
+	if ($addsat != '') {
+		echo $addsat;
+	}
 
         echo '</tr>
         </table>

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -259,7 +259,10 @@
 		$addsat='<td>' . $band . '</td>';
 	    }
         }
-        echo '<td>' . __("Total") . '</td>';
+        echo '<td><b>' . __("Total") . '</b></td>';
+        if (count($bands) > 1) {
+           echo '<td class="spacingcell"></td>';
+        }
 	echo $addsat;
 	echo '
         </tr>
@@ -270,12 +273,21 @@
 	$addsat='';
         foreach ($dxcc_summary['worked'] as $band => $dxcc) {      // Fills the table with the data
 	    if ($band != 'SAT') {
-            	echo '<td style="text-align: center">' . $dxcc . '</td>';
+          echo '<td style="text-align: center">';
+          if ($band == 'Total') {
+             echo '<b>'.$dxcc.'</b>';
+          } else {
+             echo $dxcc;
+          }
+          echo '</td>';
 	    } else {
 		$addsat='<td style="text-align: center">' . $dxcc . '</td>';
 	    }
         }
-	if ($addsat != '') {
+	if ($addsat != '' && count($dxcc_summary['worked']) > 1) {
+        if (count($bands) > 1) {
+		echo '<td class="spacingcell"></td>';
+        }
 		echo $addsat;
 	}
 
@@ -284,12 +296,21 @@
 	$addsat='';
         foreach ($dxcc_summary['confirmed'] as $band => $dxcc) {      // Fills the table with the data
 	    if ($band != 'SAT') {
-            	echo '<td style="text-align: center">' . $dxcc . '</td>';
+          echo '<td style="text-align: center">';
+          if ($band == 'Total') {
+             echo '<b>'.$dxcc.'</b>';
+          } else {
+             echo $dxcc;
+          }
+          echo '</td>';
 	    } else {
 		$addsat='<td style="text-align: center">' . $dxcc . '</td>';
 	    }
         }
-	if ($addsat != '') {
+	if ($addsat != '' && count($dxcc_summary['confirmed']) > 1) {
+        if (count($bands) > 1) {
+		echo '<td class="spacingcell"></td>';
+        }
 		echo $addsat;
 	}
 

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -225,6 +225,9 @@
 			<td>' . __("DXCC Name") . '</td>
 			<td>' . __("Prefix") . '</td>';
 	    foreach($bands as $band) {
+		    if (($posted_band != 'SAT') && ($band == 'SAT')) {
+			   continue;
+		    }
 		    echo '<td>' . $band . '</td>';
 	    }
 	echo '</tr>

--- a/application/views/awards/iota/index.php
+++ b/application/views/awards/iota/index.php
@@ -199,6 +199,9 @@
             echo '      <td>' . __("Deleted") . '</td>';
 
         foreach($bands as $band) {
+	    if (($posted_band != 'SAT') && ($band == 'SAT')) {
+		   continue;
+	    }
             echo '<td>' . $band . '</td>';
         }
         echo '</tr>

--- a/application/views/awards/iota/index.php
+++ b/application/views/awards/iota/index.php
@@ -220,26 +220,68 @@
         <table class="table-sm tablesummary table table-bordered table-hover table-striped table-condensed text-center">
         <thead>
         <tr><td></td>';
-
-        foreach($bands as $band) {
-            echo '<td>' . $band . '</td>';
-        }
-        echo '<td>' . __("Total") . '</td></tr>';
-
+	$addsat='';
+	foreach($bands as $band) {
+		if ($band != 'SAT') {
+			echo '<td>' . $band . '</td>';
+		} else {
+			$addsat='<td>' . $band . '</td>';
+		}
+	}
+	echo '<td><b>' . __("Total") . '</b></td>';
+	if (count($bands) > 1) {
+		echo '<td class="spacingcell"></td>';
+	}
+	echo $addsat;
         echo '</thead>
         <tbody>
 
         <tr><td>' . __("Total worked") . '</td>';
 
-        foreach ($iota_summary['worked'] as $dxcc) {      // Fills the table with the data
-            echo '<td style="text-align: center">' . $dxcc . '</td>';
-        }
+	$addsat='';
+	foreach ($iota_summary['worked'] as $band => $iota) {      // Fills the table with the data
+		if ($band != 'SAT') {
+			echo '<td style="text-align: center">';
+			if ($band == 'Total') {
+				echo '<b>'.$iota.'</b>';
+			} else {
+				echo $iota;
+			}
+			echo '</td>';
+		} else {
+			$addsat='<td style="text-align: center">' . $iota . '</td>';
+		}
+	}
+	if ($addsat != '' && count($iota_summary['worked']) > 1) {
+		if (count($bands) > 1) {
+			echo '<td class="spacingcell"></td>';
+		}
+		echo $addsat;
+	}
 
-        echo '</tr><tr>
-        <td>' . __("Total confirmed") . '</td>';
-        foreach ($iota_summary['confirmed'] as $dxcc) {      // Fills the table with the data
-            echo '<td style="text-align: center">' . $dxcc . '</td>';
-        }
+	echo '</tr><tr>
+	<td>' . __("Total confirmed") . '</td>';
+
+	$addsat='';
+	foreach ($iota_summary['confirmed'] as $band => $iota) {      // Fills the table with the data
+		if ($band != 'SAT') {
+			echo '<td style="text-align: center">';
+			if ($band == 'Total') {
+				echo '<b>'.$iota.'</b>';
+			} else {
+				echo $iota;
+			}
+			echo '</td>';
+		} else {
+			$addsat='<td style="text-align: center">' . $iota . '</td>';
+		}
+	}
+	if ($addsat != '' && count($iota_summary['confirmed']) > 1) {
+		if (count($bands) > 1) {
+			echo '<td class="spacingcell"></td>';
+		}
+		echo $addsat;
+	}
 
         echo '</tr>
         </table>

--- a/application/views/awards/iota/index.php
+++ b/application/views/awards/iota/index.php
@@ -117,7 +117,7 @@
                 <label class="col-md-2 control-label" for="band"><?= __("Band"); ?></label>
                 <div class="col-md-2">
                     <select id="band2" name="band" class="form-select form-select-sm">
-                        <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("Every band"); ?></option>
+                        <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("Every band (w/o SAT)"); ?></option>
                         <?php foreach($worked_bands as $band) {
                             echo '<option value="' . $band . '"';
                             if ($this->input->post('band') == $band) echo ' selected';

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1222,3 +1222,12 @@ svg text.month { fill: #AAA; }
       opacity: 0;
    }
 }
+
+.spacingcell {
+   background-color: transparent !important;
+   border-top-style: none !important;
+   border-bottom-style: none !important;
+   border-right-style: none !important;
+   --dt-row-hover: transparent !important;
+   --dt-row-stripe: transparent !important;
+}

--- a/assets/js/sections/dxccmap.js
+++ b/assets/js/sections/dxccmap.js
@@ -1,5 +1,6 @@
 var osmUrl = $('#dxccmapjs').attr("tileUrl");
 
+
 $('#band2').change(function(){
    var band = $("#band2 option:selected").text();
    if (band != "SAT") {
@@ -12,6 +13,8 @@ $('#band2').change(function(){
       $("#orbitrow").show();
    }
 });
+
+$('#band2').change();	// trigger the change on fresh-load to hide/show SAT-Params
 
 $('#sats').change(function(){
    var sat = $("#sats option:selected").text();


### PR DESCRIPTION
This is a proposal for getting rid of the different summaries at DXCC-Award.

Before patch:
- Chosen "Every Band" calculates a different summary for cnfmd/worked DXCC at the Map compared to the table

After Patch:
- "Every Band" now excludes the SAT-QSOs (`PROP_MODE != "SAT" or PROP_MODE is null`) from the map.

the table is still the same as it already distinguishes between SAT and other QSOs.

If(!) this is okay for everyone i am going to continue the same for other awards (it's minimal-invasive compared to adding to extra-Sum at the map)

Bonus: If show was clicked (while "every band" was chosen and SAT-Params were hidden by default) the SAT-Params popped up again. this patch fixes that as well. SAT-Params are only shown on band=sat now