### PR TITLE
Allow LoTW confirmations including CNTY for some DXCCs

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1122,6 +1122,23 @@ class Lotw extends CI_Controller {
 	}
 
 	/*
+	|	Function: lotw_ru_oblast_map
+	|	Requires: russian oblast map $ru_oblast
+	*/
+	function lotw_ru_oblast_map($ru_oblast) {
+		switch ($ru_oblast):
+			case "YR":
+				return "JA";
+				break;
+			case "YN":
+				return "JN";
+				break;
+			default:
+				return $ru_oblast;
+		endswitch;
+	}
+
+	/*
 	|	Function: mode_map
 	|	Requires: mode as $mode, submode as $submode
 	|

--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -79,6 +79,7 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 
 <?php }
       break;
+   case 5:       // Aland Island
    case 224:     // Finland
       if($station_profile->state != "") { ?>
 <FI_KUNTA:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>

--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -4,7 +4,7 @@ $clean_cert = trim($lotw_cert_info->cert);
 $cert1 = str_replace("-----BEGIN CERTIFICATE-----", "", $clean_cert);
 $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 ?>
-<TQSL_IDENT:54>TQSL V2.5.4 Lib: V2.5 Config: V11.12 AllowDupes: false
+<TQSL_IDENT:54>TQSL V2.8.1 Lib: V2.6 Config: V11.34 AllowDupes: false
 
 <Rec_Type:5>tCERT
 <CERT_UID:1>1
@@ -27,13 +27,66 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 
 <?php if($station_profile->station_iota) { ?><IOTA:<?php echo strlen($station_profile->station_iota); ?>><?php echo $station_profile->station_iota; } ?>
 
-<?php if($station_profile->state != "" && $station_profile->station_country == "CANADA") { ?><CA_PROVINCE:<?php echo strlen($CI->lotw_ca_province_map($station_profile->state)); ?>><?php echo $CI->lotw_ca_province_map($station_profile->state); } ?>
+<?php
+   switch ($lotw_cert_info->cert_dxcc_id) {
+   case 6:       // Alaska
+   case 110:     // Hawaii
+   case 291:     // Cont US
+      if($station_profile->state != "") { ?>
+<US_STATE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>
 
-<?php if($station_profile->state != "" && $station_profile->station_country == "UNITED STATES OF AMERICA") { ?><US_STATE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; } ?>
+<?php }
+         if($station_profile->station_cnty != "") { ?>
+<US_COUNTY:<?php echo strlen($station_profile->station_cnty); ?>><?php echo $station_profile->station_cnty; ?>
 
-<?php if($station_profile->state != "" && $station_profile->station_country == "CHINA") { ?><CN_PROVINCE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; } ?>
+<?php }
+      break;
+   case 1:       // Canada
+      if($station_profile->state != "") { ?>
+<CA_PROVINCE:<?php echo strlen($CI->lotw_ca_province_map($station_profile->state)); ?>><?php echo $CI->lotw_ca_province_map($station_profile->state); ?>
 
-<?php if($station_profile->station_cnty != ""  && $station_profile->station_country == "UNITED STATES OF AMERICA") { ?><US_COUNTY:<?php echo strlen($station_profile->station_cnty); ?>><?php echo $station_profile->station_cnty; } ?>
+      <?php }
+      break;
+   case 15:      // Asiatic Russia
+   case 54:      // European Russia
+   case 61:      // FJL
+   case 125:     // Juan Fernandez
+   case 151:     // Malyj Vysotskij
+      if($station_profile->state != "") { ?>
+<RU_OBLAST:<?php echo strlen($CI->lotw_ru_oblast_map($station_profile->state)); ?>><?php echo $CI->lotw_ru_oblast_map($station_profile->state); ?>
+
+      <?php }
+      break;
+   case 318:     // China
+      if($station_profile->state != "") { ?>
+<CN_PROVINCE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>
+
+      <?php }
+      break;
+   case 150:     // Australia
+      if($station_profile->state != "") { ?>
+<AU_STATE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>
+
+      <?php }
+      break;
+   case 339:     // Japan
+      if($station_profile->state != "") { ?>
+<JA_PREFECTURE:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>
+
+<?php }
+      if($station_profile->station_cnty != "") { ?>
+<JA_CITY_GUN_KU:<?php echo strlen($station_profile->station_cnty); ?>><?php echo $station_profile->station_cnty; ?>
+
+<?php }
+      break;
+   case 5:       // Finland
+      if($station_profile->state != "") { ?>
+<FI_KUNTA:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>
+
+      <?php }
+      break;
+   }
+?>
 
 <EOR>
 

--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -79,7 +79,7 @@ $cert2 = str_replace("-----END CERTIFICATE-----", "", $cert1);
 
 <?php }
       break;
-   case 5:       // Finland
+   case 224:     // Finland
       if($station_profile->state != "") { ?>
 <FI_KUNTA:<?php echo strlen($station_profile->state); ?>><?php echo $station_profile->state; ?>
 


### PR DESCRIPTION
LoTW confirmations only include STATE and CNTY for U.S., China and Canada. This aims to also add the other DXCCs which are handled in tqsl. Code has been taken from tqsl sources and adapted accordingly.

This does not include UI patches to set the CNTY part correctly. E.g. for Japan the user would have to enter the number according to https://adif.org.uk/316/ADIF_316.htm#Secondary_Administrative_Subdivision. This should be handled in a separate PR.

Also this fixes some code that compares country names as strings to decide which LoTW cert tot take. This was fixed to use the official ADIF ID instead.