### PR TITLE
Clublog: Force User to enter mailadress instead of call

### DIFF
--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -153,6 +153,7 @@ class User extends CI_Controller {
 		$this->form_validation->set_rules('user_name', 'Username', 'required');
 		$this->form_validation->set_rules('user_name', 'Username', 'required|callback_check_username');
 		$this->form_validation->set_rules('user_email', 'E-mail', 'required');
+		$this->form_validation->set_rules('user_clublog_name', 'Clublog Username', 'valid_email');
 		$this->form_validation->set_rules('user_password', 'Password', 'required');
 		$this->form_validation->set_rules('user_type', 'Type', 'required');
 		$this->form_validation->set_rules('user_callsign', 'Callsign', 'required');
@@ -386,6 +387,7 @@ class User extends CI_Controller {
 		$this->form_validation->set_rules('user_name', 'Username', 'required|xss_clean');
 		$this->form_validation->set_rules('user_name', 'Username', 'required|callback_check_username');
 		$this->form_validation->set_rules('user_email', 'E-mail', 'required|xss_clean');
+		$this->form_validation->set_rules('user_clublog_name', 'Clublog Username', 'valid_email');
 		if($this->session->userdata('user_type') == 99)
 		{
 			$this->form_validation->set_rules('user_type', 'Type', 'required|xss_clean');
@@ -396,6 +398,7 @@ class User extends CI_Controller {
 		$this->form_validation->set_rules('user_locator', 'Locator', 'callback_check_locator');
 		$this->form_validation->set_rules('user_email', 'EMail', 'required|callback_check_email');
 		$this->form_validation->set_rules('user_email', 'EMail', 'required|valid_email');
+		$this->form_validation->set_rules('user_clublog_name', 'Clublog Username', 'valid_email');
 		$this->form_validation->set_rules('user_timezone', 'Timezone', 'required');
 
 		$data['user_form_action'] = site_url('user/edit')."/".$this->uri->segment(3);

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -902,8 +902,8 @@
 								<div class="card-header"><?= __("Club Log"); ?></div>
 								<div class="card-body">
 									<div class="mb-3">
-										<label><?= __("Club Log Email/Callsign"); ?></label>
-										<input class="form-control" type="text" name="user_clublog_name" value="<?php if(isset($user_clublog_name)) { echo $user_clublog_name; } ?>" />
+										<label><?= __("Club Log Email"); ?></label>
+										<input class="form-control" type="email" name="user_clublog_name" value="<?php if(isset($user_clublog_name)) { echo $user_clublog_name; } ?>" />
 										<?php if(isset($userclublogname_error)) { echo "<small class=\"badge bg-danger\">".$userclublogname_error."</small>"; } ?>
 									</div>
 


### PR DESCRIPTION
There was/is a bug in our code. Clublog denies login (via API) with only the Call.
eMail is more reliable and documented in Clublog-API: https://clublog.freshdesk.com/support/solutions/articles/54905-how-to-upload-logs-directly-into-club-log

this PR takes care of it.

PS: Thinking about a migration to kill every "Call-ONLY" credentialset. But i think that's too much.