### PR TITLE
Change default RST on fav selection

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -436,6 +436,7 @@ $(document).on("click", "#fav_recall", function (event) {
 	$('#frequency').val(favs[this.innerText].frequency).trigger("change");
 	$('#selectPropagation').val(favs[this.innerText].prop_mode);
 	$('#mode').val(favs[this.innerText].mode).on("change");
+	setRst($('.mode').val());
 });
 
 


### PR DESCRIPTION
We should also set default RST according to mode on selection of a saved fav. Mode is set from fav but defautl RST not:

https://github.com/user-attachments/assets/61414f95-29e9-47d7-ace1-1e5267146510

