### PR TITLE
Fixes an issue, when a spot doesn't contain continent

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2791,13 +2791,13 @@ class Logbook_model extends CI_Model {
 
 		foreach ($spots as $spot) {
 			// Validate spot has required properties (must be non-empty)
-			if (empty($spot->spotted) || empty($spot->dxcc_spotted->dxcc_id) || empty($spot->dxcc_spotted->cont) || empty($spot->band) || empty($spot->mode)) {
+			if (empty($spot->spotted) || empty($spot->dxcc_spotted->dxcc_id) || empty($spot->band) || empty($spot->mode)) {
 				continue;
 			}
 
 			$callsign = $spot->spotted;
 			$dxcc = $spot->dxcc_spotted->dxcc_id;
-			$cont = $spot->dxcc_spotted->cont;
+			$cont = $spot->dxcc_spotted->cont ?? '';
 
 			// Collect unique callsigns/dxccs/continents - query once per unique value
 			$callsigns[$callsign] = true;


### PR DESCRIPTION
if a spot doesn't contain a continent (derived at dxcacheAPI), it's completly skipped for worked/cnf-lookup.
This Quickfix mitigates it at Wavelog, even if root-cause is the DXClusteAPI (no Cont).

But even with a fix at DXClusterAPI a maritime-mobile spot would also have no Continent.

So this fix makes the cluster more resilient against such "strange" spots