### PR TITLE
Map T2 sat names for amsat status upload

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1253,6 +1253,8 @@ class Logbook_model extends CI_Model {
 			}
 		} else if ($data['COL_SAT_NAME'] == 'CAS-3H') {
 			$sat_name = 'LilacSat-2';
+		} else if (preg_match('/TEV2-[1-9]/', $data['COL_SAT_NAME'])) {
+			$sat_name = str_replace('TEV2-', 'TEVEL2-', $data['COL_SAT_NAME']);
 		} else {
 			$sat_name = $data['COL_SAT_NAME'];
 		}


### PR DESCRIPTION
We need to (re)map satellite names for AMSAT status page for all Tevel2 satellites as the LoTW name (TEV2-*) differs from the values used on the status page (TEVEL2-*):

<img width="333" height="144" alt="Screenshot 2025-08-19 111435" src="https://github.com/user-attachments/assets/cdd67a29-24b7-4928-9924-ae67895172ea" />
