### PR TITLE
Add option to display frequency and mark all QSOs for given QSL method in QSLPrint view

### DIFF
--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -70,7 +70,7 @@ class Qslprint_model extends CI_Model {
 	function get_qsos_for_print($station_id = 'All') {
 		$binding=[];
 		$binding[]=$this->session->userdata('user_id');
-		$sql="SELECT count(distinct oldlog.col_primary_key) as previous_qsl, log.COL_QSL_SENT, log.COL_PRIMARY_KEY, log.COL_DXCC, log.COL_CALL, log.COL_SAT_NAME, log.COL_SAT_MODE, log.COL_BAND_RX, log.COL_TIME_ON, log.COL_MODE, log.COL_RST_SENT, log.COL_RST_RCVD, log.COL_QSL_VIA, log.COL_QSL_SENT_VIA, log.COL_SUBMODE, log.COL_BAND, sp.station_id, sp.station_callsign, sp.station_profile_name, o.qsoid
+		$sql="SELECT count(distinct oldlog.col_primary_key) as previous_qsl, log.COL_QSL_SENT, log.COL_PRIMARY_KEY, log.COL_DXCC, log.COL_CALL, log.COL_SAT_NAME, log.COL_SAT_MODE, log.COL_BAND_RX, COALESCE(log.COL_FREQ_RX, log.COL_FREQ) as frequency, log.COL_TIME_ON, log.COL_MODE, log.COL_RST_SENT, log.COL_RST_RCVD, log.COL_QSL_VIA, log.COL_QSL_SENT_VIA, log.COL_SUBMODE, log.COL_BAND, sp.station_id, sp.station_callsign, sp.station_profile_name, o.qsoid
 			FROM ".$this->config->item('table_name')." log
 			INNER JOIN station_profile sp ON sp.`station_id` = log.`station_id`
 			LEFT OUTER JOIN oqrs o ON o.`qsoid` = log.`COL_PRIMARY_KEY`

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -26,6 +26,15 @@
 				</select>
 			</form>
 
+			<div>
+				<?= __("Show Band or Frequency:"); ?>
+  				<select id="frequency_or_band" class="form-select mb-3 me-sm-3" style="width: 20%;">
+					<option value="band" selected><?= __("Band"); ?></option>
+					<option value="frequency"><?= __("Frequency"); ?></option>
+					<option value="both"><?= __("Both"); ?></option>
+				</select>
+			</div>
+
 	    <p class="card-text"><?= __("Here you can export requested QSLs as CSV or ADIF files for printing and, optionally, mark them as sent."); ?></p>
 	    <p class="card-text">
 			<?= __("Requested QSLs are any QSOs with a value of 'Requested' or 'Queued' in their 'QSL Sent' field."); ?><br>

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -17,7 +17,7 @@
 	  </div>
 		<div class="card-body">
 			<form class="form" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
-				<?= __("Station Location"); ?>:
+				<label for="station_profile" class="me-2"><?= __("Station Location"); ?>:</label>	
 				<select name="station_profile" class="station_id form-select mb-3 me-sm-3" style="width: 20%;">
 					<option value="All"><?= __("All"); ?></option>
 					<?php foreach ($station_profile->result() as $station) { ?>
@@ -26,8 +26,9 @@
 				</select>
 			</form>
 
+			<!-- Switch Band or Frequency display -->
 			<div>
-				<?= __("Show Band or Frequency:"); ?>
+				<label for="frequency_or_band" class="me-2"><?= __("Show Band or Frequency:"); ?></label>
   				<select id="frequency_or_band" class="form-select mb-3 me-sm-3" style="width: 20%;">
 					<option value="band" selected><?= __("Band"); ?></option>
 					<option value="frequency"><?= __("Frequency"); ?></option>

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -31,7 +31,7 @@
   				<select id="frequency_or_band" class="form-select mb-3 me-sm-3" style="width: 20%;">
 					<option value="band" selected><?= __("Band"); ?></option>
 					<option value="frequency"><?= __("Frequency"); ?></option>
-					<option value="both"><?= __("Both"); ?></option>
+					<option value="both"><?= __("Band & Frequency"); ?></option>
 				</select>
 			</div>
 

--- a/application/views/qslprint/qslprint.php
+++ b/application/views/qslprint/qslprint.php
@@ -1,4 +1,5 @@
 <?php
+$ci =& get_instance();
 
 function echo_qsl_sent_via($method) {
 	switch($method) {
@@ -22,7 +23,8 @@ if ($qsos->result() != NULL) {
 <th style=\'text-align: center\'>' . __("Date") . '</th>
 <th style=\'text-align: center\'>'. __("Time") .'</th>
 <th style=\'text-align: center\'>' . __("Mode") . '</th>
-<th style=\'text-align: center\'>' . __("Band") . '</th>
+<th class=\'col-band\' style=\'text-align: center\'>' . __("Band") . '</th>
+<th class=\'col-freq\' style=\'text-align: center;display:none;\'>' . __("Frequency") . '</th>
 <th style=\'text-align: center\'>' . __("RST (S)") . '</th>
 <th style=\'text-align: center\'>' . __("RST (R)") . '</th>
 <th style=\'text-align: center\'>' . __("QSL") . ' ' . __("Via") . '</th>
@@ -52,7 +54,8 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\'>'; $timestamp = strtotime($qsl->COL_TIME_ON); echo date($custom_date_format, $timestamp); echo '</td>';
 		echo '<td style=\'text-align: center\'>'; $timestamp = strtotime($qsl->COL_TIME_ON); echo date('H:i', $timestamp); echo '</td>';
 		echo '<td style=\'text-align: center\'>'; echo $qsl->COL_SUBMODE==null?$qsl->COL_MODE:$qsl->COL_SUBMODE; echo '</td>';
-		echo '<td style=\'text-align: center\'>'; if($qsl->COL_SAT_NAME != null) { echo $qsl->COL_SAT_NAME; } else { echo strtolower($qsl->COL_BAND); }; echo '</td>';
+		echo '<td class=\'col-band\' style=\'text-align: center\'>'; if($qsl->COL_SAT_NAME != null) { echo $qsl->COL_SAT_NAME; } else { echo strtolower($qsl->COL_BAND); }; echo '</td>';
+		echo '<td class=\'col-freq\' style=\'text-align: center;display:none;\'>'; if($qsl->COL_SAT_NAME != null) { echo $qsl->COL_SAT_NAME; } else { echo $ci->frequency->qrg_conversion($qsl->frequency); }; echo '</td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_RST_SENT . '</td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_RST_RCVD . '</td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_QSL_VIA . '</td>';

--- a/application/views/qslprint/qslprint.php
+++ b/application/views/qslprint/qslprint.php
@@ -61,7 +61,7 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_QSL_VIA . '</td>';
 		echo '<td style=\'text-align: center\'><span class="badge text-bg-light">' . $qsl->station_callsign . '</span></td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->station_profile_name . '</span></td>';
-		echo '<td style=\'text-align: center\'>'; echo_qsl_sent_via($qsl->COL_QSL_SENT_VIA); echo '</td>';
+		echo '<td class=\'send-method\' style=\'text-align: center\'>'; echo_qsl_sent_via($qsl->COL_QSL_SENT_VIA); echo '</td>';
 		echo '<td style=\'text-align: center\'>'; if ($qsl->previous_qsl > 0 ) { echo '<span class="badge bg-warning">' . $qsl->previous_qsl . '</span>'; } else { echo '<span class="badge bg-success">0</span>'; } echo '</td>';
 		echo '<td style=\'text-align: center\'><button onclick="mark_qsl_sent(\''.$qsl->COL_PRIMARY_KEY.'\', \''. $qsl->COL_QSL_SENT_VIA. '\')" class="btn btn-sm btn-success"><i class="fa fa-check"></i></button></td>';
 		echo '<td style=\'text-align: center\'><button onclick="deleteFromQslQueue(\''.$qsl->COL_PRIMARY_KEY.'\')" class="btn btn-sm btn-danger"><i class="fas fa-trash-alt"></i></button></td>';
@@ -71,15 +71,33 @@ if ($qsos->result() != NULL) {
 	echo '</tbody></table></div>';
 	?>
 
-	<p><button onclick="markSelectedQsos();" title="<?= __("Mark selected QSOs as sent"); ?>" class="btn btn-success markallprinted"><?= __("Mark selected QSOs as sent"); ?></button>
-	<button onclick="removeSelectedQsos();" title="<?= __("Remove selected QSOs from the queue"); ?>" class="btn btn-danger removeall"><?= __("Remove selected QSOs from the queue"); ?></button>
-	<button onclick="exportSelectedQsos();" title="<?= __("Export selected QSOs to ADIF-file"); ?>" class="btn btn-primary exportselected"><?= __("Export selected QSOs to ADIF-file"); ?></button></p>
+	
+	<!-- all the buttons to manipulate QSOs -->
+	<p>
+		<div>
+			<label for="markqslmethod" class="me-2"><?= __("Mark QSOs for a certain QSL Method:"); ?></label>
+			<div class="d-flex align-items-center mb-3">
+				<select id="markqslmethod" class="form-select me-2" style="width: 20%;">
+				<option value="ALL" selected><?= __("All"); ?></option>	
+				<option value="B"><?= echo_qsl_sent_via("B") ?></option>
+				<option value="D"><?= echo_qsl_sent_via("D") ?></option>
+				<option value="E"><?= echo_qsl_sent_via("E") ?></option>
+				</select>
+				<button onclick="markMethod()" title="<?= __("Mark all QSOs for the chosen QSL method"); ?>" class="btn btn-success markmethod"><?= __("Mark all QSOs for the chosen QSL method"); ?></button>
+				<button onclick="unmarkallQSOs()" style="margin-left: 5px;" title="<?= __("Unmark every QSO"); ?>" class="btn btn-danger unmarkall"><?= __("Unmark every QSO"); ?></button>
+			</div>
+		</div>
+		<button onclick="markSelectedQsos();" title="<?= __("Mark selected QSOs as sent"); ?>" class="btn btn-success markallprinted"><?= __("Mark selected QSOs as sent"); ?></button>
+		<button onclick="removeSelectedQsos();" title="<?= __("Remove selected QSOs from the queue"); ?>" class="btn btn-danger removeall"><?= __("Remove selected QSOs from the queue"); ?></button>
+		<button onclick="exportSelectedQsos();" title="<?= __("Export selected QSOs to ADIF-file"); ?>" class="btn btn-primary exportselected"><?= __("Export selected QSOs to ADIF-file"); ?></button>
+	</p>
+	
 
-	<p><a href="<?php echo site_url('qslprint/exportcsv/' . $station_id); ?>" title="<?= __("Export CSV-file"); ?>" class="btn btn-primary"><?= __("Export requested QSLs to CSV-file"); ?></a>
-
-	<a href="<?php echo site_url('qslprint/exportadif/' . $station_id); ?>" title="<?= __("Export ADIF"); ?>" class="btn btn-primary"><?= __("Export requested QSLs to ADIF-file"); ?></a>
-
-	<a href="<?php echo site_url('qslprint/qsl_printed/' . $station_id); ?>" title="<?= __("Mark QSLs as printed"); ?>" class="btn btn-primary"><?= __("Mark requested QSLs as sent"); ?></a></p>
+	<p>
+		<a href="<?php echo site_url('qslprint/exportcsv/' . $station_id); ?>" title="<?= __("Export CSV-file"); ?>" class="btn btn-primary"><?= __("Export requested QSLs to CSV-file"); ?></a>
+		<a href="<?php echo site_url('qslprint/exportadif/' . $station_id); ?>" title="<?= __("Export ADIF"); ?>" class="btn btn-primary"><?= __("Export requested QSLs to ADIF-file"); ?></a>
+		<a href="<?php echo site_url('qslprint/qsl_printed/' . $station_id); ?>" title="<?= __("Mark QSLs as printed"); ?>" class="btn btn-primary"><?= __("Mark requested QSLs as sent"); ?></a>
+	</p>
 
 <?php
 } else {

--- a/application/views/qslprint/qslprint.php
+++ b/application/views/qslprint/qslprint.php
@@ -87,6 +87,11 @@ if ($qsos->result() != NULL) {
 				<button onclick="unmarkallQSOs()" style="margin-left: 5px;" title="<?= __("Unmark every QSO"); ?>" class="btn btn-danger unmarkall"><?= __("Unmark every QSO"); ?></button>
 			</div>
 		</div>
+	</p>
+	
+	<label class="me-2"><?= __("Update QSOs"); ?>:</label>
+	<p>
+		
 		<button onclick="markSelectedQsos();" title="<?= __("Mark selected QSOs as sent"); ?>" class="btn btn-success markallprinted"><?= __("Mark selected QSOs as sent"); ?></button>
 		<button onclick="removeSelectedQsos();" title="<?= __("Remove selected QSOs from the queue"); ?>" class="btn btn-danger removeall"><?= __("Remove selected QSOs from the queue"); ?></button>
 		<button onclick="exportSelectedQsos();" title="<?= __("Export selected QSOs to ADIF-file"); ?>" class="btn btn-primary exportselected"><?= __("Export selected QSOs to ADIF-file"); ?></button>

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -332,3 +332,30 @@ function exportSelectedQsos() {
 
 	$('.exportselected').prop("disabled", false);
 }
+
+document.getElementById('frequency_or_band').addEventListener('change', function (event) {
+  //get selected option
+  const selectedValue = event.target.value;
+  
+  //react to the different states
+  if (selectedValue === "band") {
+    bandcols = document.querySelectorAll('.col-band');
+	bandcols.forEach(cell => { cell.style.display = '';});
+	freqcols = document.querySelectorAll('.col-freq');
+	freqcols.forEach(cell => { cell.style.display = 'none';});
+  }
+
+  if (selectedValue === "frequency") {
+    bandcols = document.querySelectorAll('.col-band');
+	bandcols.forEach(cell => { cell.style.display = 'none';});
+	freqcols = document.querySelectorAll('.col-freq');
+	freqcols.forEach(cell => { cell.style.display = '';});
+  }
+
+  if (selectedValue === "both") {
+    bandcols = document.querySelectorAll('.col-band');
+	bandcols.forEach(cell => { cell.style.display = '';});
+	freqcols = document.querySelectorAll('.col-freq');
+	freqcols.forEach(cell => { cell.style.display = '';});
+  }
+});

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -333,35 +333,97 @@ function exportSelectedQsos() {
 	$('.exportselected').prop("disabled", false);
 }
 
-document.getElementById('frequency_or_band').addEventListener('change', function (event) {
-  //get selected option
-  const selectedValue = event.target.value;
+function markMethod(){
+	
+	//grab the dropdown
+	const select = document.getElementById('markqslmethod');
 
-  //switch state according to selected value
-  switch(selectedValue) {
-  case 'band':
-    bandcols = document.querySelectorAll('.col-band');
-	bandcols.forEach(cell => { cell.style.display = '';});
-	freqcols = document.querySelectorAll('.col-freq');
-	freqcols.forEach(cell => { cell.style.display = 'none';});
-    break;
-  case 'frequency':
-    bandcols = document.querySelectorAll('.col-band');
-	bandcols.forEach(cell => { cell.style.display = 'none';});
-	freqcols = document.querySelectorAll('.col-freq');
-	freqcols.forEach(cell => { cell.style.display = '';});
-    break;
-  case 'both':
-	bandcols = document.querySelectorAll('.col-band');
-	bandcols.forEach(cell => { cell.style.display = '';});
-	freqcols = document.querySelectorAll('.col-freq');
-	freqcols.forEach(cell => { cell.style.display = '';});
-	break;
-  default:
-    bandcols = document.querySelectorAll('.col-band');
-	bandcols.forEach(cell => { cell.style.display = '';});
-	freqcols = document.querySelectorAll('.col-freq');
-	freqcols.forEach(cell => { cell.style.display = 'none';});
-    break;
-  }
+	//grab the selected method
+	const methodkey = select.value;  
+	const method = select.options[select.selectedIndex].text;
+
+	//perform function
+	markMethodQSOs(methodkey === "ALL" ? '' : method);
+}
+
+function markMethodQSOs(method) {
+
+	//unmark any QSO that is already marked for cleanup purposes
+	unmarkallQSOs();
+	
+	//grab the table
+	const table = document.getElementById('qslprint_table');
+
+    //loop through each row except the header
+    Array.from(table.tBodies[0].rows).forEach(row => {
+        
+		//get the send-method column
+        const sendMethodCell = row.querySelector('td.send-method');
+
+		//check if it contains the right method (or skip check if method is empty)
+        if (sendMethodCell && (method === "" || sendMethodCell.textContent.trim() === method)) {
+            
+			//find the checkbox in the first cell
+            const checkbox = row.querySelector('td:first-child input[type="checkbox"]');
+            
+			//check that box
+			if (checkbox) {
+                checkbox.checked = true;
+            }
+        }
+    });
+}
+
+function unmarkallQSOs(){
+	
+	//grab the table
+	const table = document.getElementById('qslprint_table');
+
+	//loop through each row except the header
+    Array.from(table.tBodies[0].rows).forEach(row => {
+		
+		//find the checkbox in the first cell
+		const checkbox = row.querySelector('td:first-child input[type="checkbox"]');
+            
+		//check that box
+		if (checkbox) {
+			checkbox.checked = false;
+		}
+    });
+}
+
+function switchbandandfrequencydisplay(mode){
+  	
+	//switch state according to selected value. Default case = band
+	switch(mode) {
+	case 'band':
+		bandcols = document.querySelectorAll('.col-band');
+		bandcols.forEach(cell => { cell.style.display = '';});
+		freqcols = document.querySelectorAll('.col-freq');
+		freqcols.forEach(cell => { cell.style.display = 'none';});
+		break;
+	case 'frequency':
+		bandcols = document.querySelectorAll('.col-band');
+		bandcols.forEach(cell => { cell.style.display = 'none';});
+		freqcols = document.querySelectorAll('.col-freq');
+		freqcols.forEach(cell => { cell.style.display = '';});
+		break;
+	case 'both':
+		bandcols = document.querySelectorAll('.col-band');
+		bandcols.forEach(cell => { cell.style.display = '';});
+		freqcols = document.querySelectorAll('.col-freq');
+		freqcols.forEach(cell => { cell.style.display = '';});
+		break;
+	default:
+		bandcols = document.querySelectorAll('.col-band');
+		bandcols.forEach(cell => { cell.style.display = '';});
+		freqcols = document.querySelectorAll('.col-freq');
+		freqcols.forEach(cell => { cell.style.display = 'none';});
+		break;
+	}
+}
+
+document.getElementById('frequency_or_band').addEventListener('change', function (event) {
+	//switch display options
+	switchbandandfrequencydisplay(event.target.value);
 });

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -336,26 +336,32 @@ function exportSelectedQsos() {
 document.getElementById('frequency_or_band').addEventListener('change', function (event) {
   //get selected option
   const selectedValue = event.target.value;
-  
-  //react to the different states
-  if (selectedValue === "band") {
+
+  //switch state according to selected value
+  switch(selectedValue) {
+  case 'band':
     bandcols = document.querySelectorAll('.col-band');
 	bandcols.forEach(cell => { cell.style.display = '';});
 	freqcols = document.querySelectorAll('.col-freq');
 	freqcols.forEach(cell => { cell.style.display = 'none';});
-  }
-
-  if (selectedValue === "frequency") {
+    break;
+  case 'frequency':
     bandcols = document.querySelectorAll('.col-band');
 	bandcols.forEach(cell => { cell.style.display = 'none';});
 	freqcols = document.querySelectorAll('.col-freq');
 	freqcols.forEach(cell => { cell.style.display = '';});
-  }
-
-  if (selectedValue === "both") {
-    bandcols = document.querySelectorAll('.col-band');
+    break;
+  case 'both':
+	bandcols = document.querySelectorAll('.col-band');
 	bandcols.forEach(cell => { cell.style.display = '';});
 	freqcols = document.querySelectorAll('.col-freq');
 	freqcols.forEach(cell => { cell.style.display = '';});
+	break;
+  default:
+    bandcols = document.querySelectorAll('.col-band');
+	bandcols.forEach(cell => { cell.style.display = '';});
+	freqcols = document.querySelectorAll('.col-freq');
+	freqcols.forEach(cell => { cell.style.display = 'none';});
+    break;
   }
 });


### PR DESCRIPTION
This PR adds 2 pieces of functionality to the qslprint view (+ a bit of cosmetics):

1) Allow the user to pick if he wants to see the band, the frequency or both values in the QSO table.
Reason: Some people use this view to hand-write QSL cards. If you have a frequency field on your QSL card instead of band, this saves you a click on each of the QSOs to view the frequency information. Default behaviour is still "band-only".

2) Allow the user to let wavelog mark all QSOs in the queue based on the QSL method. 
Reason: Event calls or club stations sometimes have a great amount of "QSL card debt". If - for example - you have 1000 QSOs to send, 400 Direct and 600 Bureau, now you can just let wavelog tag every QSO for the Bureau without clicking 400 times to remove all the "Direct" QSOs from the list. This way you can quickly export those QSOs to ADIF and set them as sent via the other buttons.

Finally, I made the labels for the select boxes a bit more pleasant to look at.