### PR TITLE
Buffering qsos when (temporary) offline

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -124,6 +124,7 @@ $("#qso_input").off('submit').on('submit', function (e) {
 					$("#noticer").show();
 					prepare_next_qso(saveQsoButtonText);
 					$("#noticer").fadeOut(2000);
+					processBacklog();	// If we have success with the live-QSO, we could also process the backlog
 				} else {
 					$("#noticer").removeClass("");
 					$("#noticer").addClass("alert alert-warning");
@@ -157,7 +158,6 @@ function prepare_next_qso(saveQsoButtonText) {
 
 async function processBacklog() {
 	const Qsobacklog = JSON.parse(localStorage.getItem('qso-backlog')) || [];
-
 	for (const entry of [...Qsobacklog]) { 
 		try {
 			await $.ajax({url: base_url + 'index.php/qso' + entry.manual_addon,  method: 'POST', type: 'post', data: JSON.parse(entry.data), 
@@ -171,7 +171,6 @@ async function processBacklog() {
 			entry.attempts++;
 		}
 	}
-
 	localStorage.setItem('qso-backlog', JSON.stringify(Qsobacklog));
 }
 
@@ -188,7 +187,8 @@ function saveToBacklog(formData,manual_addon) {
 	localStorage.setItem('qso-backlog', JSON.stringify(backlog));
 }
 
-
+window.addEventListener('beforeunload', processBacklog());	// process possible QSO-Backlog on unload of page
+window.addEventListener('pagehide', processBacklog());		// process possible QSO-Backlog on Hide of page (Mobile-Browsers)
 
 $('#reset_time').on("click", function () {
 	var now = new Date();

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -111,6 +111,7 @@ $("#qso_input").off('submit').on('submit', function (e) {
 			url: base_url + 'index.php/qso' + manual_addon,
 			method: 'POST',
 			type: 'post',
+			timeout: 10000,
 			data: $(this).serialize(),
 			success: function (resdata) {
 				result = JSON.parse(resdata);


### PR DESCRIPTION
Situation:
- If you killed your Internetconnection (e.g. by HF) or have weak internet, the QSO could not be saved.
- You've to wait until it's back and save or postlog the QSO

With this patch:
- The QSO will be buffered (at localstorage) // Timeout for saving is set to 10seconds - be patient ;)
- The buffer will be processed along with a (successful) logged new QSO
- The buffer will be processed when leaving the page. (not 100% reliable)
- The buffer will be processed when re-entering the QSO-Log-page.
- The buffer can hold multiple QSOs. Once the page was able to store them at the backend, the buffer is reduced by the successful ones.

