### PR TITLE
Extend hint about operator callsign in clubstation login

### DIFF
--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -79,7 +79,7 @@
                         $show_operator_question = true;
                         if ($this->config->item('special_callsign') && (!empty($club_operators))) {
                             $show_operator_question = false; ?>
-                            <div class="small form-text text-muted"><?= __("Type in the operators callsign of the imported QSOs") ?></div>
+                            <div class="small form-text text-muted"><?= __("Type in the operators callsign of the imported QSOs. Leave empty to use the operator callsign in the ADIF file.") ?></div>
                             <input type="text"  name="club_operator" class="form-control mb-2 me-sm-2 w-50 w-lg-100" value="<?php echo ($this->session->userdata('cd_src_call') ?? ''); ?>">
                         <?php } ?>
                         <div class="small form-text text-muted"><?= __("Add QSOs to Contest") ?></div>


### PR DESCRIPTION
When importing ADIF files in clubstations you can override the operator callsign. But then the adif file contains multiple operator you don't want that. Leaving the field empty disables the override. **This is already implemented** 

But to make it more clear to the user I extended the field description.