### PR TITLE
Show confirmation-Method at DXCC Award instead of simple "C"

### DIFF
--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -132,7 +132,7 @@ class DXCC extends CI_Model {
 
 	private function cf_type($postdata,$qsl,$lotw,$eqsl,$qrz,$clublog) {
 		$string='';
-		if ((($qsl ?? 0)>0) && (($postdata['qrz'] ?? '') != '')) { $string.='Q'; }
+		if ((($qsl ?? 0)>0) && (($postdata['qsl'] ?? '') != '')) { $string.='Q'; }
 		if ((($lotw ?? 0)>0) && (($postdata['lotw'] ?? '') != '')) { $string.='L'; }
 		if ((($eqsl ?? 0)>0) && (($postdata['eqsl'] ?? '') != '')) { $string.='E'; }
 		if ((($qrz ?? 0)>0) && (($postdata['qrz'] ?? '') != '')) { $string.='Z'; }

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -98,7 +98,7 @@ class DXCC extends CI_Model {
 			if ($postdata['confirmed'] != NULL) {
 				$confirmedDXCC = $this->getDxccBandConfirmed($location_list, $band, $postdata);
 				foreach ($confirmedDXCC as $cdxcc) {
-					$dxccMatrix[$cdxcc->dxcc][$band] = '<div class="bg-success awardsBgSuccess"><a href=\'javascript:displayContacts("'.$cdxcc->dxcc.'","'. $band . '","'. $postdata['sat'] . '","'. $postdata['orbit'] . '","' . $postdata['mode'] . '","DXCC2","'.$qsl.'")\'>'.$this->cf_type($postdata, $cdxcc->qsl,$cdxcc->lotw, $cdxcc->eqsl, $cdxcc->qrz, $cdxcc->clublog).'</a></div>';
+					$dxccMatrix[$cdxcc->dxcc][$band] = '<div class="bg-success awardsBgSuccess" additional_successinfo=">C<"><a href=\'javascript:displayContacts("'.$cdxcc->dxcc.'","'. $band . '","'. $postdata['sat'] . '","'. $postdata['orbit'] . '","' . $postdata['mode'] . '","DXCC2","'.$qsl.'")\'>'.$this->cf_type($postdata, $cdxcc->qsl,$cdxcc->lotw, $cdxcc->eqsl, $cdxcc->qrz, $cdxcc->clublog).'</a></div>';
 				}
 			}
 		}

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -98,7 +98,7 @@ class DXCC extends CI_Model {
 			if ($postdata['confirmed'] != NULL) {
 				$confirmedDXCC = $this->getDxccBandConfirmed($location_list, $band, $postdata);
 				foreach ($confirmedDXCC as $cdxcc) {
-					$dxccMatrix[$cdxcc->dxcc][$band] = '<div class="bg-success awardsBgSuccess"><a href=\'javascript:displayContacts("'.$cdxcc->dxcc.'","'. $band . '","'. $postdata['sat'] . '","'. $postdata['orbit'] . '","' . $postdata['mode'] . '","DXCC2","'.$qsl.'")\'>C</a></div>';
+					$dxccMatrix[$cdxcc->dxcc][$band] = '<div class="bg-success awardsBgSuccess"><a href=\'javascript:displayContacts("'.$cdxcc->dxcc.'","'. $band . '","'. $postdata['sat'] . '","'. $postdata['orbit'] . '","' . $postdata['mode'] . '","DXCC2","'.$qsl.'")\'>'.$this->cf_type($postdata, $cdxcc->qsl,$cdxcc->lotw, $cdxcc->eqsl, $cdxcc->qrz, $cdxcc->clublog).'</a></div>';
 				}
 			}
 		}
@@ -130,11 +130,22 @@ class DXCC extends CI_Model {
 		}
 	}
 
+	private function cf_type($postdata,$qsl,$lotw,$eqsl,$qrz,$clublog) {
+		$string='';
+		if ((($qsl ?? 0)>0) && (($postdata['qrz'] ?? '') != '')) { $string.='Q'; }
+		if ((($lotw ?? 0)>0) && (($postdata['lotw'] ?? '') != '')) { $string.='L'; }
+		if ((($eqsl ?? 0)>0) && (($postdata['eqsl'] ?? '') != '')) { $string.='E'; }
+		if ((($qrz ?? 0)>0) && (($postdata['qrz'] ?? '') != '')) { $string.='Z'; }
+		if ((($clublog ?? 0)>0) && (($postdata['clublog'] ?? '') != '')) { $string.='C'; }
+		if ($string == '') { $string='C'; }
+		return $string;
+	}
+
 	function getDxccBandConfirmed($location_list, $band, $postdata) {
 		$bindings=[];
-		$sql = "select adif as dxcc, name from dxcc_entities
+		$sql = "select adif as dxcc, name, lotw, qsl, eqsl, qrz, clublog from dxcc_entities
 				join (
-					select col_dxcc from ".$this->config->item('table_name')." thcv
+					select col_dxcc, sum(case when thcv.col_lotw_qsl_rcvd ='Y' then 1 else 0 end) as lotw,sum(case when thcv.col_qsl_rcvd = 'Y' then 1 else 0 end) as qsl,sum(case when thcv.col_eqsl_qsl_rcvd = 'Y' then 1 else 0 end) as eqsl,sum(case when thcv.COL_QRZCOM_QSO_DOWNLOAD_STATUS= 'Y' then 1 else 0 end) as qrz,sum(case when thcv.COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y' then 1 else 0 end) as clublog from ".$this->config->item('table_name')." thcv
 					LEFT JOIN satellite on thcv.COL_SAT_NAME = satellite.name
 					where station_id in (" . $location_list .
 				  ") and col_dxcc > 0";
@@ -337,9 +348,9 @@ class DXCC extends CI_Model {
 
 	function getDxccConfirmed($location_list, $postdata) {
 		$bindings=[];
-		$sql = "SELECT adif as dxcc FROM dxcc_entities
+		$sql = "SELECT adif, lotw, qsl as dxcc FROM dxcc_entities
 	    join (
-		select col_dxcc
+		select col_dxcc, sum(case when thcv.col_lotw_qsl_rcvd ='Y' then 1 else 0 end) as lotw,sum(case when thcv.col_qsl_rcvd = 'Y' then 1 else 0 end) as qsl,sum(case when thcv.col_eqsl_qsl_rcvd = 'Y'     then 1 else 0 end) as eqsl,sum(case when thcv.COL_QRZCOM_QSO_DOWNLOAD_STATUS= 'Y' then 1 else 0 end) as qrz,sum(case when thcv.COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y' then 1 else 0 end) as clublog
 		from ".$this->config->item('table_name')." thcv
 		LEFT JOIN satellite on thcv.COL_SAT_NAME = satellite.name
 		where station_id in (". $location_list .
@@ -434,6 +445,8 @@ class DXCC extends CI_Model {
 			$confirmed = $this->getSummaryByBandConfirmed($band, $postdata, $location_list);
 			$dxccSummary['worked'][$band] = $worked[0]->count;
 			$dxccSummary['confirmed'][$band] = $confirmed[0]->count;
+			$dxccSummary['confirmed_lotw'][$band] = $confirmed[0]->lotw;
+			$dxccSummary['confirmed_qsl'][$band] = $confirmed[0]->qsl;
 		}
 
 		$workedTotal = $this->getSummaryByBand($postdata['band'], $postdata, $location_list);
@@ -441,6 +454,8 @@ class DXCC extends CI_Model {
 
 		$dxccSummary['worked']['Total'] = $workedTotal[0]->count;
 		$dxccSummary['confirmed']['Total'] = $confirmedTotal[0]->count;
+		$dxccSummary['confirmed_lotw']['Total'] = $confirmedTotal[0]->lotw;
+		$dxccSummary['confirmed_qsl']['Total'] = $confirmedTotal[0]->qsl;
 
 		return $dxccSummary;
 	}
@@ -506,7 +521,7 @@ class DXCC extends CI_Model {
 
 	function getSummaryByBandConfirmed($band, $postdata, $location_list) {
 		$bindings=[];
-		$sql = "SELECT count(distinct thcv.col_dxcc) as count FROM " . $this->config->item('table_name') . " thcv";
+		$sql = "SELECT count(distinct thcv.col_dxcc) as count, sum(case when thcv.col_lotw_qsl_rcvd ='Y' then 1 else 0 end) as lotw,sum(case when thcv.col_qsl_rcvd = 'Y' then 1 else 0 end) as qsl,sum(case when thcv.col_eqsl_qsl_rcvd = 'Y'     then 1 else 0 end) as eqsl,sum(case when thcv.COL_QRZCOM_QSO_DOWNLOAD_STATUS= 'Y' then 1 else 0 end) as qrz,sum(case when thcv.COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y' then 1 else 0 end) as clublog FROM " . $this->config->item('table_name') . " thcv";
 		$sql .= " LEFT JOIN satellite on thcv.COL_SAT_NAME = satellite.name";
 		$sql .= " join dxcc_entities d on thcv.col_dxcc = d.adif";
 

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -348,9 +348,9 @@ class DXCC extends CI_Model {
 
 	function getDxccConfirmed($location_list, $postdata) {
 		$bindings=[];
-		$sql = "SELECT adif, lotw, qsl as dxcc FROM dxcc_entities
+		$sql = "SELECT adif as dxcc, lotw, qsl, eqsl, qrz, clublog FROM dxcc_entities
 	    join (
-		select col_dxcc, sum(case when thcv.col_lotw_qsl_rcvd ='Y' then 1 else 0 end) as lotw,sum(case when thcv.col_qsl_rcvd = 'Y' then 1 else 0 end) as qsl,sum(case when thcv.col_eqsl_qsl_rcvd = 'Y'     then 1 else 0 end) as eqsl,sum(case when thcv.COL_QRZCOM_QSO_DOWNLOAD_STATUS= 'Y' then 1 else 0 end) as qrz,sum(case when thcv.COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y' then 1 else 0 end) as clublog
+		select col_dxcc, sum(case when thcv.col_lotw_qsl_rcvd ='Y' then 1 else 0 end) as lotw,sum(case when thcv.col_qsl_rcvd = 'Y' then 1 else 0 end) as qsl,sum(case when thcv.col_eqsl_qsl_rcvd = 'Y' then 1 else 0 end) as eqsl,sum(case when thcv.COL_QRZCOM_QSO_DOWNLOAD_STATUS= 'Y' then 1 else 0 end) as qrz,sum(case when thcv.COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y' then 1 else 0 end) as clublog
 		from ".$this->config->item('table_name')." thcv
 		LEFT JOIN satellite on thcv.COL_SAT_NAME = satellite.name
 		where station_id in (". $location_list .
@@ -454,8 +454,6 @@ class DXCC extends CI_Model {
 
 		$dxccSummary['worked']['Total'] = $workedTotal[0]->count;
 		$dxccSummary['confirmed']['Total'] = $confirmedTotal[0]->count;
-		$dxccSummary['confirmed_lotw']['Total'] = $confirmedTotal[0]->lotw;
-		$dxccSummary['confirmed_qsl']['Total'] = $confirmedTotal[0]->qsl;
 
 		return $dxccSummary;
 	}

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -218,12 +218,12 @@
     $i = 1;
     if ($dxcc_array) {
 	    echo __('Legend:');
-	    echo '<pre>'.__("Q: QSL-Paper-Card")."\n";
-	    echo __("L: LoTW")."\n";
-	    echo __("E: eQSL")."\n";
-	    echo __('Z: QRZ-"confirmation"')."\n";
-	    echo __("C: Clublog")."\n";
-	    echo __("W: Worked").'</pre>';
+	    echo '<pre>'.__("(Q)SL-Paper-Card").", ";
+	    echo __("(L)oTW").", ";
+	    echo __("(e)QSL").", ";
+	    echo __('QR(Z)-"confirmation"').", ";
+	    echo __("(C)lublog").", ";
+	    echo __("(W)orked").'</pre>';
 	    echo '
 		<table style="width:100%" class="table-sm table tabledxcc table-bordered table-hover table-striped table-condensed text-center">
 		    <thead>

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -217,6 +217,12 @@
     <?php
     $i = 1;
     if ($dxcc_array) {
+	    echo __('Legend:');
+	    echo '<pre>'.__("Q: QSL-Paper-Card")."\n";
+	    echo __("L: LoTW")."\n";
+	    echo __("E: eQSL")."\n";
+	    echo __('Z: QRZ-"confirmation"')."\n";
+	    echo __("C: Clublog").'</pre>';
 	    echo '
 		<table style="width:100%" class="table-sm table tabledxcc table-bordered table-hover table-striped table-condensed text-center">
 		    <thead>

--- a/application/views/awards/dxcc/index.php
+++ b/application/views/awards/dxcc/index.php
@@ -222,7 +222,8 @@
 	    echo __("L: LoTW")."\n";
 	    echo __("E: eQSL")."\n";
 	    echo __('Z: QRZ-"confirmation"')."\n";
-	    echo __("C: Clublog").'</pre>';
+	    echo __("C: Clublog")."\n";
+	    echo __("W: Worked").'</pre>';
 	    echo '
 		<table style="width:100%" class="table-sm table tabledxcc table-bordered table-hover table-striped table-condensed text-center">
 		    <thead>


### PR DESCRIPTION
This one shows the confirmation-Method (if checked) instead of the "C".
so it's easy to see which DXCC was confirmed via QSL-Card but not via LoTW and so on.

<img width="1280" height="222" alt="image" src="https://github.com/user-attachments/assets/45d6284e-bd29-421a-9f86-ed40ec3120ba" />

open issues:
- [x] Get map back to work
- [x] Add Legend for QLEZC (**Q**SL-Card, **L**oTW, **E**QSL, QR**Z**, **C**lublog)