### PR TITLE
Fixes DXCC in Search when no QSO is found and callbook returns nothing

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -915,6 +915,10 @@ class Logbook extends CI_Controller {
 						$data['grid_worked'] = $this->logbook_model->check_if_grid_worked_in_logbook(strtoupper(substr($data['callsign']['gridsquare'],0,4)), null, $this->session->userdata('user_default_band'))->num_rows();
 					}
 					if (isset($data['callsign']['dxcc'])) {
+						//if Callbook lookup does not result in any DXCC, try to resolve it ourselves
+						if($data['callsign']['dxcc'] == ""){
+							$data['callsign']['dxcc'] = $this->dxcheck($data['callsign']['callsign'], "")['adif'];
+						}
 						$entity = $this->logbook_model->get_entity($data['callsign']['dxcc']);
 						$data['callsign']['dxcc_name'] = $entity['name'];
 						$data['dxcc_worked'] = $this->logbook_model->check_if_dxcc_worked_in_logbook($data['callsign']['dxcc'], null, $this->session->userdata('user_default_band'));


### PR DESCRIPTION
This PR fixes something that has bugged me a long time.

When using QRZ without a subscription, a search for a callsign that existed, but was not yet worked, always resulted in 

``"DXCC: - NONE - (E.G. /MM, /AM)"``

which was almost always obviously wrong.

In the case of using QRZ free lookup, the callbook lookup returns empty string for the dxcc. 

This PR adds that in this case, we could try looking it up ourselves using our lookup function to display sensible information, while leaving the rest of the data intact.