### PR TITLE
Use ID mode instead of class

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -725,7 +725,7 @@ $(document).ready(function() {
         var $band = $('#band');
         var $frequencyRx = $('#frequency_rx');
         var $bandRx = $('#band_rx');
-        var $mode = $('.mode');
+        var $mode = $('#mode');
 
         // If radio name is not in data, try to get it from cache first, then from dropdown
         if (!data.radio || data.radio == null || data.radio == '') {

--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -198,6 +198,9 @@ $(document).ready(function() {
             ui.data('catValue',cat);
             if (typeof callback_on_update === 'function') { callback_on_update(cat); }
         }
+        if (ui.attr('id') === 'mode') {
+            setRst($("#mode").val());
+        }
     }
 
     /**
@@ -246,6 +249,7 @@ $(document).ready(function() {
         } else {
             mode = mode.toLowerCase();
         }
+	setRst($("#mode").val());
 
         // Check if DX Waterfall is ACTIVE and should handle this (only if not called from within DX Waterfall)
         // DX Waterfall is active if dxWaterfall object exists AND has a canvas (meaning it's initialized)

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -587,7 +587,7 @@ $(document).on("click", "#fav_recall", function (event) {
 	$('#frequency').val(favs[this.innerText].frequency).trigger("change");
 	$('#selectPropagation').val(favs[this.innerText].prop_mode);
 	$('#mode').val(favs[this.innerText].mode).on("change");
-	setRst($('.mode').val());
+	setRst($('#mode').val());
 });
 
 
@@ -774,6 +774,7 @@ bc.onmessage = function (ev) {
 			// Set mode if provided (backward compatible - optional field)
 			if (ev.data.mode) {
 				$("#mode").val(ev.data.mode);
+				setRst($('#mode').val());
 			}
 			$("#callsign").val(ev.data.call);
 			$("#callsign").focusout();
@@ -1111,7 +1112,7 @@ function reset_fields() {
 	$('#partial_view').hide();
 	$('.callsign-suggest').hide();
 	$("#distance").val("");
-	setRst($(".mode").val());
+	setRst($("#mode").val());
 	var $select = $('#sota_ref').selectize();
 	var selectize = $select[0].selectize;
 	selectize.clear();
@@ -2574,8 +2575,8 @@ $("#ant_path").on("change", function () {
 });
 
 // Change report based on mode
-$('.mode').on('change', function () {
-	setRst($('.mode').val());
+$('#mode').on('change', function () {
+	setRst($('#mode').val());
 });
 
 function convert_case(str) {
@@ -2823,7 +2824,7 @@ $(document).ready(function () {
 
 	$('.callsign-suggest').hide();
 
-	setRst($(".mode").val());
+	setRst($("#mode").val());
 
 	/* On Page Load */
 	var catcher = function () {


### PR DESCRIPTION
when editing a previous QSO from QSO-Page (History),
one wasn't able to change the Mode, because CAT always overwrites it.

this patch targets ONLY the element `id="mode"` instead of every field which has the class `mode`.

pse check carefully for side-effects.

things to test:
Play with / without CAT and look carefully for MODE and default-RST