### PR TITLE
Fix CBR Export

### DIFF
--- a/application/libraries/Cabrilloformat.php
+++ b/application/libraries/Cabrilloformat.php
@@ -147,7 +147,7 @@ class Cabrilloformat {
       }
 
       if ($grid_export == true) {
-         $returnstring .= substr($qso->station_gridsquare, 0, 4) ?? '' ." ";
+         $returnstring .= (substr($qso->station_gridsquare, 0, 4) ?? '') ." ";
       }
 
       if ($qso->COL_STX_STRING != "") {
@@ -161,7 +161,7 @@ class Cabrilloformat {
       }  
 
       if ($grid_export == true) {
-         $returnstring .= substr($qso->COL_GRIDSQUARE, 0, 4) ?? '' ." ";
+         $returnstring .= (substr($qso->COL_GRIDSQUARE, 0, 4) ?? '') ." ";
       }
       
       if ($qso->COL_SRX_STRING != "") {


### PR DESCRIPTION
Given a contest with Grid as exchange, the CBR export exports - e.g. - this row:

`QSO:   7049 DG 2025-08-12 1900 DJ7NT        -03 JN49DF2ET         +10 JO44 0`

see the missing space between own loc and call?
this patch fixes it:

`QSO:   7049 DG 2025-08-12 1900 DJ7NT         -03 JO30 DF2ET         +10 JO44  0`
