### PR TITLE
Added number of results to simplesearch-footer

### DIFF
--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -451,7 +451,13 @@ function echoQrbCalcLink($mygrid, $grid, $vucc, $isVisitor = false) {
                 </td>
             <?php } ?>
             </tr>
-            <?php $i++; } ?>
+            <?php $i++; } 
+		if ($i>1) {
+			echo '<caption>'.$i.' '.__("Results").'</caption>'; 
+		} elseif ($i==1) {
+			echo '<caption>'.$i.' '.__("Result").'</caption>'; 
+		}
+	    ?>
                             </tbody>
     </table></div>
     <?php } ?>


### PR DESCRIPTION
Adds the number of found matches to the result-view.

e.g.:

<img width="363" alt="image" src="https://github.com/user-attachments/assets/14335c99-7254-483b-833e-f87330ecd504" />
