### PR TITLE
Fix HRD status dropdown in station profile

### DIFF
--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -398,7 +398,7 @@ if ($dxcc_list->result() > 0) {
 						<select class="form-select" id="hrdlogrealtime" name="hrdlogrealtime">
 							<option value="1" <?php if ($my_station_profile->hrdlogrealtime == 1) { echo " selected =\"selected\""; } ?>><?= __("Yes"); ?></option>
 							<option value="0" <?php if ($my_station_profile->hrdlogrealtime == 0) { echo " selected =\"selected\""; } ?>><?= __("No"); ?></option>
-							<option value="0" <?php if ($my_station_profile->hrdlogrealtime == -1) { echo " selected =\"selected\""; } ?>><?= __("Disabled"); ?></option>
+							<option value="-1" <?php if ($my_station_profile->hrdlogrealtime == -1) { echo " selected =\"selected\""; } ?>><?= __("Disabled"); ?></option>
 						</select>
 					</div>
 				</div>


### PR DESCRIPTION
This fixes the dropdown for HRDLog upload in the station profile.
The disabled state was not correctly shown and also user was not able to set it themselves.