### PR TITLE
[DX Cluster] Fix missing set_new_qrg() error

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -973,7 +973,9 @@ $(document).ready(function() {
             $('#frequency').val('');
             $('#frequency_rx').val('');
             $('#band_rx').val('');
-            set_new_qrg();
+            if (typeof set_new_qrg === 'function') {
+                set_new_qrg();
+            }
             $('#selectPropagation').val($('#selectPropagation option:first').val());
             // Set DX Waterfall CAT state to none if variable exists
             if (typeof dxwaterfall_cat_state !== 'undefined') {


### PR DESCRIPTION
Problem:
At DX cluster set_new_qrg() fails as the qrg handler is not loaded.

Solution:
Check if function is defined before calling it.

<img width="603" height="75" alt="image" src="https://github.com/user-attachments/assets/c65e4251-8b69-466e-ab2e-1d765e4321d0" />

