### PR TITLE
Add (current) streak to motivation Banner

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -91,6 +91,7 @@ class Dashboard extends CI_Controller {
 
 		$this->load->model('cat');
 		$this->load->model('vucc');
+		$this->load->model('dayswithqso_model');
 
 		$data['radio_status'] = $this->cat->recent_status();
 
@@ -99,6 +100,13 @@ class Dashboard extends CI_Controller {
 		$data['total_qsos'] = $this->logbook_model->total_qsos($logbooks_locations_array);
 		$data['month_qsos'] = $this->logbook_model->month_qsos($logbooks_locations_array);
 		$data['year_qsos'] = $this->logbook_model->year_qsos($logbooks_locations_array);
+
+		$rawstreak=$this->dayswithqso_model->getAlmostCurrentStreak();
+		if (is_array($rawstreak)) {
+			$data['current_streak']=$rawstreak['highstreak'];
+		} else {
+			$data['current_streak']=0;
+		}
 
 		// Load  Countries Breakdown data into array
 		$CountriesBreakdown = $this->logbook_model->total_countries_confirmed($logbooks_locations_array);

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -179,7 +179,7 @@ function getDistance($distance) {
 		<div class="alert alert-warning alert-dismissible fade show" role="alert" style="margin-top: 1rem;">
 			<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-broadcast-tower"></i> 
 			<?php if (($current_streak ?? 0)>0) { 
-				echo sprintf(__("Don't lose your streak - You have already had at least one QSO for the last %s consecutive days."),$current_streak); 
+				echo sprintf(__("Don't loose your streak - You have already had at least one QSO for the last %s consecutive days."),$current_streak); 
 			} else {
 				echo __("You have made no QSOs today; time to turn on the radio!"); 
 			} ?>

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -177,7 +177,12 @@ function getDistance($distance) {
 		</div>
 	<?php } else { ?>
 		<div class="alert alert-warning alert-dismissible fade show" role="alert" style="margin-top: 1rem;">
-			<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-broadcast-tower"></i> <?= __("You have made no QSOs today; time to turn on the radio!"); ?>
+			<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-broadcast-tower"></i> 
+			<?php if (($current_streak ?? 0)>0) { 
+				echo sprintf(__("Don't lose your streak - You have already had at least one QSO for the last %s consecutive days."),$current_streak); 
+			} else {
+				echo __("You have made no QSOs today; time to turn on the radio!"); 
+			} ?>
 			<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
 		</div>
 	<?php } ?>


### PR DESCRIPTION
Great idea from #2374 

No current Streak:
<img width="682" height="136" alt="image" src="https://github.com/user-attachments/assets/57090b6d-dea3-44f4-9a6f-ff0124d42867" />

Today's QSO missing, but running streak:
<img width="886" height="148" alt="image" src="https://github.com/user-attachments/assets/bd010154-4773-46db-b64e-0b5a1d8efa7e" />
