### PR TITLE
Remove dangerous function

### DIFF
--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -67,14 +67,6 @@ class Options extends CI_Controller {
 				$this->session->set_flashdata('success', __("Options saved"));
 			}
 
-			// Update theme choice within the options system
-			$search_update_status = $this->optionslib->update('global_search', $this->input->post('globalSearch'));
-
-			// If theme update is complete set a flashsession with a success note
-			if($search_update_status == TRUE) {
-				$this->session->set_flashdata('success', __("Options saved"));
-			}
-
 			// Update logbook map within the options system
 			$logbook_map_update_status = $this->optionslib->update('logbook_map', $this->input->post('logbookMap'), 'yes');
 

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -7,10 +7,8 @@ class Search extends CI_Controller {
 		parent::__construct();
 
 		$this->load->helper(array('form', 'url'));
-		if($this->optionslib->get_option('global_search') != "true") {
-			$this->load->model('user_model');
-			if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
-		}
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
 	public function index() {

--- a/application/views/options/appearance.php
+++ b/application/views/options/appearance.php
@@ -51,12 +51,6 @@
                             <small id="themeHelp" class="form-text text-muted"><?= __("Global Theme Choice, this is used when users arent logged in."); ?></small>
                         </div>
 
-
-                            <select class="form-select" id="globalSearch" name="globalSearch" style="display: none;">
-                                <option value='true' <?php if($this->optionslib->get_option('global_search') == "true") { echo "selected=\"selected\""; } ?>><?= __("Enabled"); ?></option>
-                                <option value='false' <?php if($this->optionslib->get_option('global_search') == "false") { echo "selected=\"selected\""; } ?>><?= __("Disabled"); ?></option>
-                            </select>
-
                         <div class="mb-3">
                             <label for="logbookMap"><?= __("Logbook Map"); ?></label>
                             <select class="form-select" id="logbookMap" name="logbookMap" aria-describedby="logbookMapHelp" required>


### PR DESCRIPTION
This one removes a dangerous (and `display:none`) setting, which enables bypassing full-login-check for the Search-Controller.

Since its disabled (invisible) it was never really used. But it's dangerous because if someone sets it, the whole search-controller is unprotected!