### PR TITLE
Redundancy "get_plaincall()" method

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -145,7 +145,8 @@ class Logbook extends CI_Controller {
 
 		$return['dxcc'] = $this->dxcheck($callsign,$date);
 
-		$lookupcall = $this->logbook_model->get_plaincall($callsign);
+		$this->load->library('callbook');
+		$lookupcall = $this->callbook->get_plaincall($callsign);
 
 		$callbook = $this->logbook_model->loadCallBook($callsign, $this->config->item('use_fullname'));
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5484,24 +5484,6 @@ class Logbook_model extends CI_Model {
 		}
 	}
 
-	function get_plaincall($callsign) {
-		$split_callsign = explode('/', $callsign);
-		if (count($split_callsign) == 1) {				// case F0ABC --> return cel 0 //
-			$lookupcall = $split_callsign[0];
-		} else if (count($split_callsign) == 3) {			// case EA/F0ABC/P --> return cel 1 //
-			$lookupcall = $split_callsign[1];
-		} else {										// case F0ABC/P --> return cel 0 OR  case EA/FOABC --> retunr 1  (normaly not exist) //
-			if (in_array(strtoupper($split_callsign[1]), array('P', 'M', 'MM', 'QRP', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))) {
-				$lookupcall = $split_callsign[0];
-			} else if (strlen($split_callsign[1]) > 3) {	// Last Element longer than 3 chars? Take that as call
-				$lookupcall = $split_callsign[1];
-			} else {									// Last Element up to 3 Chars? Take first element as Call
-				$lookupcall = $split_callsign[0];
-			}
-		}
-		return $lookupcall;
-	}
-
 	public function loadCallBook($callsign, $use_fullname = false) {
 		$callbook = null;
 		try {


### PR DESCRIPTION
The method `get_plaincall()` was twice  in the codebase. No need for that. reduced to one.