### PR TITLE
Persist after edit at SAT-Editor

### DIFF
--- a/assets/js/sections/satellite.js
+++ b/assets/js/sections/satellite.js
@@ -276,6 +276,7 @@ function saveUpdatedSatellite(form) {
 					'orbit': form.orbit.value,
 			},
 			success: function (html) {
+				sessionStorage.setItem('datatableSearch', tablex.search());
 				location.reload();
 			}
 		});

--- a/assets/js/sections/satellite.js
+++ b/assets/js/sections/satellite.js
@@ -1,6 +1,5 @@
 var tablex;
 $(document).ready(function () {
-	$("#dt-search-0").val("XX");
 	tablex = $('.sattable').DataTable({
 		"pageLength": 25,
 		"language": {

--- a/assets/js/sections/satellite.js
+++ b/assets/js/sections/satellite.js
@@ -1,5 +1,7 @@
+var tablex;
 $(document).ready(function () {
-	$('.sattable').DataTable({
+	$("#dt-search-0").val("XX");
+	tablex = $('.sattable').DataTable({
 		"pageLength": 25,
 		"language": {
 			url: getDataTablesLanguageUrl(),
@@ -14,6 +16,10 @@ $(document).ready(function () {
 			url: getDataTablesLanguageUrl(),
 		}
 	});
+
+	var presetSearch = sessionStorage.getItem('datatableSearch') || '';
+	sessionStorage.removeItem('datatableSearch');
+	tablex.search(presetSearch).draw();
 
 	$(document).on('click','.deleteSatmode', function (e) {
 		deleteSatmode(e.currentTarget.id,e.currentTarget.attributes.infotext.value);
@@ -48,6 +54,7 @@ function editTle(id) {
 					label: lang_admin_close,
 					action: function (dialogItself) {
 						dialogItself.close();
+						sessionStorage.setItem('datatableSearch', tablex.search());
 						location.reload();
 					}
 				}]
@@ -245,6 +252,7 @@ function editSatelliteDialog(id) {
 					label: lang_admin_close,
 					action: function (dialogItself) {
 						dialogItself.close();
+						sessionStorage.setItem('datatableSearch', tablex.search());
 						location.reload();
 					}
 				}]


### PR DESCRIPTION
Problem:
When using the Admin-Sat-Editor and filtering for e.g. "SO-", the filter is lost after editing TLE or Modes.
So if you copypaste things from a similar SAT you've to type in the filter again (or chose manually). Minor annoying.

Solution (in this PR)
- Save search short before reloading the (updated) page and fetch it again from localstorage shortly after rendering to fill the search-item again. 
- Remove saved search (it's only stored for "surviving" the reload which is done onClose of TLE or Mode-Edit)