### PR TITLE
fix wrong table field to COL_QSLSDATE

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -563,7 +563,7 @@ class Logbookadvanced_model extends CI_Model {
 		} else {
 			$sql = "UPDATE " . $this->config->item('table_name') ."
 				SET
-				COL_QSLRDATE = CURRENT_TIMESTAMP,
+				COL_QSLSDATE = CURRENT_TIMESTAMP,
 				COL_QSL_SENT = ?,
 				COL_QSL_SENT_VIA = ?,
 				COL_QRZCOM_QSO_UPLOAD_STATUS = CASE


### PR DESCRIPTION
When one would use the function "Mark selected QSOs as sent" button in the qslprint view, it would correctly mark the QSOs as sent, but it would modify the timestamp of QSL received, not QSL sent.

This fixes it to use the right field in the database.