### PR TITLE
feat(oqrs): Oqrs page detect browser language

### DIFF
--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -380,7 +380,8 @@ class Oqrs extends CI_Controller {
 		$this->load->model('user_options_model');
 
 		if ($public_slug ?? '' != '') {
-			$user_id = $this->user_model->get_user_id_from_slug($public_slug);
+			$user = $this->user_model->get_by_slug($public_slug)->row();
+			$user_id = $user->user_id ?? null;
 
 			if ($user_id) {
 				$lang_setting = $this->user_options_model->get_options('oqrs', array('option_name' => 'oqrs_use_visitor_browser_language', 'option_key' => 'boolean'), $user_id)->row();

--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -390,12 +390,12 @@ class Oqrs extends CI_Controller {
 		$this->load->helper('language');
 		$available_languages = $this->config->item('languages');
 		$browser_languages = parse_accept_language($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '');
-		$detected_language_folder = null; // <--- 修正 #1: 变量名，使其更清晰
+		$detected_language_folder = null; 
 
 		foreach ($browser_languages as $browser_lang_code => $priority) {
 			foreach ($available_languages as $app_lang) {
 				if (strcasecmp($browser_lang_code, $app_lang['locale']) === 0) {
-					$detected_language_folder = $app_lang['folder']; // <--- 修正 #2: 获取 'folder' 的值
+					$detected_language_folder = $app_lang['folder']; 
 					break 2; // Found the best match, exit both loops
 				}
 			}
@@ -423,7 +423,7 @@ class Oqrs extends CI_Controller {
 				if ($detected_language_folder !== $current_cookie_value) {
 					$this->input->set_cookie(array(
 						'name'   => $cookie_name,
-						'value'  => $detected_language_folder, // <--- 修正 #3: 使用 'folder' 的值
+						'value'  => $detected_language_folder, 
 						'expire' => 3600 * 24 * 30,
 						'secure' => FALSE,
 					));
@@ -431,7 +431,7 @@ class Oqrs extends CI_Controller {
 				// 	$this->load->helper('url');
 				// 	redirect(current_url());
 				echo '<script type="text/javascript">window.location.reload();</script>';
-					exit; // 立即停止脚本，防止输出页面其他内容
+					exit; 
 				}
 			}
 		}

--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -382,15 +382,12 @@ class Oqrs extends CI_Controller {
 	 * @param string|null $public_slug The public slug from the URL.
 	 */
 	private function _initialize_visitor_language($public_slug = NULL) {
-		// 获取 gettext cookie 的配置名称
 		$cookie_name = $this->config->item('gettext_cookie', 'gettext');
 
-		// 步骤 1: 检查 Cookie 是否已存在。如果存在，则无需任何操作。
 		if ($this->input->cookie($cookie_name, TRUE)) {
 			return;
 		}
 
-		// 步骤 2: 如果 Cookie 不存在，则开始检测语言
 		if (empty($public_slug)) {
 			return;
 		}
@@ -412,20 +409,17 @@ class Oqrs extends CI_Controller {
 					foreach ($available_languages as $app_lang) {
 						if (strcasecmp($browser_lang_code, $app_lang['locale']) === 0) {
 							
-							// 步骤 3: 使用正确的 'gettext' 值设置 Cookie
 							$cookie = array(
 								'name'   => $cookie_name,
-								'value'  => $app_lang['gettext'], // 使用 'gettext' 字段的值
-								'expire' => 3600 * 24 * 30, // 延长有效期至30天
+								'value'  => $app_lang['gettext'], 
+								'expire' => 3600 * 24 * 30, 
 								'secure' => FALSE,
 							);
 							$this->input->set_cookie($cookie);
 
-							// 步骤 4: 重定向以立即应用语言变更
-							$this->load->helper('url'); // 加载 URL 辅助函数
-							redirect(current_url());    // 重定向到当前页面
+							$this->load->helper('url'); 
+							redirect(current_url());    
 
-							// redirect() 会自动 exit，但为保险起见
 							exit;
 						}
 					}

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -838,6 +838,15 @@ class User extends CI_Controller {
 				}
 			}
 
+			if($this->input->post('oqrs_use_visitor_browser_language')) {
+				$data['oqrs_use_visitor_browser_language'] = $this->input->post('oqrs_use_visitor_browser_language', false);
+			} else {
+				$qkey_opt = $this->user_options_model->get_options('oqrs', array('option_name' => 'oqrs_use_visitor_browser_language', 'option_key' => 'boolean'), $this->uri->segment(3))->result();
+				if (count($qkey_opt) > 0) {
+					$data['oqrs_use_visitor_browser_language'] = $qkey_opt[0]->option_value;
+				}
+			}
+
 			// [MAP Custom] GET user options //
 			$options_object = $this->user_options_model->get_options('map_custom')->result();
 			if (count($options_object)>0) {
@@ -935,6 +944,7 @@ class User extends CI_Controller {
 						$this->user_options_model->set_option('oqrs', 'oqrs_grouped_search_show_station_name', array('boolean'=>$this->input->post('oqrs_grouped_search_show_station_name', true)));
 						$this->user_options_model->set_option('oqrs', 'oqrs_auto_matching', array('boolean'=>$this->input->post('oqrs_auto_matching', true)));
 						$this->user_options_model->set_option('oqrs', 'oqrs_direct_auto_matching', array('boolean'=>$this->input->post('oqrs_direct_auto_matching', true)));
+						$this->user_options_model->set_option('oqrs', 'oqrs_use_visitor_browser_language', array('boolean'=>$this->input->post('oqrs_use_visitor_browser_language', true)));
 
 						$this->session->set_flashdata('success', sprintf(__("User %s edited"), $this->input->post('user_name', true)));
 						redirect('user/edit/'.$this->uri->segment(3));

--- a/application/helpers/MY_language_helper.php
+++ b/application/helpers/MY_language_helper.php
@@ -1,0 +1,51 @@
+<?php
+if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+/**
+ * Parses the HTTP_ACCEPT_LANGUAGE header to determine the user's preferred language.
+ *
+ * This function analyzes the 'Accept-Language' header string sent by the browser,
+ * extracts language tags and their associated quality factor values (q-factors),
+ * and returns them as an associative array sorted by priority.
+ *
+ * @param string $accept_language The raw 'Accept-Language' header string.
+ * @return array An associative array where keys are language codes (e.g., 'en-US', 'en')
+ * and values are their quality factors (e.g., 1.0, 0.9). The array is
+ * sorted in descending order by quality factor.
+ */
+if (!function_exists('parse_accept_language')) {
+    function parse_accept_language(string $accept_language): array
+    {
+        $languages = [];
+
+        // Split the header string into individual language parts
+        // e.g., "en-US,en;q=0.9,fr;q=0.8" -> ["en-US", "en;q=0.9", "fr;q=0.8"]
+        $language_parts = explode(',', $accept_language);
+
+        foreach ($language_parts as $part) {
+            // Split each part into language code and quality factor
+            // e.g., "en;q=0.9" -> ["en", "q=0.9"]
+            $elements = explode(';', trim($part));
+            $lang_code = strtolower(trim($elements[0]));
+            $quality = 1.0; // Default quality factor
+
+            if (isset($elements[1])) {
+                $q_factor_str = trim($elements[1]);
+                // Check if it is a valid quality factor string "q=..."
+                if (strpos($q_factor_str, 'q=') === 0) {
+                    $quality = (float) substr($q_factor_str, 2);
+                }
+            }
+
+            // Add the language code and its quality to the array
+            if ($lang_code) {
+                $languages[$lang_code] = $quality;
+            }
+        }
+
+        // Sort the languages by quality factor in descending order
+        arsort($languages);
+
+        return $languages;
+    }
+}

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -737,6 +737,14 @@
 												</select>
 												<small id="oqrs_direct_auto_matching_help" class="form-text text-muted"><?= __("If this is on, automatic OQRS matching for direct request will happen."); ?></small>
 											</div>
+											<div class="mb-3">
+												<label for="oqrs_use_visitor_browser_language"><?= __("Default to visitor's browser language"); ?></label>
+												<select name="oqrs_use_visitor_browser_language" class="form-select" id="oqrs_use_visitor_browser_language">
+													<option value="on" <?php if(($oqrs_use_visitor_browser_language ?? 'on') == "on") { echo "selected=\"selected\""; } ?>><?= __("On"); ?></option>
+													<option value="off" <?php if(($oqrs_use_visitor_browser_language ?? 'on') == "off") { echo "selected=\"selected\""; } ?>><?= __("Off"); ?></option>
+												</select>
+												<small id="oqrs_use_visitor_browser_language_help" class="form-text text-muted"><?= __("If enabled, the OQRS page will automatically try to display in the visitor's browser language."); ?></small>
+											</div>
 										</div>
 									</div>
 							</div>


### PR DESCRIPTION
### Description

This pull request introduces an automatic language detection feature for the public-facing OQRS and Log Search pages.

When a first-time, non-authenticated visitor accesses these pages, the application now detects their browser's preferred language (`Accept-Language` header). If the detected language is supported by Wavelog, the page will automatically switch to that language, significantly improving the user experience for international visitors.

A new option has been added to the User Profile page, allowing each user to enable or disable this feature for their public logbook pages. It is enabled by default.

### Implementation Details

-   A new helper function, `parse_accept_language`, has been added to `MY_language_helper.php` to parse the `Accept-Language` header according to RFC 2616.
-   A new private method, `_initialize_visitor_language`, has been added to the `Oqrs.php` controller.
-   This method contains robust logic to handle various server environments and potential race conditions with default cookies. It compares the browser's preferred language with the currently set language cookie.
-   If a language switch is necessary, it sets a new cookie with the application-specific `folder` name (e.g., `chinese_simplified`) and performs a one-time redirect to apply the change immediately.

While implementing this feature, I encountered several complex issues across different server environments (like URL rewriting and HTTPS proxies) and tried to provide a robust solution. Although the current implementation has been tested on my setup, I'm sure there is still room for improvement. I would be very grateful for any feedback or suggestions from the maintainers to help me better align with the project's standards. Thank you!
DE BH6SKD, 73