### PR TITLE
Remove warning for QSO end date expiry on dashboard and change danger to warning in cert view

### DIFF
--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -203,11 +203,11 @@ function getDistance($distance) {
 	<?php } ?>
 
 	<?php if ($this->session->userdata('user_id')) { ?>
-		<?php if ($lotw_cert_expired == true || $lotw_cert_qsoenddate_expired == true || $lotw_cert_expiring == true || $lotw_cert_qsoenddate_expiring == true) { ?>
+		<?php if ($lotw_cert_expired == true || $lotw_cert_expiring == true) { ?>
 			<?php
-				if($lotw_cert_expired == true || $lotw_cert_qsoenddate_expired == true) { ?>
+				if($lotw_cert_expired == true) { ?>
 				<div class="alert alert-danger alert-dismissible fade show" role="alert">
-				<?php } elseif($lotw_cert_expiring == true || $lotw_cert_qsoenddate_expiring == true) { ?>
+				<?php } elseif($lotw_cert_expiring == true) { ?>
 				<div class="alert alert-warning alert-dismissible fade show" role="alert">
 				<?php } ?>
 					<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-hourglass-half"></i> <?= sprintf(_pgettext("LoTW Warning", "LoTW Warning: There is an issue with at least one of your %sLoTW certificates%s!"), '<u><a href="'.site_url('lotw').'">', "</a></u>"); ?>
@@ -215,8 +215,6 @@ function getDistance($distance) {
 					<ul style="margin-top: 0.5em; margin-bottom: 0.1em;">
 						<?php if ($lotw_cert_expired == true) { echo "<li>".__("At least one of your certificates is expired"); } ?>
 						<?php if ($lotw_cert_expiring == true) { echo "<li>".__("At least one of your certificates is expiring"); } ?>
-						<?php if ($lotw_cert_qsoenddate_expired == true) { echo "<li>".__("The QSO end date of at least one of your certificates was exceeded"); } ?>
-						<?php if ($lotw_cert_qsoenddate_expiring == true) { echo "<li>".__("The QSO end date of at least one of your certificates is about to be exceeded"); } ?>
 					</ul>
 				</div>
 		<?php } ?>

--- a/application/views/lotw_views/index.php
+++ b/application/views/lotw_views/index.php
@@ -63,7 +63,7 @@
 										$new_valid_qso_end = date($this->config->item('qso_date_format'), $valid_qso_end );
 										$qso_warning_date = date('Y-m-d H:i:s', strtotime($row->qso_end_date.'-30 days'));
 										if ($current_date > $row->qso_end_date) {
-											echo "<span class='fw-bolder text-danger'>".$new_valid_qso_end."</span>";
+											echo "<span class='fw-bolder text-warning'>".$new_valid_qso_end."</span>";
 										} else if ($current_date <= $row->qso_end_date && $current_date > $qso_warning_date) {
 											echo "<span class='fw-bolder text-warning'>".$new_valid_qso_end."</span>";
 										} else {
@@ -104,7 +104,7 @@
 											<span class="badge text-bg-success"><?= __("Certificate valid"); ?></span>
 										<?php } ?>
 										<?php if ($current_date > $row->qso_end_date) { ?>
-											<span class="badge text-bg-danger">QSO end date exceeded</span>
+											<span class="badge text-bg-warning">QSO end date exceeded</span>
 										<?php } else if ($current_date <= $row->qso_end_date && $current_date > $qso_warning_date) { ?>
 											<span class="badge text-bg-warning"><?= __("QSO end date nearing"); ?></span>
 										<?php } ?>


### PR DESCRIPTION
We should be a little more relaxed concerning QSO end date expiry with LoTW certificates.