### PR TITLE
Club adif

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -28,7 +28,7 @@ class adif extends CI_Controller {
 
 	private function determine_allowed_tabs() {
 		if (clubaccess_check(6) && !clubaccess_check(9)) {
-			// Only ClubMember Plus and NOT ClubOfficer
+			// Only ClubMember ADIF and NOT ClubOfficer
 			$this->allowed_tabs = ['import', 'export'];
 		} else {
 			// Default: show all tabs (backward compatible)
@@ -346,7 +346,7 @@ class adif extends CI_Controller {
 								$record['operator'] = strtoupper($club_operator);
 							}
 						} elseif ($user_permission_level == 6) {
-							// ClubMemberPlus: Force operator to current user, ignore input
+							// ClubMemberADIF: Force operator to current user, ignore input
 							$record['operator'] = strtoupper($this->session->userdata('operator_callsign'));
 						}
 						// Note: Regular Club Member (Level 3) should not reach here due to constructor permission check

--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -219,6 +219,7 @@ class adif extends CI_Controller {
 
 		$data['page_title'] = __("ADIF Import / Export");
 		$data['max_upload'] = ini_get('upload_max_filesize');
+		$data['cd_p_level'] = ($this->session->userdata('cd_p_level') ?? 0);
 
 		if ($this->config->item('special_callsign') && clubaccess_check(9) && $this->session->userdata('clubstation') == 1) {
 			$this->load->model('club_model');

--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -10,7 +10,7 @@ class adif extends CI_Controller {
 		$this->load->helper(array('form', 'url'));
 
 		$this->load->model('user_model');
-		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
+		if(!$this->user_model->authorize(2) || !clubaccess_check(6)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
 	public function test() {
@@ -242,10 +242,18 @@ class adif extends CI_Controller {
 							$record['contest_id'] = $contest;
 						}
 
-						//handle club operator
-						if ($club_operator != '') {
-							$record['operator'] = strtoupper($club_operator);
+						//handle club operator based on permission level
+						$user_permission_level = $this->session->userdata('cd_p_level');
+						if ($user_permission_level >= 9) {
+							// Club Officer: Allow operator override
+							if ($club_operator != '') {
+								$record['operator'] = strtoupper($club_operator);
+							}
+						} elseif ($user_permission_level == 6) {
+							// ClubMemberPlus: Force operator to current user, ignore input
+							$record['operator'] = strtoupper($this->session->userdata('operator_callsign'));
 						}
+						// Note: Regular Club Member (Level 3) should not reach here due to constructor permission check
 
 						//check if contest_id exists in record and extract all found contest_ids
 						if(array_key_exists('contest_id', $record)){

--- a/application/controllers/Club.php
+++ b/application/controllers/Club.php
@@ -21,7 +21,7 @@ class Club extends CI_Controller
 
 		$this->permissions = [
 			9 => __("Club Officer"),
-			6 => __("Club Member Plus"),
+			6 => __("Club Member ADIF"),
 			3 => __("Club Member"),
 		];
 	}

--- a/application/controllers/Club.php
+++ b/application/controllers/Club.php
@@ -21,6 +21,7 @@ class Club extends CI_Controller
 
 		$this->permissions = [
 			9 => __("Club Officer"),
+			6 => __("Club Member Plus"),
 			3 => __("Club Member"),
 		];
 	}
@@ -118,9 +119,9 @@ class Club extends CI_Controller
 			$this->session->set_flashdata('error', __("Invalid Club ID!"));
 			redirect('dashboard'); 
 		}
-		if(!$this->user_model->authorize(99) && !$this->club_model->club_authorize(9, $club_id)) { 
-			$this->session->set_flashdata('error', __("You're not allowed to do that!")); 
-			redirect('dashboard'); 
+		if(!$this->user_model->authorize(99) && !$this->club_model->club_authorize(9, $club_id) && !$this->club_model->club_authorize(6, $club_id)) {
+			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
+			redirect('dashboard');
 		}
 
 		$this->club_model->alter_member($club_id, $user_id, $p_level);
@@ -147,9 +148,9 @@ class Club extends CI_Controller
 			$this->session->set_flashdata('error', __("Invalid Club ID!"));
 			redirect('dashboard'); 
 		}
-		if(!$this->user_model->authorize(99) && !$this->club_model->club_authorize(9, $club_id)) { 
-			$this->session->set_flashdata('error', __("You're not allowed to do that!")); 
-			redirect('dashboard'); 
+		if(!$this->user_model->authorize(99) && !$this->club_model->club_authorize(9, $club_id) && !$this->club_model->club_authorize(6, $club_id)) {
+			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
+			redirect('dashboard');
 		}
 
 		if ($this->club_model->delete_member($club_id, $user_id)) {

--- a/application/helpers/club_helper.php
+++ b/application/helpers/club_helper.php
@@ -33,12 +33,12 @@ if (!function_exists('clubaccess_check')) {
                     $user_level = $CI->session->userdata('cd_p_level');
                     $operator_callsign = $CI->session->userdata('operator_callsign');
 
-                    // Enhanced logic for ClubMemberPlus (Level 6)
+                    // Enhanced logic for ClubMemberADIF (Level 6)
                     if ($user_level >= 9) {
                         // Officers can access any QSO
                         return true;
                     } elseif ($user_level >= 6) {
-                        // ClubMemberPlus and regular members can only access their own QSOs
+                        // ClubMemberADIF and regular members can only access their own QSOs
                         return $qso->COL_OPERATOR == $operator_callsign;
                     } else {
                         // Lower levels (shouldn't reach here for ADIF access)

--- a/application/helpers/club_helper.php
+++ b/application/helpers/club_helper.php
@@ -30,9 +30,18 @@ if (!function_exists('clubaccess_check')) {
                     // check if the QSO belongs to the user
                     $CI->load->model('logbook_model');
                     $qso = $CI->logbook_model->get_qso($qso_id)->row();
-                    if ($qso->COL_OPERATOR == $CI->session->userdata('operator_callsign') || $CI->session->userdata('cd_p_level') >= 9) {
+                    $user_level = $CI->session->userdata('cd_p_level');
+                    $operator_callsign = $CI->session->userdata('operator_callsign');
+
+                    // Enhanced logic for ClubMemberPlus (Level 6)
+                    if ($user_level >= 9) {
+                        // Officers can access any QSO
                         return true;
+                    } elseif ($user_level >= 6) {
+                        // ClubMemberPlus and regular members can only access their own QSOs
+                        return $qso->COL_OPERATOR == $operator_callsign;
                     } else {
+                        // Lower levels (shouldn't reach here for ADIF access)
                         return false;
                     }
                 } else {

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -2,7 +2,7 @@
 
 class adif_data extends CI_Model {
 
-	function export_all($api_key = null,$from = null, $to = null, $exportLotw = false) {
+	function export_all($api_key = null,$from = null, $to = null, $exportLotw = false, $onlyop = null) {
 		$this->load->model('logbooks_model');
 		if ($api_key != null) {
 			$this->load->model('api_model');
@@ -24,6 +24,9 @@ class adif_data extends CI_Model {
 		}
 		if ($to) {
 			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= ",$to);
+		}
+		if ($onlyop) {
+			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
 		}
 		if ($exportLotw) {
 			$this->db->group_start();
@@ -76,7 +79,7 @@ class adif_data extends CI_Model {
 		return $query;
 	}
 
-	function sat_all() {
+	function sat_all($onlyop = null) {
 		$this->load->model('stations');
 		$active_station_id = $this->stations->find_active();
 
@@ -84,6 +87,10 @@ class adif_data extends CI_Model {
 		$this->db->from($this->config->item('table_name'));
 		$this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
 		$this->db->where($this->config->item('table_name').'.COL_PROP_MODE', 'SAT');
+
+		if ($onlyop) {
+			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
+		}
 
 		$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 
@@ -93,7 +100,7 @@ class adif_data extends CI_Model {
 		return $this->db->get();
 	}
 
-	function satellte_lotw() {
+	function satellte_lotw($onlyop = null) {
 		$this->load->model('stations');
 		$active_station_id = $this->stations->find_active();
 
@@ -101,6 +108,10 @@ class adif_data extends CI_Model {
 		$this->db->from($this->config->item('table_name'));
 		$this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
 		$this->db->where($this->config->item('table_name').'.COL_PROP_MODE', 'SAT');
+
+		if ($onlyop) {
+			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
+		}
 
 		$where = $this->config->item('table_name').".COL_LOTW_QSLRDATE IS NOT NULL";
 		$this->db->where($where);
@@ -114,7 +125,7 @@ class adif_data extends CI_Model {
 		return $this->db->get();
 	}
 
-	function export_custom($from, $to, $station_id, $exportLotw = false) {
+	function export_custom($from, $to, $station_id, $exportLotw = false, $onlyop = null) {
 		// be sure that station belongs to user
 		$this->load->model('Stations');
 		if ($station_id == 0) {
@@ -135,6 +146,9 @@ class adif_data extends CI_Model {
 			if ($to) {
 				$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= ",$to);
 			}
+			if ($onlyop) {
+				$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
+			}
 			if ($exportLotw) {
 				$this->db->group_start();
 				$this->db->where($this->config->item('table_name').".COL_LOTW_QSL_SENT != 'Y'");
@@ -151,7 +165,7 @@ class adif_data extends CI_Model {
 		}
 	}
 
-	function export_past_id($station_id, $fetchfromid, $limit) {
+	function export_past_id($station_id, $fetchfromid, $limit, $onlyop = null) {
 		//create query
 		$this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
 		$this->db->from($this->config->item('table_name'));
@@ -160,6 +174,9 @@ class adif_data extends CI_Model {
 		$this->db->order_by($this->config->item('table_name').".COL_TIME_ON", "ASC");
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		$this->db->join('dxcc_entities', 'station_profile.station_dxcc = dxcc_entities.adif', 'left outer');
+		if ($onlyop) {
+			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
+		}
 		$this->db->order_by("COL_PRIMARY_KEY", "ASC");
 
 		if ($limit > -1) {
@@ -170,7 +187,7 @@ class adif_data extends CI_Model {
 		return $this->db->get();
 	}
 
-	function export_lotw() {
+	function export_lotw($onlyop = null) {
 		$this->load->model('stations');
 		$active_station_id = $this->stations->find_active();
 
@@ -178,6 +195,9 @@ class adif_data extends CI_Model {
 		$this->db->select(''.$this->config->item('table_name').'.*, station_profile.*, dxcc_entities.name as station_country');
 		$this->db->from($this->config->item('table_name'));
 		$this->db->where($this->config->item('table_name').'.station_id', $active_station_id);
+		if ($onlyop) {
+			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
+		}
 		$this->db->group_start();
 		$this->db->where($this->config->item('table_name').".COL_LOTW_QSL_SENT != 'Y'");
 		$this->db->or_where($this->config->item('table_name').".COL_LOTW_QSL_SENT", NULL);

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -11,58 +11,84 @@
     <div class="card">
         <div class="card-header">
             <ul class="nav nav-tabs card-header-tabs pull-right" role="tablist">
+                <?php
+                // Define all available tabs
+                $all_tabs = ['import', 'export', 'lotw', 'dcl', 'pota', 'cbr'];
+
+                // Use allowed_tabs if set, otherwise show all tabs
+                $tabs_to_show = isset($allowed_tabs) ? $allowed_tabs : $all_tabs;
+                ?>
+
+                <?php if (in_array('import', $tabs_to_show)): ?>
                 <li class="nav-item">
                     <a class="nav-link <?php if ($showtab == '' || $showtab == 'adif') {
-                                            echo 'active';
-                                        } ?>" id="import-tab" data-bs-toggle="tab" href="#import" role="tab" aria-controls="import" aria-selected="<?php if ($showtab == '' || $showtab == 'adif') {
-                                                                                                                                                        echo 'true';
-                                                                                                                                                    } else {
-                                                                                                                                                        echo 'false';
-                                                                                                                                                    } ?>"><?= __("ADIF Import") ?></a>
+                                                    echo 'active';
+                                                } ?>" id="import-tab" data-bs-toggle="tab" href="#import" role="tab" aria-controls="import" aria-selected="<?php if ($showtab == '' || $showtab == 'adif') {
+                                                                                                echo 'true';
+                                                                                            } else {
+                                                                                                echo 'false';
+                                                                                            } ?>"><?= __("ADIF Import") ?></a>
                 </li>
+                <?php endif; ?>
+
+                <?php if (in_array('export', $tabs_to_show)): ?>
                 <li class="nav-item">
                     <a class="nav-link" id="export-tab" data-bs-toggle="tab" href="#export" role="tab" aria-controls="export" aria-selected="false"><?= __("ADIF Export") ?></a>
                 </li>
+                <?php endif; ?>
+
+                <?php if (in_array('lotw', $tabs_to_show)): ?>
                 <li class="nav-item">
                     <a class="nav-link" id="lotw-tab" data-bs-toggle="tab" href="#lotw" role="tab" aria-controls="lotw" aria-selected="false"><?= __("Logbook of the World") ?></a>
                 </li>
+                <?php endif; ?>
+
+                <?php if (in_array('dcl', $tabs_to_show)): ?>
                 <li class="nav-item">
                     <a class="nav-link <?php if ($showtab == 'dcl') {
-                                            echo 'active';
-                                        } ?>" id="dcl-tab" data-bs-toggle="tab" href="#dcl" role="tab" aria-controls="dcl" aria-selected="<?php if ($showtab == 'dcl') {
-                                                                                                                                                echo 'true';
-                                                                                                                                            } else {
-                                                                                                                                                echo 'false';
-                                                                                                                                            } ?>"><?= __("DARC DCL") ?></a>
+                                                    echo 'active';
+                                                } ?>" id="dcl-tab" data-bs-toggle="tab" href="#dcl" role="tab" aria-controls="dcl" aria-selected="<?php if ($showtab == 'dcl') {
+                                                                                                        echo 'true';
+                                                                                                    } else {
+                                                                                                        echo 'false';
+                                                                                                    } ?>"><?= __("DARC DCL") ?></a>
                 </li>
+                <?php endif; ?>
+
+                <?php if (in_array('pota', $tabs_to_show)): ?>
                 <li class="nav-item">
                     <a class="nav-link <?php if ($showtab == 'potab') {
-                                            echo 'active';
-                                        } ?>" id="potab-tab" data-bs-toggle="tab" href="#potab" role="tab" aria-controls="potab" aria-selected="<?php if ($showtab == 'potab') {
-                                                                                                                                                echo 'true';
-                                                                                                                                            } else {
-                                                                                                                                                echo 'false';
-                                                                                                                                            } ?>"><?= __("POTA") ?></a>
+                                                    echo 'active';
+                                                } ?>" id="potab-tab" data-bs-toggle="tab" href="#potab" role="tab" aria-controls="potab" aria-selected="<?php if ($showtab == 'potab') {
+                                                                                                        echo 'true';
+                                                                                                    } else {
+                                                                                                        echo 'false';
+                                                                                                    } ?>"><?= __("POTA") ?></a>
                 </li>
+                <?php endif; ?>
+
+                <?php if (in_array('cbr', $tabs_to_show)): ?>
                 <li class="nav-item">
                     <a class="nav-link <?php if ($showtab == 'cbr') {
-                                            echo 'active';
-                                        } ?>" id="cbr-tab" data-bs-toggle="tab" href="#cbr" role="tab" aria-controls="cbr" aria-selected="<?php if ($showtab == 'cbr') {
-                                                                                                                                                echo 'true';
-                                                                                                                                            } else {
-                                                                                                                                                echo 'false';
-                                                                                                                                            } ?>"><?= __("CBR Import") ?></a>
+                                                    echo 'active';
+                                                } ?>" id="cbr-tab" data-bs-toggle="tab" href="#cbr" role="tab" aria-controls="cbr" aria-selected="<?php if ($showtab == 'cbr') {
+                                                                                                        echo 'true';
+                                                                                                    } else {
+                                                                                                        echo 'false';
+                                                                                                    } ?>"><?= __("CBR Import") ?></a>
                 </li>
+                <?php endif; ?>
             </ul>
         </div>
 
         <div class="card-body">
             <div class="tab-content">
+                <?php if (in_array('import', $tabs_to_show)): ?>
                 <div class="tab-pane <?php if ($showtab == '' || $showtab == 'adif') {
-                                            echo 'active';
-                                        } else {
-                                            echo 'fade';
-                                        } ?>" id="import" role="tabpanel" aria-labelledby="import-tab">
+                                                    echo 'active';
+                                                } else {
+                                                    echo 'fade';
+                                                } ?>" id="import" role="tabpanel" aria-labelledby="import-tab">
 
                     <?php if (isset($error) && ($showtab == '' || $showtab == 'adif')) { ?>
                         <div class="alert alert-danger" role="alert">
@@ -221,7 +247,9 @@
                         <button id="prepare_sub" class="btn btn-sm btn-primary mb-2 ld-ext-right" value="Upload"><?= __("Upload") ?><div class="ld ld-ring ld-spin"></div></button>
                     </form>
                 </div>
+                <?php endif; ?>
 
+                <?php if (in_array('export', $tabs_to_show)): ?>
                 <div class="tab-pane fade" id="export" role="tabpanel" aria-labelledby="export-tab">
 
                     <form class="form" action="<?php echo site_url('adif/export_custom'); ?>" method="post" enctype="multipart/form-data">
@@ -298,7 +326,9 @@
 
                     <p><a href="<?php echo site_url('adif/exportsatlotw'); ?>" title="Export All Satellite QSOs Confirmed on LoTW" target="_blank" class="btn btn-sm btn-primary"><?= __("Export All Satellite QSOs Confirmed on LoTW") ?></a></p>
                 </div>
+                <?php endif; ?>
 
+                <?php if (in_array('lotw', $tabs_to_show)): ?>
                 <div class="tab-pane fade" id="lotw" role="tabpanel" aria-labelledby="lotw-tab">
                     <form class="form" action="<?php echo site_url('adif/mark_lotw'); ?>" method="post" enctype="multipart/form-data">
                         <select name="station_profile" class="form-select mb-2 me-sm-2 w-50 w-lg-100">
@@ -318,12 +348,14 @@
                         <button type="button" class="btn btn-sm btn-primary" id="markExportedToLotw" value="Export"><?= __("Mark QSOs as exported to LoTW") ?></button>
                     </form>
                 </div>
+                <?php endif; ?>
 
+                <?php if (in_array('dcl', $tabs_to_show)): ?>
                 <div class="tab-pane <?php if ($showtab == 'dcl') {
-                                            echo 'active';
-                                        } else {
-                                            echo 'fade';
-                                        } ?>" id="dcl" role="tabpanel" aria-labelledby="dcl-tab">
+                                                    echo 'active';
+                                                } else {
+                                                    echo 'fade';
+                                                } ?>" id="dcl" role="tabpanel" aria-labelledby="dcl-tab">
                     <?php if (isset($error) && $showtab == 'dcl') { ?>
                         <div class="alert alert-danger" role="alert">
                             <?php echo $error; ?>
@@ -364,12 +396,14 @@
                         <button type="submit" class="btn btn-sm btn-primary mb-2" value="Upload"><?= __("Upload") ?></button>
                     </form>
                 </div>
+                <?php endif; ?>
 
+                <?php if (in_array('pota', $tabs_to_show)): ?>
                 <div class="tab-pane <?php if ($showtab == 'potab') {
-                                            echo 'active';
-                                        } else {
-                                            echo 'fade';
-                                        } ?>" id="potab" role="tabpanel" aria-labelledby="potab-tab">
+                                                    echo 'active';
+                                                } else {
+                                                    echo 'fade';
+                                                } ?>" id="potab" role="tabpanel" aria-labelledby="potab-tab">
                     <?php if (isset($error) && $showtab == 'potab') { ?>
                         <div class="alert alert-danger" role="alert">
                             <?php echo $error; ?>
@@ -384,7 +418,9 @@
                         <button type="submit" class="btn btn-sm btn-primary mb-2" value="Upload"><?= __("Upload") ?></button>
                     </form>
                 </div>
+                <?php endif; ?>
 
+                <?php if (in_array('cbr', $tabs_to_show)): ?>
                 <div class="tab-pane <?php if ($showtab == 'cbr') {
                                             echo 'active';
                                         } else {
@@ -426,6 +462,7 @@
                         <button type="submit" class="btn btn-sm btn-primary mb-2" value="Upload"><?= __("Upload") ?></button>
                     </form>
                 </div>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -169,7 +169,7 @@
 										<div class="small form-text text-muted"><?= sprintf(__("If selected, Wavelog will try to import %sall%s QSOs from the ADIF, regardless if they match to the chosen station-location."), '<b>', '</b>'); ?></div>
 									</div>
 
-								<?php if ($show_operator_question) { ?>
+								<?php if (($show_operator_question) && ($cd_p_level != 6)){ ?>
 										<div class="col-md-6">
 											<div class="form-check-inline">
 												<input class="form-check-input" type="checkbox" name="operatorName" value="1" id="operatorName">
@@ -181,6 +181,7 @@
 							</div>
 						</div>
 
+						<?php if ($cd_p_level != 6) { ?>
 						<div class="card mb-3">
 							<div class="card-header">
 								<h6 class="mb-0"><?= __("Mark QSOs as uploaded (This does NOT upload QSOs to these services!)") ?></h6>
@@ -242,6 +243,7 @@
 								<button type="button" class="btn mb-2 btn-sm btn-success" onclick="toggleAll(this)"><?= __("Toggle all checkboxes") ?></button>
 							</div>
 						</div>
+						<?php } ?>
 
 
                         <button id="prepare_sub" class="btn btn-sm btn-primary mb-2 ld-ext-right" value="Upload"><?= __("Upload") ?><div class="ld ld-ring ld-spin"></div></button>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -297,6 +297,7 @@
 								<h6 class="mb-0"><?= __("Export options") ?></h6>
 							</div>
 							<div class="card-body">
+                						<?php if (in_array('lotw', $tabs_to_show)) {?>
 								<div class="mb-3 row">
 									<div class="col-md-10">
 										<div class="form-check-inline">
@@ -305,6 +306,7 @@
 										</div>
 									</div>
 								</div>
+								<?php } ?>
 								<div class="mb-3 row">
 									<div class="col-md-10">
 										<div class="form-check-inline">

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -161,6 +161,7 @@
 								</div>
 
 								<div class="mb-3 row">
+								<?php if ($cd_p_level != 6){ ?>
 									<div class="col-md-6">
 										<div class="form-check-inline">
 											<input class="form-check-input" type="checkbox" name="skipStationCheck" value="1" id="skipStationCheck">
@@ -169,7 +170,7 @@
 										<div class="small form-text text-muted"><?= sprintf(__("If selected, Wavelog will try to import %sall%s QSOs from the ADIF, regardless if they match to the chosen station-location."), '<b>', '</b>'); ?></div>
 									</div>
 
-								<?php if (($show_operator_question) && ($cd_p_level != 6)){ ?>
+								<?php } if (($show_operator_question) && ($cd_p_level != 6)){ ?>
 										<div class="col-md-6">
 											<div class="form-check-inline">
 												<input class="form-check-input" type="checkbox" name="operatorName" value="1" id="operatorName">

--- a/application/views/club/permissions.php
+++ b/application/views/club/permissions.php
@@ -185,6 +185,7 @@
                                                 <td>
                                                     <select class="form-select" id="permission" name="permission" required>
                                                         <option value="3"><?php echo $permissions[3]; ?></option>
+                                                        <option value="6"><?php echo $permissions[6]; ?></option>
                                                         <option value="9"><?php echo $permissions[9]; ?></option>
                                                     </select>
                                                     <div class="mt-2 form-check d-flex justify-content-end text-muted">

--- a/application/views/club/permissions.php
+++ b/application/views/club/permissions.php
@@ -237,6 +237,8 @@
                                     <td style="text-align: center; vertical-align: middle;">
                                         <?php if ($member->p_level == 3) { ?>
                                             <span class="badge bg-info"><?php echo $permissions[3]; ?></span>
+                                        <?php } else if ($member->p_level == 6) { ?>
+                                            <span class="badge bg-success"><?php echo $permissions[6]; ?></span>
                                         <?php } else if ($member->p_level == 9) { ?>
                                             <span class="badge bg-warning"><?php echo $permissions[9]; ?></span>
                                         <?php } ?>
@@ -277,6 +279,7 @@
                                                                             <td>
                                                                                 <select class="form-select" id="permission" name="permission" required>
                                                                                     <option value="3" <?php if ($member->p_level == 3) { echo 'selected'; } ?>><?php echo $permissions[3]; ?></option>
+                                                                                    <option value="6" <?php if ($member->p_level == 6) { echo 'selected'; } ?>><?php echo $permissions[6]; ?></option>
                                                                                     <option value="9" <?php if ($member->p_level == 9) { echo 'selected'; } ?>><?php echo $permissions[9]; ?></option>
                                                                                 </select>
                                                                                 <div class="mt-2 form-check d-flex justify-content-end text-muted">

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -464,7 +464,9 @@
 
 								<div class="dropdown-divider"></div>
 
+								<?php } if (clubaccess_check(6) || clubaccess_check(9)) { ?> <!-- Club Access Check -->
 								<li><a class="dropdown-item" href="<?php echo site_url('adif'); ?>" title="Amateur Data Interchange Format (ADIF) import / export"><i class="fas fa-sync"></i> <?= __("ADIF Import / Export"); ?></a></li>
+								<?php } if (clubaccess_check(9)) { ?> <!-- Club Access Check -->
 
 								<li><a class="dropdown-item dropdown-toggle dropdown-toggle-submenu" data-bs-toggle="dropdown"><i class="fas fa-sync"></i> <?= __("Other Export Options"); ?></a>
 									<ul class="submenu submenu-left dropdown-menu">


### PR DESCRIPTION
Introduce a new Role "Clubmember ADIF" (Clublevel 6) which is allowed to import ADIFS (for their own Call) and Export ADIFS (from their own Call / they made)

- [x] Introduce new role
- [x] Refactor ADIF-Views and Controller for more granular permission-management
- [x] Check Imported ADIF in case of Clubmember ADIF uploaded it. // If Clubmember ADIF uploads the OP-Call is strictly overwritten with the one from the Operator.
- [x] Export only QSOs from Operator
- [-] ~Adjust LBA in similar way.~ // Will be done in extra-PR just for LBA by @AndreasK79 

Testhints:
- Edit Clubstation, set new permission ("Clubmember ADIF")
- Test ADIF Functionality (everything below adif-menu) for normal user and admin.
- Test ADIF Functionality (everything below adif-menu) for ClubOfficer on Clubstation.
- Test ADIF Functionality (everything below adif-menu) for ClubMember on Clubstation.
- Test ADIF Functionality (everything below adif-menu) for ClubMember ADIF on Clubstation

Expected outcome:

- Normal User and Admin: As b4
- ClubMember: as b4 - no export via ADIF-Menu (ADIF Menu-entry not even visible)
- ClubMember ADIF: ADIF Menu visible.
  * Import: All ADIF Entries imported are strictly overwritten with Operators Call. No option to mark ADIF as already sent to 3rd party services, since OP != Owner of the call.
  * Export: Only QSOs the OP made will be exported. no "Mark exported QSOs as exported to LoTW"
 - Club Officer: As b4