### PR TITLE
Reduce Grids / Take oldest

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3793,6 +3793,7 @@ class Logbook_model extends CI_Model {
 				$data['COL_GRIDSQUARE'] = $qsl_gridsquare;
 				$data['COL_DISTANCE'] = $this->qra->distance($station_gridsquare, $qsl_gridsquare, 'K', $ant_path);
 			} elseif ($qsl_vucc_grids != "") {
+				$data['COL_GRIDSQUARE'] = null;
 				$data['COL_VUCC_GRIDS'] = $qsl_vucc_grids;
 				$data['COL_DISTANCE'] = $this->qra->distance($station_gridsquare, $qsl_vucc_grids, 'K', $ant_path);
 			}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3790,6 +3790,7 @@ class Logbook_model extends CI_Model {
 				$this->load->library('Qra');
 			}
 			if ($qsl_gridsquare != "") {
+				$data['COL_VUCC_GRIDS'] = null;
 				$data['COL_GRIDSQUARE'] = $qsl_gridsquare;
 				$data['COL_DISTANCE'] = $this->qra->distance($station_gridsquare, $qsl_gridsquare, 'K', $ant_path);
 			} elseif ($qsl_vucc_grids != "") {

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -380,7 +380,7 @@ class Timeline_model extends CI_Model {
 				} else {
 					// Exists, check the date
 					if ($gridSplit->date < $timeline[$index]['date']) {
-						// Update only if the new date is more recent
+						// Update only if the new date is older
 						$timeline[$index]['date'] = $gridSplit->date;
 					}
 				}
@@ -389,7 +389,7 @@ class Timeline_model extends CI_Model {
 		usort($timeline, function($a, $b) {
 			return $b['date'] <=> $a['date'];
 		});
-		
+
 		return $timeline;
 	}
 

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -380,8 +380,23 @@ class Timeline_model extends CI_Model {
 		usort($timeline, function($a, $b) {
 			return $b['date'] <=> $a['date'];
 		});
+		
+		$result=[];
+		foreach ($timeline as $grid => $date) {
+			$existingKey = array_search($date, $result);
 
-		return $timeline;
+			if ($existingKey === false) {
+				if (!isset($result[$grid]) || strtotime($date) < strtotime($result[$grid])) {
+					$result[$grid] = $date;
+				}
+			} elseif ($existingKey !== $grid) {
+				if (strcmp($grid, $existingKey) < 0) {
+					unset($result[$existingKey]);
+					$result[$grid] = $date;
+				}
+			}
+		}
+		return $result;
 	}
 
 	public function get_gridsquare($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
@@ -471,7 +486,6 @@ class Timeline_model extends CI_Model {
 		$sql .= " and col_vucc_grids <> ''";
 
 		$query = $this->db->query($sql, $binding);
-
 		return $query->result();
 	}
 

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -370,10 +370,19 @@ class Timeline_model extends CI_Model {
 			$grids = explode(",", $gridSplit->gridsquare);
 			foreach($grids as $key) {
 				$grid_four = strtoupper(substr(trim($key),0,4));
-				if (!array_search($grid_four, array_column($timeline, 'gridsquare'))) {
+				$index = array_search($grid_four, array_column($timeline, 'gridsquare'));
+				if ($index === false) {
+					// Doesn't exist, add new entry
 					$timeline[] = array(
 						'gridsquare' => $grid_four,
-						'date'       => $gridSplit->date);
+						'date'       => $gridSplit->date
+					);
+				} else {
+					// Exists, check the date
+					if ($gridSplit->date < $timeline[$index]['date']) {
+						// Update only if the new date is more recent
+						$timeline[$index]['date'] = $gridSplit->date;
+					}
 				}
 			}
 		}
@@ -381,22 +390,7 @@ class Timeline_model extends CI_Model {
 			return $b['date'] <=> $a['date'];
 		});
 		
-		$result=[];
-		foreach ($timeline as $grid => $date) {
-			$existingKey = array_search($date, $result);
-
-			if ($existingKey === false) {
-				if (!isset($result[$grid]) || strtotime($date) < strtotime($result[$grid])) {
-					$result[$grid] = $date;
-				}
-			} elseif ($existingKey !== $grid) {
-				if (strcmp($grid, $existingKey) < 0) {
-					unset($result[$existingKey]);
-					$result[$grid] = $date;
-				}
-			}
-		}
-		return $result;
+		return $timeline;
 	}
 
 	public function get_gridsquare($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {


### PR DESCRIPTION
Example given: Following QSO-Constellation:

- Worked DF2ET at JO30 (Entered that at grid)
- First Time working JO30!
- DF2ET confirms, but with conjunction at VUCC_GRIDS via LoTW for JO30,JO31

Now you've JO30 new (for Grid itself), JO30 new (at VUCC_GRIDs) and JO31 new (at VUCC_GRIDs).

**Timeline**-View now doubles JO30, because the "reducer" for the Grid (out of grid and vucc_grid) was missing.

This one fixes it