### PR TITLE
Get Rid of CI-Syntax and implement timerange for DCL

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4811,13 +4811,17 @@ class Logbook_model extends CI_Model {
 		}
 
 		if ($darc_dok != '') {
-			$this->db->select('COL_PRIMARY_KEY, COL_DARC_DOK');
-			$this->db->where('COL_CALL', $call);
-			$this->db->like('COL_TIME_ON', $time_on, 'after');
-			$this->db->where('COL_BAND', $band);
-			$this->db->where('COL_MODE', $mode);
-			$this->db->where_in('station_id', $logbooks_locations_array);
-			$check = $this->db->get($this->config->item('table_name'));
+		$bindings=[];
+			$sql="select COL_PRIMARY_KEY, COL_DARC_DOK from ".$this->config->item('table_name')." 
+			where col_call=? and col_band=? and col_mode=? and station_id in ? 
+			AND COL_TIME_ON >= DATE_ADD(DATE_FORMAT(?, '%Y-%m-%d %H:%i' ), INTERVAL -15 MINUTE) AND COL_TIME_ON <= DATE_ADD(DATE_FORMAT(?, '%Y-%m-%d %H:%i' ), INTERVAL +15 MINUTE)";
+			$bindings[]=$call;	
+			$bindings[]=$band;	
+			$bindings[]=$mode;	
+			$bindings[]=$logbooks_locations_array;	
+			$bindings[]=$time_on;
+			$bindings[]=$time_on;
+			$check = $this->db->query($sql,$bindings);
 			if ($check->num_rows() != 1) {
 				if ($ignoreAmbiguous == '1') {
 					return array();


### PR DESCRIPTION
Old Logic only updated QSO within WL, where WL-Timestamp in the same minute than DCL.
This PR:
- uses the usual 30min. timeframe around the QSO-Time.
- refactored the DB-Query to the more read- and maintainable SQL-Syntax