### PR TITLE
Add possibility to surpress dupe error messages in adif import API call

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -254,7 +254,7 @@ class adif extends CI_Controller {
 					};
 					$record='';	// free memory
 					try {
-						$custom_errors = $this->logbook_model->import_bulk($alladif, $this->input->post('station_profile', TRUE), $this->input->post('skipDuplicate'), $this->input->post('markClublog'),$this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markEqsl'), $this->input->post('markHrd'), $this->input->post('markDcl'), true, $this->input->post('operatorName') ?? false, false, $this->input->post('skipStationCheck'));
+						$custom_errors = $this->logbook_model->import_bulk($alladif, $this->input->post('station_profile', TRUE), $this->input->post('skipDuplicate'), $this->input->post('markClublog'),$this->input->post('markLotw'), $this->input->post('dxccAdif'), $this->input->post('markQrz'), $this->input->post('markEqsl'), $this->input->post('markHrd'), $this->input->post('markDcl'), true, $this->input->post('operatorName') ?? false, false, $this->input->post('skipStationCheck'), true);
 					} catch (Exception $e) {
 						log_message('error', 'Import error: '.$e->getMessage());
 						$data['page_title'] = __("ADIF Import failed!");

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -208,6 +208,12 @@ class API extends CI_Controller {
 		$userid = $this->api_model->key_userid($obj['key']);
 		$created_by = $this->api_model->key_created_by($obj['key']);
 
+		//check if dupes should count as errors
+		$dupesaserrors = true;
+		if(isset($obj['dupesaserrors'])) {
+		   $dupesaserrors = (bool)$obj['dupesaserrors'];
+		}
+
 		/**
 		 * As the API key user could use it also for clubstations we need to do an additional check here. Only if clubstations are enabled
 		 *
@@ -277,7 +283,7 @@ class API extends CI_Controller {
 				};
 				$record='';	// free memory
 				gc_collect_cycles();
-				$custom_errors = $this->logbook_model->import_bulk($alladif, $obj['station_profile_id'], false, false, false, false, false, false, false, false, true, false, true, false);
+				$custom_errors = $this->logbook_model->import_bulk($alladif, $obj['station_profile_id'], false, false, false, false, false, false, false, false, true, false, true, false, $dupesaserrors);
 				if ($custom_errors) {
 					$adif_errors++;
 				}


### PR DESCRIPTION
After a nice chat with one developer from the PoLo team, they had difficulties implementing the sync feature to Wavelog, since Wavelog skips all the dupes perfectly fine, but still outputs an error message, which prompts the API to return HTTP 400.

I added a new optional attribute ("dupesaserrors") in the input json to override this behaviour on demand. It still defaults to showing errors without the attribute to preserve functionality for all other apps using the API.

I tested this pretty extensively, since I had to change the error handling of the core import logic to include an error type to handle dupes differently then other errors, but additional tests would surely be good.

Testing:
Skipping dupes without error messages:
`curl -X POST https://<WAVELOG_URL>/index.php/api/qso -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\",\"dupesaserrors\":false,\"station_profile_id\":\"<STATION_PROFILE_ID>\",\"type\":\"adif\",\"string\":\"<call:5>N9EAT<band:4>70cm<mode:3>SSB<freq:10>432.166976<qso_date:8>20190616<time_on:6>170600<time_off:6>170600<rst_rcvd:2>59<rst_sent:2>55<qsl_rcvd:1>N<qsl_sent:1>N<country:24>United States Of America<gridsquare:4>EN42<sat_mode:3>U/V<sat_name:4>AO-7<prop_mode:3>SAT<name:5>Marty<eor>\"}"`

Skipping dupes with error messages (including attribute):
`curl -X POST https://<WAVELOG_URL>/index.php/api/qso -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\",\"dupesaserrors\":true,\"station_profile_id\":\"<STATION_PROFILE_ID>\",\"type\":\"adif\",\"string\":\"<call:5>N9EAT<band:4>70cm<mode:3>SSB<freq:10>432.166976<qso_date:8>20190616<time_on:6>170600<time_off:6>170600<rst_rcvd:2>59<rst_sent:2>55<qsl_rcvd:1>N<qsl_sent:1>N<country:24>United States Of America<gridsquare:4>EN42<sat_mode:3>U/V<sat_name:4>AO-7<prop_mode:3>SAT<name:5>Marty<eor>\"}"`

or without the attribute alltogether (shows errors):
`curl -X POST https://<WAVELOG_URL>/index.php/api/qso -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\",\"station_profile_id\":\"<STATION_PROFILE_ID>\",\"type\":\"adif\",\"string\":\"<call:5>N9EAT<band:4>70cm<mode:3>SSB<freq:10>432.166976<qso_date:8>20190616<time_on:6>170600<time_off:6>170600<rst_rcvd:2>59<rst_sent:2>55<qsl_rcvd:1>N<qsl_sent:1>N<country:24>United States Of America<gridsquare:4>EN42<sat_mode:3>U/V<sat_name:4>AO-7<prop_mode:3>SAT<name:5>Marty<eor>\"}"`