### PR TITLE
[Advanced Logbook] Link to DOK summary in table

### DIFF
--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -1296,6 +1296,10 @@ class QSO
 		} else {
 			$dokstring = $this->dxDARCDOK;
 		}
+		if ($dokstring !== '') {
+			$dokstring .= '<a href="javascript:spawnLookupModal(\''.$this->dxDARCDOK.'\',\'dok\');"> <i class="fas fa-globe"></a>';
+		}
+
 		return $dokstring;
 	}
 


### PR DESCRIPTION
Added link for DOK summary now that it is available in the Quick Lookup:
![image](https://github.com/user-attachments/assets/9ab82e54-73e6-4039-b953-e1833cf3deab)
