### PR TITLE
Show VUCC_GRIDS in case GRIDSQUARE is empty

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -609,7 +609,7 @@ class Lotw extends CI_Controller {
 				$table .= "<td>".$record['qsl_rcvd']."</td>";
 				$table .= "<td>".$qsl_date."</td>";
 				$table .= "<td>".$state."</td>";
-				$table .= "<td>".(($qsl_gridsquare != '' ? $qsl_gridsquare : ($record['gridsquare'] ?? '')) ?? $qsl_vucc_grids)."</td>";
+				$table .= "<td>".($qsl_gridsquare != '' ? $qsl_gridsquare : $qsl_vucc_grids)."</td>";
 				$table .= "<td>".$iota."</td>";
 				$table .= "<td>QSO Record: ".$status[0]."</td>";
 				$table .= "<td>LoTW Record: ".$lotw_status."</td>";


### PR DESCRIPTION
The LoTW analysis page should show VUCC_GRIDS in report if GRIDSQUARE is empty. There is a bug that if GRIDSQUARE is null VUCC_GRIDS are not shown.

Before:
<img width="1388" height="169" alt="image" src="https://github.com/user-attachments/assets/a246adea-c3ec-4cc3-ba33-1744908c7ba2" />

After:
<img width="1388" height="169" alt="image" src="https://github.com/user-attachments/assets/cd90299a-8925-4abf-9474-2058f85d02e4" />

This fix shows the GRID/GRIDS which are incoming from LoTW and the log is updated with.