### PR TITLE
Fix bug with length calculation of LoTW signatures.

### DIFF
--- a/application/views/lotw_views/adif_views/adif_export.php
+++ b/application/views/lotw_views/adif_views/adif_export.php
@@ -226,9 +226,8 @@ $sign_string = strtoupper($sign_string);
 $signed_item = trim($CI->signlog($lotw_cert_info->cert_key, $sign_string));
 print "<SIGN_LOTW_V2.0:".(strlen($signed_item)+intdiv(strlen($signed_item),64)+1).":6>";
 for ($i=0; $i<strlen($signed_item); $i+=64) {
-	print substr($signed_item, $i, 64);
+	print substr($signed_item, $i, 64)."\n";
 }
-print "\n";
 print "<SIGNDATA:".strlen($sign_string).">".$sign_string."\n";
 ?>
 <eor>


### PR DESCRIPTION
In certain cases LoTW length of LoTW signatures were not calculated correctly leading to error messages in LoTW like:

```
2025-03-18 11:01:04 LOTW_QSO: Error in record 3: Unable to verify tCONTACT signature: QSOVerify failed - Verification failed
```

There is a discussion re this bug in https://github.com/wavelog/wavelog/discussions/2385.

With bit help of @R1BLH we were able to refactor the code and fix the bug.

tqsl spits out the signatures in base64 so lines are basically wrapped at 64chars. This was not done in WL code. tqsl's output also counted newlines for determining the length of the signature in the ADIF tag. So we changed the code to wrap signatures at 64 chars also and added the number of newlines to the calculation.

In addition to that the code was updated to include DXCC specific stuff in signatures which are included according to the source code of tqsl 2.8.2. The logic was copied from their sources.