### PR TITLE
add support for ldap

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -782,9 +782,32 @@ $config['max_login_attempts'] = 3;
 |--------------------------------------------------------------------------
 | Disable User QSO Count in User List (Admin Menu)
 | Reason for this setting is to prevent performance issues on large installations
-| where the QSO count is not needed. Set to true to disable the QSO count. 
+| where the QSO count is not needed. Set to true to disable the QSO count.
 | This also hides the last Operator for CLubstations. Default is false.
 |--------------------------------------------------------------------------
  */
 
- $config['disable_user_stats'] = false;
+$config['disable_user_stats'] = false;
+
+/*
+* LDAP Configuration
+* ldap_uri: the uri of the ldap server
+* ldap_basedn: the dn used to find users informtion, eg ou=member,dc=club,dc=com
+* ldap_user: this is prepended to ldap_basedn to find the user, %user is replaced by the username entered in the login field
+* ldap_filter: this is used the query the user when creating it
+*
+* ldap_mail: the attribute containing the users mail address
+* ldap_firstname: the attribute containing the users firstname
+* ldap_name: the attribute containing the users name
+* ldap_call: the attribute containing the users callsign
+* */
+$config['enable_ldap'] = false;
+$config['ldap_uri'] = 'ldaps://my.server:636';
+$config['ldap_basedn'] = 'ou=member,dc=club,dc=com';
+$config['ldap_user'] = 'uid=%user';
+$config['ldap_filter'] = '(&(uid=%user))';
+
+$config['ldap_mail'] = 'mail';
+$config['ldap_firstname'] = 'cn';
+$config['ldap_name'] = 'sn';
+$config['ldap_call'] = 'uid';

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -798,4 +798,27 @@ $config['enable_eqsl_massdownload'] = false;
  |--------------------------------------------------------------------------
   */
 
-  $config['disable_user_stats'] = false;
+$config['disable_user_stats'] = false;
+
+/*
+* LDAP Configuration
+* ldap_uri: the uri of the ldap server
+* ldap_basedn: the dn used to find users informtion, eg ou=member,dc=club,dc=com
+* ldap_user: this is prepended to ldap_basedn to find the user, %user is replaced by the username entered in the login field
+* ldap_filter: this is used the query the user when creating it
+*
+* ldap_mail: the attribute containing the users mail address
+* ldap_firstname: the attribute containing the users firstname
+* ldap_name: the attribute containing the users name
+* ldap_call: the attribute containing the users callsign
+* */
+$config['enable_ldap'] = false;
+$config['ldap_uri'] = 'ldaps://my.server:636';
+$config['ldap_basedn'] = 'ou=member,dc=club,dc=com';
+$config['ldap_user'] = 'uid=%user';
+$config['ldap_filter'] = '(&(uid=%user))';
+
+$config['ldap_mail'] = 'mail';
+$config['ldap_firstname'] = 'cn';
+$config['ldap_name'] = 'sn';
+$config['ldap_call'] = 'uid';


### PR DESCRIPTION
Hi,

we use ldap in to manage our members of our clubstation. The "recent" change with the special event callsings broke out integration so we kept the old version.
I finally had some time to hack some ldap implementation together.

The current implementation has a "bug" in development mode, where after logging in and creating the user account you get the following errors:
![image](https://github.com/user-attachments/assets/76f3048a-39b6-4598-8edf-d7d57c3ecdd1)
after pressing f5 you are logged in.

Personally I would like to add a new column to the usermodel called something like `ldap_user`. This would make the authentication much better. The current implementation tries to authenticate the user against the wavelog db and if that fails, it retries via ldap. But I don't know how to do that.

This is more a proof of concept that and no production ready code so I await your feedback.
Cheers
Lieven, DF1CN (ex DF1ASH)
