### PR TITLE
[QSO Entry] Added fullsize map option, gridsquare and grid on hover

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1127,6 +1127,7 @@ mymap.on('mousemove', onQsoMapMove);
 
   L.tileLayer('<?php echo $this->optionslib->get_option('option_map_tile_server');?>', {
     maxZoom: 18,
+    minZoom: 1,
     attribution: '<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>',
     id: 'mapbox.streets'
   }).addTo(mymap);
@@ -1159,7 +1160,7 @@ mymap.on('mousemove', onQsoMapMove);
 	var lat = LatLng.lat;
 	var lng = LatLng.lng;
 	var locator = latLngToLocator(lat,lng);
-	$('#qsomapgrid').html(locator);
+	$('#qsomapgrid').html(locator.toUpperCase());
   }
   function toggleGridsquares(bool) {
 	if(!bool) {


### PR DESCRIPTION
To follow up on the feature @phl0 added with grid on click, I added fullscreen option to the map.
I also added gridsquare overlay with toggle.

Gridsquare is displayed in the legend on hover as well.

![image](https://github.com/user-attachments/assets/0efc1f47-88a6-4020-bdab-41407d30edf2)
