### PR TITLE
Dead links

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -593,7 +593,7 @@ class Awards extends CI_Controller {
         }
 
         // Render page
-        $data['page_title'] = sprintf(__("Awards - %s"), __("CQ Magazine WAZ"));
+        $data['page_title'] = sprintf(__("Awards - %s"), __("CQ WAZ (Worked All Zones)"));
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('awards/cq/index');
 		$this->load->view('interface_assets/footer', $footerData);

--- a/application/views/awards/counties/index.php
+++ b/application/views/awards/counties/index.php
@@ -5,7 +5,7 @@
             <script>
             var lang_awards_info_button = "<?= __("Award Info"); ?>";
             var lang_award_info_ln1 = "<?= __("US County Award"); ?>";
-            var lang_award_info_ln2 = "<?= sprintf(__("The United States of America Counties Award (USA-CA), sponsored by CQ magazine, is issued for confirmed two-way radio contacts with specified numbers of U.S. counties under rules and conditions you can find %s."), "<a href='https://cq-amateur-radio.com/cq_awards/cq_usa_ca_awards/cq_usa_ca_awards.html' target='_blank'>" . __("here") . "</a>"); ?>";
+            var lang_award_info_ln2 = "<?= sprintf(__("The United States of America Counties Award (USA-CA), sponsored by MARAC (Mobile Amateur Radio Awards Club), is issued for confirmed two-way radio contacts with specified numbers of U.S. counties under rules and conditions you can find %s."), "<a href='http://www.marac.org/' target='_blank'>" . __("here") . "</a>"); ?>";
             var lang_award_info_ln3 = "<?= __("USA-CA is available to all licensed amateurs worldwide and is issued to individuals for all county contacts made, regardless of callsigns used, operating locations, or dates."); ?>";
             var lang_award_info_ln4 = "<?= __("Special USA-CA awards are also available to SWLs on a heard basis."); ?>";
             </script>

--- a/application/views/awards/cq/index.php
+++ b/application/views/awards/cq/index.php
@@ -17,12 +17,12 @@
   <div id="awardInfoButton">
     <script>
       var lang_awards_info_button = "<?= __("Award Info"); ?>";
-      var lang_award_info_ln1 = "<?= __("CQ Magazine WAZ Award"); ?>";
-      var lang_award_info_ln2 = "<?= __("The CQ Magazine is located in the US and one of the most popular amateur radio magazines in the world. The magazine first appeared in January 1945 and focuses on awards and the practical aspects of amateur radio."); ?>";
-      var lang_award_info_ln3 = "<?= __("The WAZ Award stands for 'Worked All Zones' and requires radio contacts to all 40 CQ Zones along with the corresponding confirmation."); ?>";
-      var lang_award_info_ln4 = "<?= sprintf(_pgettext("uses 'CQ Magazine'", "You can find all the information and rules on the Website of the %s."), "<a href='https://cq-amateur-radio.com/cq_awards/cq_waz_awards/index_cq_waz_award.html' target='_blank'>CQ Magazine</a>"); ?>";
+      var lang_award_info_ln1 = "<?= __("CQ WAZ (Worked All Zones) Award"); ?>";
+      var lang_award_info_ln2 = "<?= __("The CQ Magazine was located in the US and one of the most popular amateur radio magazines in the world. They stopped service by the end of 2023. The magazine first appeared in January 1945 and focuses on awards and the practical aspects of amateur radio."); ?>";
+      var lang_award_info_ln3 = "<?= __("The WAZ Award stands for 'Worked All Zones' and requires radio contacts to all 40 CQ Zones along with the corresponding confirmation. Since the CQ Magazine does no longer exists the CQ WAZ Awards is now managed directly by N4BAA."); ?>";
+      var lang_award_info_ln4 = "<?= sprintf(__("You can find all the information and rules on the Website of N4BAA: %s"), "<a href='https://n4baa.com/cqwaz.html' target='_blank'>N4BAA.com</a>"); ?>";
     </script>
-    <h2><?= __("Awards - CQ Magazine WAZ"); ?></h2>
+    <h2><?= __("Awards - CQ WAZ"); ?></h2>
     <button type="button" class="btn btn-sm btn-primary me-1" id="displayAwardInfo"><?= __("Award Info"); ?></button>
   </div>
   <!-- End of Award Info Box -->

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -171,7 +171,7 @@
 							<ul class="dropdown-menu header-dropdown">
 								<li><a class="dropdown-item dropdown-toggle dropdown-toggle-submenu" data-bs-toggle="dropdown" href="#"><i class="fas fa-globe"></i> <?= __("International"); ?></a>
 									<ul class="submenu dropdown-menu">
-										<li><a class="dropdown-item" href="<?php echo site_url('awards/cq'); ?>"><i class="fas fa-trophy"></i> <?= __("CQ"); ?></a></li>
+										<li><a class="dropdown-item" href="<?php echo site_url('awards/cq'); ?>"><i class="fas fa-trophy"></i> <?= __("CQ WAZ"); ?></a></li>
 										<div class="dropdown-divider"></div>
 										<li><a class="dropdown-item" href="<?php echo site_url('awards/dxcc'); ?>"><i class="fas fa-trophy"></i> <?= __("DXCC"); ?></a></li>
 										<div class="dropdown-divider"></div>


### PR DESCRIPTION
Thanks to @Reid-n0rc who pointed us to the dead link in the US Counties Award page (#1853) due to the fact that the CQ Magazine stopped by the End for 2023. 

This not only affects the US Counties Award but also for example the WAZ Award. The award programm seems to be still alive but I need to figure out the new source links. 