### PR TITLE
fix the order of clearing and populating data

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1056,7 +1056,7 @@ function reset_to_default() {
 }
 
 /* Function: reset_fields is used to reset the fields on the QSO page */
-function reset_fields() {	
+function reset_fields() {
 	// we set the pendingReferences to null to avoid they get prefilled in the next QSO after clear
 	// we do this first to avoid race conditions for slow javascript
 	pendingReferences = null;
@@ -1212,7 +1212,12 @@ $("#callsign").on("focusout", function () {
 		lookupInProgress = true;
 
 		// Capture pendingReferences for THIS lookup (before it gets overwritten by another click)
+		// If pendingReferences exists, use it; otherwise set to null to prevent old references
+		// from being populated when user manually types a different callsign
 		var capturedReferences = pendingReferences ? Object.assign({}, pendingReferences) : null;
+
+		// Clear pendingReferences immediately after capturing to prevent reuse on next manual lookup
+		pendingReferences = null;
 
 		// Disable Save QSO button and show fetch status
 		$('#saveQso').prop('disabled', true);


### PR DESCRIPTION
We need to first clear the fields before populating new data. 

also moved the pendingReferences = null to the top of the resetFields function as I noticed on slow javascript the clearing of the selectize fields can cause minimal race conditions in this case. Another way would be to make reset_fields() async which would need a bit more work and is kinda cumbersome. So I think this light fix should work for the majority of setups (testing with a real slow machine here, should be fine)