### PR TITLE
Exclude DXCC none from counter

### DIFF
--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -48,6 +48,7 @@ class DXCC extends CI_Model {
 	 */
 	function list_current($orderer = 'name') {
 		$this->db->where('end', null);
+		$this->db->where('adif !=', 0);
 
 		if ($orderer == 'name') {
 			$this->db->order_by('name', 'ASC');

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3530,6 +3530,7 @@ class Logbook_model extends CI_Model {
 			$this->db->where_in($this->config->item('table_name') . '.station_id', $logbooks_locations_array);
 			$this->db->where($this->config->item('table_name') . '.COL_COUNTRY !=', 'Invalid');
 			$this->db->where('dxcc_entities.end is null');
+			$this->db->where('dxcc_entities.adif != 0');
 			$query = $this->db->get($this->config->item('table_name'));
 
 			return $query->num_rows();


### PR DESCRIPTION
We should not count DXCC none for the QSO breakdown:

![image](https://github.com/user-attachments/assets/4c88204b-bb16-4223-9296-fbaaa85ca781)

Adresses https://github.com/wavelog/wavelog/issues/2078 but not sure if that is all to fix.