### PR TITLE
[Notes] Basic notes support at the QSO logging and QSO view 

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -617,6 +617,12 @@ class Logbook extends CI_Controller {
 		$data['query'] = $this->logbook_model->get_qso($id);
 		$data['dxccFlag'] = $this->dxccflag->get($data['query']->result()[0]->COL_DXCC);
 
+		// Check for note for this callsign and current user
+		$callsign = $data['query']->result()[0]->COL_CALL;
+		$user_id = $this->session->userdata('user_id');
+		$this->load->model('note');
+		$data['contacts_note_id'] = $this->note->get_note_id_by_category($user_id, 'Contacts', $callsign);
+
 		if ($this->session->userdata('user_measurement_base') == NULL) {
 			$data['measurement_base'] = $this->config->item('measurement_base');
 		}

--- a/application/controllers/Notes.php
+++ b/application/controllers/Notes.php
@@ -253,31 +253,17 @@ class Notes extends CI_Controller {
         $category = $this->input->get('category', TRUE);
         $title = $this->input->get('title', TRUE);
         $id = $this->input->get('id', TRUE); // Optional, for edit
-        $check_title = $title;
-        if ($category === 'Contacts') {
-            $this->load->library('callbook');
-            $check_title = strtoupper($this->callbook->get_plaincall($title));
-        }
-        $where = [
-            'cat' => $category,
-            'user_id' => $user_id,
-            'title' => $check_title
-        ];
-        $query = $this->db->get_where('notes', $where);
         $exists = false;
         $note_id = null;
-        if ($id) {
-            foreach ($query->result() as $note) {
-                if ($note->id != $id) {
-                    $exists = true;
-                    $note_id = $note->id;
-                    break;
-                }
-            }
-        } else {
-            if ($query->num_rows() > 0) {
+        $this->load->model('note');
+        $note_id_found = $this->note->get_note_id_by_category($user_id, $category, $title);
+        if ($note_id_found) {
+            // If editing, ignore current note
+            if ($id && $note_id_found == $id) {
+                $exists = false;
+            } else {
                 $exists = true;
-                $note_id = $query->row()->id;
+                $note_id = $note_id_found;
             }
         }
         $response = ['exists' => $exists];

--- a/application/models/Note.php
+++ b/application/models/Note.php
@@ -162,6 +162,24 @@ class Note extends CI_Model {
 		return $result;
 	}
 
+	// Return note ID for given category and title (callsign for Contacts), else false
+	public function get_note_id_by_category($user_id, $category, $title) {
+		$check_title = $title;
+		if ($category === 'Contacts') {
+			$this->load->library('callbook'); // Used for callsign parsing
+			$check_title = strtoupper($this->callbook->get_plaincall($title));
+		}
+		$query = $this->db->get_where('notes', [
+			'cat' => $category,
+			'user_id' => $user_id,
+			'title' => $check_title
+		]);
+		if ($query->num_rows() > 0) {
+			return $query->row()->id;
+		}
+		return false;
+	}
+
 	// Search notes with pagination and sorting for the logged-in user
 	public function search_paginated($criteria = [], $page = 1, $per_page = 25, $sort_col = null, $sort_dir = null) {
 		$user_id = $this->session->userdata('user_id');

--- a/application/views/notes/add.php
+++ b/application/views/notes/add.php
@@ -29,7 +29,18 @@
       <form method="post" action="<?php echo site_url('notes/add'); ?>" name="notes_add" id="notes_add">
         <div class="mb-3">
           <label for="inputTitle"><?= __("Title"); ?></label>
-          <input type="text" name="title" class="form-control" id="inputTitle" value="<?php echo isset($suggested_title) && $suggested_title ? $suggested_title : set_value('title'); ?>">
+      <input type="text" name="title" class="form-control" id="inputTitle" value="<?php
+      // Priority: suggested_title > POST value > prefill_title > ''
+      if (isset($suggested_title) && $suggested_title) {
+        echo $suggested_title;
+      } elseif (set_value('title')) {
+        echo set_value('title');
+      } elseif (isset($prefill_title) && $prefill_title) {
+        echo htmlspecialchars($prefill_title);
+      } else {
+        echo '';
+      }
+      ?>">
         </div>
         <div class="mb-3">
           <label for="catSelect">
@@ -39,8 +50,10 @@
             </span>
           </label>
           <select name="category" class="form-select" id="catSelect">
-            <?php foreach (Note::get_possible_categories() as $category_key => $category_label): ?>
-              <option value="<?= htmlspecialchars($category_key) ?>"<?= (set_value('category', 'General') == $category_key ? ' selected="selected"' : '') ?>><?= $category_label ?></option>
+            <?php
+              $selected_category = set_value('category', isset($category) ? $category : (isset($prefill_category) ? $prefill_category : 'General'));
+              foreach (Note::get_possible_categories() as $category_key => $category_label): ?>
+                <option value="<?= htmlspecialchars($category_key) ?>"<?= ($selected_category == $category_key ? ' selected="selected"' : '') ?>><?= $category_label ?></option>
             <?php endforeach; ?>
           </select>
         </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -154,7 +154,7 @@ switch ($date_format) {
               <!-- Callsign Input -->
               <div class="row">
                 <div class="mb-3 col-md-12">
-                  <label for="callsign"><?= __("Callsign"); ?></label>&nbsp;<i id="check_cluster" data-bs-toggle="tooltip" title="<?= __("Search DXCluster for latest Spot"); ?>" class="fas fa-search"></i>
+                  <label for="callsign"><?= __("Callsign"); ?></label>&nbsp;<i id="check_cluster" data-bs-toggle="tooltip" title="<?= __("Search DXCluster for latest Spot"); ?>" class="fas fa-search"></i></label>&nbsp;<i id="note_create_edit" data-bs-toggle="tooltip" title="<?= __("Create or edit note for this callsign"); ?>" class="fas fa-sticky-note text-secondary"></i>
                   <div class="input-group">
                     <input tabindex="7" type="text" class="form-control uppercase" id="callsign" name="callsign" autocomplete="off" required>
                     <span id="qrz_info" class="input-group-text btn-included-on-field d-none py-0"></span>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -81,7 +81,13 @@
 
                     <tr>
                         <td><?= __("Callsign"); ?></td>
-                        <td><b><?php echo str_replace("0","&Oslash;",strtoupper($row->COL_CALL)); ?></b> <a target="_blank" href="https://www.qrz.com/db/<?php echo strtoupper($row->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/qrz.png" alt="Lookup <?php echo strtoupper($row->COL_CALL); ?> on QRZ.com"></a> <a target="_blank" href="https://www.hamqth.com/<?php echo strtoupper($row->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/hamqth.png" alt="Lookup <?php echo strtoupper($row->COL_CALL); ?> on HamQTH"></a> <a target="_blank" href="http://www.eqsl.cc/Member.cfm?<?php echo strtoupper($row->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/eqsl.png" alt="Lookup <?php echo strtoupper($row->COL_CALL); ?> on eQSL.cc"></a> <a target="_blank" href="https://clublog.org/logsearch.php?log=<?php echo strtoupper($row->COL_CALL); ?>&call=<?php echo strtoupper($row->station_callsign); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/clublog.png" alt="Clublog Log Search"></a></td>
+                        <td><b><?php echo str_replace("0","&Oslash;",strtoupper($row->COL_CALL)); ?></b> <a target="_blank" href="https://www.qrz.com/db/<?php echo strtoupper($row->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/qrz.png" alt="Lookup <?php echo strtoupper($row->COL_CALL); ?> on QRZ.com"></a> <a target="_blank" href="https://www.hamqth.com/<?php echo strtoupper($row->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/hamqth.png" alt="Lookup <?php echo strtoupper($row->COL_CALL); ?> on HamQTH"></a> <a target="_blank" href="http://www.eqsl.cc/Member.cfm?<?php echo strtoupper($row->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/eqsl.png" alt="Lookup <?php echo strtoupper($row->COL_CALL); ?> on eQSL.cc"></a> <a target="_blank" href="https://clublog.org/logsearch.php?log=<?php echo strtoupper($row->COL_CALL); ?>&call=<?php echo strtoupper($row->station_callsign); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/clublog.png" alt="Clublog Log Search"></a>
+                        <?php if (!empty($contacts_note_id)) { ?>
+                            <a href="<?php echo base_url(); ?>index.php/notes/view/<?php echo $contacts_note_id; ?>" target="_blank" title="<?= __("View note for this callsign"); ?>" style="margin-left:2px;vertical-align:middle;">
+                                <i class="fa fa-sticky-note text-info" style="font-size:16px;vertical-align:middle;"></i>
+                            </a>
+                        <?php } ?>
+                        </td>
                     </tr>
 
                     <tr>


### PR DESCRIPTION
This continues the implementation of call sign–related notes and initially addresses this feature request:  
https://github.com/wavelog/wavelog/discussions/1653  

The changes are minor and affect two areas on the frontend.

## QSO Add Page
A small icon has been added to the QSO page with basic JS logic:  
<img width="466" height="121" alt="2025-10-07 22_59_28-Greenshot" src="https://github.com/user-attachments/assets/e60bec8a-e354-43b3-b6e6-37bd9d6cf9c2" />

- By default, the icon is grayed out.  
- Once lookup is active, the existence of a note is checked. If a note for the callsign is available, the icon becomes active.  
- Clicking the icon opens a new tab allowing the user to **Add/Edit** note pages.  
- Resetting the form grays out the icon again.  

## QSO View
<img width="697" height="325" alt="2025-10-07 23_48_06-qso php - wavelog (Workspace) - Visual Studio Code" src="https://github.com/user-attachments/assets/bfcc93f2-b0dd-4e4d-b266-36a9a6a94088" />

- If a note for the callsign exists, a small icon is displayed.  
- Clicking it opens a new tab allowing the user to view the note.  

## General Notes
Callsigns are normalized by the backend using an existing function, so only one note per callsign is allowed.  
A user may enter `SP9MOA`, `SP9MOA/P`, `DL/SP9MOA`, or even `DL/SP9MOA/M` — all of these will refer to the same `SP9MOA` note.  

The idea (as in the recent PR for the Notes overhaul https://github.com/wavelog/wavelog/pull/2362) is that notes describe the **operator or club (i.e., the callsign)** rather than being tied to a specific QSO.