### PR TITLE
Introduce resubmission avoidance for contest logging

### DIFF
--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -236,7 +236,7 @@
                         </div>
 
                         <button type="button" class="mb-3 btn btn-sm btn-secondary" onclick="reset_log_fields()"><i class="fas fa-sync-alt"></i> <?= __("Reset QSO"); ?></button>
-                        <button type="button" class="mb-3 btn btn-sm btn-primary" onclick="logQso();"><i class="fas fa-save"></i> <?= __("Save QSO"); ?></button>
+                        <button type="button" class="mb-3 btn btn-sm btn-primary" onclick="logQso();" id="saveQso"><i class="fas fa-save"></i> <?= __("Save QSO"); ?></button>
                     </form>
                 </div>
             </div>

--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -650,6 +650,10 @@ function logQso() {
 		// Only "Start a new contest session" will enable it again
 		disabledContestnameSelect(true);
 
+		// Avoid resubmission by disabling the button
+		var saveQsoButtonText = $("#saveQso").html();
+		$("#saveQso").html('<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> ' + saveQsoButtonText + '...').prop('disabled', true);
+
 		$('.callsign-suggestions').text("");
 		$('#callsign_info').text("");
 
@@ -747,6 +751,8 @@ function logQso() {
 				var qTable = $('.qsotable').DataTable();
 				qTable.search('').order([0, 'desc']).draw();
 
+				// Re-enable the previously disabled button for resubmission avoidance
+				$("#saveQso").html(saveQsoButtonText).prop("disabled", false);
 			}
 		});
 	}


### PR DESCRIPTION
The contest logging page doesn't have resubmission avoidance so users could click the save button multiple times and get duplicated QSOs. What's more, this happends more commonly in contest because of the high pace.

The fix was borrowed from the implimentation in `assets/js/sections/qso.js'.

Ref: https://github.com/wavelog/wavelog/blob/e4d17a2a07be52b12420cb351b35b72ab4c9e8fa/assets/js/sections/qso.js#L158

However, this looks great but could be annoying for slow servers. It could also be implemented by blanking the qso info earlier so that the user wouldn't be able to click again. But this may trick users to think the QSO was already uploaded when it really isn't.