### PR TITLE
Prevent auto-usage from (probably) wrong qrz.com grids

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -159,6 +159,7 @@ class Logbook extends CI_Controller {
 
 		$return['callsign_name'] 		= $this->nval($callbook['name'] ?? '', $this->logbook_model->call_name($callsign));
 		$return['callsign_qra'] 		= $this->nval($callbook['gridsquare'] ?? '',  $this->logbook_model->call_qra($callsign));
+		$return['callsign_geoloc'] 		= $callbook['geoloc'] ?? '';
 		$return['callsign_distance'] 	= $this->distance($return['callsign_qra'], $station_id);
 		$return['callsign_qth'] 		= $this->nval($callbook['city'] ?? '', $this->logbook_model->call_qth($callsign));
 		$return['callsign_iota'] 		= $this->nval($callbook['iota'] ?? '', $this->logbook_model->call_iota($callsign));

--- a/application/libraries/Callbook.php
+++ b/application/libraries/Callbook.php
@@ -22,35 +22,35 @@ class Callbook {
 			case 'qrz':
 				if ($this->ci->config->item('qrz_username') == null || $this->ci->config->item('qrz_password') == null) {
 					$callbook['error'] = 'Lookup not configured. Please review configuration.';
-					return $callbook;
 				}
-				return $this->qrz($this->ci->config->item('qrz_username'), $this->ci->config->item('qrz_password'), $callsign, $this->ci->config->item('use_fullname'));
+				$callbook = $this->qrz($this->ci->config->item('qrz_username'), $this->ci->config->item('qrz_password'), $callsign, $this->ci->config->item('use_fullname'));
 				break;
 			case 'qrzcq':
 				if ($this->ci->config->item('qrzcq_username') == null || $this->ci->config->item('qrzcq_password') == null) {
 					$callbook['error'] = 'Lookup not configured. Please review configuration.';
-					return $callbook;
 				}
-				return $this->qrzcq($this->ci->config->item('qrzcq_username'), $this->ci->config->item('qrzcq_password'), $callsign);
+				$callbook = $this->qrzcq($this->ci->config->item('qrzcq_username'), $this->ci->config->item('qrzcq_password'), $callsign);
 				break;
 			case 'hamqth':
 				if ($this->ci->config->item('hamqth_username') == null || $this->ci->config->item('hamqth_password') == null) {
 					$callbook['error'] = 'Lookup not configured. Please review configuration.';
-					return $callbook;
 				}
-				return $this->hamqth($this->ci->config->item('hamqth_username'), $this->ci->config->item('hamqth_password'), $callsign);
+				$callbook = $this->hamqth($this->ci->config->item('hamqth_username'), $this->ci->config->item('hamqth_password'), $callsign);
 				break;
 			case 'qrzru':
 				if ($this->ci->config->item('qrzru_username') == null || $this->ci->config->item('qrzru_password') == null) {
 					$callbook['error'] = 'Lookup not configured. Please review configuration.';
-					return $callbook;
 				}
-				return $this->qrzru($this->ci->config->item('qrzru_username'), $this->ci->config->item('qrzru_password'), $callsign);
+				$callbook = $this->qrzru($this->ci->config->item('qrzru_username'), $this->ci->config->item('qrzru_password'), $callsign);
 				break;
 			default:
 				$callbook['error'] = 'No callbook defined. Please review configuration.';
-				return $callbook;
 		}
+		// Handle callbook specific fields
+		if (! array_key_exists('geoloc', $callbook)) {
+			$callbook['geoloc'] = '';
+		}
+		return $callbook;
 	}
 
 	function qrz($username, $password, $callsign, $fullname) {

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -112,16 +112,17 @@ class Qrz {
 			if ($reduced == false) {
 
 				$data['gridsquare'] = $clean_gridsquare;
-				$data['city'] 	= (string)$xml->Callsign->addr2;
-				$data['lat'] 	= (string)$xml->Callsign->lat;
-				$data['long'] 	= (string)$xml->Callsign->lon;
-				$data['dxcc'] 	= (string)$xml->Callsign->dxcc;
-				$data['state'] 	= (string)$xml->Callsign->state;
-				$data['iota'] 	= (string)$xml->Callsign->iota;
+				$data['geoloc'] = (string)$xml->Callsign->geoloc;
+				$data['city'] = (string)$xml->Callsign->addr2;
+				$data['lat'] = (string)$xml->Callsign->lat;
+				$data['long'] = (string)$xml->Callsign->lon;
+				$data['dxcc'] = (string)$xml->Callsign->dxcc;
+				$data['state'] = (string)$xml->Callsign->state;
+				$data['iota'] = (string)$xml->Callsign->iota;
 				$data['qslmgr'] = (string)$xml->Callsign->qslmgr;
-				$data['image'] 	= (string)$xml->Callsign->image;
-				$data['ituz'] 	= (string)$xml->Callsign->ituzone;
-				$data['cqz'] 	= (string)$xml->Callsign->cqzone;
+				$data['image'] = (string)$xml->Callsign->image;
+				$data['ituz'] = (string)$xml->Callsign->ituzone;
+				$data['cqz'] = (string)$xml->Callsign->cqzone;
 
 				if ($xml->Callsign->country == "United States") {
 					$data['us_county'] = (string)$xml->Callsign->county;
@@ -132,14 +133,14 @@ class Qrz {
 			} else {
 
 				$data['gridsquare'] = '';
-				$data['city'] 	= '';
-				$data['lat'] 	= '';
-				$data['long'] 	= '';
-				$data['dxcc'] 	= '';
-				$data['state'] 	= '';
-				$data['iota'] 	= '';
+				$data['city'] = '';
+				$data['lat'] = '';
+				$data['long'] = '';
+				$data['dxcc'] = '';
+				$data['state'] = '';
+				$data['iota'] = '';
 				$data['qslmgr'] = (string)$xml->Callsign->qslmgr;
-				$data['image'] 	= (string)$xml->Callsign->image;
+				$data['image'] = (string)$xml->Callsign->image;
 				$data['us_county'] = '';
 				$data['ituz'] = '';
 				$data['cqz'] = '';

--- a/application/views/search/result.php
+++ b/application/views/search/result.php
@@ -54,6 +54,9 @@
 		} else {
 			echo " <span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge text-bg-danger\" style=\"padding-left: 0.2em; padding-right: 0.2em;\">".strtoupper($callsign['gridsquare'])."</span>";
 		}
+		if ($callsign['geoloc'] == "grid") {
+			echo " <span data-bs-toggle=\"tooltip\" title=\"Grid auto-detected\" class=\"badge text-bg-danger\">".__("Grid is auto-detected by callbook and probably wrong")."</span>";
+		}
 	?>
 	</td>
 </tr>

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1128,7 +1128,7 @@ $("#callsign").on("focusout", function () {
 
 				/* Find Locator if the field is empty */
 				if ($('#locator').val() == "") {
-					if (result.callsign_geoloc != 'grid') {
+					if (result.callsign_geoloc != 'grid' || result.timesWorked > 0) {
 						$('#locator').val(result.callsign_qra);
 						$('#locator_info').html(result.bearing);
 					}
@@ -1137,7 +1137,7 @@ $("#callsign").on("focusout", function () {
 						document.getElementById("distance").value = result.callsign_distance;
 					}
 
-					if (result.callsign_qra != "" && result.callsign_geoloc != 'grid') {
+					if (result.callsign_qra != "" && (result.callsign_geoloc != 'grid' || result.timesWorked > 0)) {
 						if (result.confirmed) {
 							$('#locator').addClass("confirmedGrid");
 							$('#locator').attr('title', 'Grid was already worked and confirmed in the past');

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1128,14 +1128,16 @@ $("#callsign").on("focusout", function () {
 
 				/* Find Locator if the field is empty */
 				if ($('#locator').val() == "") {
-					$('#locator').val(result.callsign_qra);
-					$('#locator_info').html(result.bearing);
+					if (result.callsign_geoloc != 'grid') {
+						$('#locator').val(result.callsign_qra);
+						$('#locator_info').html(result.bearing);
+					}
 
 					if (result.callsign_distance != "" && result.callsign_distance != 0) {
 						document.getElementById("distance").value = result.callsign_distance;
 					}
 
-					if (result.callsign_qra != "") {
+					if (result.callsign_qra != "" && result.callsign_geoloc != 'grid') {
 						if (result.confirmed) {
 							$('#locator').addClass("confirmedGrid");
 							$('#locator').attr('title', 'Grid was already worked and confirmed in the past');


### PR DESCRIPTION
We should skip using a grid from qrz.com if it is obviously guessed and not set by the user but "calculated" from unknown information. Also we display a warning next to the grid in search results if this is the case.

Detection is based on XML tag called geoloc in qrz.com API. If this is set to "grid" it is wrong in almost every case. So we should not use it (automatically).

<img width="1052" height="594" alt="Screenshot 2025-09-04 162917" src="https://github.com/user-attachments/assets/e93da8fe-2196-444a-89a6-34de18e5ce1f" />


<img width="1124" height="900" alt="Screenshot 2025-09-04 162943" src="https://github.com/user-attachments/assets/2940c06b-68f9-46ef-8a15-a3b4a6ad0d30" />
