### PR TITLE
Fix or-grouping conditions when (not) to update requested qsl

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1958,9 +1958,9 @@ class Logbook_model extends CI_Model {
 			);
 
 			$this->db->where('COL_PRIMARY_KEY', $qso_id);
-			$this->db->or_group_start();
+			$this->db->group_start();
 			$this->db->where('COL_QSL_SENT !=','R');
-			$this->db->where('COL_QSL_SENT_VIA !=', $method);
+			$this->db->or_where('COL_QSL_SENT_VIA !=', $method);
 			$this->db->group_end();
 
 			$this->db->update($this->config->item('table_name'), $data);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1958,8 +1958,10 @@ class Logbook_model extends CI_Model {
 			);
 
 			$this->db->where('COL_PRIMARY_KEY', $qso_id);
+			$this->db->or_group_start();
 			$this->db->where('COL_QSL_SENT !=','R');
 			$this->db->where('COL_QSL_SENT_VIA !=', $method);
+			$this->db->group_end();
 
 			$this->db->update($this->config->item('table_name'), $data);
 


### PR DESCRIPTION
Without an or-group, you may end up not updating due to either the QSL being already requested (but with different method) or the method already being set (but status is not requested).

The other (Paper-)QSL-update related methods (ignore, update_sent, sent) don't suffer from this, as there's only one condition checked.

Maybe additionally it would be desirable to prevent setting QSL-sent-status to requested if the QSL status is already confirmed here in the SQL as well?
