### PR TITLE
Make LoTW cert details query more verbose

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -211,11 +211,23 @@ class Lotw extends CI_Controller {
 				// Get Certificate Data
 				$this->load->model('Lotw_model');
 				$data['station_profile'] = $station_profile;
-				$data['lotw_cert_info'] = $this->Lotw_model->lotw_cert_details($station_profile->station_callsign, $station_profile->station_dxcc, $station_profile->user_id);
+
+				$cert_query = $this->Lotw_model->lotw_cert_details($station_profile->station_callsign, $station_profile->user_id);
+				if ($cert_query->num_rows() > 1) {
+					echo $station_profile->station_callsign.": Multiple matching LoTW certificates found. Skipping.<br>";
+					continue;
+				}
 
 				// If Station Profile has no LoTW Cert continue on.
-				if(!isset($data['lotw_cert_info']->cert_dxcc_id)) {
+				if ($cert_query->num_rows() == 0) {
 					echo $station_profile->station_callsign.": No LoTW certificate for station callsign found.<br>";
+					continue;
+				}
+
+				$data['lotw_cert_info'] = $cert_query->row();
+				// Check if station profile DXCC matches cert DXCC
+				if ($data['lotw_cert_info']->cert_dxcc_id != $station_profile->station_dxcc) {
+					echo $station_profile->station_callsign.": DXCC of station profile does not match DXCC of LoTW certificate.<br>";
 					continue;
 				}
 

--- a/application/models/Lotw_model.php
+++ b/application/models/Lotw_model.php
@@ -22,13 +22,12 @@ class Lotw_model extends CI_Model {
 	}
 
 
-	function lotw_cert_details($callsign, $dxcc, $user_id) {
-		$this->db->where('cert_dxcc_id', $dxcc);
+	function lotw_cert_details($callsign, $user_id) {
 		$this->db->where('user_id', $user_id);
 		$this->db->where('callsign', $callsign);
 		$query = $this->db->get('lotw_certs');
 
-		return $query->row();
+		return $query;
 	}
 
 	function find_cert($callsign, $dxcc, $user_id) {


### PR DESCRIPTION
If station profile has a different DXCC than the (according to callsign) matching LoTW certificate the error message is a bit misleading:

```
DF2ET: No LoTW certificate for station callsign found.
```

Actually in most/some cases we have a cert but $user failed to set the proper DXCC in station profile. So we want to detect that. In order to achieve this we relaxed the cert query itself a little but made the checks on the results a bit more specific. New error message in this case would be:

```
DF2ET: DXCC of station profile does not match DXCC of LoTW certificate.
```

To test either change the cert_dxcc_id of an existing cert used for signing to an arbitrary value or change the DXCC in station profile (e.g. Germany instead of Federal Republic of Germany).