### PR TITLE
Rename reset button in public search result table

### DIFF
--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -231,6 +231,13 @@ if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_language
                 "scrollY":        "500px",
                 "scrollCollapse": true,
                 "paging":         true,
+                "layout": {
+                  "topEnd": {
+                     "search": {
+                        "text": 'Filter Results'
+                     }
+                  }
+                },
                 "scrollX": true,
                 "order": [ 0, 'desc' ],
                 "language": {

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -231,17 +231,11 @@ if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_language
                 "scrollY":        "500px",
                 "scrollCollapse": true,
                 "paging":         true,
-                "layout": {
-                  "topEnd": {
-                     "search": {
-                        "text": 'Filter Results'
-                     }
-                  }
-                },
                 "scrollX": true,
                 "order": [ 0, 'desc' ],
                 "language": {
                   url: getDataTablesLanguageUrl(),
+                     search: '<?= __("Filter Results"); ?>',
                 },
                 dom: 'Bfrtip',
                 buttons: [

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -248,7 +248,7 @@ if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_language
                    },
                    {
                       extend: 'clear',
-                      text: '<?= __("Clear"); ?>',
+                      text: '<?= __("Clear Filter"); ?>',
 					  className: 'mb-1 btn btn-primary', // Bootstrap classes
 						init: function(api, node, config) {
 							$(node).removeClass('dt-button').addClass('btn btn-primary'); // Ensure Bootstrap class applies


### PR DESCRIPTION
Just a test trying to refactor search functions in the DT results table.
Need to find out how to rename "Search" next to the DT search box. Layout does not work for some reason.