### PR TITLE
Handle tags properly

### DIFF
--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -472,7 +472,7 @@
                                     <td><?= __("Tag"); ?></td>
                                     <td>
                                         <?php if ($commitHash != "") { ?>
-                                            <a target="_blank" href="https://github.com/wavelog/wavelog/releases/tag/<?php echo substr($tag, 0, strpos($tag, '-')); ?>"><span class="badge text-bg-success"><?php echo $tag; ?></span></a>
+                                            <a target="_blank" href="https://github.com/wavelog/wavelog/releases/tag/<?php echo strpos($tag, '-') ? substr($tag, 0, strpos($tag, '-')) : $tag; ?>"><span class="badge text-bg-success"><?php echo $tag; ?></span></a>
                                         <?php } else { ?>
                                             <span class="badge text-bg-danger"><?= __("n/a"); ?></span>
                                         <?php } ?>


### PR DESCRIPTION
Tags without additional modified info are not parsed properly and thus the link shown is broken (missing the tag).

<img width="861" height="234" alt="image" src="https://github.com/user-attachments/assets/575b36c5-4a31-475e-9c00-452dc0e26dee" />
