### PR TITLE
[OQRS] Fix the qso match button

### DIFF
--- a/application/models/Oqrs_model.php
+++ b/application/models/Oqrs_model.php
@@ -603,7 +603,7 @@ class Oqrs_model extends CI_Model {
 		$this->db->from('oqrs');
 		$this->db->join('station_profile', 'station_profile.station_id = oqrs.station_id');
 		$this->db->where('oqrs.id', $oqrsid);
-		$this->db->where('oqrs.qsoid', 0); // Ensure we are adding a match to an empty qsoid
+		$this->db->where('oqrs.qsoid IS NULL', null, false); // Ensure we are adding a match to an empty qsoid
 		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
 		$query = $this->db->get();
 

--- a/application/views/oqrs/qsolist.php
+++ b/application/views/oqrs/qsolist.php
@@ -206,7 +206,7 @@ function return_add_print_button($qso_id, $qslsent) {
 }
 
 function return_add_match_qso_button($qso_id, $qsoid, $matchqsoid, $oqrsid) {
-	if ($qso_id != $qsoid && $matchqsoid == 0) return '<button onclick="addQsoMatchToOqrs(\'' . $qso_id . '\', \'' . $oqrsid . '\')" class="btn btn-sm btn-success">' . __("Match QSO") . '</button>';
+	if ($qso_id != $qsoid && $matchqsoid == null) return '<button onclick="addQsoMatchToOqrs(\'' . $qso_id . '\', \'' . $oqrsid . '\')" class="btn btn-sm btn-success">' . __("Match QSO") . '</button>';
 
 	return '';
 }


### PR DESCRIPTION
Adding the cascade delete broke a lot of stuff, and this was missed in the original PR.

PR brings the button back, and fixes the backend.