### PR TITLE
Show LoTW confirmed gridsquare even if not updated in DB

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -611,7 +611,7 @@ class Lotw extends CI_Controller {
 				$table .= "<td>".$record['qsl_rcvd']."</td>";
 				$table .= "<td>".$qsl_date."</td>";
 				$table .= "<td>".$state."</td>";
-				$table .= "<td>".($qsl_gridsquare != '' ? $qsl_gridsquare : $qsl_vucc_grids)."</td>";
+				$table .= "<td>".(($qsl_gridsquare != '' ? $qsl_gridsquare : ($record['gridsquare'] ?? '')) ?? $qsl_vucc_grids)."</td>";
 				$table .= "<td>".$iota."</td>";
 				$table .= "<td>QSO Record: ".$status[0]."</td>";
 				$table .= "<td>LoTW Record: ".$lotw_status."</td>";


### PR DESCRIPTION
With https://github.com/wavelog/wavelog/pull/324 we implemented a check whether the LotW confirmed square is more precise than the one we already have in the log. If that it not the case we do not update the gridsquare. As a side effect the (not-updated) gridsquare is not shown in the results of a (manual) LoTW sync:

![image](https://github.com/user-attachments/assets/885f98bc-5167-412b-9244-75831b3fb627)

In this case the grids which were confirmed on LoTW were already in the log. But the results pretend that there was no grid (confirmed). This fixes the issue so that the already confirmed grid is shown in case it is already in the log:

![image](https://github.com/user-attachments/assets/e7e44a1f-68a4-43e7-9a03-f869b296f9c1)
