### PR TITLE
[Backend] Skip spot enrichment when contest data is available in the spot

### DIFF
--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -630,21 +630,23 @@ class Dxcluster_model extends CI_Model {
 			$spot->dxcc_spotted = (object)[];
 		}
 
-	// Initialize all properties at once using array merge
-	$defaults = [
-		'sota_ref' => '',
-		'pota_ref' => '',
-		'iota_ref' => '',
-		'wwff_ref' => '',
-		'isContest' => false,
-		'contestName' => null
-	];
+		// Initialize all properties at once using array merge
+		$defaults = [
+			'sota_ref' => '',
+			'pota_ref' => '',
+			'iota_ref' => '',
+			'wwff_ref' => '',
+			'isContest' => false,
+			'contestName' => null
+		];
 
-	foreach ($defaults as $prop => $defaultValue) {
-		if (!property_exists($spot->dxcc_spotted, $prop)) {
-			$spot->dxcc_spotted->$prop = $defaultValue;
+		foreach ($defaults as $prop => $defaultValue) {
+			if (!property_exists($spot->dxcc_spotted, $prop)) {
+				$spot->dxcc_spotted->$prop = $defaultValue;
+			}
 		}
-	}		// Early exit if message is empty
+
+		// Early exit if message is empty
 		$message = $spot->message ?? '';
 		if (empty($message)) {
 			return $spot;
@@ -657,9 +659,10 @@ class Dxcluster_model extends CI_Model {
 		$needsPota = empty($spot->dxcc_spotted->pota_ref);
 		$needsIota = empty($spot->dxcc_spotted->iota_ref);
 		$needsWwff = empty($spot->dxcc_spotted->wwff_ref);
+		$hasContestData = property_exists($spot->dxcc_spotted, 'isContest');
 
-		// Early exit if all references already populated
-		if (!$needsSota && !$needsPota && !$needsIota && !$needsWwff && $spot->dxcc_spotted->isContest) {
+		// Early exit if all references already populated and contest data exists
+		if (!$needsSota && !$needsPota && !$needsIota && !$needsWwff && $hasContestData) {
 			return $spot;
 		}
 


### PR DESCRIPTION
Problem:
New DX Cluster API can provide contest enrichment information. If this is available, we don't need to run the expensive REGEX.

Solution:
Simple property check and early return.

Tested:
New DX Cluster API and test spot:
<img width="1009" height="220" alt="image" src="https://github.com/user-attachments/assets/2eb48954-be57-48e7-be7f-fbadac60387a" />
