### PR TITLE
strip < from qslmessage, because eqsl can't handle it

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -194,7 +194,7 @@ class eqsl extends CI_Controller {
 					$this->eqslmethods_model->disable_eqsl_uid($this->session->userdata('user_id'));
                         	} elseif ($status == 'Nick Error') {
                                 	log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile'.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
-                                	$this->eqlsmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$data['eqsl_station_id']);
+                                	$this->eqslmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$data['eqsl_station_id']);
 				}
 
 				if($status == 'Error') {

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -192,6 +192,9 @@ class eqsl extends CI_Controller {
 				if ($status == 'Login Error') {
 					log_message('error', 'eQSL Credentials-Error for '.$data['user_eqsl_name'].' Login will be disabled!');
 					$this->eqslmethods_model->disable_eqsl_uid($this->session->userdata('user_id'));
+                        	} elseif ($status == 'Nick Error') {
+                                	log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile'.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
+                                	$this->eqlsmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$data['eqsl_station_id']);
 				}
 
 				if($status == 'Error') {

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -193,8 +193,8 @@ class eqsl extends CI_Controller {
 					log_message('error', 'eQSL Credentials-Error for '.$data['user_eqsl_name'].' Login will be disabled!');
 					$this->eqslmethods_model->disable_eqsl_uid($this->session->userdata('user_id'));
                         	} elseif ($status == 'Nick Error') {
-                                	log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile'.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
-                                	$this->eqslmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$data['eqsl_station_id']);
+                                	log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile'.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
+                                	$this->eqslmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$qsl['eqsl_station_id']);
 				}
 
 				if($status == 'Error') {

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -192,9 +192,11 @@ class eqsl extends CI_Controller {
 				if ($status == 'Login Error') {
 					log_message('error', 'eQSL Credentials-Error for '.$data['user_eqsl_name'].' Login will be disabled!');
 					$this->eqslmethods_model->disable_eqsl_uid($this->session->userdata('user_id'));
-                        	} elseif ($status == 'Nick Error') {
-                                	log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile'.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
-                                	$this->eqslmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$qsl['eqsl_station_id']);
+					$status=__("User/Pass wrong for eQSL");
+				} elseif ($status == 'Nick Error') {
+					log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile'.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
+					$this->eqslmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$qsl['eqsl_station_id']);
+					$status=__("No such Nickname at eQSL");
 				}
 
 				if($status == 'Error') {

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -190,13 +190,13 @@ class eqsl extends CI_Controller {
 				$status = $this->eqslmethods_model->uploadQso($adif, $qsl);
 
 				if ($status == 'Login Error') {
-					log_message('error', 'eQSL Credentials-Error for '.$data['user_eqsl_name'].' Login will be disabled!');
+					log_message('error', 'eQSL Credentials-Error for '.$data['user_eqsl_name'].'. Login will be disabled!');
 					$this->eqslmethods_model->disable_eqsl_uid($this->session->userdata('user_id'));
 					$status=__("User/Pass wrong for eQSL");
 				} elseif ($status == 'Nick Error') {
-					log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile'.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
+					log_message('error', 'eQSL error for user '.$data['user_eqsl_name'].' with QTH Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile '.($qsl['eqsl_station_id'] ?? '').'. eQSL QTH Nickname will be removed from station location!');
 					$this->eqslmethods_model->disable_eqsl_station_id($this->session->userdata('user_id'),$qsl['eqsl_station_id']);
-					$status=__("No such Nickname at eQSL");
+					$status=sprintf(__("No such eQSL QTH Nickname: %s"), $qsl['eqslqthnickname'] ?? '');
 				}
 
 				if($status == 'Error') {

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -261,6 +261,7 @@ class Eqslmethods_model extends CI_Model {
 		// basic curl options for all requests
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_HEADER, 1);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 
 		// use the URL we built
 		curl_setopt($ch, CURLOPT_URL, $adif);

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -209,7 +209,7 @@ class Eqslmethods_model extends CI_Model {
 
 		// adding qslmsg if it isn't blank
 		if ($qsl['COL_QSLMSG'] != '') {
-			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13),'<','>',':'), array(' ', ' ','','',' '), $qsl['COL_QSLMSG']);
+			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13),'<','>',':','_'), array(' ', ' ','','',' ',' '), $qsl['COL_QSLMSG']);
 			$adif .= "%3C";
 			$adif .= "QSLMSG";
 			$adif .= "%3A";
@@ -217,6 +217,7 @@ class Eqslmethods_model extends CI_Model {
 			$adif .= "%3E";
 			$adif .= str_replace('&', '%26', $qsl['COL_QSLMSG']);
 			$adif .= str_replace('?', '%3F', $qsl['COL_QSLMSG']);
+			$adif .= str_replace('-', '%2D', $qsl['COL_QSLMSG']);
 			$adif .= "%20";
 		}
 

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -49,16 +49,16 @@ class Eqslmethods_model extends CI_Model {
 		foreach ($qslsnotsent->result_array() as $qsl) {
 			$data['user_eqsl_name'] = $qsl['station_callsign'];
 			$adif = $this->generateAdif($qsl, $data);
-			
+
 			$status = $this->uploadQso($adif, $qsl);
 
 			if ($status == 'Error') {
 				log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
 				break;
-                        } elseif ($status == 'Nick Error') {
-                                log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile: '.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
-                                $this->disable_eqsl_station_id($userid,$qsl['eqsl_station_id']);
-                                break;
+			} elseif ($status == 'Nick Error') {
+				log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile: '.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
+				$this->disable_eqsl_station_id($userid,$qsl['eqsl_station_id']);
+				break;
 			} elseif ($status == 'Login Error') {
 				log_message('error', 'eQSL Credentials-Error (User, Pass or Nickname) for '.$data['user_eqsl_name'].' Login will be disabled!');
 				$this->disable_eqsl_uid($userid);

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -45,6 +45,7 @@ class Eqslmethods_model extends CI_Model {
 		$clean_userid = $this->security->xss_clean($userid);
 
 		$qslsnotsent = $this->eqsl_not_yet_sent($clean_userid);
+		log_message("Error",$this->db->last_query());
 
 		foreach ($qslsnotsent->result_array() as $qsl) {
 			$data['user_eqsl_name'] = $qsl['station_callsign'];
@@ -209,7 +210,7 @@ class Eqslmethods_model extends CI_Model {
 
 		// adding qslmsg if it isn't blank
 		if ($qsl['COL_QSLMSG'] != '') {
-			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13)), array(' ', ' '), $qsl['COL_QSLMSG']);
+			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13),'<'), array(' ', ' ',''), $qsl['COL_QSLMSG']);
 			$adif .= "%3C";
 			$adif .= "QSLMSG";
 			$adif .= "%3A";

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -55,6 +55,10 @@ class Eqslmethods_model extends CI_Model {
 			if ($status == 'Error') {
 				log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
 				break;
+                        } elseif ($status == 'Nick Error') {
+                                log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile'.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
+                                $this->disable_eqsl_station_id($userid,$data['eqsl_station_id']);
+                                break;
 			} elseif ($status == 'Login Error') {
 				log_message('error', 'eQSL Credentials-Error (User, Pass or Nickname) for '.$data['user_eqsl_name'].' Login will be disabled!');
 				$this->disable_eqsl_uid($userid);
@@ -300,7 +304,7 @@ class Eqslmethods_model extends CI_Model {
 				} elseif (stristr($result, "No match on APP_EQSL_QTH_NICKNAME")) {
 					$msg = __("eQSL-Nickname doesn't exist at eQSL");
 					$this->session->set_flashdata('warning', $msg);
-					$status = "Login Error";
+					$status = "Nick Error";
 				} elseif (stristr($result, "Bad record: Duplicate")) {
 					$status = "Duplicate";
 					$this->eqsl_mark_sent($qsl['COL_PRIMARY_KEY']);
@@ -359,6 +363,13 @@ class Eqslmethods_model extends CI_Model {
 				$this->db->update($this->config->item('table_name'), $data);
 			}
 		}
+	}
+
+	function disable_eqsl_station_id($user_id,$station_id) {
+		$sql='update station_profile set eqslqthnickname=null where user_id=? and station_id=?';
+		$bindings=[$userid,$station_id];
+		$this->db->query($sql,$bindings);
+		return;
 	}
 
 	function disable_eqsl_uid($userid) {

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -45,7 +45,6 @@ class Eqslmethods_model extends CI_Model {
 		$clean_userid = $this->security->xss_clean($userid);
 
 		$qslsnotsent = $this->eqsl_not_yet_sent($clean_userid);
-		log_message("Error",$this->db->last_query());
 
 		foreach ($qslsnotsent->result_array() as $qsl) {
 			$data['user_eqsl_name'] = $qsl['station_callsign'];
@@ -210,13 +209,14 @@ class Eqslmethods_model extends CI_Model {
 
 		// adding qslmsg if it isn't blank
 		if ($qsl['COL_QSLMSG'] != '') {
-			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13),'<'), array(' ', ' ',''), $qsl['COL_QSLMSG']);
+			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13),'<','>',':'), array(' ', ' ','','',' '), $qsl['COL_QSLMSG']);
 			$adif .= "%3C";
 			$adif .= "QSLMSG";
 			$adif .= "%3A";
 			$adif .= strlen($qsl['COL_QSLMSG']);
 			$adif .= "%3E";
 			$adif .= str_replace('&', '%26', $qsl['COL_QSLMSG']);
+			$adif .= str_replace('?', '%3F', $qsl['COL_QSLMSG']);
 			$adif .= "%20";
 		}
 

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -367,7 +367,7 @@ class Eqslmethods_model extends CI_Model {
 
 	function disable_eqsl_station_id($user_id,$station_id) {
 		$sql='update station_profile set eqslqthnickname=null where user_id=? and station_id=?';
-		$bindings=[$userid,$station_id];
+		$bindings=[$user_id,$station_id];
 		$this->db->query($sql,$bindings);
 		return;
 	}

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -291,6 +291,7 @@ class Eqslmethods_model extends CI_Model {
 				} else {
 					if (stristr($result, "Result: 0 out of 0 records added")) {
 						$msg = __("Something went wrong with eQSL.cc!");
+						log_message('error', 'eQSL at QSO: '.$qsl['COL_PRIMARY_KEY']); // No leftover-Debug, but Find the faulty QSO for not known errors!
 						log_message('error', 'eQSL: '.$msg);
 						$this->session->set_flashdata('warning', $msg);
 						$status = "Error";

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -215,9 +215,7 @@ class Eqslmethods_model extends CI_Model {
 			$adif .= "%3A";
 			$adif .= strlen($qsl['COL_QSLMSG']);
 			$adif .= "%3E";
-			$adif .= str_replace('&', '%26', $qsl['COL_QSLMSG']);
-			$adif .= str_replace('?', '%3F', $qsl['COL_QSLMSG']);
-			$adif .= str_replace('-', '%2D', $qsl['COL_QSLMSG']);
+			$adif .= rawurlencode($qsl['COL_QSLMSG']);
 			$adif .= "%20";
 		}
 

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -56,8 +56,8 @@ class Eqslmethods_model extends CI_Model {
 				log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
 				break;
                         } elseif ($status == 'Nick Error') {
-                                log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile: '.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
-                                $this->disable_eqsl_station_id($userid,$data['eqsl_station_id']);
+                                log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile: '.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
+                                $this->disable_eqsl_station_id($userid,$qsl['eqsl_station_id']);
                                 break;
 			} elseif ($status == 'Login Error') {
 				log_message('error', 'eQSL Credentials-Error (User, Pass or Nickname) for '.$data['user_eqsl_name'].' Login will be disabled!');

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -56,7 +56,7 @@ class Eqslmethods_model extends CI_Model {
 				log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
 				break;
 			} elseif ($status == 'Login Error') {
-				log_message('error', 'eQSL Credentials-Error for '.$data['user_eqsl_name'].' Login will be disabled!');
+				log_message('error', 'eQSL Credentials-Error (User, Pass or Nickname) for '.$data['user_eqsl_name'].' Login will be disabled!');
 				$this->disable_eqsl_uid($userid);
 				break;
 			}
@@ -289,21 +289,23 @@ class Eqslmethods_model extends CI_Model {
 					log_message('error', 'eQSL: '.$msg);
 					$this->session->set_flashdata('warning', $msg);
 					$status = "Login Error";
+				} elseif (stristr($result, "Result: 0 out of 0 records added")) {
+					$msg = __("Something went wrong with eQSL.cc!");
+					log_message('error', 'eQSL at QSO-ID: '.$qsl['COL_PRIMARY_KEY']); // No leftover-Debug, but Find the faulty QSO for not known errors!
+					$this->session->set_flashdata('warning', $msg);
+					$status = "Error";
+				} elseif (stristr($result, "Result: 0 out of 1 records added")) {
+					$this->eqsl_mark_invalid($qsl['COL_PRIMARY_KEY']);
+					$status = "Invalid";
+				} elseif (stristr($result, "No match on APP_EQSL_QTH_NICKNAME")) {
+					$msg = __("eQSL-Nickname doesn't exist at eQSL");
+					$this->session->set_flashdata('warning', $msg);
+					$status = "Login Error";
+				} elseif (stristr($result, "Bad record: Duplicate")) {
+					$status = "Duplicate";
+					$this->eqsl_mark_sent($qsl['COL_PRIMARY_KEY']);
 				} else {
-					if (stristr($result, "Result: 0 out of 0 records added")) {
-						$msg = __("Something went wrong with eQSL.cc!");
-						log_message('error', 'eQSL at QSO: '.$qsl['COL_PRIMARY_KEY']); // No leftover-Debug, but Find the faulty QSO for not known errors!
-						log_message('error', 'eQSL: '.$msg);
-						$this->session->set_flashdata('warning', $msg);
-						$status = "Error";
-					} else {
-						if (stristr($result, "Bad record: Duplicate")) {
-							$status = "Duplicate";
-
-							# Mark the QSL as sent if this is a dupe.
-							$this->eqsl_mark_sent($qsl['COL_PRIMARY_KEY']);
-						}
-					}
+					log_message("Error","eQSL: Uncaught exception at QSO-ID: ".$qsl['COL_PRIMARY_KEY']);
 				}
 			}
 		} else {
@@ -312,20 +314,21 @@ class Eqslmethods_model extends CI_Model {
 				log_message('error', 'eQSL: '.$msg);
 				$this->session->set_flashdata('warning', $msg);
 				$status = "Error";
+			} elseif ($chi['http_code'] == "400") {
+				$msg = __("There was an error in one of the QSOs. You might want to manually upload them.");
+				log_message('error', 'eQSL: '.$msg);
+				$this->session->set_flashdata('warning', $msg);
+				$status = "Error";
+			} elseif ($chi['http_code'] == "404") {
+				$msg = __("It seems that the eQSL site has changed. Please open up an issue on GitHub.");
+				log_message('error', 'eQSL: '.$msg);
+				$this->session->set_flashdata('warning', $msg);
+				$status = "Error";
 			} else {
-				if ($chi['http_code'] == "400") {
-					$msg = __("There was an error in one of the QSOs. You might want to manually upload them.");
-					log_message('error', 'eQSL: '.$msg);
-					$this->session->set_flashdata('warning', $msg);
-					$status = "Error";
-				} else {
-					if ($chi['http_code'] == "404") {
-						$msg = __("It seems that the eQSL site has changed. Please open up an issue on GitHub.");
-						log_message('error', 'eQSL: '.$msg);
-						$this->session->set_flashdata('warning', $msg);
-						$status = "Error";
-					}
-				}
+				log_message("Error","eQSL: Uncaught HTTP-exception at QSO-ID: ".$qsl['COL_PRIMARY_KEY']);
+				$msg = __("An uncaught Error occured while uploading QSOs. Perhaps eQSL has hiccups");
+				$this->session->set_flashdata('warning', $msg);
+				$status= "Error";
 			}
 		}
 		return $status;
@@ -398,7 +401,7 @@ class Eqslmethods_model extends CI_Model {
 			array_push($logbooks_locations_array, -9999);
 		}
 
-		$this->db->select('station_profile.*, ' . $this->config->item('table_name') . '.COL_PRIMARY_KEY, ' . $this->config->item('table_name') . '.COL_TIME_ON, ' . $this->config->item('table_name') . '.COL_CALL, ' . $this->config->item('table_name') . '.COL_MODE, ' . $this->config->item('table_name') . '.COL_SUBMODE, ' . $this->config->item('table_name') . '.COL_BAND, ' . $this->config->item('table_name') . '.COL_COMMENT, ' . $this->config->item('table_name') . '.COL_RST_SENT, ' . $this->config->item('table_name') . '.COL_PROP_MODE, ' . $this->config->item('table_name') . '.COL_SAT_NAME, ' . $this->config->item('table_name') . '.COL_SAT_MODE, ' . $this->config->item('table_name') . '.COL_QSLMSG');
+		$this->db->select('station_profile.*, ' . $this->config->item('table_name') . '.COL_PRIMARY_KEY, ' . $this->config->item('table_name') . '.COL_TIME_ON, ' . $this->config->item('table_name') . '.COL_CALL, ' . $this->config->item('table_name') . '.COL_MODE, ' . $this->config->item('table_name') . '.COL_SUBMODE, ' . $this->config->item('table_name') . '.COL_BAND, ' . $this->config->item('table_name') . '.COL_COMMENT, ' . $this->config->item('table_name') . '.COL_RST_SENT, ' . $this->config->item('table_name') . '.COL_PROP_MODE, ' . $this->config->item('table_name') . '.COL_SAT_NAME, ' . $this->config->item('table_name') . '.COL_SAT_MODE, ' . $this->config->item('table_name') . '.COL_QSLMSG, '. $this->config->item('table_name') . '.station_id as eqsl_station_id');
 		$this->db->from('station_profile');
 		$this->db->join($this->config->item('table_name'), 'station_profile.station_id = ' . $this->config->item('table_name') . '.station_id');
 		$this->db->where("coalesce(station_profile.eqslqthnickname, '') <> ''");
@@ -456,6 +459,19 @@ class Eqslmethods_model extends CI_Model {
 		$this->db->update($this->config->item('table_name'), $data);
 
 		return "eQSL Sent";
+	}
+
+	function eqsl_mark_invalid($primarykey) {
+		$data = array(
+			'COL_EQSL_QSLSDATE' => date('Y-m-d H:i:s'), // eQSL doesn't give us a date, so let's use current
+			'COL_EQSL_QSL_SENT' => 'I',
+		);
+
+		$this->db->where('COL_PRIMARY_KEY', $primarykey);
+
+		$this->db->update($this->config->item('table_name'), $data);
+
+		return "eQSL Invalid";
 	}
 
 	// Returns all the distinct callsign, eqsl nick pair for the current user/supplied user

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -56,7 +56,7 @@ class Eqslmethods_model extends CI_Model {
 				log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
 				break;
                         } elseif ($status == 'Nick Error') {
-                                log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile'.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
+                                log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($data['eqslqthnickname'] ?? '').' at station_profile: '.($data['eqsl_station_id'] ?? '').' Nickname will be removed!');
                                 $this->disable_eqsl_station_id($userid,$data['eqsl_station_id']);
                                 break;
 			} elseif ($status == 'Login Error') {

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -213,7 +213,7 @@ class Eqslmethods_model extends CI_Model {
 
 		// adding qslmsg if it isn't blank
 		if ($qsl['COL_QSLMSG'] != '') {
-			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13),'<','>',':','_'), array(' ', ' ','','',' ',' '), $qsl['COL_QSLMSG']);
+			$qsl['COL_QSLMSG'] = str_replace(array(chr(10), chr(13)), array(' ', ' '), $qsl['COL_QSLMSG']);
 			$adif .= "%3C";
 			$adif .= "QSLMSG";
 			$adif .= "%3A";

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -56,11 +56,11 @@ class Eqslmethods_model extends CI_Model {
 				log_message('error', 'eQSL Error for '.$data['user_eqsl_name']);
 				break;
 			} elseif ($status == 'Nick Error') {
-				log_message('error', 'eQSL Nickname-Error for User '.$data['user_eqsl_name'].' with Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile: '.($qsl['eqsl_station_id'] ?? '').' Nickname will be removed!');
+				log_message('error', 'eQSL error for user '.$data['user_eqsl_name'].' with QTH Nickname '.($qsl['eqslqthnickname'] ?? '').' at station_profile '.($qsl['eqsl_station_id'] ?? '').'. eQSL QTH Nickname will be removed from station location!');
 				$this->disable_eqsl_station_id($userid,$qsl['eqsl_station_id']);
 				break;
 			} elseif ($status == 'Login Error') {
-				log_message('error', 'eQSL Credentials-Error (User, Pass or Nickname) for '.$data['user_eqsl_name'].' Login will be disabled!');
+				log_message('error', 'eQSL credentials error (user, pass or QTH Nickname) for '.$data['user_eqsl_name'].'. Login will be disabled!');
 				$this->disable_eqsl_uid($userid);
 				break;
 			}
@@ -302,7 +302,7 @@ class Eqslmethods_model extends CI_Model {
 					$this->eqsl_mark_invalid($qsl['COL_PRIMARY_KEY']);
 					$status = "Invalid";
 				} elseif (stristr($result, "No match on APP_EQSL_QTH_NICKNAME")) {
-					$msg = __("eQSL-Nickname doesn't exist at eQSL");
+					$msg = __("QTH Nickname does not exist at eQSL");
 					$this->session->set_flashdata('warning', $msg);
 					$status = "Nick Error";
 				} elseif (stristr($result, "Bad record: Duplicate")) {

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -298,6 +298,9 @@ class Eqslmethods_model extends CI_Model {
 					log_message('error', 'eQSL at QSO-ID: '.$qsl['COL_PRIMARY_KEY']); // No leftover-Debug, but Find the faulty QSO for not known errors!
 					$this->session->set_flashdata('warning', $msg);
 					$status = "Error";
+				} elseif (stristr($result, "Bad record: Duplicate")) {
+					$status = "Duplicate";
+					$this->eqsl_mark_sent($qsl['COL_PRIMARY_KEY']);
 				} elseif (stristr($result, "Result: 0 out of 1 records added")) {
 					$this->eqsl_mark_invalid($qsl['COL_PRIMARY_KEY']);
 					$status = "Invalid";
@@ -305,9 +308,6 @@ class Eqslmethods_model extends CI_Model {
 					$msg = __("QTH Nickname does not exist at eQSL");
 					$this->session->set_flashdata('warning', $msg);
 					$status = "Nick Error";
-				} elseif (stristr($result, "Bad record: Duplicate")) {
-					$status = "Duplicate";
-					$this->eqsl_mark_sent($qsl['COL_PRIMARY_KEY']);
 				} else {
 					log_message("Error","eQSL: Uncaught exception at QSO-ID: ".$qsl['COL_PRIMARY_KEY']);
 				}


### PR DESCRIPTION
it's much more than only being sure the content it properly encoded.

Current situation: imagine an instance with 100 Users, everyone has 50.000 QSOs == 5Mio QSOs.
Now assume 10 Users have either invalid-QSOs (Mode: "HTTY" or "Band 40m / Freq 21.800") or a Nickname which doesn't exist at eQSL.
Since we're processing QSO by QSO, and those exceptions weren't handled in the past, the syncer has to do this over and over and again until the Database gives us a timeout (becuse eQSL is so slow).

At the next run of thee syncer the same will happen. causing that some users never will be synced.

This patch adresses proper cathing of those exceptions. in detail:
- Wrong Nickname? abort sync for user // remove eQSL-Nick from station and show user a message (if manual synced)
- Invalid QSO (0 of 1 record inserted) ? Mark it as invalid, so it won't be fetched for future syncs.
- QSO-Payload invalid (0 of 0 records inserted): Skip the whole user for now and create a error-log-entry to do further investigations (exceptions we're not aware of)
- HTTP-Error other than 400,404 or 500 from eQSL: Skip the user for now and produce logentry and warning (exceptions we're not aware of)