### PR TITLE
[DX Waterfall] Various fixes

### DIFF
--- a/assets/js/dxwaterfall.js
+++ b/assets/js/dxwaterfall.js
@@ -6227,9 +6227,6 @@ function setFrequency(frequencyInKHz, fromWaterfall) {
         return;
     }
 
-    // Update frequency field with value in Hz
-    $('#frequency').val(frequencyInKHz * 1000);
-
     // Write to frequency field in Hz (single source of truth)
     // The change event will trigger set_qrg() which updates freq_calculated display
     $('#frequency').val(frequencyInKHz * 1000);


### PR DESCRIPTION
Please merge after (it's the continuation):
- https://github.com/wavelog/wavelog/pull/2517

Changes:
- https://github.com/wavelog/wavelog/pull/2510 rises the SERIOUS concern about the frequency and frequency_calculated fields being used, this PR ensures that we use frequency for logic and freq_calculated only as display (thanks @HB9HIL !)
- the top bar (spot information) in the DX Waterfall is updated and then call-sign lookup starts - this improves user experience (better responsiveness)
- DX Waterfall will load even if the initial frequency is out of band (additional fence is provided by https://github.com/wavelog/wavelog/pull/2523)
- improved form clearing when clicking at the spot label (better responsiveness)
- potential fix for WJE issue rised by @HB9HIL - thus I was not able to reproduce it