### PR TITLE
Order by col_time_on at eqsl-sync for upload (better debugging)

### DIFF
--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -409,6 +409,7 @@ class Eqslmethods_model extends CI_Model {
 		$this->db->or_where($this->config->item('table_name') . '.COL_EQSL_QSL_SENT', 'N');
 		$this->db->group_end();
 		$this->db->where_in('station_profile.station_id', $logbooks_locations_array);
+		$this->db->order_by($this->config->item('table_name') . '.COL_TIME_ON','ASC');
 
 		return $this->db->get();
 	}


### PR DESCRIPTION
Order the upload for eQSL by TIME_ON Ascending.
Background: If sth. fails, there's a much better chance to identify the "fishy" QSO