### PR TITLE
Fix an issue where qsl_sent wasn't set

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1880,7 +1880,7 @@ class Logbook_model extends CI_Model {
 			);
 
 			$this->db->where('COL_PRIMARY_KEY', $qso_id);
-			$this->db->where('COL_QSL_SENT !=', 'Y');
+			$this->db->where('COL_QSL_RCVD !=', 'Y');
 
 			$this->db->update($this->config->item('table_name'), $data);
 			if ($this->db->affected_rows()>0) {	// Only set to modified if REALLY modified

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -15,105 +15,105 @@ function setRst(mode) {
 }
 
 function qsl_rcvd(id, method) {
-    $(".ld-ext-right-r-"+method).addClass('running');
-    $(".ld-ext-right-r-"+method).prop('disabled', true);
-    $.ajax({
-        url: base_url + 'index.php/qso/qsl_rcvd_ajax',
-        type: 'post',
-        data: {'id': id,
-            'method': method
-        },
-        success: function(data) {
-            $(".ld-ext-right-r-"+method).removeClass('running');
-            $(".ld-ext-right-r-"+method).prop('disabled', false);
-            if (data.message == 'OK') {
-                $("#qsl_" + id).find("span:eq(1)").attr('class', 'qsl-green'); // Paints arrow green
-		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
-                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+	$(".ld-ext-right-r-"+method).addClass('running');
+	$(".ld-ext-right-r-"+method).prop('disabled', true);
+	$.ajax({
+		url: base_url + 'index.php/qso/qsl_rcvd_ajax',
+		type: 'post',
+		data: {'id': id,
+			'method': method
+		},
+		success: function(data) {
+			$(".ld-ext-right-r-"+method).removeClass('running');
+			$(".ld-ext-right-r-"+method).prop('disabled', false);
+			if (data.message == 'OK') {
+				$("#qsl_" + id).find("span:eq(1)").attr('class', 'qsl-green'); // Paints arrow green
+				if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+					$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+				}
+				$(".qsl_rcvd_" + id).remove(); // removes choice from menu
+			}
+			else {
+				$(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
+			}
 		}
-                $(".qsl_rcvd_" + id).remove(); // removes choice from menu
-            }
-            else {
-                $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
-            }
-        }
-    });
+	});
 }
 
 function qsl_sent(id, method) {
-    $.ajax({
-        url: base_url + 'index.php/qso/qsl_sent_ajax',
-        type: 'post',
-        data: {'id': id,
-            'method': method
-        },
-        success: function(data) {
-            if (data.message == 'OK') {
-                $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-green'); // Paints arrow green
-		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
-                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+	$.ajax({
+		url: base_url + 'index.php/qso/qsl_sent_ajax',
+		type: 'post',
+		data: {'id': id,
+			'method': method
+		},
+		success: function(data) {
+			if (data.message == 'OK') {
+				$("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-green'); // Paints arrow green
+				if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+					$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+				}
+				$(".qsl_sent_" + id).remove(); // removes choice from menu
+			}
+			else {
+				$(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
+			}
 		}
-                $(".qsl_sent_" + id).remove(); // removes choice from menu
-            }
-            else {
-                $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
-            }
-        }
-    });
+	});
 }
 
 // Function: qsl_requested
 // Marks QSL card requested against the QSO.
 function qsl_requested(id, method) {
-    $(".ld-ext-right-t-"+method).addClass('running');
-    $(".ld-ext-right-t-"+method).prop('disabled', true);
-    $.ajax({
-        url: base_url + 'index.php/qso/qsl_requested_ajax',
-        type: 'post',
-        data: {'id': id,
-            'method': method
-        },
-        success: function(data) {
-            $(".ld-ext-right-t-"+method).removeClass('running');
-            $(".ld-ext-right-t-"+method).prop('disabled', false);
-            if (data.message == 'OK') {
-                $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // Paints arrow yellow
-		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
-                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+	$(".ld-ext-right-t-"+method).addClass('running');
+	$(".ld-ext-right-t-"+method).prop('disabled', true);
+	$.ajax({
+		url: base_url + 'index.php/qso/qsl_requested_ajax',
+		type: 'post',
+		data: {'id': id,
+			'method': method
+		},
+		success: function(data) {
+			$(".ld-ext-right-t-"+method).removeClass('running');
+			$(".ld-ext-right-t-"+method).prop('disabled', false);
+			if (data.message == 'OK') {
+				$("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // Paints arrow yellow
+				if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+					$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+				}
+			}
+			else {
+				$(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
+			}
 		}
-            }
-            else {
-                $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
-            }
-        }
-    });
+	});
 }
 
 // Function: qsl_ignore
 // Marks QSL card ignore against the QSO.
 function qsl_ignore(id, method) {
-    $(".ld-ext-right-ignore").addClass('running');
-    $(".ld-ext-right-ignore").prop('disabled', true);
-    $.ajax({
-        url: base_url + 'index.php/qso/qsl_ignore_ajax',
-        type: 'post',
-        data: {'id': id,
-            'method': method
-        },
-        success: function(data) {
-            $(".ld-ext-right-ignore").removeClass('running');
-            $(".ld-ext-right-ignore").prop('disabled', false);
-            if (data.message == 'OK') {
-                $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-grey'); // Paints arrow grey
-		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
-                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+	$(".ld-ext-right-ignore").addClass('running');
+	$(".ld-ext-right-ignore").prop('disabled', true);
+	$.ajax({
+		url: base_url + 'index.php/qso/qsl_ignore_ajax',
+		type: 'post',
+		data: {'id': id,
+			'method': method
+		},
+		success: function(data) {
+			$(".ld-ext-right-ignore").removeClass('running');
+			$(".ld-ext-right-ignore").prop('disabled', false);
+			if (data.message == 'OK') {
+				$("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-grey'); // Paints arrow grey
+				if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+					$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+				}
+			}
+			else {
+				$(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
+			}
 		}
-            }
-            else {
-                $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
-            }
-        }
-    });
+	});
 }
 
 function displayQso(id) {

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -28,7 +28,9 @@ function qsl_rcvd(id, method) {
             $(".ld-ext-right-r-"+method).prop('disabled', false);
             if (data.message == 'OK') {
                 $("#qsl_" + id).find("span:eq(1)").attr('class', 'qsl-green'); // Paints arrow green
-                $("#qrz_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // marks the QRZ Upload as modified
+		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+		}
                 $(".qsl_rcvd_" + id).remove(); // removes choice from menu
             }
             else {
@@ -48,7 +50,9 @@ function qsl_sent(id, method) {
         success: function(data) {
             if (data.message == 'OK') {
                 $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-green'); // Paints arrow green
-                $("#qrz_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // marks the QRZ Upload as modified
+		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+		}
                 $(".qsl_sent_" + id).remove(); // removes choice from menu
             }
             else {
@@ -74,7 +78,9 @@ function qsl_requested(id, method) {
             $(".ld-ext-right-t-"+method).prop('disabled', false);
             if (data.message == 'OK') {
                 $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // Paints arrow yellow
-                $("#qrz_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // marks the QRZ Upload as modified
+		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+		}
             }
             else {
                 $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');
@@ -99,7 +105,9 @@ function qsl_ignore(id, method) {
             $(".ld-ext-right-ignore").prop('disabled', false);
             if (data.message == 'OK') {
                 $("#qsl_" + id).find("span:eq(0)").attr('class', 'qsl-grey'); // Paints arrow grey
-                $("#qrz_" + id).find("span:eq(0)").attr('class', 'qsl-yellow'); // marks the QRZ Upload as modified
+		if ($("#qrz_"+ id).find("span:eq(0)").hasClass("qrz-green")) {
+                	$("#qrz_" + id).find("span:eq(0)").attr('class', 'qrz-yellow'); // marks the QRZ Upload as modified
+		}
             }
             else {
                 $(".bootstrap-dialog-message").append('<div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>You are not allowed to update QSL status!</div>');


### PR DESCRIPTION
This one fixes two issues:

- [x] Issue 1:
Fresh QSO:
1. mark qsl as received. qsl arrow turns green. qrz arrow turns orange in UI (only)
2. reload, qrz is red
Logically correct because QRZ was never sent, but UI-Issue

- [x] Issue 2:
Fresh QSO:
1. mark qsl as sent. qsl arrow turns green.
2. mark qsl as received, qsl sent arrow turns green
3. reload, qsl received is red
Logically incorrect. Patch should solve that