### PR TITLE
Set proper last_run for DCL-Cron

### DIFF
--- a/application/controllers/Dcl.php
+++ b/application/controllers/Dcl.php
@@ -68,7 +68,7 @@ class Dcl extends CI_Controller {
 		$data['page_title'] = __("DCL");
 
 		$this->load->model('cron_model');
-		$data['next_run'] = $this->cron_model->get_next_run("dcl_dcl_upload");
+		$data['next_run'] = $this->cron_model->get_next_run("sync_dcl");
 
 		// Load Views
 		$this->load->view('interface_assets/header', $data);

--- a/application/controllers/Dcl.php
+++ b/application/controllers/Dcl.php
@@ -90,7 +90,7 @@ class Dcl extends CI_Controller {
 
 		// set the last run in cron table for the correct cron id
 		$this->load->model('cron_model');
-		$this->cron_model->set_last_run($this->router->class.'_'.$this->router->method);
+		$this->cron_model->set_last_run('sync_dcl');
 
 		// Get Station Profile Data
 		$this->load->model('Stations');


### PR DESCRIPTION
Copypaste of "set_last_run" from lotw wasn't working, since naming of the job was done "different". (My fault)
But since we already have a migration, this is less effort.

Tested it on my prod. Without patch, "last run" was never set (cosmetics)