### PR TITLE
[Leaflet] Suppress console warnings

### DIFF
--- a/assets/js/leaflet/L.Maidenhead.activators.js
+++ b/assets/js/leaflet/L.Maidenhead.activators.js
@@ -23,16 +23,20 @@ L.MaidenheadActivators = L.LayerGroup.extend({
 	onAdd: function (map) {
 		this._map = map;
 		var grid = this.redraw(map);
-		this._map.on('viewreset '+ this.options.redraw, function () {
+		// Store the event handler function so we can remove it later
+		this._onViewChange = function () {
 			grid.redraw(map);
-		});
+		};
+		this._map.on('viewreset '+ this.options.redraw, this._onViewChange);
 
 		this.eachLayer(map.addLayer, map);
 	},
 
 	onRemove: function (map) {
 		// remove layer listeners and elements
-		map.off('viewreset '+ this.options.redraw, this.map);
+		if (this._onViewChange) {
+			map.off('viewreset '+ this.options.redraw, this._onViewChange);
+		}
 		this.eachLayer(this.removeLayer, this);
 	},
 

--- a/assets/js/leaflet/L.Maidenhead.js
+++ b/assets/js/leaflet/L.Maidenhead.js
@@ -4,7 +4,7 @@
 
 L.Maidenhead = L.LayerGroup.extend({
 
-	
+
 	options: {
 		// Line and label color
 		color: 'rgba(255, 0, 0, 0.4)',
@@ -21,16 +21,20 @@ L.Maidenhead = L.LayerGroup.extend({
 	onAdd: function (map) {
 		this._map = map;
 		var grid = this.redraw();
-		this._map.on('viewreset '+ this.options.redraw, function () {
+		// Store the event handler function so we can remove it later
+		this._onViewChange = function () {
 			grid.redraw();
-		});
+		};
+		this._map.on('viewreset '+ this.options.redraw, this._onViewChange);
 
 		this.eachLayer(map.addLayer, map);
 	},
-	
+
 	onRemove: function (map) {
 		// remove layer listeners and elements
-		map.off('viewreset '+ this.options.redraw, this.map);
+		if (this._onViewChange) {
+			map.off('viewreset '+ this.options.redraw, this._onViewChange);
+		}
 		this.eachLayer(this.removeLayer, this);
 	},
 
@@ -64,7 +68,7 @@ L.Maidenhead = L.LayerGroup.extend({
 		}
 		return this;
 	},
-    	
+
 	_getLabel: function(lon,lat) {
 	  var title_size = new Array(0 ,10,12,16,20,26,15,16,24,36,12  ,14  ,20  ,36  ,60  ,12   ,20   ,36   ,60   ,12      ,24       );
 	  var zoom = this._map.getZoom();
@@ -74,7 +78,7 @@ L.Maidenhead = L.LayerGroup.extend({
       var marker = L.marker([lat,lon], {icon: myIcon}, clickable=false);
       return marker;
 	},
-	
+
 	_getLocator: function(lon,lat) {
 	  var ydiv_arr=new Array(10, 1, 1/24, 1/240, 1/240/24);
 	  var d1 = "ABCDEFGHIJKLMNOPQR".split("");
@@ -96,15 +100,15 @@ L.Maidenhead = L.LayerGroup.extend({
 			if ((i%2)==0) {
 				locator += Math.floor(rlon/(ydiv_arr[i+1]*2)) +""+ Math.floor(rlat/(ydiv_arr[i+1]));
 			} else {
-				locator += d2[Math.floor(rlon/(ydiv_arr[i+1]*2))] +""+ d2[Math.floor(rlat/(ydiv_arr[i+1]))];	
+				locator += d2[Math.floor(rlon/(ydiv_arr[i+1]*2))] +""+ d2[Math.floor(rlat/(ydiv_arr[i+1]))];
 			}
 		}
-	  }  
+	  }
       return locator;
 	},
 
-  
-	
+
+
 
 });
 

--- a/assets/js/leaflet/L.Maidenhead.qrb.js
+++ b/assets/js/leaflet/L.Maidenhead.qrb.js
@@ -22,16 +22,20 @@ L.MaidenheadQrb = L.LayerGroup.extend({
 	onAdd: function (map) {
 		this._map = map;
 		var grid = this.redraw(map);
-		this._map.on('viewreset '+ this.options.redraw, function () {
+		// Store the event handler function so we can remove it later
+		this._onViewChange = function () {
 			grid.redraw(map);
-		});
+		};
+		this._map.on('viewreset '+ this.options.redraw, this._onViewChange);
 
 		this.eachLayer(map.addLayer, map);
 	},
 
 	onRemove: function (map) {
 		// remove layer listeners and elements
-		map.off('viewreset '+ this.options.redraw, this.map);
+		if (this._onViewChange) {
+			map.off('viewreset '+ this.options.redraw, this._onViewChange);
+		}
 		this.eachLayer(this.removeLayer, this);
 	},
 

--- a/assets/js/leaflet/L.MaidenheadColoured.js
+++ b/assets/js/leaflet/L.MaidenheadColoured.js
@@ -21,16 +21,20 @@ L.Maidenhead = L.LayerGroup.extend({
 	onAdd: function (map) {
 		this._map = map;
 		var grid = this.redraw();
-		this._map.on('viewreset '+ this.options.redraw, function () {
+		// Store the event handler function so we can remove it later
+		this._onViewChange = function () {
 			grid.redraw();
-		});
+		};
+		this._map.on('viewreset '+ this.options.redraw, this._onViewChange);
 
 		this.eachLayer(map.addLayer, map);
 	},
 
 	onRemove: function (map) {
 		// remove layer listeners and elements
-		map.off('viewreset '+ this.options.redraw, this.map);
+		if (this._onViewChange) {
+			map.off('viewreset '+ this.options.redraw, this._onViewChange);
+		}
 		this.eachLayer(this.removeLayer, this);
 	},
 
@@ -61,9 +65,9 @@ L.Maidenhead = L.LayerGroup.extend({
 				for (var lat = bottom; lat < top; lat += unit) {
 					var bounds = [[lat,lon],[lat+unit,lon+(unit*2)]];
 					var locator = this._getLocator(lon,lat);
-	
+
 					if(grid_two.includes(locator) || grid_four.includes(locator) || grid_six.includes(locator)) {
-	
+
 						if(grid_two_confirmed.includes(locator) || grid_four_confirmed.includes(locator) || grid_six_confirmed.includes(locator)) {
 							var rectConfirmed = L.rectangle(bounds, {className: 'grid-rectangle grid-confirmed', color: 'rgba(144,238,144, 0.6)', weight: 1, fillOpacity: 1, fill:true, interactive: false});
 							this.addLayer(rectConfirmed);

--- a/assets/js/leaflet/L.MaidenheadColouredGridMap.js
+++ b/assets/js/leaflet/L.MaidenheadColouredGridMap.js
@@ -20,16 +20,20 @@ L.Maidenhead = L.LayerGroup.extend({
 	onAdd: function (map) {
 		this._map = map;
 		var grid = this.redraw();
-		this._map.on('viewreset '+ this.options.redraw, function () {
+		// Store the event handler function so we can remove it later
+		this._onViewChange = function () {
 			grid.redraw();
-		});
+		};
+		this._map.on('viewreset '+ this.options.redraw, this._onViewChange);
 
 		this.eachLayer(map.addLayer, map);
 	},
 
 	onRemove: function (map) {
 		// remove layer listeners and elements
-		map.off('viewreset '+ this.options.redraw, this.map);
+		if (this._onViewChange) {
+			map.off('viewreset '+ this.options.redraw, this._onViewChange);
+		}
 		this.eachLayer(this.removeLayer, this);
 	},
 

--- a/assets/js/leaflet/L.MaidenheadColouredGridmasterMap.js
+++ b/assets/js/leaflet/L.MaidenheadColouredGridmasterMap.js
@@ -21,16 +21,20 @@ L.Maidenhead = L.LayerGroup.extend({
 	onAdd: function (map) {
 		this._map = map;
 		var grid = this.redraw();
-		this._map.on('viewreset '+ this.options.redraw, function () {
+		// Store the event handler function so we can remove it later
+		this._onViewChange = function () {
 			grid.redraw();
-		});
+		};
+		this._map.on('viewreset '+ this.options.redraw, this._onViewChange);
 
 		this.eachLayer(map.addLayer, map);
 	},
 
 	onRemove: function (map) {
 		// remove layer listeners and elements
-		map.off('viewreset '+ this.options.redraw, this.map);
+		if (this._onViewChange) {
+			map.off('viewreset '+ this.options.redraw, this._onViewChange);
+		}
 		this.eachLayer(this.removeLayer, this);
 	},
 
@@ -59,9 +63,9 @@ L.Maidenhead = L.LayerGroup.extend({
 				for (var lat = bottom; lat < top; lat += unit) {
 					var bounds = [[lat,lon],[lat+unit,lon+(unit*2)]];
 					var locator = this._getLocator(lon,lat);
-	
+
 					if(grid_four.includes(locator)) {
-	
+
 						if(grid_four_lotw.includes(locator)) {
 							var rectConfirmed = L.rectangle(bounds, {className: 'grid-rectangle grid-confirmed', color: 'rgba(144,238,144, 0.6)', weight: 1, fillOpacity: 1, fill:true, interactive: false});
 							this.addLayer(rectConfirmed);


### PR DESCRIPTION
### Summary

This PR introduces a minor bug fix to address console warnings that appear when visiting a page containing a Leaflet map (observed in the latest Chrome on Windows 11):

<img width="640" height="297" alt="image" src="https://github.com/user-attachments/assets/b57442f4-eca6-4828-8f12-4e4a4f5e981b" />

### Details

The fix wraps the related action in a function and adds a check to ensure it exists before execution, preventing the warnings from being triggered.
