### PR TITLE
[Advanced Logbook] Fix error if call was not found in the callbook

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -196,17 +196,16 @@ class Logbookadvanced extends CI_Controller {
 			$station_profile = $this->stations->profile($active_station_id)->row_array();
 			$this->logbookadvanced_model->updateQsoWithCallbookInfo($qso['COL_PRIMARY_KEY'], $qso, $callbook, $station_profile['station_gridsquare']);
 			$qso = $this->logbookadvanced_model->getQsosForAdif(json_encode($qsoID), $this->session->userdata('user_id'))->row_array();
+		}
 
-			$qsoObj = new QSO($qso);		// Redirection via Object to clean/convert QSO (get rid of cols)
-			$cleaned_qso=$qsoObj->toArray();	// And back to Array for the JSON
+		$qsoObj = new QSO($qso);		// Redirection via Object to clean/convert QSO (get rid of cols)
+		$cleaned_qso = $qsoObj->toArray();	// And back to Array for the JSON
 
-			$flag = $this->dxccflag->get($qsoObj->getDXCCId());
-			if ($flag != null) {
-				$cleaned_qso['flag'] = ' '.$flag;
-			} else {
-				$cleaned_qso['flag'] = '';
-			}
-
+		$flag = $this->dxccflag->get($qsoObj->getDXCCId());
+		if ($flag != null) {
+			$cleaned_qso['flag'] = ' ' . $flag;
+		} else {
+			$cleaned_qso['flag'] = '';
 		}
 
 		header("Content-Type: application/json");

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -426,13 +426,14 @@ function processNextCallbookItem() {
 		},
 		dataType: 'json',
 		success: function (data) {
-			if (data != []) {
+			if (data && data.dx) {
 				updateRow(data);
-				unselectQsoID(id);
 			}
+			unselectQsoID(id);
 			setTimeout("processNextCallbookItem()", 50);
 		},
 		error: function (data) {
+			unselectQsoID(id);
 			setTimeout("processNextCallbookItem()", 50);
 		},
 	});


### PR DESCRIPTION
Found this in the console while testing callbook stuff:
<div style="border:1px solid #990000;padding-left:20px;margin:0 0 10px 0;">

<h4>A PHP Error was encountered</h4>

<p>Severity: Warning</p>
<p>Message:  Undefined variable $cleaned_qso</p>
<p>Filename: controllers/Logbookadvanced.php</p>
<p>Line Number: 213</p>

</div>null

No errors in the gui, and the dialog closes, but good to get rid of errors anyway.