### PR TITLE
fix QSO panel when using a date format with commas

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -77,9 +77,13 @@ class Logbook extends CI_Controller {
 
 		// Normalize the date only if it's not empty
 		if (!empty($date)) {
+			// Characters '/' and ',' are not URL safe, so we replace
+			// them with  '_' and '%'. Switch them back here.
 			if (strpos($date, '_') !== false) {
-				// Replace slashes with dashes for URL processing
 				$date = str_replace('_', '/', $date);
+			}
+			if (strpos($date, '%') !== false) {
+				$date = str_replace('%', ',', $date);
 			}
 			// Get user-preferred date format
 			if ($this->session->userdata('user_date_format')) {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -940,8 +940,13 @@ $("#callsign").on("focusout", function () {
 		let find_callsign = $(this).val().toUpperCase();
 		let callsign = find_callsign;
 		let startDate = $('#start_date').val();
+		// Characters '/' and ',' are not URL safe, so we replace
+		// them with  '_' and '%'.
 		if (startDate.includes('/')) {
 			startDate = startDate.replaceAll('/', '_');
+		}
+		if (startDate.includes(',')) {
+			startDate = startDate.replaceAll(',', '%');
 		}
 		startDate = encodeURIComponent(startDate);
 		const stationProfile = $('#stationProfile').val();


### PR DESCRIPTION
Commas are not an allowed URI character, and so they need to be replaced with a URI-safe stand in before being used. Of the default URI-safe characters, only `'~%:\'` are not used yet. I chose to use `'%'` as it seems the least likely to be used in any future date formats.

I've tested this to make sure the QSO panel works as expected for dates with and without commas, and that I can add a QSO with it. Searching the codebase for other string replacement, it looks like this is the only place dates are mangled like this.

Closes #2343.