### PR TITLE
[Contesting] Display a dialog to confirm new session

### DIFF
--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -1,9 +1,10 @@
 <script>
     var lang_contestname_warning = "<?= __("You need to start a new session before you can change the contest name!"); ?>";
+	var lang_contest_reset_session = "<?= __("Are you really sure you want to start a new contest session?"); ?>";
 </script>
 
 <div class="container qso_panel contesting">
-    <button type="button" class="btn btn-sm btn-warning float-end" onclick="reset_contest_session()"><i class="fas fa-sync-alt"></i> <?= __("Start new Contest Session"); ?></button>
+    <button type="button" class="btn btn-sm btn-warning float-end" onclick="reset_dialog()"><i class="fas fa-sync-alt"></i> <?= __("Start new Contest Session"); ?></button>
     <h2 style="display:inline"><?= __("Contest Logging"); ?> </h2> <?php echo ($manual_mode == 0 ? " <span style='display:inline' class='align-text-top badge text-bg-success'>LIVE</span>" : " <span style='display:inline' class='align-text-top badge text-bg-danger'>POST</span>");  ?>
     <div class="row">
 
@@ -67,8 +68,8 @@
                                                 </div>
                                                 <div class="row mb-3">
                                                     <label class="col-auto control-label me-1"><?= __("Sequence of Exchanges"); ?>
-                                                        <i class="fas fa-question-circle" id="exchangesequence" 
-                                                            data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top" 
+                                                        <i class="fas fa-question-circle" id="exchangesequence"
+                                                            data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="top"
                                                             title="<?= __("Choose in which order you want to type in the different reports. However, only the elements contained in the selected exchange type are displayed."); ?>">
                                                         </i>
                                                     </label>
@@ -199,7 +200,7 @@
                                     <input type="text" class="form-control form-control-sm" name="rst_rcvd" id="rst_rcvd" value="59">
                                 </div>
                             </div>
-                            
+
                             <div id="rcvd_exchange" class="d-flex gap-2">
                                 <div style="display:none" class="serialr">
                                     <label for="exch_serial_r"><?= __("Serial (R)"); ?></label>

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -52,6 +52,22 @@ function disabledContestnameSelect(disabled) {
 	}
 }
 
+function reset_dialog() {
+	BootstrapDialog.confirm({
+			title: lang_general_word_danger,
+			message: lang_contest_reset_session,
+			type: BootstrapDialog.TYPE_DANGER,
+			closable: true,
+			draggable: true,
+			btnOKClass: 'btn-danger',
+			callback: function(result) {
+				if(result) {
+					reset_contest_session();
+				}
+			}
+	});
+}
+
 // Resets the logging form and deletes session from database
 async function reset_contest_session() {
 	await $.ajax({


### PR DESCRIPTION
Added a confirmation dialog so that you don't reset session by accident:
![image](https://github.com/user-attachments/assets/e1b3b87b-8385-4898-8889-5c40e626b0fa)

Just a nice to have thing, since this button was mentioned too many times during the weekend :p