### PR TITLE
Sort the first user timezone list as floats, rather than strings.

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -1009,7 +1009,7 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 												];
 
 												usort($timezones, function ($a, $b) {
-													return strcmp($a[1], $b[1]);
+													return floatval($a[1]) <=> floatval($b[1]);
 												});
 
 												// Loop through timezones to generate options


### PR DESCRIPTION
When creating a new install, at the time of setting the first user, the time zones are incorrectly ordered as a result of comparing hour offset as strings rather than floats.

This can be reproduced by:
1. Create a new install of WaveLog
2. Progress to creating the first user.
3. Expand the Timezone DDL.
4. Observe, the ordering is screwy.  i.e. "GMT+10 Hobart" is in the wrong position.

This PR fixes the sorting of time zones.

Kind regards,
  Lance - VK7TO