### PR TITLE
[Advanced logbook] Get rid of error in the adif file

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -217,6 +217,7 @@ class Logbookadvanced extends CI_Controller {
 		$postdata['user_id'] = (int)$this->session->userdata('user_id');
 		$postdata['qsoresults'] = 'All';
 		$postdata['de'] = explode(',', $postdata['de']);
+		$postdata['qsoids'] = '';
 		$data['qsos'] = $this->logbookadvanced_model->getSearchResult($postdata);
 
 		$this->load->view('adif/data/exportall', $data);


### PR DESCRIPTION
<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">

<h4>A PHP Error was encountered</h4>

<p>Severity: Warning</p>
<p>Message:  Undefined array key "qsoids"</p>
<p>Filename: models/Logbookadvanced_model.php</p>
<p>Line Number: 102</p>

Seems I created an error here. PR fixes that.