### PR TITLE
Added Warning for Band-Edit

### DIFF
--- a/application/views/bands/edit.php
+++ b/application/views/bands/edit.php
@@ -1,4 +1,5 @@
 <div class="container" id="edit_band_dialog">
+	<b class="badge text-bg-danger"><?= __("WARNING")."</b> ".__("Changes made here are instance-wide and will affect EVERY User. You see this, because you're an instance-admin"); ?></p>
 	<form>
 
 		<input type="hidden" name="id" value="<?php echo $my_band->id; ?>">


### PR DESCRIPTION
This one adds a warning at Band-Edit. Since Band-Edit lives in Usermenu, the Admin is able to edit default-QRGs and so on. We should at least inform him, that changes are affecting every user