### PR TITLE
Fix club edit

### DIFF
--- a/application/helpers/club_helper.php
+++ b/application/helpers/club_helper.php
@@ -37,7 +37,7 @@ if (!function_exists('clubaccess_check')) {
                     if ($user_level >= 9) {
                         // Officers can access any QSO
                         return true;
-                    } elseif ($user_level >= 6) {
+                    } elseif ($user_level >= $required_level) {
                         // ClubMemberADIF and regular members can only access their own QSOs
                         return $qso->COL_OPERATOR == $operator_callsign;
                     } else {


### PR DESCRIPTION
Accidently built in a bug with the new Role, where even a normal clubmember wasn't able to edit his own QSOs.

Testing Hints:
- Log in as a normal User, which is granted for a clubstation (incognito session / real clubmember-user, no impersonante)
- Switch to Clubstation into the clubstation and log a QSO.
- Try to edit it

without patch: no way

with patch: possible (because OP is the same)