### PR TITLE
Check Club-Keys more carefully on API

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -224,6 +224,7 @@ class API extends CI_Controller {
 		$this->load->model('api_model');
 
 		$this->load->model('stations');
+		$this->load->model('club_model');
 
 		if (!$this->load->is_loaded('Qra')) {
 			$this->load->library('Qra');
@@ -252,6 +253,7 @@ class API extends CI_Controller {
 
 		$userid = $this->api_model->key_userid($obj['key']);
 		$created_by = $this->api_model->key_created_by($obj['key']);
+		$club_perm = $this->club_model->get_permission_noui($userid,$created_by);
 
 		/**
 		 * As the API key user could use it also for clubstations we need to do an additional check here. Only if clubstations are enabled
@@ -260,12 +262,11 @@ class API extends CI_Controller {
 		 * If the user is not the creator of the API key, it's likely a clubstation. In this case the callsign of the clubstation
 		 * can not be the same as the callsign of the user (operator call provided by the user). If this is the case, we need to use the callsign of the creator of the API key
 		 */
-		$real_operator = null;
+		$real_operator = null;	// real_operator is only filled if its a clubstation and the used key is created by an OP. otherwise its null
 		if ($this->config->item('special_callsign')) {
 			if ($userid != $created_by) {
 				$this->load->model('user_model');
 				$real_operator = $this->user_model->get_by_id($created_by)->row()->user_callsign;
-				// TODO: It would be possible to check here if operator is allowed to use the clubstation, but this can be added later if needed
 			} else {
 				$real_operator = null;
 			}
@@ -324,6 +325,11 @@ class API extends CI_Controller {
 					// in case the provided op call is the same as the clubstation callsign, we need to use the creator of the API key as the operator
 					$recorded_operator = $record['operator'] ?? '';
 					if (key_exists('operator',$record) && $real_operator != null && ($record['operator'] == $record['station_callsign']) || ($recorded_operator == '')) {
+						$record['operator'] = $real_operator;
+					}
+
+					// in case the caller is an OP for a clubstation (real_operator is filled - see above) and the OP only has level 3 or 6 - take the OP from real_operator!
+					if ($real_operator != null && ((($club_perm ?? 0) == 3) || (($club_perm ?? 0) == 6))) {
 						$record['operator'] = $real_operator;
 					}
 

--- a/application/models/Club_model.php
+++ b/application/models/Club_model.php
@@ -57,6 +57,38 @@ class Club_model extends CI_Model {
     }
 
     /**
+     * Get Permissionlevel for User in Club in a real model-way without UI
+     * 
+     * @param int $club_id
+     * @param int $user_id
+     * 
+     * @return int
+     */
+    function get_permission_noui($club_id, $user_id) {
+
+        if ($club_id == 0 || !is_numeric($club_id)) {
+		return 0;
+        }
+
+        if ($user_id == 0 || !is_numeric($user_id)) {
+		return 0;
+        }
+
+        $binding = [];
+        $sql = 'SELECT p_level FROM `club_permissions` WHERE user_id = ? AND club_id = ?';
+        $binding[] = $user_id;
+        $binding[] = $club_id;
+
+        $query = $this->db->query($sql, $binding);
+
+        if ($query->num_rows() > 0) {
+            return $query->row()->p_level;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
      * Get Permissionlevel for User in Club
      * 
      * @param int $club_id


### PR DESCRIPTION
The best Grant-concept doesn't work if it's bypassable by API.

This PR fixes the following things:
- [x] Force Operator to Club-OP if it's a Member or ADIF-Member at logging. Officer and normal User aren't affected
- [x] more coming