### PR TITLE
fix[installer] make sure the correct config dir is created if not existent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /application/config/database.php
 /application/config/config.php
+/application/config/*/config.php
+/application/config/*/database.php
 /application/logs/*
 /application/cache/*
 /backup/*.adi
@@ -25,5 +27,3 @@ sync.sh
 .demo
 .htaccess
 .user.ini
-/application/config/*/config.php
-/application/config/*/database.php

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .idea/*
 .DS_Store
 sync.sh
+docker-compose.yml
 *.p12
 *.swp
 .debug

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ sync.sh
 .demo
 .htaccess
 .user.ini
+/application/config/*/config.php
+/application/config/*/database.php

--- a/install/includes/core/core_class.php
+++ b/install/includes/core/core_class.php
@@ -192,7 +192,15 @@ class Core
 		$template_path 	= 'config/config.php';
 		$output_path 	= '../application/config/config.php';
 		if (isset($_ENV['CI_ENV'])) {
-			$output_path 	= '../application/config/'.$_ENV['CI_ENV'].'/config.php';
+			$output_path = '../application/config/'.$_ENV['CI_ENV'].'/config.php';
+			$output_dir = dirname($output_path);
+			if (!is_dir($output_dir)) {
+				if (!mkdir($output_dir, 0755, true)) {
+					log_message('error', 'Failed to create directory: ' . $output_dir);
+					return false;
+				}
+				log_message('info', 'Directory created: ' . $output_dir);
+			}
 			log_message('info', 'CI_ENV is set to ' . $_ENV['CI_ENV'] . '. Using ' . $_ENV['CI_ENV'] . ' config.php config path.');
 		} else {
 			log_message('info', 'CI_ENV is not set. Using default config.php config path.');


### PR DESCRIPTION
in the case the correct config directory is not existent yet (which is the case by non default environments), we can create it to prevent the installer from failing. This does not affect normal user installations but makes installer development with docker more stable. 