### PR TITLE
Adding support for optional `cat_url` argument in `api/radio` endpoint

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -655,7 +655,7 @@ class API extends CI_Controller {
 
 		// Handle optional cat_url
 		if (isset($obj['cat_url']) && !empty($obj['cat_url'])) {
-			$cat_url = $this->sanitize_callback_url($obj['cat_url']);
+			$cat_url = $this->sanitize_cat_url($obj['cat_url']);
 			if ($cat_url !== false) {
 				$obj['cat_url'] = $cat_url;
 			}
@@ -1138,7 +1138,7 @@ class API extends CI_Controller {
 	 * @param string $url The URL to sanitize
 	 * @return string|false Returns sanitized URL or false if invalid
 	 */
-	private function sanitize_callback_url($url) {
+	private function sanitize_cat_url($url) {
 		// Basic sanitization
 		$url = trim($url);
 		

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -653,6 +653,13 @@ class API extends CI_Controller {
 				break;
 		}
 
+		// Handle optional cat_url
+		if (isset($obj['cat_url']) && !empty($obj['cat_url'])) {
+			$cat_url = $this->sanitize_callback_url($obj['cat_url']);
+			if ($cat_url !== false) {
+				$obj['cat_url'] = $cat_url;
+			}
+		}
 
 		// Store Result to Database
 		$this->cat->update($obj, $user_id, $operator);
@@ -1124,6 +1131,30 @@ class API extends CI_Controller {
 		// Return result
 		http_response_code(200);
 		echo json_encode(['status' => 'successful', 'message' => 'Export successful', 'statistics' => $data]);
+	}
+
+	/**
+	 * Sanitize and validate callback URL
+	 * @param string $url The URL to sanitize
+	 * @return string|false Returns sanitized URL or false if invalid
+	 */
+	private function sanitize_callback_url($url) {
+		// Basic sanitization
+		$url = trim($url);
+		
+		// Check if URL is valid and uses http or https
+		if (!filter_var($url, FILTER_VALIDATE_URL) || 
+			(!preg_match('/^https?:\/\//', $url))) {
+			return false;
+		}
+		
+		// Remove trailing slashes
+		$url = rtrim($url, '/');
+		
+		// Additional XSS cleaning
+		$url = $this->security->xss_clean($url);
+		
+		return $url;
 	}
 
 }

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -27,6 +27,11 @@
 				'timestamp' => $timestamp,
 			);
 
+			// Handle callback URL if provided
+			if (isset($result['cat_url']) && !empty($result['cat_url'])) {
+				$data['cat_url'] = $result['cat_url'];
+			}
+
 			if ( (isset($result['power'])) && ($result['power'] != "NULL") && ($result['power'] != '') && (is_numeric($result['power']))) {
 				$data['power'] = $result['power'];
 			} else {


### PR DESCRIPTION
# Radio API Callback URL Enhancement

## Overview
The `/api/radio` endpoint has been enhanced to support an optional `cat_url` field that allows programmatic configuration of the CAT callback URL for each radio as proposed in #2305.

## Changes Made

### 1. API Controller (Api.php)
- Added support for **optional** `cat_url` field in the JSON payload
- Implemented URL validation and sanitization
- Added `sanitize_cat_url()` method to ensure URLs are properly formatted

### 2. CAT Model (Cat.php)
- Enhanced the `update()` method to handle `cat_url` field
- Ensures callback URLs are stored in the database alongside other radio data

## Usage

### JSON Payload Example

```json
{
  "key": "your_api_key_here",
  "radio": "FT-950",
  "frequency": 14075000,
  "mode": "SSB",
  "power": 100,
  "timestamp": "2025-09-14 16:47:00",
  "cat_url": "https://log.example.com:54321"
}
```

<img width="1319" height="485" alt="image" src="https://github.com/user-attachments/assets/2b96fe2b-04c9-4c3d-b962-eb73cf371872" />

## Test script

This was the Python script I used to test the feature

```python
import requests
from datetime import datetime

WAVELOG_API_URL = "http://wavelog.localhost/index.php/api/radio"
WAVELOG_API_KEY = "aaBBccDDeeFFgg"
RADIO_NAME = "ICOM IC-7850"

# Define required headers
headers = {
    "Content-Type": "application/json",
    "Accept": "application/json"
}

payload = {
   "key": WAVELOG_API_KEY, 
   "radio": RADIO_NAME,
   "frequency": 14075000,
   "mode": "SSB",
   "power": '', # Optional field defined in watts
   "timestamp": datetime.now().strftime("%Y/%m/%d %H:%M"),
   "cat_url": "http://localhost:12345/meow", # Optional field
}

# Send the POST request
try:
    response = requests.post(WAVELOG_API_URL, json=payload, headers=headers)
    # Check if the request was successful
    if response.status_code == 200:
        print("Request successful!")
        print("Response:", response)
    else:
        print(f"Request failed with status code: {response.status_code}")
        print("Response:", response.text)
except requests.exceptions.RequestException as e:
    print("An error occurred:", e)
```

## Documentation

Wiki will be updated accordingly as soon as this PR gets approved
