### PR TITLE
Export/Show UUID on station_info

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -177,6 +177,7 @@ class API extends CI_Controller {
 				$result['station_gridsquare']=$row->station_gridsquare;
 				$result['station_callsign']=$row->station_callsign;;
 				$result['station_active']=$row->station_active;
+				$result['station_uuid']=$row->station_uuid;
 				array_push($station_ids, $result);
 			}
 			echo json_encode($station_ids);


### PR DESCRIPTION
since we allow inserting station_locations with UUID we should expose them as well on station_info.

test:

`curl https://[your_wl_instance]/index.php/api/station_info/[valid_wl_key]  | jq .`