### PR TITLE
show more specified permission paths in the installer

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -236,6 +236,24 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 													</td>
 												</tr>
 											</table>
+										</div>
+										<div class="col-md-5 mb-4 mx-auto">
+											<p class="border-bottom mb-2"><b><?= __("Web Server"); ?></b></p>
+											<table width="100%" style="margin-bottom: 25px;">
+												<tr>
+													<td><?= __("Version:"); ?> </td>
+													<td><span class="badge text-bg-info"><?php echo detect_webserver(); ?></span></td>
+												</tr>
+											</table>
+											<?php if (strpos(strtolower(detect_webserver()), 'nginx') !== false) {
+												if (detect_nginx_php_setting($http_scheme) != 200) { ?>
+													<div class="alert alert-warning d-flex flex-column align-items-center" role="alert">
+														<p class="mb-2 border-bottom"><?= __("Important note for nginx users!"); ?></p>
+														<p class="mb-0"><?= __("Since you are using nginx as web server please make sure that you have made the changes described in the Wiki before continuing."); ?></p><br>
+														<p class="mb-0"><a target="_blank" href="https://github.com/wavelog/Wavelog/wiki/Installation#nginx-configuration">https://github.com/wavelog/Wavelog/wiki/Installation#nginx-configuration</a></p>
+													</div>
+												<?php } ?>
+											<?php } ?>
 											<p class="border-bottom mb-2" style="margin-top: 2rem;"><b><?= __("Folder Write Permissions"); ?></b></p>
 											<table width="100%">
 												<tr>
@@ -316,24 +334,7 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 													</td>
 												</tr>
 											</table>
-										</div>
-										<div class="col-md-5 mb-4 mx-auto">
-											<p class="border-bottom mb-2"><b><?= __("Web Server"); ?></b></p>
-											<table width="100%" style="margin-bottom: 25px;">
-												<tr>
-													<td><?= __("Version:"); ?> </td>
-													<td><span class="badge text-bg-info"><?php echo detect_webserver(); ?></span></td>
-												</tr>
-											</table>
-											<?php if (strpos(strtolower(detect_webserver()), 'nginx') !== false) {
-												if (detect_nginx_php_setting($http_scheme) != 200) { ?>
-													<div class="alert alert-warning d-flex flex-column align-items-center" role="alert">
-														<p class="mb-2 border-bottom"><?= __("Important note for nginx users!"); ?></p>
-														<p class="mb-0"><?= __("Since you are using nginx as web server please make sure that you have made the changes described in the Wiki before continuing."); ?></p><br>
-														<p class="mb-0"><a target="_blank" href="https://github.com/wavelog/Wavelog/wiki/Installation#nginx-configuration">https://github.com/wavelog/Wavelog/wiki/Installation#nginx-configuration</a></p>
-													</div>
-												<?php } ?>
-											<?php } ?>
+											<hr style="border-width: 1px;border-color: #D8DCE0; opacity: 1;">
 											<?php if ($prechecks_passed == 'failed') {
 												$prechecks_icon = "fa-times-circle";
 												$prechecks_color = "red"; ?>


### PR DESCRIPTION
we can show the permission status of `application/config`, `application/cache` and `application/logs` instead just `application/` in the installer. 