### PR TITLE
[QSO Page] Fix for non-positive frequency value when band is not selected

### DIFF
--- a/assets/js/sections/qrg_handler.js
+++ b/assets/js/sections/qrg_handler.js
@@ -76,7 +76,8 @@ async function set_new_qrg() {
 
 	// If field is empty or parsing failed, fetch default frequency for current band/mode
 	if (!new_qrg || new_qrg === '' || isNaN(parsed_qrg) || !isFinite(parsed_qrg) || parsed_qrg <= 0) {
-		if (typeof base_url !== 'undefined') {
+		// Check if band is selected before attempting to fetch frequency
+		if ($('#band').val() && typeof base_url !== 'undefined') {
 			try {
 				const result = await $.get(base_url + 'index.php/qso/band_to_freq/' + $('#band').val() + '/' + $('.mode').val());
 				$('#frequency').val(result);
@@ -89,11 +90,21 @@ async function set_new_qrg() {
 				return;
 			}
 		}
+		// If band is empty or base_url is undefined, set frequency to 1 Hz
+		$('#frequency').val(1);
+		$('#qrg_unit').html('kHz');
+		$('#freq_calculated').val(0.001);
 		window.user_updating_frequency = false; // Clear flag
 		return;
 	}
 
 	let unit = $('#qrg_unit').html();
+
+	// If unit is not properly set (shows '...'), default to kHz for bare numbers
+	if (unit === '...' || unit === '') {
+		unit = 'kHz';
+		$('#qrg_unit').html('kHz');
+	}
 
 	// check if the input contains a unit and parse the qrg
 	if (/^\d+(\.\d+)?\s*(hz|h)$/i.test(new_qrg)) {


### PR DESCRIPTION
Problem statement - there is wrong logic implemented:
- open QSO page
- ensure CAT is OFF
- enter out of band frequency like 225kHz - band dropdown will be null
- enter 0 or negative frequency - this will be allowed

Why this is important:
- DX Waterfall expects the frequency to be non-negative (more than 0)

Solution:
- the current ajax query at line 82 in qrg_hanlder.js is incorrect, null value is being send in given test case
- we want to run the mentioned query only when band is selected or default to some non-negative number