### PR TITLE
[Login Screen] Suppressed console warning

### DIFF
--- a/application/views/user/login.php
+++ b/application/views/user/login.php
@@ -38,18 +38,18 @@
     <?php } ?>
     <div class="my-2 rounded-0 shadow-sm card mb-2 shadow-sm">
         <div class="card-body">
-            <?php 
+            <?php
             /**
              * Wavelog Demo
-             * 
+             *
              * This enables the Wavelog Demo as used in https://demo.wavelog.org.
-             * 
-             * If you want to use this, place a file called `.demo` in the root folder 
-             * and create a non-admin user `demo` with password `demo` by hand. 
-             * 
+             *
+             * If you want to use this, place a file called `.demo` in the root folder
+             * and create a non-admin user `demo` with password `demo` by hand.
+             *
              * It's recommend to create a cronjob which resets this installation every day at 0200 UTC from a backup.
              * We do not provide any functionality for this, so you have to build this on your own.
-             * 
+             *
              */
             if (file_exists('.demo')) { ?>
                 <div class="border-bottom mb-3">
@@ -67,11 +67,11 @@
                 <input type="hidden" name="id" value="<?php echo $this->uri->segment(3); ?>" />
                 <div class="mb-2">
                     <label for="floatingInput"><strong><?= __("Username"); ?></strong></label>
-                    <input type="text" name="user_name" class="form-control" id="floatingInput" placeholder="<?php if (file_exists('.demo')) { echo "demo"; } else { echo __("Username"); } ?>" value="<?php echo $this->input->post('user_name'); ?>" autofocus>
+                    <input type="text" name="user_name" class="form-control" id="floatingInput" placeholder="<?php if (file_exists('.demo')) { echo "demo"; } else { echo __("Username"); } ?>" value="<?php echo $this->input->post('user_name'); ?>" autocomplete="username" autofocus>
                 </div>
                 <div class="mb-2">
                     <label for="floatingPassword"><strong><?= __("Password"); ?></strong></label>
-                    <input type="password" name="user_password" class="form-control" id="floatingPassword" placeholder="<?php if (file_exists('.demo')) { echo "demo"; } else { echo __("Password"); } ?>">
+                    <input type="password" name="user_password" class="form-control" id="floatingPassword" placeholder="<?php if (file_exists('.demo')) { echo "demo"; } else { echo __("Password"); } ?>" autocomplete="current-password">
                 </div>
                 <div class="mb-2">
                     <div class="row">


### PR DESCRIPTION
The login screen is now rising a warning (Latest Chrome/Win11):
<img width="852" height="187" alt="image" src="https://github.com/user-attachments/assets/4d89143f-9ac6-41b2-ad4e-763f1d69c6dc" />

Changes:
- suppressed warning with autocomplete attributes as per https://www.chromium.org/developers/design-documents/create-amazing-password-forms/