### PR TITLE
[Advanced Logbook] Unselected row only after update, realign columns

### DIFF
--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -409,23 +409,26 @@ function processNextCallbookItem() {
 	if (nElements == 0) {
 		inCallbookProcessing = false;
 		callBookProcessingDialog.close();
+		let table = $('#qsoList').DataTable();
+		table.draw(false);
 		return;
 	}
 
-	callBookProcessingDialog.setMessage("Retrieving callbook data : " + nElements + " remaining");
+	let id = elements.first().closest('tr').attr('id')?.replace(/\D/g, ''); // Removes non-numeric characters
 
-	unselectQsoID(elements.first().closest('tr').attr('id')?.replace(/\D/g, '')); // Removes non-numeric characters
+	callBookProcessingDialog.setMessage("Retrieving callbook data : " + nElements + " remaining");
 
 	$.ajax({
 		url: site_url + '/logbookadvanced/updateFromCallbook',
 		type: 'post',
 		data: {
-			qsoID: elements.first().closest('tr').attr('id')?.replace(/\D/g, '')
+			qsoID: id
 		},
 		dataType: 'json',
 		success: function (data) {
 			if (data != []) {
 				updateRow(data);
+				unselectQsoID(id);
 			}
 			setTimeout("processNextCallbookItem()", 50);
 		},


### PR DESCRIPTION
I noticed while updating from callbook that rows were unselected before the update.
I rearranged so that the row is unselected after the update instead.
The header and table columns will some times misaligned, so I added a draw to fix this after all updates were processed.