### PR TITLE
Fix Time-Off Bug when logging manual

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -57,7 +57,12 @@ class Logbook_model extends CI_Model {
 				$end_datetime_obj = DateTime::createFromFormat("$date_format H:i:s", "$start_date $end_time");
 
 				if ($end_datetime_obj === false) {
-					$datetime_off = $datetime;
+					$end_datetime_obj = DateTime::createFromFormat("$date_format H:i", "$start_date $end_time");	// Try converting as H:i if H:i:s failed b4
+					if ($end_datetime_obj === false) {
+						$datetime_off = $datetime; // No Luck? Than end = start
+					} else {
+						$datetime_off = $end_datetime_obj->format('Y-m-d H:i:s');
+					}
 				} else {
 					// If time-off is before time-on and hour is 00 → add 1 day
 					if ($end_datetime_obj < $datetime_obj && str_starts_with($end_time, "00")) {


### PR DESCRIPTION
Try logging a QSO with Post-QSO and Enter a different End-Time than start-time (e.g.: 11:50 till 12:00).
it's always saved with 11:50 for both timestamps.

Reason:
create_qso expects format H:i:s and not H:i (as posted from form).

This patch fixes it by adding a second iteration.
1st iteration: Try to parse H:i:s end-date
2nd iteration: Try to parse H:i end-date (if 1st iteration failed)
3rd iteration: Take start_time if 1 and 2 failed