### PR TITLE
Use values for grid, qth, state etc. from last QSO

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1628,9 +1628,6 @@ class Logbook_model extends CI_Model {
 
 	/* Callsign QRA */
 	function call_qra($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_GRIDSQUARE, COL_TIME_ON');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1673,9 +1670,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_email($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_EMAIL, COL_TIME_ON');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1738,9 +1732,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_state($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_STATE');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1762,9 +1753,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_us_county($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_CNTY');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1787,9 +1775,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_ituzone($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_ITUZ');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1811,9 +1796,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_cqzone($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_CQZ');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1835,9 +1817,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_qth($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_QTH, COL_TIME_ON');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);
@@ -1859,9 +1838,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function call_iota($callsign) {
-		if ($callsign !== $this->get_plaincall($callsign)) {
-			return null;
-		}
 		$this->db->select('COL_CALL, COL_IOTA, COL_TIME_ON');
 		$this->db->join('station_profile', 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where('COL_CALL', $callsign);


### PR DESCRIPTION
With https://github.com/wavelog/wavelog/pull/1193 we removed the lookup for grid, state, zones etc. from previous QSOs for pre-/suffixed callsigns. This seems rather unhelpful as most of the info taken from last QSO may still be valid. The values can be changed upon logging anyway. If you tab through the fields there is even no need to delete the previous value if an update is needed. So this change may be reverted.