### PR TITLE
Separate table ids

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -474,6 +474,7 @@ class Awards extends CI_Controller {
 		if (!empty($qsltype)) {
 			$data['filter'] .= __(" and ").implode('/', $qsltype);
 		}
+		$data['ispopup'] = true;
 		$this->load->view('awards/details', $data);
 	}
 

--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -304,6 +304,7 @@ class Statistics extends CI_Controller {
 
 		$data['page_title'] = __("Log View")." - " . __("Satellite QSOs");
 		$data['filter'] = $sat;
+		$data['ispopup'] = true;
 
 		$this->load->view('statistics/details', $data);
 	}

--- a/application/views/awards/details.php
+++ b/application/views/awards/details.php
@@ -1,3 +1,6 @@
 <h5><?= __("Filtering on"); ?> <?php echo $filter; ?></h5>
 
-<?php $this->load->view('view_log/partial/log_ajax'); ?>
+<?php
+$data['ispopup'] = $ispopup;
+$this->load->view('view_log/partial/log_ajax', $data);
+?>

--- a/application/views/awards/details.php
+++ b/application/views/awards/details.php
@@ -1,6 +1,6 @@
 <h5><?= __("Filtering on"); ?> <?php echo $filter; ?></h5>
 
 <?php
-$data['ispopup'] = $ispopup;
+$data['ispopup'] = $ispopup ?? '';
 $this->load->view('view_log/partial/log_ajax', $data);
 ?>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2662,7 +2662,7 @@ function viewEqsl(picture, callsign) {
 			    message: html,
 			    onshown: function(dialog) {
 				    $('[data-bs-toggle="tooltip"]').tooltip();
-				    $('.contacttable').DataTable({
+				    $('.displaycontactstable').DataTable({
 				    "pageLength": 25,
 					    responsive: false,
 					    ordering: false,

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2590,7 +2590,7 @@ function viewEqsl(picture, callsign) {
                     message: html,
                     onshown: function(dialog) {
                        $('[data-bs-toggle="tooltip"]').tooltip();
-                       $('.contacttable').DataTable({
+                       $('.displaycontactstable').DataTable({
                             "pageLength": 7,
                             responsive: false,
                             ordering: false,

--- a/application/views/statistics/details.php
+++ b/application/views/statistics/details.php
@@ -1,3 +1,6 @@
 <h5><?= __("Filtering on"); ?> <?php echo $filter; ?></h5>
 
-<?php $this->load->view('view_log/partial/log_ajax'); ?>
+<?php
+$data['ispopup'] = $ispopup ?? '';
+$this->load->view('view_log/partial/log_ajax');
+?>

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -183,7 +183,7 @@ function echoQrbCalcLink($mygrid, $grid, $vucc, $isVisitor = false) {
 <?php
 	if ($results) {
 		$tableid = "contacttable";
-		if (isset($ispopup)) {
+		if (!empty($ispopup)) {
 			$tableid = "displaycontactstable";
 		}
 

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -180,10 +180,17 @@ function echoQrbCalcLink($mygrid, $grid, $vucc, $isVisitor = false) {
 
 ?>
 
-<?php if ($results) { ?>
+<?php
+	if ($results) {
+		$tableid = "contacttable";
+		if (isset($ispopup)) {
+			$tableid = "displaycontactstable";
+		}
+
+?>
 
 <div class="table-responsive">
-    <table style="width:100%" id="contacttable" class="table contacttable table-striped table-hover">
+    <table style="width:100%" id="<?= $tableid ?>" class="table <?= $tableid ?> table-striped table-hover">
         <thead>
             <tr class="titles">
                 <th><?= __("Date"); ?></th>

--- a/assets/js/sections/distancerecords.js
+++ b/assets/js/sections/distancerecords.js
@@ -19,7 +19,7 @@ function displayDistanceQsos(sat) {
 					onshown: function(dialog) {
 						modalloading=false;
 						$('[data-bs-toggle="tooltip"]').tooltip();
-						$('.contacttable').DataTable({
+						$('.displaycontactstable').DataTable({
 							"pageLength": 25,
 							responsive: false,
 							ordering: false,

--- a/assets/js/sections/distances.js
+++ b/assets/js/sections/distances.js
@@ -169,7 +169,7 @@ function getDistanceQsos(distance) {
 				message: html,
 				onshown: function(dialog) {
 						$('[data-bs-toggle="tooltip"]').tooltip();
-						$('.contacttable').DataTable({
+						$('.displaycontactstable').DataTable({
 						"pageLength": 25,
 						responsive: false,
 						ordering: false,

--- a/assets/js/sections/ffma.js
+++ b/assets/js/sections/ffma.js
@@ -111,7 +111,7 @@ function spawnGridsquareModal(loc_4char) {
                 onshown: function(dialog) {
 
                     $('[data-bs-toggle="tooltip"]').tooltip();
-                    $('.contacttable').DataTable({
+                    $('.displaycontactstable').DataTable({
                             "pageLength": 25,
                             responsive: false,
                             ordering: false,

--- a/assets/js/sections/gridmap.js
+++ b/assets/js/sections/gridmap.js
@@ -176,7 +176,7 @@ function spawnGridsquareModal(loc_4char) {
 					onshown: function(dialog) {
 						modalloading=false;
 						$('[data-bs-toggle="tooltip"]').tooltip();
-						$('.contacttable').DataTable({
+						$('.displaycontactstable').DataTable({
 							"pageLength": 25,
 							responsive: false,
 							ordering: false,

--- a/assets/js/sections/gridmaster.js
+++ b/assets/js/sections/gridmaster.js
@@ -117,7 +117,7 @@ function spawnGridsquareModal(loc_4char) {
                 onshown: function(dialog) {
 
                     $('[data-bs-toggle="tooltip"]').tooltip();
-                    $('.contacttable').DataTable({
+                    $('.displaycontactstable').DataTable({
                             "pageLength": 25,
                             responsive: false,
                             ordering: false,

--- a/assets/js/sections/statistics.js
+++ b/assets/js/sections/statistics.js
@@ -835,7 +835,7 @@ function displaySatQsos(sat,mode) {
 					onshown: function(dialog) {
 						modalloading=false;
 						$('[data-bs-toggle="tooltip"]').tooltip();
-						$('.contacttable').DataTable({
+						$('.displaycontactstable').DataTable({
 							"pageLength": 25,
 							responsive: false,
 							ordering: false,


### PR DESCRIPTION
Calling the quick lookup function from the Logbook overview and then showing some details popup for listing filtered QSOs results in the Logbook overview table being applied the data table stuff as well as to the table popping up. This is due to both tables being loaded from the same PHP and thus having the same ID.

The bug can be reproduced as follows:

- Go to Logbook -> Overview
- Call the quick lookup function with ALT-L
- Lookup a zone e.g. 14
- Press "Show"
- Click on the details for a mode/band combination e.g. 20m FT8

Result:

![image](https://github.com/user-attachments/assets/55e62b6f-84bc-45ec-9c64-6f1ad87b87e3)

Selecting some other mode / band even makes it worse as the DT stuff is applied again:

![image](https://github.com/user-attachments/assets/db91b137-4fb0-4420-ad99-4aa41a42185b)

And on the third try even resulting in a user-visible error message:

![image](https://github.com/user-attachments/assets/ebdb1c20-9d32-4e3d-8191-73c9fbcd3bce)

This fixes the bug by adding a variable to the view which sets a different id for the table if it is loaded as a popup so that the DT code only applies to the table shown in the popup.