### PR TITLE
Trim Space for Call at QSO-form at JS and last-defense saving

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -18,7 +18,7 @@ class Logbook_model extends CI_Model {
 	/* Add QSO to Logbook */
 	function create_qso() {
 
-		$callsign = str_replace('Ø', '0', $this->input->post('callsign'));
+		$callsign = trim(str_replace('Ø', '0', $this->input->post('callsign')));
 		// Join date+time
 		$datetime = date("Y-m-d", strtotime($this->input->post('start_date'))) . " " . $this->input->post('start_time');
 		if (($this->input->post('end_time') ?? '') != '') {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -69,6 +69,7 @@ $('#callsign').on('input', function () {
 	$(this).val($(this).val().replace(/\s/g, ''));
 	$(this).val($(this).val().replace(/0/g, 'Ø'));
 	$(this).val($(this).val().replace(/\./g, '/P'));
+	$(this).val($(this).val().replace(/\W/g, ''));
 });
 
 $('#locator').on('input', function () {


### PR DESCRIPTION
One more "fence".

if you copy/paste a call into the form. e.g.: `" DJ7NT"` (leading space), the QSO will be saved with the space. Which is wrong.

this one mitigates it.