### PR TITLE
Default localhost for cronmanager in docker environments

### DIFF
--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -92,7 +92,17 @@ class cron extends CI_Controller {
 						echo "CRON: " . $cron->id . " -> is due: " . $isdue_result . "\n";
 						echo "CRON: " . $cron->id . " -> RUNNING...\n";
 
-						$url = local_url() . $cron->function;
+						if (ENVIRONMENT == "docker") {
+							// In Docker, we use the localhost[:80] to call the cron directly inside the container
+							$url = 'http://localhost/' . $cron->function;
+							log_message('debug', 'Docker Environment detected. Using URL: ' . $url);
+						} else {
+							// In other environments, we use the local_url() function to get the default url
+							// Even this local_url() helper created in https://github.com/wavelog/wavelog/pull/795 is not really necessary anymore
+							// we keep it in case of users do fancy things with it. It doesn't hurt to have it here as it usually returns the base_url
+							// from the config.php file.
+							$url = local_url() . $cron->function;
+						}
                         if (ENVIRONMENT == "development") {
 						    echo "CRON: " . $cron->id . " -> URL: " . $url . "\n";
                         }


### PR DESCRIPTION
There is a logical issue since the beginning of the cronmanager implementation in https://github.com/wavelog/wavelog/pull/306

It only affects installations which are using docker and keep the base_url at localhost and a different port then 80. It's quite simple (e.g. `$config['base_url'] = 'http://localhost:8086/';`)

`localhost` inside the container !== `localhost` in the host machine. 

Reason is that we use port `8086` per default in our [docker-compose.yml](https://github.com/wavelog/wavelog/wiki/Installation-via-Docker#docker-composeyaml). This leads into the problem that the mastercron is correctly called inside the container with `http://localhost[:80]` ([see Dockerfile](https://github.com/wavelog/wavelog/blob/master/Dockerfile#L45)) but the cron/run method gets `http://localhost:8086` from the base_url config ([via local_url() method](https://github.com/wavelog/wavelog/blob/6704c35b1dea2b4539c1102af94a30fc668ae1cd/application/controllers/Cron.php#L95)). This obvisouly fails inside the container as in this little cute blue whale Wavelog is running on port `80`, and not `8086`.

There was a good solution around a year ago by @winnieXY in https://github.com/wavelog/wavelog/pull/795 but the people (and myself) forget about the config option. Therefore we use now `http://localhost[:80]` by default in docker environments which always works (because inside the container Wavelog always runs on localhost port 80). Thanks to @blhoward2 for poking me here. Even this is not a bug, it leads into a bad user experience when people running Wavelog in docker for the first time on their local machine and the cronmanager fails... 

Solves 
- https://github.com/wavelog/wavelog/issues/2208
- https://github.com/wavelog/wavelog/discussions/2180
- .. and probably some more