### PR TITLE
Reset HoN-Field when entering/looking up new Call

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -649,6 +649,10 @@ $("#callsign").on("focusout", function () {
 							$('#callsign').removeClass("confirmedGrid");
 							$('#callsign').removeClass("newGrid");
 							$('#callsign').attr('title', '');
+							$('#ham_of_note_info').text("");
+							$('#ham_of_note_link').html("");
+							$('#ham_of_note_link').removeAttr('href');
+							$('#ham_of_note_line').hide();
 
 							if (result.confirmed) {
 								$('#callsign').addClass("confirmedGrid");
@@ -669,6 +673,10 @@ $("#callsign").on("focusout", function () {
 							$('#callsign').removeClass("workedGrid");
 							$('#callsign').removeClass("newGrid");
 							$('#callsign').attr('title', '');
+							$('#ham_of_note_info').text("");
+							$('#ham_of_note_link').html("");
+							$('#ham_of_note_link').removeAttr('href');
+							$('#ham_of_note_line').hide();
 
 							if (result.confirmed) {
 								$('#callsign').addClass("confirmedGrid");


### PR DESCRIPTION
when entering a Call which matches a HoN-Call it shows the Note.
if correcting the call to some other call (without Reset via ESC or Reset-Button), the HoN-Note is still there.

this patch resolves it