### PR TITLE
Fix get plaincall logic

### DIFF
--- a/application/libraries/Callbook.php
+++ b/application/libraries/Callbook.php
@@ -170,19 +170,20 @@ class Callbook {
 
 	function get_plaincall($callsign) {
 		$split_callsign = explode('/', $callsign);
-		if (count($split_callsign) == 1) {				// case F0ABC --> return cel 0 //
-			$lookupcall = $split_callsign[0];
-		} else if (count($split_callsign) == 3) {			// case EA/F0ABC/P --> return cel 1 //
-			$lookupcall = $split_callsign[1];
-		} else {										// case F0ABC/P --> return cel 0 OR  case EA/FOABC --> retunr 1  (normaly not exist) //
-			if (in_array(strtoupper($split_callsign[1]), array('P', 'M', 'MM', 'QRP', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))) {
-				$lookupcall = $split_callsign[0];
-			} else if (strlen($split_callsign[1]) > 3) {	// Last Element longer than 3 chars? Take that as call
-				$lookupcall = $split_callsign[1];
-			} else {									// Last Element up to 3 Chars? Take first element as Call
-				$lookupcall = $split_callsign[0];
-			}
+		if (count($split_callsign) == 1) {				// case of plain callsign --> return callsign
+			return $callsign;
 		}
-		return $lookupcall;
+
+		// Case of known suffixes that are not part of the callsign
+		if (in_array(strtoupper($split_callsign[1]), array('LGT', 'AM', 'LH', 'A', 'B', 'R', 'T', 'X', 'D', 'P', 'M', 'MM', 'QRP', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'))) {
+			return $split_callsign[0];
+		}
+		// case EA/FOABC --> return 1
+		if (strlen($split_callsign[1]) > 3) {	// Last Element longer than 3 chars? Take that as call
+			return $split_callsign[1];
+		}
+		// case F0ABC/KH6 --> return cell 0
+		return $split_callsign[0];
 	}
+
 }


### PR DESCRIPTION
Fixes #1227.

In some rare cases, the plaincall logic would fail, like R4FBJ/0/P. The plaincall would return as 0, which is not correct.
With this fix, R4FBJ is returned.

Hopefully I didn't break anything while refacoring this. I've tested with several callsigns, but I might have overlooked some cases.