### PR TITLE
Allow LBA edit function to set QSL sent/rcvd

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -825,6 +825,8 @@ class Logbookadvanced_model extends CI_Model {
 			case "lotwreceived": $column = 'COL_LOTW_QSL_RCVD'; break;
 			case "qslmsg": $column = 'COL_QSLMSG'; break;
 			case "continent": $column = 'COL_CONT'; break;
+			case "qslsent": $column = 'COL_QSL_SENT'; break;
+			case "qslreceived": $column = 'COL_QSL_RCVD'; break;
 			case "qrzsent": $column = 'COL_QRZCOM_QSO_UPLOAD_STATUS'; break;
 			case "qrzreceived": $column = 'COL_QRZCOM_QSO_DOWNLOAD_STATUS'; break;
 			case "eqslsent": $column = 'COL_EQSL_QSL_SENT'; break;

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -45,6 +45,8 @@
 				<option value="lotwsent"><?= __("LoTW Sent"); ?></option>
 				<option value="qrzreceived"><?= __("QRZ Received"); ?></option>
 				<option value="qrzsent"><?= __("QRZ Sent"); ?></option>
+				<option value="qslreceived"><?= __("QSL Received"); ?></option>
+				<option value="qslsent"><?= __("QSL Sent"); ?></option>
 				<option value="qslmsg"><?= __("QSLMSG"); ?></option>
 				<option value="qslreceivedmethod"><?= __("QSL Received Method"); ?></option>
 				<option value="qslsentmethod"><?= __("QSL Sent Method"); ?></option>
@@ -158,6 +160,13 @@
 					echo '<option value="' . $contest['adifname'] . '">' . $contest["name"] . '</option>'."\n";
 				}
 			?>
+		</select>
+
+		<select style="display:none" class="form-select w-auto form-select-sm w-auto" id="editQsl"  name="qsl">
+			<option value="Y"><?= __("Yes"); ?></option>
+			<option value="N"><?= __("No"); ?></option>
+			<option value="R"><?= __("Requested"); ?></option>
+			<option value="I"><?= __("Invalid"); ?></option>
 		</select>
 
 		<select style="display:none" class="form-select w-auto form-select-sm w-auto" id="editLoTW"  name="lotw">

--- a/assets/js/sections/logbookadvanced_edit.js
+++ b/assets/js/sections/logbookadvanced_edit.js
@@ -180,6 +180,9 @@ function saveBatchEditQsos(id_list) {
 	if (column == 'contest') {
 		value = $("#editContest").val();
 	}
+	if (column == 'qslsent' || column == 'qslreceived') {
+		value = $("#editQsl").val();
+	}
 	if (column == 'lotwsent' || column == 'lotwreceived') {
 		value = $("#editLoTW").val();
 	}
@@ -309,6 +312,8 @@ function changeEditType(type) {
 		$('#editBandRxLabel').show();
 	} else if (type == "contest") {
 		$('#editContest').show();
+	} else if (type == "qslsent" || type == "qslreceived") {
+		$('#editQsl').show();
 	} else if (type == "lotwsent" || type == "lotwreceived") {
 		$('#editLoTW').show();
 	} else if (type == "qrzsent" || type == "qrzreceived") {


### PR DESCRIPTION
Reviving https://github.com/wavelog/wavelog/pull/2334 as the actions under actions do not allow for QSL to be set to (I)nvalid and all other QSL methods are there anyway. So would not harm to have QSL in the edit function as well.