### PR TITLE
Fix a Error 500 on saving SFLE-QSOs

### DIFF
--- a/application/controllers/Simplefle.php
+++ b/application/controllers/Simplefle.php
@@ -82,7 +82,7 @@ class SimpleFLE extends CI_Controller {
 		$this->load->model('logbook_model');
 
 		$qsos = json_decode($qsos, true);
-		$station_id = $qsos[0]['station_id']; // we can trust this value
+		$station_id = $qsos[0]['station_id']; // we can trust this value, but only because it's checked at bulk-import!
 
 		$result = $this->logbook_model->import_bulk($qsos, $station_id);
 		$bulk_result = $result['errormessage'];

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4560,7 +4560,8 @@ class Logbook_model extends CI_Model {
 		$amsat_qsos = [];
 		$today = time();
 		if (!$this->stations->check_station_is_accessible($station_id) && $apicall == false) {
-			return 'Station not accessible<br>';
+			$custom_errors['errormessage'] = 'Station not accessible<br>';
+			return $custom_errors;
 		}
 		$station_id_ok = true;
 		$station_profile = $this->stations->profile_clean($station_id);


### PR DESCRIPTION
# Situation:
- Open a SFLE Tab
- Switch inanother tab to Clubstation
- Try logging your SFLE-QSOs from 1st tab with a personal-station-id (or a faked one - js-injection)

# Error
- Results in a 500

# Patch
- Mitigates it, and shows at least "Station location inaccesible"