### PR TITLE
Fix code to show the active logbook

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -2395,9 +2395,7 @@ class Awards extends CI_Controller {
 		$this->load->model('logbooks_model');
 		$this->load->model('stations');
 
-		// Get station profiles for multiselect
-		$data['station_profile'] = $this->stations->all_of_user();
-		$data['active_station_id'] = $this->session->userdata('active_station_logbook');
+		$data['active_station_logbook'] = $this->logbooks_model->find_name($this->session->userdata('active_station_logbook'));
 
 		$this->load->model('award_pl_polska');
 		$this->load->model('bands');

--- a/application/views/awards/pl_polska/index.php
+++ b/application/views/awards/pl_polska/index.php
@@ -51,20 +51,9 @@
         <fieldset>
 
         <div class="mb-3 row">
-            <label class="col-md-2 control-label"><?= __("Station Location"); ?></label>
+            <label class="col-md-2 control-label"><?= __("Station Logbook"); ?></label>
             <div class="col-md-10">
-                <?php
-                $active_station = null;
-                foreach ($station_profile->result() as $station) {
-                    if ($station->station_id == $active_station_id) {
-                        $active_station = $station;
-                        break;
-                    }
-                }
-                if ($active_station) {
-                    echo '<span class="badge text-bg-info">' . htmlspecialchars($active_station->station_profile_name) . '</span>';
-                }
-                ?>
+            <span class="badge text-bg-info"><?= htmlspecialchars($active_station_logbook); ?></span>
             </div>
         </div>
 


### PR DESCRIPTION
The Polska Awards page shows false information regarding station location. Locations and Logbooks where mixed up here:

<img width="1277" height="378" alt="image" src="https://github.com/user-attachments/assets/9040f4a1-f3cc-4f35-80cd-d5db8d89155c" />

As the code uses the active station logbook we changed the description and fixed the code to fetch the name of the active logbook.