### PR TITLE
Show error message in case ant el is (too) negative

### DIFF
--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -10,6 +10,7 @@
   var lang_dxccsummary_for = "<?= __("DXCC Summary for "); ?>";
   var lang_lotw_upload_day_ago = "<?= __("LoTW User. Last upload was 1 day ago."); ?>";
   var lang_lotw_upload_days_ago = "<?= __("LoTW User. Last upload was %x days ago."); ?>"; // due to the way the string is built (PHP to JS), %x is replaced with the number of days
+  var lang_invalid_ant_el = "<?= __("Invalid value for antenna elevation:"); ?>";
   var latlng=[<?php echo $lat.','.$lng;?>];
 </script>
 
@@ -604,7 +605,7 @@
 
             <div class="mb-3">
               <label for="ant_el"><?= __("Antenna Elevation (°)"); ?></label>
-              <input type="number" inputmode="decimal" step="0.1" min="-5" max="90" class="form-control" id="ant_el" name="ant_el" />
+              <input type="number" inputmode="decimal" step="0.1" min="-5" max="90" class="form-control" id="ant_el" name="ant_el" onInvalid="invalidAntEl()" />
               <small id="elHelp" class="form-text text-muted"><?= __("Antenna elevation in decimal degrees."); ?></small>
             </div>
           </div>

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -97,6 +97,15 @@ function set_timers() {
 	}, 100);
 }
 
+function invalidAntEl() {
+	var saveQsoButtonText = $("#saveQso").html();
+	$("#noticer").removeClass("");
+	$("#noticer").addClass("alert alert-warning");
+	$("#noticer").html(lang_invalid_ant_el+" "+parseFloat($("#ant_el").val()).toFixed(1));
+	$("#noticer").show();
+	$("#saveQso").html(saveQsoButtonText).prop("disabled", false);
+}
+
 $("#qso_input").off('submit').on('submit', function (e) {
 	var _submit = true;
 	if ((typeof qso_manual !== "undefined") && (qso_manual == "1")) {


### PR DESCRIPTION
In case a SAT QSO is to be logged and calculation of ant/el leads to a (too) negative value of elevation the QSO cannot be saved though no error message is shown.

JS console shows an error about a non-focusable element because ant el is hidden on SAT tab an cannot be focussed:

![image](https://github.com/user-attachments/assets/e58de5f8-ddbf-4dbd-ba5d-cc8da3be0bd0)

This adds a warning message for the user to see if the ant el value is not valid:

![image](https://github.com/user-attachments/assets/e466bd5b-b106-47d1-b0ed-9dd9180bbf5c)
