### PR TITLE
Adds creationdate and modifydate to nearly every table

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 255;
+$config['migration_version'] = 256;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/256_crea_modidates.php
+++ b/application/migrations/256_crea_modidates.php
@@ -22,11 +22,25 @@ class Migration_crea_modidates extends CI_Migration {
 	}
 
 	function add_create_modi($table) {
-			$this->dbtry("ALTER TABLE ".$table." ADD COLUMN `CREATION_DATE` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,  ADD COLUMN `LAST_MODIFIED` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;");
+        	$col_check = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'creation_date';")->num_rows() > 0;
+        	if (!$col_check) {
+			$this->dbtry("ALTER TABLE ".$table." ADD COLUMN `creation_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;");
+		}
+        	$col_check = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'last_modified';")->num_rows() > 0;
+        	if (!($col_check) && !(($table == 'paper_types') || ($table == 'label_types'))) {
+			$this->dbtry("ALTER TABLE ".$table." ADD COLUMN `last_modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;");
+		}
 	}
 
 	function rm_create_modi($table) {
-			$this->dbtry("ALTER TABLE ".$table." DROP COLUMN IF EXISTS `CREATION_DATE`, DROP COLUMN IF EXISTS `LAST_MODIFIED`;");
+        	$col_check = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'creation_date';")->num_rows() > 0;
+        	if ($col_check) {
+			$this->dbtry("ALTER TABLE ".$table." DROP COLUMN `creation_date`;");
+		}
+        	$col_check = $this->db->query("SHOW COLUMNS FROM ".$table." LIKE 'last_modified';")->num_rows() > 0;
+        	if (($col_check) && !(($table == 'paper_types') || ($table == 'label_types'))) {
+			$this->dbtry("ALTER TABLE ".$table." DROP COLUMN `last_modified`;");
+		}
 	}
 
 	function dbtry($what) {

--- a/application/migrations/256_crea_modidates.php
+++ b/application/migrations/256_crea_modidates.php
@@ -47,7 +47,7 @@ class Migration_crea_modidates extends CI_Migration {
 		try {
 			$this->db->query($what);
 		} catch (Exception $e) {
-			log_message("error", "Something gone wrong while altering the OQRS table: ".$e." // Executing: ".$this->db->last_query());
+			log_message("error", "Something gone wrong while altering a table: ".$e." // Executing: ".$this->db->last_query());
 		}
 	}
 }

--- a/application/migrations/256_crea_modidates.php
+++ b/application/migrations/256_crea_modidates.php
@@ -1,0 +1,40 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_crea_modidates extends CI_Migration {
+	protected array $tables;
+
+	public function __construct() {
+		$this->tables = [$this->config->item('table_name'), 'adif_modes','api','bandedges','bands','bandxuser','cat','club_permissions','contest','contest_session','cron','cwmacros','dxpedition','eQSL_images','hams_of_note','iota','label_types','lotw_certs','lotw_users','migrations','notes','oqrs','paper_types','primary_subdivisions','qsl_images','queries','satellite','satellitemode','station_logbooks','station_logbooks_relationship','station_profile','themes','thirdparty_logins','timezones','tle','user_options','users','webadif'];
+	}
+
+	public function up() {
+		foreach ($this->tables as $tname) {
+			$this->add_create_modi($tname);
+		}
+	}
+
+	public function down(){
+		foreach ($this->tables as $tname) {
+			$this->rm_create_modi($tname);
+		}
+	}
+
+	function add_create_modi($table) {
+			$this->dbtry("ALTER TABLE ".$table." ADD COLUMN `CREATION_DATE` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,  ADD COLUMN `LAST_MODIFIED` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;");
+	}
+
+	function rm_create_modi($table) {
+			$this->dbtry("ALTER TABLE ".$table." DROP COLUMN IF EXISTS `CREATION_DATE`, DROP COLUMN IF EXISTS `LAST_MODIFIED`;");
+	}
+
+	function dbtry($what) {
+		try {
+			$this->db->query($what);
+		} catch (Exception $e) {
+			log_message("error", "Something gone wrong while altering the OQRS table: ".$e." // Executing: ".$this->db->last_query());
+		}
+	}
+}
+


### PR DESCRIPTION
This mig adds two columns to the most-volatile tables of wavelog.
* CREATION_DATE
* LAST_MODIFIED

it helps debugging and future logics