### PR TITLE
Only validate grid if existent

### DIFF
--- a/application/libraries/Callbook.php
+++ b/application/libraries/Callbook.php
@@ -52,7 +52,7 @@ class Callbook {
 		}
 		// qrz.com gives AA00aa if the user deleted his grid from the profile
 		$this->ci->load->library('qra');
-		if (!$this->ci->qra->validate_grid($callbook['gridsquare'])) {
+		if (!array_key_exists('gridsquare', $callbook) || !$this->ci->qra->validate_grid($callbook['gridsquare'])) {
 			$callbook['gridsquare'] = '';
 		}
 		return $callbook;


### PR DESCRIPTION
PR https://github.com/wavelog/wavelog/pull/2504 introduced a bug. Searching for a prefix/part of call there are some errors because grid cannot be validated. We need to check if gridsquare array key exists.

Repro:
- Enable debug mode
- Search for prefix / part of call

Result:

<img width="1549" height="802" alt="image" src="https://github.com/user-attachments/assets/0a71498c-c60b-4f75-8c52-0a6951727925" />
