### PR TITLE
Removed a duplicate colon at the end of explanatory text

### DIFF
--- a/application/views/search/cqzones_result.php
+++ b/application/views/search/cqzones_result.php
@@ -1,6 +1,6 @@
 <?php
 if ($qsos->result() != NULL) {
-	echo __("The following QSOs were found to have an incorrect CQ zone that this DXCC normally has (a maximum of 5000 QSOs are shown)::");
+	echo __("The following QSOs were found to have an incorrect CQ zone that this DXCC normally has (a maximum of 5000 QSOs are shown):");
 	echo '<table style="width:100%" class="qsolist table table-sm table-bordered table-hover table-striped table-condensed">
 	<thead>
 	<tr>


### PR DESCRIPTION
It seems that the duplicate colon was added by mistake in commit https://github.com/wavelog/wavelog/commit/beed25d37d0a26634523215345f31f35a8e78220.