### PR TITLE
Fix HRDLog upload dialogue when upload was disabled - add error message

### DIFF
--- a/application/controllers/Hrdlog.php
+++ b/application/controllers/Hrdlog.php
@@ -60,12 +60,31 @@ class Hrdlog extends CI_Controller {
 		    $postData = $this->input->post();
 
 		    $this->load->model('logbook_model');
+
+			//checks for credentials. Returns "false" if credentials are there, but upload was disabled
 		    $result = $this->logbook_model->exists_hrdlog_credentials($postData['station_id']);
+
+			//check for credential errors before accessing them
+			if($result == false){
+				$data['status'] = 'Credential_Error';
+			    $data['infomessage'] = __("HRD Log upload for this station is disabled or credentials not filled in completely.");
+			    $data['errormessages'] = array(__("HRD Log upload for this station is disabled or credentials not filled in completely."));
+			    echo json_encode($data);
+				return;
+			}
+
+			//read hrd credentials
 		    $hrdlog_username = $result->hrdlog_username;
 		    $hrdlog_code = $result->hrdlog_code;
-		    header('Content-type: application/json');
-		    $result = $this->Hrdlog_model->mass_upload_qsos($postData['station_id'], $hrdlog_username, $hrdlog_code);
-		    if ($result['status'] == 'OK') {
+
+			//set header
+			header('Content-type: application/json');
+		    
+			//perform upload
+			$result = $this->Hrdlog_model->mass_upload_qsos($postData['station_id'], $hrdlog_username, $hrdlog_code);
+		    
+			//return success
+			if ($result['status'] == 'OK') {
 			    $stationinfo = $this->stations->stations_with_hrdlog_code();
 			    $info = $stationinfo->result();
 

--- a/application/controllers/Hrdlog.php
+++ b/application/controllers/Hrdlog.php
@@ -67,8 +67,8 @@ class Hrdlog extends CI_Controller {
 			//check for credential errors before accessing them
 			if($result == false){
 				$data['status'] = 'Credential_Error';
-			    $data['infomessage'] = __("HRD Log upload for this station is disabled or credentials not filled in completely.");
-			    $data['errormessages'] = array(__("HRD Log upload for this station is disabled or credentials not filled in completely."));
+			    $data['infomessage'] = __("HRD Log upload for this station is disabled.");
+			    $data['errormessages'] = array(__("HRD Log upload for this station is disabled."));
 			    echo json_encode($data);
 				return;
 			}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -941,7 +941,7 @@ class Logbook_model extends CI_Model {
 		
 		//checks disabled state AND content of hrdlog_username and hrdlog_code
 		$sql = 'select hrdlog_username, hrdlog_code, hrdlogrealtime from station_profile
-		  where station_id = ? and hrdlogrealtime >= 0 and COALESCE(hrdlog_username, "") != "" AND COALESCE(hrdlog_code, "") != "";';
+		  where station_id = ? and hrdlogrealtime >= 0;';
 
 		$query = $this->db->query($sql, $station_id);
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -938,8 +938,10 @@ class Logbook_model extends CI_Model {
    * Function checks if a HRDLog Code and Username exists in the table with the given station id
    */
 	function exists_hrdlog_credentials($station_id) {
+		
+		//checks disabled state AND content of hrdlog_username and hrdlog_code
 		$sql = 'select hrdlog_username, hrdlog_code, hrdlogrealtime from station_profile
-		  where station_id = ? and hrdlogrealtime>=0';
+		  where station_id = ? and hrdlogrealtime >= 0 and COALESCE(hrdlog_username, "") != "" AND COALESCE(hrdlog_code, "") != "";';
 
 		$query = $this->db->query($sql, $station_id);
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -939,7 +939,7 @@ class Logbook_model extends CI_Model {
    */
 	function exists_hrdlog_credentials($station_id) {
 		
-		//checks disabled state AND content of hrdlog_username and hrdlog_code
+		//checks only disabled state
 		$sql = 'select hrdlog_username, hrdlog_code, hrdlogrealtime from station_profile
 		  where station_id = ? and hrdlogrealtime >= 0;';
 

--- a/assets/js/sections/hrdlog.js
+++ b/assets/js/sections/hrdlog.js
@@ -12,9 +12,14 @@ function ExportHrd(station_id) {
 		url: base_url + 'index.php/hrdlog/upload_station',
 		type: 'post',
 		data: {'station_id': station_id},
+		dataType: 'json',
 		success: function (data) {
+			
+			//modify running state
 			$(".ld-ext-right-"+station_id).removeClass('running');
 			$(".ld-ext-right-"+station_id).prop('disabled', false);
+			
+			//react to success
 			if (data.status == 'OK') {
 				$.each(data.info, function(index, value){
 					$('#modcount'+value.station_id).html(value.modcount);
@@ -22,29 +27,39 @@ function ExportHrd(station_id) {
 					$('#totcount'+value.station_id).html(value.totcount);
 				});
 				$(".card-body").append('<div class="alert alert-success" role="alert">' + data.infomessage + '</div>');
-			}
-			else {
-				$(".card-body").append('<div class="alert alert-info" role="alert">' + data.info + '</div>');
+				return;
 			}
 
-			if (data.errormessages.length > 0) {
-				$("#hrdlog_export").append(
-					'<div class="errormessages">\n' +
-					'    <div class="card mt-2">\n' +
-					'        <div class="card-header bg-danger">\n' +
-					'            Error Message\n' +
-					'        </div>\n' +
-					'        <div class="card-body">\n' +
-					'            <div class="errors"></div>\n' +
-					'        </div>\n' +
-					'    </div>\n' +
-					'</div>'
-				);
-				$.each(data.errormessages, function (index, value) {
-					$(".errors").append('<li>' + value);
-				});
+			//react to errors during upload
+			if (data.status == 'Error') {
+				$(".card-body").append('<div class="alert alert-info" role="alert">' + data.info + '</div>');
+
+				if (data.errormessages.length > 0) {
+					$("#hrdlog_export").append(
+						'<div class="errormessages">\n' +
+						'    <div class="card mt-2">\n' +
+						'        <div class="card-header bg-danger">\n' +
+						'            Error Message\n' +
+						'        </div>\n' +
+						'        <div class="card-body">\n' +
+						'            <div class="errors"></div>\n' +
+						'        </div>\n' +
+						'    </div>\n' +
+						'</div>'
+					);
+					$.each(data.errormessages, function (index, value) {
+						$(".errors").append('<li>' + value);
+					});
+				}
+				return;
 			}
-			
+
+			//react to errors due to credentials or disabled upload
+			if (data.status == 'Credential_Error'){
+				$(".card-body").append('<div class="alert alert-danger" role="alert">' + data.infomessage + '</div>');
+				return;
+			}
+
 		}
 	});
 }


### PR DESCRIPTION
If your HRDLog upload was disabled and you clicked upload, the spinner would run indefinitely without any error message.

Reason was, Logbook_models function exists_hrdlog_credentials would return false instead of credentials if upload was disabled for that station.

This PR handles that with a nice error message.

Cron handles disabled or invalid stations graciously already, so no fix there.