### PR TITLE
Fixes an issue with shift-click and a js-error on 1st load of LBA

### DIFF
--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -366,8 +366,11 @@ function loadQSOTable(rows) {
 		table.rows(createdRow).nodes().to$().data('qsoID', qso.qsoID);
 	//	table.row(createdRow).node().to$().attr("id", 'qsoID-' + qso.qsoID);
 	}
-	// table.draw();
-	table.columns.adjust().draw();
+	try {
+		table.columns.adjust().draw();
+	} catch (e) {
+		table.draw();
+	}
 	$('[data-bs-toggle="tooltip"]').tooltip();
 
 	document.querySelectorAll('.row-check').forEach(checkbox => {


### PR DESCRIPTION
Under rare circumstances, the LBA isn't working properly when it is called (SHIFT-Click-Feature introduced in #2040 )
it throws this one:

![image](https://github.com/user-attachments/assets/40a14df2-ab06-4245-8f56-d8548e68238e)

with this patch the error is catched, and a fallback to a simple draw (which enables the shift-click and prevents the error) is done.

