### PR TITLE
better use site_url() instead base_url() to include index page (if set)

### DIFF
--- a/application/views/api/index.php
+++ b/application/views/api/index.php
@@ -16,7 +16,7 @@
 			<li><a href="https://github.com/wavelog/Wavelog/wiki/Third-Party-Tools" target="_thirdparty"><?=__("More Tools")?></a></li>
 			</ul>
 			</p>
-			<p class="card-text"><span class="badge text-bg-warning"><?= __("API URL"); ?></span> <?= __("The API URL for this Wavelog instance is"); ?>: <span class="api-url" id="apiUrl"><code class="ms-3 me-3"><?php echo base_url(); ?></code></span><span data-bs-toggle="tooltip" title="<?= __("Copy to clipboard"); ?>" onClick='copyApiUrl()'><i class="copy-icon fas fa-copy"></i></span></p>
+			<p class="card-text"><span class="badge text-bg-warning"><?= __("API URL"); ?></span> <?= __("The API URL for this Wavelog instance is"); ?>: <span class="api-url" id="apiUrl"><code class="ms-3 me-3"><?php echo site_url(); ?></code></span><span data-bs-toggle="tooltip" title="<?= __("Copy to clipboard"); ?>" onClick='copyApiUrl()'><i class="copy-icon fas fa-copy"></i></span></p>
 			<p class="card-text"><span class="badge text-bg-info"><?= __("Info"); ?></span> <?= __("It's good practice to delete a key if you are no longer using the associated application."); ?></p>
 			<?php if ($clubmode) { ?>
 				<p class="card-text"><span class="badge text-bg-danger"><?= __("Important"); ?></span> <?= __("On Clubstations the API Keys are personal and not shared. Clubstation users can only see their own keys."); ?></p>

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -43,7 +43,7 @@
                         </tr>
                         <tr>
                             <td><?= __("Base URL"); ?></td>
-                            <td><span id="baseUrl"><a href="<?php echo $this->config->item('base_url') ?>" target="_blank"><?php echo $this->config->item('base_url'); ?></a></span> <span data-bs-toggle="tooltip" title="<?= __("Copy to clipboard"); ?>" onclick='copyURL("<?php echo $this->config->item('base_url'); ?>")'><i class="copy-icon fas fa-copy"></span></td>
+                            <td><span id="baseUrl"><a href="<?php echo site_url(); ?>" target="_blank"><?php echo site_url(); ?></a></span> <span data-bs-toggle="tooltip" title="<?= __("Copy to clipboard"); ?>" onclick='copyURL("<?php echo site_url(); ?>")'><i class="copy-icon fas fa-copy"></span></td>
                         </tr>
                         <tr>
                             <td><?= __("Migration"); ?></td>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -352,7 +352,7 @@ function copyApiKey(apiKey) {
 
 function copyApiUrl() {
    var apiUrlField = $('#apiUrl');
-   navigator.clipboard.writeText("<?php echo base_url(); ?>").then(function() {
+   navigator.clipboard.writeText("<?php echo site_url(); ?>").then(function() {
    });
    apiUrlField.addClass('flash-copy')
       .delay('1000').queue(function() {


### PR DESCRIPTION
We should use `site_url()` instead `base_url()` in some places (especially when the URL is displayed in the UI) since `site_url()` includes the index_page (index.php) if still set in config.php. Some users were facing issues when in their config.php the index page is still set to "index.php" (instead empty string) and they use this url without index.php for API calls. Depending on the webserver / reverse proxy configuration this can cause issues