### PR TITLE
Catch error for calling a deleted qso

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -660,26 +660,28 @@ class Logbook extends CI_Controller {
 
 		$this->load->model('logbook_model');
 		$data['query'] = $this->logbook_model->get_qso($id);
-		$data['dxccFlag'] = $this->dxccflag->get($data['query']->result()[0]->COL_DXCC);
+		if ($data['query']) {	// QSO not found // Skip fetching details
+			$data['dxccFlag'] = $this->dxccflag->get($data['query']->result()[0]->COL_DXCC);
 
-		// Check for note for this callsign and current user
-		$callsign = $data['query']->result()[0]->COL_CALL;
-		$user_id = $this->session->userdata('user_id');
-		$this->load->model('note');
-		$data['contacts_note_id'] = $this->note->get_note_id_by_category($user_id, 'Contacts', $callsign);
+			// Check for note for this callsign and current user
+			$callsign = $data['query']->result()[0]->COL_CALL;
+			$user_id = $this->session->userdata('user_id');
+			$this->load->model('note');
+			$data['contacts_note_id'] = $this->note->get_note_id_by_category($user_id, 'Contacts', $callsign);
 
-		if ($this->session->userdata('user_measurement_base') == NULL) {
-			$data['measurement_base'] = $this->config->item('measurement_base');
-		}
-		else {
-			$data['measurement_base'] = $this->session->userdata('user_measurement_base');
-		}
+			if ($this->session->userdata('user_measurement_base') == NULL) {
+				$data['measurement_base'] = $this->config->item('measurement_base');
+			}
+			else {
+				$data['measurement_base'] = $this->session->userdata('user_measurement_base');
+			}
 
-		$this->load->model('Qsl_model');
-		$data['qslimages'] = $this->Qsl_model->getQslForQsoId($id);
-		$data['primary_subdivision'] = $this->subdivisions->get_primary_subdivision_name($data['query']->result()[0]->COL_DXCC);
-		$data['secondary_subdivision'] = $this->subdivisions->get_secondary_subdivision_name($data['query']->result()[0]->COL_DXCC);
-		$data['max_upload'] = ini_get('upload_max_filesize');
+			$this->load->model('Qsl_model');
+			$data['qslimages'] = $this->Qsl_model->getQslForQsoId($id);
+			$data['primary_subdivision'] = $this->subdivisions->get_primary_subdivision_name($data['query']->result()[0]->COL_DXCC);
+			$data['secondary_subdivision'] = $this->subdivisions->get_secondary_subdivision_name($data['query']->result()[0]->COL_DXCC);
+			$data['max_upload'] = ini_get('upload_max_filesize');
+		} 
 		$this->load->view('interface_assets/mini_header', $data);
 		$this->load->view('view_log/qso');
 		$this->load->view('interface_assets/footer');

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -1,4 +1,4 @@
-<?php if ($query->num_rows() > 0) {  foreach ($query->result() as $row) { ?>
+<?php if ($query && ($query->num_rows() > 0)) {  foreach ($query->result() as $row) { ?>
 <div class="container-fluid">
 
     <ul style="margin-bottom: 10px;" class="nav nav-tabs" id="myTab" role="tablist">
@@ -911,4 +911,8 @@ var callsign = "<?php echo $row->COL_CALL; ?>";
     <div hidden id ='callsign'><?php echo $row->COL_CALL; ?></div>
     <div hidden id ='qsoid'><?php echo $row->COL_PRIMARY_KEY; ?></div>
 
-<?php } } ?>
+<?php }
+	} else {
+		echo __("QSO not found");
+	}
+?>


### PR DESCRIPTION
# Scenario:
Two tabs.
- One with Overview/Dashboard/LBA (something where one can click on a made QSO)
- Second tab: Delete a QSO

After deletion go back to Overview/Dashboard/LBA and click on the previous removed QSO. Results in a 500.
This patch fixes it, and shows a message "QSO not found" instead.