### PR TITLE
Set custom header (which can be processed by reverse proxy)

### DIFF
--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -1109,6 +1109,8 @@ class User extends CI_Controller {
 				if ($user->clubstation == 1) {
 					log_message('debug', "User ID: [$uid] Login rejected because of a external clubstation login attempt with a modified cookie. Attack?");
 					$this->session->set_flashdata('error', __("This is not allowed!"));
+					$this->output->set_header('X-Login-Status: failed');
+					$this->output->_display();
 					redirect('user/login');
 				}
 
@@ -1144,6 +1146,8 @@ class User extends CI_Controller {
 					$this->input->set_cookie('keep_login', '', -3600, '');
 					$this->input->set_cookie('re_login', '', -3600, '');
 					$this->session->set_flashdata('error', __("Login failed. Try again."));
+					$this->set_header('X-Login-Status: failed');
+					$this->output->_display();
 					redirect('user/login');
 				}
 			} catch (Exception $e) {
@@ -1153,8 +1157,9 @@ class User extends CI_Controller {
 				// Delete keep_login cookie
 				$this->input->set_cookie('keep_login', '', -3600, '');
 				$this->input->set_cookie('re_login', '', -3600, '');
-
+				$this->set_header('X-Login-Status: failed');
 				$this->session->set_flashdata('error', __("Login failed. Try again."));
+				$this->output->_display();
 				redirect('user/login');
 			}
 
@@ -1210,6 +1215,8 @@ class User extends CI_Controller {
 					redirect('user/login');
 				} else {
 					$this->session->set_flashdata('error', __("Incorrect username or password!"));
+					$this->output->set_header('X-Login-Status: failed');
+					$this->output->_display();
 					redirect('user/login');
 				}
 			}


### PR DESCRIPTION
Set custom Header (`X-Login-Status: failed`) on failed login.
This one can be processed by your Reverseproxy to block/ban/tarpit a possible attacker.

Possible haproxy-Config in backend could be (This example blocks the requester IP for 5mins if there were more than 10 failed requests either on API or loginpage)
```
backend wavelog
        mode http
	stick-table type ipv6 size 100k expire 5m store gpc0
	http-request track-sc0 src
	acl ip_blocked sc0_get_gpc0 gt 10
	http-request deny deny_status 429 if ip_blocked
	acl login_failed status 401
	acl header_failed res.hdr(X-Login-Status) -i "failed"
	http-response sc-inc-gpc0(0) if login_failed or header_failed
        server local 127.0.0.1:81 check maxconn 250
```