### PR TITLE
Show stationlist for ClubMembers

### DIFF
--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -7,15 +7,15 @@
 class Station extends CI_Controller
 {
 
-	function __construct()
-	{
+	function __construct() {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
 		$this->load->model('user_model');
-		if (!$this->user_model->authorize(2)) {
-			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
-			redirect('dashboard');
+		if (($this->router->method == 'stationProfileCoords') && $this->user_model->authorize(2) && ((clubaccess_check(3) || clubaccess_check(6)))) { return; }	// Allow Clubmembers and Clubmembers ADIF to access list_locations
+		if (!$this->user_model->authorize(2) || !clubaccess_check(9)) { 
+			$this->session->set_flashdata('error', __("You're not allowed to do that!")); 
+			redirect('dashboard'); 
 		}
 	}
 

--- a/application/controllers/Stationsetup.php
+++ b/application/controllers/Stationsetup.php
@@ -12,6 +12,7 @@ class Stationsetup extends CI_Controller {
 		$this->load->helper(array('form', 'url'));
 
 		$this->load->model('user_model');
+		if (($this->router->method == 'list_locations') && $this->user_model->authorize(2) && ((clubaccess_check(3) || clubaccess_check(6)))) { return; }	// Allow Clubmembers and Clubmembers ADIF to access list_locations
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
@@ -524,6 +525,7 @@ class Stationsetup extends CI_Controller {
 		$this->load->model('stationsetup_model');
 		$data['locations'] = $this->stationsetup_model->list_all_locations();
 		$data['page_title'] = __("Station location list");
+		$data['cd_p_level'] = ($this->session->userdata('cd_p_level') ?? 0);
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('stationsetup/locationlist');
 		$this->load->view('interface_assets/footer');

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -470,6 +470,8 @@
 
 								<div class="dropdown-divider"></div>
 
+								<?php } if ((clubaccess_check(3) || clubaccess_check(3)) && !(clubaccess_check(9))) { ?> <!-- Club Access Check -->
+								<li><a class="dropdown-item" href="<?php echo site_url('stationsetup/list_locations'); ?>" title="Manage station setup"><i class="fas fa-home"></i> <?= __("Station Setup"); ?></a></li>
 								<?php } if (clubaccess_check(6) || clubaccess_check(9)) { ?> <!-- Club Access Check -->
 								<li><a class="dropdown-item" href="<?php echo site_url('adif'); ?>" title="Amateur Data Interchange Format (ADIF) import / export"><i class="fas fa-sync"></i> <?= __("ADIF Import / Export"); ?></a></li>
 								<?php } if (clubaccess_check(9)) { ?> <!-- Club Access Check -->

--- a/application/views/stationsetup/locationlist.php
+++ b/application/views/stationsetup/locationlist.php
@@ -116,6 +116,7 @@
 						$(node).removeClass('dt-button').addClass('btn btn-primary');
 					}
 				},
+				<?php if (!($cd_p_level == 3) && !($cd_p_level == 6)) { // ClubOfficer (9) and normal User can import, while ClubOfficer (ADIF) (3,6) can only see. ?>
 				{
 				text: 'Import Locations',
 				className: 'mb-1 btn btn-sm btn-primary',
@@ -158,6 +159,7 @@
 					$(node).removeClass('dt-button').addClass('btn btn-primary');
 				}
 			}
+			<?php } ?>
 
 			]
 		});

--- a/application/views/stationsetup/locationlist.php
+++ b/application/views/stationsetup/locationlist.php
@@ -45,7 +45,11 @@
                             <td><?php echo $loc->station_id; ?></td>
                             <td><?php echo $loc->station_active ? 'Yes' : 'No' ?></td>
                             <td><?php echo $loc->qso_total; ?></td>
+			<?php if (!($cd_p_level == 3) && !($cd_p_level == 6)) { // ClubOfficer (9) and normal User can click on a link, while ClubOfficer (ADIF) (3,6) can only see. ?>
                             <td><a href="<?php echo site_url('station/edit')."/".$loc->station_id; ?>"><?php echo $loc->station_profile_name; ?></a></td>
+			<?php } else { ?>
+                            <td><?php echo $loc->station_profile_name; ?></td>
+			<?php } ?>
                             <td><?php echo $loc->station_callsign; ?></td>
                             <td><?php echo $loc->station_gridsquare; ?></td>
                             <td><?php echo $loc->station_city; ?></td>


### PR DESCRIPTION
Problem:

Clubmembers are not able to see valid station_ids for the clubstation they're granted for (except API).

Solution:
Show Stationlist (List only) for Clubmember and Clubmember ADIF without "import function".

Test:
Create a User, grant it to:
a) Clubmember
b) Clubmember ADIF
c) ClubOfficer

"Impersonate" to ClubStation with those three Users, and test:
- User a and b should see "Station Setup" (Since it shows the Setup) in their Usermenu. Page is only the List without Import-Function
- User c should see "Station Setup" as well, but in a normal manner.
- Adminuser should see/do everything as before