### PR TITLE
New 404 Error Page

### DIFF
--- a/application/views/errors/html/error_404.php
+++ b/application/views/errors/html/error_404.php
@@ -3,8 +3,6 @@
 <title>404 Page Not Found</title>
 	<!-- Bootstrap CSS -->
 	<?php
-	$CI =& get_instance();
-	$theme = $CI->optionslib->get_theme();
 	if ($theme) { ?>
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/bootstrap-multiselect.css">
 		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/bootstrap.min.css">

--- a/system/core/Controller.php
+++ b/system/core/Controller.php
@@ -99,7 +99,10 @@ class CI_Controller {
         $languages = $this->config->item('languages');
 
         // Remove current language from available languages
-        unset($languages[$data['language']['folder']]);
+        //if ($data['language']['folder'] !== null) {
+        if ($data['language'] !== null) {
+           unset($languages[$data['language']['folder']]);
+        }
         $data['languages'] = $languages;
 
 		/* 

--- a/system/core/Exceptions.php
+++ b/system/core/Exceptions.php
@@ -161,6 +161,10 @@ class CI_Exceptions {
 	 */
 	public function show_error($heading, $message, $template = 'error_general', $status_code = 500)
 	{
+		new CI_Controller();
+		$CI =& get_instance();
+		$theme = $CI->optionslib->get_theme();
+
 		$templates_path = config_item('error_views_path');
 		if (empty($templates_path))
 		{


### PR DESCRIPTION
Thought we can give this some color and eyecandy.. even it's an error page

Before

<img width="1131" height="621" alt="image" src="https://github.com/user-attachments/assets/882ea3b3-b05d-4c55-8fa9-378dd242d8b1" />


After

<img width="1097" height="758" alt="image" src="https://github.com/user-attachments/assets/dd7f5445-d724-41da-bb4c-5bddaee11177" />

This only affects the function `show_404('message')` which was broken anyway (we added a message but it was never display :-)

It behaves the same like the login page or also the header
Theme is chosen based on global options (if not logged in) and Logo is chosen based on theme
