### PR TITLE
Fix _getLocator

### DIFF
--- a/assets/js/leaflet/L.Maidenhead.activators.js
+++ b/assets/js/leaflet/L.Maidenhead.activators.js
@@ -140,7 +140,7 @@ L.MaidenheadActivators = L.LayerGroup.extend({
       var y = lat;
       var precision = d4[map.getZoom()];
       while (x < -180) {x += 360;}
-      while (x > 180) {x -=360;}
+      while (x >= 180) {x -=360;}
       x = x + 180;
       y = y + 90;
       locator = locator + d1[Math.floor(x/20)] + d1[Math.floor(y/10)];

--- a/assets/js/leaflet/L.Maidenhead.js
+++ b/assets/js/leaflet/L.Maidenhead.js
@@ -85,7 +85,7 @@ L.Maidenhead = L.LayerGroup.extend({
       var y = lat;
       var precision = d4[this._map.getZoom()];
       while (x < -180) {x += 360;}
-      while (x > 180) {x -=360;}
+      while (x >= 180) {x -=360;}
       x = x + 180;
       y = y + 90;
       locator = locator + d1[Math.floor(x/20)] + d1[Math.floor(y/10)];

--- a/assets/js/leaflet/L.Maidenhead.qrb.js
+++ b/assets/js/leaflet/L.Maidenhead.qrb.js
@@ -120,7 +120,7 @@ L.MaidenheadQrb = L.LayerGroup.extend({
       var y = lat;
       var precision = d4[map.getZoom()];
       while (x < -180) {x += 360;}
-      while (x > 180) {x -=360;}
+      while (x >= 180) {x -=360;}
       x = x + 180;
       y = y + 90;
       locator = locator + d1[Math.floor(x/20)] + d1[Math.floor(y/10)];

--- a/assets/js/leaflet/L.MaidenheadColoured.js
+++ b/assets/js/leaflet/L.MaidenheadColoured.js
@@ -146,7 +146,7 @@ L.Maidenhead = L.LayerGroup.extend({
       var y = lat;
       var precision = d4[map.getZoom()];
       while (x < -180) {x += 360;}
-      while (x > 180) {x -=360;}
+      while (x >= 180) {x -=360;}
       x = x + 180;
       y = y + 90;
       locator = locator + d1[Math.floor(x/20)] + d1[Math.floor(y/10)];

--- a/assets/js/leaflet/L.MaidenheadColouredGridMap.js
+++ b/assets/js/leaflet/L.MaidenheadColouredGridMap.js
@@ -158,7 +158,7 @@ L.Maidenhead = L.LayerGroup.extend({
       var y = lat;
       var precision = d4[map.getZoom()];
       while (x < -180) {x += 360;}
-      while (x > 180) {x -=360;}
+      while (x >= 180) {x -=360;}
       x = x + 180;
       y = y + 90;
       locator = locator + d1[Math.floor(x/20)] + d1[Math.floor(y/10)];

--- a/assets/js/leaflet/L.MaidenheadColouredGridmasterMap.js
+++ b/assets/js/leaflet/L.MaidenheadColouredGridmasterMap.js
@@ -130,7 +130,7 @@ L.Maidenhead = L.LayerGroup.extend({
       var y = lat;
       var precision = d4[map.getZoom()];
       while (x < -180) {x += 360;}
-      while (x > 180) {x -=360;}
+      while (x >= 180) {x -=360;}
       x = x + 180;
       y = y + 90;
       locator = locator + d1[Math.floor(x/20)] + d1[Math.floor(y/10)];


### PR DESCRIPTION

<img width="2128" height="830" alt="image" src="https://github.com/user-attachments/assets/44a4778e-b290-4fa6-a6a5-b7a7f8c684ae" />

There is a bug in the /gridmap page. The grid starting with A cannot display the worked/confirmed background color.

<img width="1220" height="246" alt="image" src="https://github.com/user-attachments/assets/847c5e62-8e0b-4fcd-8352-567bb0d20c9e" />

Because _getLocator returns the wrong grid name
