### PR TITLE
Ignore keyup/input event when composing with IME, and trigger them when finished

### DIFF
--- a/assets/js/sections/contesting.js
+++ b/assets/js/sections/contesting.js
@@ -385,8 +385,17 @@ $("#callsign").on( "blur", function() {
 
 var scps=[];
 
+$("#callsign").on("compositionstart", function(){ this.isComposing = true; });
+$("#callsign").on("compositionend", function(e){
+	this.isComposing = false;
+	$(this).trigger("keyup");
+});
+
 // On Key up check and suggest callsigns
 $("#callsign").keyup(async function (e) {
+	// Prevent checking when the user's composing in IME
+	if (this.isComposing || e.isComposing) return;
+
 	var call = $(this).val();
 	if ((!((e.keyCode == 10 || e.keyCode == 13) && (e.ctrlKey || e.metaKey))) && (call.length >= 3)) {	// prevent checking again when pressing CTRL-Enter
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -99,6 +99,12 @@ $('.qso_panel .qso_eqsl_qslmsg_update').off('click').on('click', function () {
 	$('#charsLeft').text(" ");
 });
 
+$("#callsign").on("compositionstart", function(){ this.isComposing = true; });
+$("#callsign").on("compositionend", function(e){
+	this.isComposing = false;
+	$(this).trigger("input");
+});
+
 $(document).on("keydown", function (e) {
 	if (e.key === "Escape" && $('#callsign').val() != '') { // escape key maps to keycode `27`
 		// console.log("Escape key pressed");
@@ -109,6 +115,9 @@ $(document).on("keydown", function (e) {
 
 // Sanitize some input data
 $('#callsign').on('input', function () {
+	// Prevent checking when the user's composing in IME
+	if (this.isComposing) return;
+
 	$(this).val($(this).val().replace(/\s/g, ''));
 	$(this).val($(this).val().replace(/0/g, 'Ø'));
 	$(this).val($(this).val().replace(/\./g, '/P'));


### PR DESCRIPTION
The current keyup/input didn't handle composing events, which leads to:
  1. Repeating input when composing in IME with other language (qso.js);
  2. Incorrect sync between the callsign field and the search field (contesting.js).

The commit solves it by not doing anything when the user compsoing in IME and firing the event later when the user finished typing.

This isn't a big deal on PC but may be troublesome for mobile users, where they often have a default IME on everytime typing in a <input>.

A screen record of how this was behaving was attached in the thread. 

https://github.com/user-attachments/assets/078fb70f-1916-495a-873b-af853c4943af

