### PR TITLE
Make note about contest imports look less error-like

### DIFF
--- a/application/views/adif/import_success.php
+++ b/application/views/adif/import_success.php
@@ -12,11 +12,11 @@
     <?= __("ADIF Imported")?>
   </div>
   <div class="card-body">
-    
+
     <!-- Success message -->
     <h3 class="card-title"><?= __("Yay, its imported!")?></h3>
     <p class="card-text"><?= __("The ADIF File has been imported.")?>
-    
+
     <!-- Dupe information -->
     <?php if(isset($skip_dupes)) {
              echo " <b>" . __("Dupes were inserted!") . "</b>";
@@ -27,10 +27,12 @@
 
     <!-- Display imported information for contest data fixing if contest data was imported -->
     <?php if(count($imported_contests) > 0) {?>
-    <p style="color:red;"><?= __("You imported at least 1 QSO containing a contest ID.")?></p>
-    <p><?= __("Sometimes, depending on your contest logging software, your exchanges will not be imported properly from that softwares ADIF. If you like to correct that, switch to the CBR Import Tab of the ADIF Import page.")?></p>
-    <p><?= __("We found the following numbers of QSOs for the following contest IDs:")?></p>
-    
+       <div class="alert alert-dark" role="alert">
+       <span class="badge text-bg-info"><?= __("Information"); ?></span> <i class="fas fa-list"></i> <b><?= __("Contest logs imported")?></b>
+          <p>
+          <p><?= __("You imported at least 1 QSO containing a contest ID.")?> <?= __("Sometimes, depending on your contest logging software, your exchanges will not be imported properly from that softwares ADIF. If you like to correct that, switch to the CBR Import Tab of the ADIF Import page.")?></p>
+          <p><?= __("We found the following numbers of QSOs for the following contest IDs:")?></p>
+
     <!-- List imported contest data -->
     <ul>
     <?php foreach ($imported_contests as $contestid => $qsocount) { ?>
@@ -38,7 +40,8 @@
     <?php } ?>
     </ul>
     <?php } ?>
-   
+       </div>
+
     <!-- Display errors for ADIF import -->
     <?php if($adif_errors) { ?>
       <h3><?= __("Import details / possible problems")?></h3>


### PR DESCRIPTION
As requested by @dg9vh we should make the contest import look a little less as if it was an error on imports:

![image](https://github.com/user-attachments/assets/731477dd-0d3c-454d-9186-d50afec5a59b)
