### PR TITLE
LoTW-Badge at cluster

### DIFF
--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -427,7 +427,7 @@
 		<!-- LoTW Users Button (separate) -->
 		<div class="btn-group flex-shrink-0" role="group">
 			<button class="btn btn-sm btn-secondary" type="button" id="toggleLotwFilter" title="<?= __("Toggle LoTW User filter"); ?>">
-				<i class="fas fa-upload"></i> <span class="d-none d-sm-inline"><?= __("LoTW users"); ?></span>
+				<span style="font-family: Helvetica; display: inline-block; width: 16px; height: 16px; line-height: 16px; text-align: center; background-color: #6c757d; color: white; border-radius: 2px; font-size: 12px; font-weight: bold; margin-right: 4px;">L</span> <span class="d-none d-sm-inline"><?= __("LoTW users"); ?></span>
 			</button>
 		</div>
 

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -1007,7 +1007,7 @@ $(function() {
 			lclass = 'lotw_info_yellow';
 		}
 		let lotw_title = lang_bandmap_lotw_last_upload.replace('%d', single.dxcc_spotted.lotw_user);
-		lotw_badge = '<a href="https://lotw.arrl.org/lotwuser/act?act=' + single.spotted + '" target="_blank" onclick="event.stopPropagation();">' + buildBadge('success ' + lclass, 'fa-upload', lotw_title) + '</a>';
+		lotw_badge = '<a href="https://lotw.arrl.org/lotwuser/act?act=' + single.spotted + '" target="_blank" onclick="event.stopPropagation();">' + buildBadge('success ' + lclass, null, lotw_title, 'L', false, "Helvetica") + '</a>';
 	}
 
 	// Build activity badges (POTA, SOTA, WWFF, IOTA, Contest, Worked)
@@ -1796,10 +1796,11 @@ $(function() {
 	// title: tooltip text
 	// text: optional text content instead of icon
 	// isLast: if true, uses margin: 0 instead of negative margin
-	function buildBadge(type, icon, title, text = null, isLast = false) {
+	function buildBadge(type, icon, title, text = null, isLast = false, fontFamily = null) {
 		const margin = isLast ? '0' : '0 2px 0 0';
 		const fontSize = text ? '0.75rem' : '0.7rem';
-		const content = text ? text : '<i class="fas ' + icon + '" style="display: block;"></i>';
+		const fontFamilyStyle = fontFamily ? 'font-family: ' + fontFamily + ';' : '';
+		const content = text ? '<span style="display: block; ' + fontFamilyStyle + '">' + text + '</span>' : '<i class="fas ' + icon + '" style="display: block;"></i>';
 		return '<small class="badge text-bg-' + type + '" style="display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; padding: 0; margin: ' + margin + '; font-size: ' + fontSize + '; line-height: 1;" data-bs-toggle="tooltip" title="' + title + '">' + content + '</small>';
 	}
 


### PR DESCRIPTION
We're using the little "L" everywhere in Wavelog. Somehow in new cluster another icon was used.
this PR fixes it:

New Cluster:
<img width="270" height="131" alt="image" src="https://github.com/user-attachments/assets/ee706559-2490-453f-ba58-e34d217a744f" />

After PR:
<img width="151" height="68" alt="image" src="https://github.com/user-attachments/assets/8361e6cc-c357-4910-85eb-4d98208181a8" />
