### PR TITLE
Fix URL for SOTA API

### DIFF
--- a/application/libraries/Sota.php
+++ b/application/libraries/Sota.php
@@ -43,7 +43,7 @@ class Sota
 
 	// fetches the summit information from SOTA
 	public function info($summit) {
-		$url = 'https://api2.sota.org.uk/api/summits/' . $summit;
+		$url = 'https://api-db2.sota.org.uk/api/summits/' . $summit;
 
 		// Let's use cURL instead of file_get_contents
 		// begin script


### PR DESCRIPTION
(Undocumented) SOTA API has changed its URL and requests to api2 are going via a translation layer.   New URL removes translation layer in between requests and goes to new URL base.

Cheers,
Andrew
VK3ARR
SOTA IT Group leader