### PR TITLE
Use stars to hide QRZ-Key and add "eye"-button

### DIFF
--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -383,7 +383,10 @@ if ($dxcc_list->result() > 0) {
 					</div>
 					<div class="mb-3">
 						<label for="webadifApiKey"><?= __("HRDLog.net API Key"); ?></label>
-						<input type="text" class="form-control" name="hrdlog_code" id="hrdlog_code" aria-describedby="hrdlog_codeHelp" value="<?php if(set_value('hrdlog_code') != "") { echo set_value('hrdlog_code'); } else { echo $my_station_profile->hrdlog_code; } ?>">
+						<div class="input-group">
+							<input type="password" class="form-control" name="hrdlog_code" id="hrdlog_code" aria-describedby="hrdlog_codeHelp" value="<?php if(set_value('hrdlog_code') != "") { echo set_value('hrdlog_code'); } else { echo $my_station_profile->hrdlog_code; } ?>">
+							<span class="input-group-btn"><button class="btn btn-default btn-pwd-showhide" type="button"><i class="fa fa-eye-slash"></i></button></span>
+						</div>
 						<small id="hrdlog_codeHelp" class="form-text text-muted"><?= sprintf(_pgettext("HRDLog.net Userprofile page", "Create your API Code on your %s"), "<a href='http://www.hrdlog.net/EditUser.aspx' target='_blank'>".__("HRDLog.net Userprofile page")."</a>"); ?></a></small>
 					</div>
 					<div class="mb-3">
@@ -405,7 +408,10 @@ if ($dxcc_list->result() > 0) {
 				<div class="card-body">
 					<div class="mb-3">
 						<label for="webadifApiKey"><?php echo _pgettext("Probably no translation needed","QO-100 Dx Club API Key"); ?></label>
-						<input type="text" class="form-control" name="webadifapikey" id="webadifApiKey" aria-describedby="webadifApiKeyHelp" value="<?php if(set_value('webadifapikey') != "") { echo set_value('webadifapikey'); } else { echo $my_station_profile->webadifapikey; } ?>">
+						<div class="input-group">
+							<input type="password" class="form-control" name="webadifapikey" id="webadifApiKey" aria-describedby="webadifApiKeyHelp" value="<?php if(set_value('webadifapikey') != "") { echo set_value('webadifapikey'); } else { echo $my_station_profile->webadifapikey; } ?>">
+							<span class="input-group-btn"><button class="btn btn-default btn-pwd-showhide" type="button"><i class="fa fa-eye-slash"></i></button></span>
+						</div>
 						<small id="webadifApiKeyHelp" class="form-text text-muted"><?= sprintf(_pgettext("QO-100 Dx Club's profile page", "Create your API key on your %s"), "<a href='https://qo100dx.club' target='_blank'>".__("QO-100 Dx Club's profile page")."</a>"); ?></a></small>
 					</div>
 					<div class="mb-3">

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -326,7 +326,8 @@ if ($dxcc_list->result() > 0) {
 					<div class="mb-3">
 						<label for="qrzApiKey">QRZ.com Logbook API Key</label> <!-- This does not need Multilanguage Support -->
 						<div class="input-group">
-							<input type="text" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(set_value('qrzapikey') != "") { echo set_value('qrzapikey'); } else { echo $my_station_profile->qrzapikey; } ?>">
+							<input type="password" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(set_value('qrzapikey') != "") { echo set_value('qrzapikey'); } else { echo $my_station_profile->qrzapikey; } ?>">
+						<span class="input-group-btn"><button class="btn btn-default btn-pwd-showhide" type="button"><i class="fa fa-eye-slash"></i></button></span>
 							<button class="btn btn-secondary" type="button" id="qrz_apitest_btn">Test API-Key</button>
 						</div>
 						<div class="alert mt-3" style="display: none;" id="qrz_apitest_msg"></div>

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -1,4 +1,15 @@
 $(document).ready(function () {
+	function btn_pwd_showhide() {
+		if ($(this).closest('div').find('input[type="password"]').length>0) {
+			$(this).closest('div').find('input[type="password"]').attr('type','text');
+			$(this).closest('div').find('.fa-eye-slash').removeClass('fa-eye-slash').addClass('fa-eye');
+		} else {
+			$(this).closest('div').find('input[type="text"]').attr('type','password');
+			$(this).closest('div').find('.fa-eye').removeClass('fa-eye').addClass('fa-eye-slash');
+		}
+	}
+	$('.btn-pwd-showhide').off('click').on('click', btn_pwd_showhide );
+
 	$("#station_locations_table").DataTable({
 		stateSave: true,
 		language: {


### PR DESCRIPTION
should fix https://github.com/wavelog/wavelog/issues/1805

Default-View with this patch:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/18bc1c97-57e2-4636-b0d5-ea80fab7342f" />

With a click on the eye the pw will be revealed
<img width="650" alt="image" src="https://github.com/user-attachments/assets/f2b3939e-275d-4af5-a4fc-2d1e2cf72fdf" />
