### PR TITLE
feat(simplefle): Add TIMEZONE support to FLE parser

### DIFF
--- a/assets/js/sections/simplefle.js
+++ b/assets/js/sections/simplefle.js
@@ -486,8 +486,8 @@ function handleInput() {
 			}
 
 			const tableRow = $(`<tr>
-			<td>${extraQsoDate}</td>
-			<td>${qsotime}</td>
+			<td>${utcDate}</td>
+			<td>${utcTime}</td>
 			<td>${callsign}</td>
 			<td><span data-bs-toggle="tooltip" data-placement="left" title="${freq}">${band}</span></td>
 			<td>${mode}</td>

--- a/assets/js/sections/simplefle.js
+++ b/assets/js/sections/simplefle.js
@@ -230,6 +230,7 @@ function handleInput() {
 	var prev_stx = "";
 	var prev_stx_string = "";
 	qsoList = [];
+	var timezoneOffsetHours = 0;
 	$("#qsoTable tbody").empty();
 	errors = [];
 	checkMainFieldsErrors();
@@ -237,6 +238,13 @@ function handleInput() {
 	var text = textarea.val().trim();
 	lines = text.split("\n");
 	lines.forEach((row) => {
+		// Solve timezone offset if specified
+		var tzMatch = row.trim().match(/^(?:TIMEZONE|TZOFS)\s+([+-]\d+)/i);
+		if (tzMatch) {
+			timezoneOffsetHours = parseInt(tzMatch[1], 10);
+			return; 
+		}
+
 		var rst_s = null;
 		var rst_r = null;
 		var gridsquare = "";
@@ -418,9 +426,22 @@ function handleInput() {
 			rst_s = getReportByMode(rst_s, mode);
 			rst_r = getReportByMode(rst_r, mode);
 
+			var utcDate = extraQsoDate;
+			var utcTime = qsotime;
+
+			if (timezoneOffsetHours !== 0) {
+				var offsetString = (timezoneOffsetHours >= 0 ? '+' : '-') + ('0' + Math.abs(timezoneOffsetHours)).slice(-2) + ':00';
+				var fullIsoString = extraQsoDate + 'T' + qsotime.slice(0, 2) + ':' + qsotime.slice(2) + ':00' + offsetString;
+
+				var dateObject = new Date(fullIsoString);
+
+				utcDate = dateObject.getUTCFullYear() + '-' + ('0' + (dateObject.getUTCMonth() + 1)).slice(-2) + '-' + ('0' + dateObject.getUTCDate()).slice(-2);
+				
+				utcTime = ('0' + dateObject.getUTCHours()).slice(-2) + ('0' + dateObject.getUTCMinutes()).slice(-2);
+			}
 			qsoList.push([
-				extraQsoDate,
-				qsotime,
+				utcDate,
+				utcTime,
 				callsign,
 				freq,
 				band,


### PR DESCRIPTION
### What does this PR do?
This pull request adds support for the `TIMEZONE` keyword to the Simple Fast Log Entry (FLE) parser.

### Why is it needed?
This feature allows users to input QSO times in their local timezone (e.g., `TIMEZONE +8` followed by `1400 BH6SKD`). The parser will then automatically convert the local time to the correct UTC time (`0600`) for logging. This greatly improves convenience for users who log in real-time but think in their local timezone.

### How to test it:
1.  Go to the SimpleFLE page.
2.  In the textarea, enter a timezone offset, for example: `TIMEZONE +8`.
3.  On a new line, enter a QSO with a time in that local timezone, for example: `1400 BH6SKD`.
4.  **Observe:** The QSO list on the right should display the time correctly converted to UTC (e.g., `0600`).
5.  Saving the QSO should also store the correct UTC time in the logbook.

---
*This feature was developed with the guidance of Gemini.* 😉

I'm a new contributor and this is my first pull request here. I'd appreciate it if you could review my code and point out any areas for improvement.