### PR TITLE
Suppress Modes at statistic if zero

### DIFF
--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -72,16 +72,31 @@ class Statistics extends CI_Controller {
 		$modestats = array();
 
 		$i = 0;
-		$modestats[$i]['mode'] = 'ssb';
-		$modestats[$i++]['total'] = $this->logbook_model->total_ssb($yr);
-		$modestats[$i]['mode'] = 'cw';
-		$modestats[$i++]['total'] = $this->logbook_model->total_cw($yr);
-		$modestats[$i]['mode'] = 'fm';
-		$modestats[$i++]['total'] = $this->logbook_model->total_fm($yr);
-		$modestats[$i]['mode'] = 'am';
-		$modestats[$i++]['total'] = $this->logbook_model->total_am($yr);
-		$modestats[$i]['mode'] = 'digi';
-		$modestats[$i]['total'] = $this->logbook_model->total_digi($yr);
+		$ssb = $this->logbook_model->total_ssb($yr);
+		$cw = $this->logbook_model->total_cw($yr);
+		$fm = $this->logbook_model->total_fm($yr);
+		$am = $this->logbook_model->total_am($yr);
+		$digi = $this->logbook_model->total_digi($yr);
+		if ($ssb > 0) {
+			$modestats[$i]['mode'] = 'ssb';
+			$modestats[$i++]['total'] = $ssb;
+		}
+		if ($cw > 0) {
+			$modestats[$i]['mode'] = 'cw';
+			$modestats[$i++]['total'] = $cw;
+		}
+		if ($fm > 0) {
+			$modestats[$i]['mode'] = 'fm';
+			$modestats[$i++]['total'] = $fm;
+		}
+		if ($am > 0) {
+			$modestats[$i]['mode'] = 'am';
+			$modestats[$i++]['total'] = $am;
+		}
+		if ($digi > 0) {
+			$modestats[$i]['mode'] = 'digi';
+			$modestats[$i]['total'] = $digi;
+		}
 		usort($modestats, fn($a, $b) => $b['total'] <=> $a['total']);
 
 		header('Content-Type: application/json');


### PR DESCRIPTION
Suppress Modes where no QSO happened.

When calling Statistics and Mode - e.g. - AM was shown with a "0" even if no AM-QSO happened/is in log.
This patch shows only Modes with at least one QSO.

Before:
<img width="1318" height="464" alt="image" src="https://github.com/user-attachments/assets/46566e5b-1a6d-44a1-91c3-1fcf6f82ba4b" />

After patch:
<img width="1329" height="495" alt="image" src="https://github.com/user-attachments/assets/f87459c7-5786-4e2e-b824-5d298c2462a2" />
