### PR TITLE
Fix QSLCheckboxes

### DIFF
--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -185,27 +185,34 @@ function mark_qsl_sent(id, method) {
     });
 }
 
-$('#checkBoxAll').change(function (event) {
-	if (this.checked) {
-		$('.qslprint tbody tr').each(function (i) {
+var target = document.body;
+var box_observer = new MutationObserver(function() {
+	$('#checkBoxAll').change(function (event) {
+		if (this.checked) {
+			$('.qslprint tbody tr').each(function (i) {
+				$(this).closest('tr').addClass('activeRow');
+				$(this).closest('tr').find("input[type=checkbox]").prop("checked", true);
+			});
+		} else {
+			$('.qslprint tbody tr').each(function (i) {
+				$(this).closest('tr').removeClass('activeRow');
+				$(this).closest('tr').find("input[type=checkbox]").prop("checked", false);
+			});
+		}
+	});
+	$('.qslprint').on('click', 'input[type="checkbox"]', function() {
+		if ($(this).is(":checked")) {
 			$(this).closest('tr').addClass('activeRow');
-			$(this).closest('tr').find("input[type=checkbox]").prop("checked", true);
-		});
-	} else {
-		$('.qslprint tbody tr').each(function (i) {
+		} else {
 			$(this).closest('tr').removeClass('activeRow');
-			$(this).closest('tr').find("input[type=checkbox]").prop("checked", false);
-		});
-	}
-});
+		}
+	});
 
-$('.qslprint').on('click', 'input[type="checkbox"]', function() {
-	if ($(this).is(":checked")) {
-		$(this).closest('tr').addClass('activeRow');
-	} else {
-		$(this).closest('tr').removeClass('activeRow');
-	}
+
 });
+var config = { childList: true, subtree: true};
+box_observer.observe(target, config);
+
 
 function markSelectedQsos() {
 	var elements = $('.qslprint tbody input:checked');


### PR DESCRIPTION
Repro of bug:
- mark some QSOs for "Requested" // add to the QSL-Queue
- Go to Labels
- Click the loupe
- Change Station-Location to all
- try to click "select all" --> doesn't work
- same with (de)selecting single QSOs. They won't appear green

This one fixes it.
Reason for bug was: Checkboxes disappeared on station-change. Eventlistener has no object to bind.
Mitigation: Wrap everything into an observer