### PR TITLE
Clear refs before filling spot data

### DIFF
--- a/assets/js/dxwaterfall.js
+++ b/assets/js/dxwaterfall.js
@@ -1204,6 +1204,8 @@ var DX_WATERFALL_UTILS = {
                 wasPreventLookupSet = true;
             }
 
+            reset_fields();
+
             // Populate the callsign input field
             var callsignInput = $('#callsign');
             var formattedCallsign = spotData.callsign.toUpperCase().replace(/0/g, 'Ø');


### PR DESCRIPTION
We need to clear reference fields on spot click to prevent stale data from being logged if the new spot clicked does not provide ref information. Maybe @szporwolik can check here as well.