### PR TITLE
Make satellite flightpath webpage header translated

### DIFF
--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -52,7 +52,7 @@ class Satellite extends CI_Controller {
 		];
 
 		// Render Page
-		$pageData['page_title'] = "Satellites";
+		$pageData['page_title'] = __("Satellites");
 		$this->load->view('interface_assets/header', $pageData);
 		$this->load->view('satellite/index');
 		$this->load->view('interface_assets/footer', $footerData);
@@ -210,7 +210,7 @@ class Satellite extends CI_Controller {
 		$pageData['latlng'] = $this->qra->qra2latlong($homegrid[0]);
 		$pageData['homegrid'] = $homegrid[0];
 		// Render Page
-		$pageData['page_title'] = "Satellite Flightpath";
+		$pageData['page_title'] = __("Satellite Flightpath");
 		$this->load->view('interface_assets/header', $pageData);
 		$this->load->view('satellite/flightpath', $data);
 		$this->load->view('interface_assets/footer', $footerData);
@@ -253,7 +253,7 @@ class Satellite extends CI_Controller {
 		];
 
 		// Render Page
-		$pageData['page_title'] = "Satellite pass";
+		$pageData['page_title'] = __("Satellite pass");
 		$this->load->view('interface_assets/header', $pageData);
 		$this->load->view('satellite/pass');
 		$this->load->view('interface_assets/footer', $footerData);


### PR DESCRIPTION
Before:
<img width="1228" height="464" alt="图片" src="https://github.com/user-attachments/assets/f52761ab-ab0e-4f5b-80b9-b481dfa8543b" />

After:
<img width="1276" height="449" alt="图片" src="https://github.com/user-attachments/assets/06e9d081-4b11-4065-a908-795ba2d7b853" />

Although `Satellites` and `Satellite pass` in this code file didn't use gettext before, these page use gettext of a hardcode text seperately in their code files (see example below), which make these translated at the end.

https://github.com/wavelog/wavelog/blob/76779b95b69726dd4b5bb9e70a3aaf9d0b71e3ff/application/views/satellite/flightpath.php#L36
https://github.com/wavelog/wavelog/blob/76779b95b69726dd4b5bb9e70a3aaf9d0b71e3ff/application/views/satellite/pass.php#L6

Obviously there are multiple solutions to this simple problem, and this pr is just one of them :)