### PR TITLE
Ignore empty QSL-Fields on empty/import

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4205,7 +4205,7 @@ class Logbook_model extends CI_Model {
 	 qslrdate, qslsdate
 	 */
 
-			if (isset($record['qslrdate'])) {
+			if (($record['qslrdate'] ?? '') != '') {
 				if (validateADIFDate($record['qslrdate']) == true) {
 					$input_qslrdate = $record['qslrdate'];
 				} else {
@@ -4216,7 +4216,7 @@ class Logbook_model extends CI_Model {
 				$input_qslrdate = NULL;
 			}
 
-			if (isset($record['qslsdate'])) {
+			if (($record['qslsdate'] ?? '') != '') {
 				if (validateADIFDate($record['qslsdate']) == true) {
 					$input_qslsdate = $record['qslsdate'];
 				} else {
@@ -4277,7 +4277,7 @@ class Logbook_model extends CI_Model {
 
 			if ($markClublog != NULL) {
 				$input_clublog_qslsdate = $date = date("Y-m-d H:i:s", strtotime("now"));
-			} elseif (isset($record['clublog_qso_upload_date'])) {
+			} elseif (($record['clublog_qso_upload_date'] ?? '') != '') {
 				if (validateADIFDate($record['clublog_qso_upload_date']) == true) {
 					$input_clublog_qslsdate = $record['clublog_qso_upload_date'];
 				} else {
@@ -4297,7 +4297,7 @@ class Logbook_model extends CI_Model {
 				$input_lotw_qsl_rcvd = NULL;
 			}
 
-			if (isset($record['lotw_qslrdate'])) {
+			if (($record['lotw_qslrdate'] ?? '') != '') {
 				if (validateADIFDate($record['lotw_qslrdate']) == true) {
 					$input_lotw_qslrdate = $record['lotw_qslrdate'];
 				} else {
@@ -4318,7 +4318,7 @@ class Logbook_model extends CI_Model {
 
 			if ($markLotw != NULL) {
 				$input_lotw_qslsdate = $date = date("Y-m-d H:i:s", strtotime("now"));
-			} elseif (isset($record['lotw_qslsdate'])) {
+			} elseif (($record['lotw_qslsdate'] ?? '') != '') {
 				if (validateADIFDate($record['lotw_qslsdate']) == true) {
 					$input_lotw_qslsdate = $record['lotw_qslsdate'];
 				} else {


### PR DESCRIPTION
Some logs emit weird values for (e)QSL/LoTW-Date-Fields (not NULL, but zero-byte-length, so date is defined but empty).
Wavelog tries to parse that (because it's defined) and fails with an error-message.
But: Errormessage isn't shown by most clients (e.g. FLDigi 4.2.0.6)

This one ignores those "empty" fields:

More details see:
https://github.com/wavelog/wavelog/discussions/1820#discussioncomment-12683871