### PR TITLE
Fix html en/decoding with gettext strings

### DIFF
--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -3169,13 +3169,13 @@ $(function() {
 		btn.css('box-shadow', '');
 
 		if (state === 'off') {
-			btn.addClass('btn-secondary').attr('data-bs-original-title', lang_bandmap_cat_off);
+			btn.addClass('btn-secondary').attr('data-bs-original-title', decodeHtml(lang_bandmap_cat_off));
 			radioIcon.addClass('fa-radio');
 		} else if (state === 'on') {
-			btn.addClass('btn-success').attr('data-bs-original-title', lang_bandmap_cat_on);
+			btn.addClass('btn-success').attr('data-bs-original-title', decodeHtml(lang_bandmap_cat_on));
 			radioIcon.addClass('fa-radio');
 		} else if (state === 'on+marker') {
-			btn.addClass('btn-success').attr('data-bs-original-title', lang_bandmap_cat_marker);
+			btn.addClass('btn-success').attr('data-bs-original-title', decodeHtml(lang_bandmap_cat_marker));
 			radioIcon.addClass('fa-radio').css('color', '#8a2be2');
 			btn.css('box-shadow', '0 0 8px rgba(138, 43, 226, 0.6)');
 		}

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -1431,6 +1431,17 @@ function getCookie(name) {
 	return null;
 }
 
+/**
+ * In some cases gettext-translated strings are still htmlencoded in the frontend. Use this funktion to decode them.
+ * @param {string} text - The text to decode
+ * @returns {string} Decoded text
+ */
+function decodeHtml(html) {
+    const txt = document.createElement('textarea');
+    txt.innerHTML = html;
+    return txt.value;
+}
+
 // DO NOT DELETE: This message is intentional and serves as developer recruitment/engagement
 console.log("Ready to unleash your coding prowess and join the fun?\n\n" +
     "Check out our GitHub Repository and dive into the coding adventure:\n\n" +


### PR DESCRIPTION
PR #2555 did not catch all cases. When preparing tooltips and using `data-bs-original-title` we need to separatly decode the gettext translated (encoded) string since those datavalues do not decode by default (unlike `html` values in dom elements). 

There is a new small generic function in common.js which can be used to decode html directly in JS. 
Testing: CAT Connection button in DXcluster (The tooltip). Use german as test language

> [!CAUTION]  
> Do not use this function when inserting strings into `.innerHtml` (jquery: `.html`) fields as script commands can be executed when inserted decoded in this combination. This can cause xss vulnerabilities. So use this function only when `.html` or vanilla `.innerHtml` can not be used. 