### PR TITLE
Prevent Re-Lookup not only on Reset-Click but also on ESC

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -232,8 +232,19 @@ $("#callsign").on("compositionend", function(e){
 
 $(document).on("keydown", function (e) {
 	if (e.key === "Escape" && $('#callsign').val() != '') { // escape key maps to keycode `27`
-		// console.log("Escape key pressed");
+		preventLookup = true;
+
+		if (lookupCall) {
+			lookupCall.abort();
+		}
+
 		reset_fields();
+
+		// make sure the focusout event is finished before we allow a new lookup
+		setTimeout(() => {
+			preventLookup = false;
+		}, 100);
+		// console.log("Escape key pressed");
 		$('#callsign').trigger("focus");
 	}
 });


### PR DESCRIPTION
When pressing ESC (with a pre-typed call), a lookup is triggered (which is wrong / overhead).
This problem was already solved for pressing the Reset-Button, but not for ESC.

this fixes it