### PR TITLE
Take Grid from confirmation also if length is the same

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -550,7 +550,7 @@ class Lotw extends CI_Controller {
 				// Present only if the QSLing station specified a single valid grid square value in its station location uploaded to LoTW.
 				$qsl_gridsquare = "";
 				if (isset($record['gridsquare'])) {
-					if (strlen($record['gridsquare']) > strlen($status[2] ?? '') || substr(strtoupper($status[2] ?? ''), 0, 4) != substr(strtoupper($record['gridsquare']), 0, 4)) {
+					if (strlen($record['gridsquare']) >= strlen($status[2] ?? '') || substr(strtoupper($status[2] ?? ''), 0, 4) != substr(strtoupper($record['gridsquare']), 0, 4)) {
 						$qsl_gridsquare = $record['gridsquare'];
 					}
 				}


### PR DESCRIPTION
Current situation:
Overwrite Grid at log with that from confirmation:
- if first 4 chars differ
- if grid provided by lotw is more precise than in own log

with this patch:
Overwrite Grid at log with that from confirmation:
- if first 4 chars differ
- if grid provided by lotw is more precise **or same precision** than in own log