### PR TITLE
Lax CORS-Logic for radio-API

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -592,6 +592,17 @@ class API extends CI_Controller {
 
 	function radio() {
 		session_write_close();
+
+                if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') { // Preflight CORS-Check: Allow posting from web-application as well (key is still needed!)
+                        header('Access-Control-Allow-Origin: *');
+                        header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
+                        header('Access-Control-Allow-Headers: Content-Type');
+                        header('Access-Control-Max-Age: 86400');
+                        http_response_code(200);
+                        exit(0);
+                }
+                header('Access-Control-Allow-Origin: *'); // Allow posting from web-application as well (key is still needed!)
+
 		header('Content-type: application/json');
 
 		$this->load->model('api_model');


### PR DESCRIPTION
Lax CORS-Logic for radio-API, so WebApps are also allowed to set frequency.

atm only 2 kinds of application can use the radio-API:

1.) FatClients like WavelogGate
2.) Web-Pages which are hosted on the same server (Referrer must be the same) - more theoretical.

This PR changes it to any webapplication. Security is still given, because of required API-Key.

Testing:
1. Test radio API as it is/was. (curl, wlgate, ...)
2. Create a small webpage, which posts the frequency to Wavelog (doesn't work without patch). An example for HTML-Only (doesn't store your data) can be found here: http://dj7nt.de/rt.html

