### PR TITLE
[DXCC id] Tweaking the DXCC id logic

### DIFF
--- a/application/controllers/Calltester.php
+++ b/application/controllers/Calltester.php
@@ -225,6 +225,27 @@ class Calltester extends CI_Controller {
     function call() {
         $testarray = array();
 
+		$testarray[] = array(
+            'Callsign'  => 'WJ7R/C6A',
+            'Country'   => 'Bahamas',
+            'Adif'      => 60,
+            'Date'      => $date = date('Ymd', time())
+        );
+
+		$testarray[] = array(
+            'Callsign'  => 'WJ7R/KH6',
+            'Country'   => 'Hawaii',
+            'Adif'      => 110,
+            'Date'      => $date = date('Ymd', time())
+        );
+
+		$testarray[] = array(
+            'Callsign'  => 'WJ7R/C6',
+            'Country'   => 'Bahamas',
+            'Adif'      => 60,
+            'Date'      => $date = date('Ymd', time())
+        );
+
         $testarray[] = array(
             'Callsign'  => 'VE3EY/VP9',
             'Country'   => 'Bermuda',

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5655,7 +5655,7 @@ class Logbook_model extends CI_Model {
 	public function check_dxcc_table($call, $date) {
 
 		$date = date("Y-m-d", strtotime($date));
-		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$/';
+		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$|^L$|^J$|^SK$/';
 
 		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`, `cont`')
 			->where('`call`', $call)
@@ -5747,7 +5747,7 @@ class Logbook_model extends CI_Model {
 	public function dxcc_lookup($call, $date) {
 
 		$date = date("Y-m-d", strtotime($date));
-		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$/';
+		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$|^L$|^J$|^SK$/';
 
 		$dxcc_exceptions = $this->db->select('`entity`, `adif`, `cqz`,`cont`,`long`,`lat`')
 			->where('`call`', $call)
@@ -5856,7 +5856,7 @@ class Logbook_model extends CI_Model {
 		$c = '';
 
 		$lidadditions = '/^QRP$|^LGT$/';
-		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$/';
+		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$|^L$|^J$|^SK$/';
 		$noneadditions = '/^MM$|^AM$/';
 
 		# First check if the call is in the proper format, A/B/C where A and C
@@ -5895,7 +5895,7 @@ class Logbook_model extends CI_Model {
 				if (preg_match($lidadditions, $b)) {        # check if $b is a lid-addition
 					$b = $a;
 					$a = null;                              # $a goes to $b, delete lid-add
-				} elseif ((preg_match('/\d[A-Z]+$/', $a)) && (preg_match('/\d$/', $b))) {   # check for call in $a
+				} elseif ((preg_match('/\d[A-Z]+$/', $a)) && (preg_match('/\d$/', $b) || preg_match('/^[A-Z]\d[A-Z]$/', $b))) {   # check for call in $a
 					$temp = $b;
 					$b = $a;
 					$a = $temp;

--- a/src/Dxcc/Dxcc.php
+++ b/src/Dxcc/Dxcc.php
@@ -13,7 +13,7 @@ class Dxcc {
 
 	public function dxcc_lookup($call, $date) {
 
-		$csadditions = '/^P$|^R$|^A$|^B$|^M$/';
+		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$|^L$|^J$|^SK$/';
 		$CI =& get_instance();
 
 		if (array_key_exists($call, $this->dxccexceptions)) {
@@ -91,7 +91,7 @@ class Dxcc {
 		$c = '';
 
 		$lidadditions = '/^QRP$|^LGT$/';
-		$csadditions = '/^P$|^R$|^B$|^A$|^M$|^LH$/';
+		$csadditions = '/^X$|^D$|^T$|^P$|^R$|^B$|^A$|^M$|^LH$|^L$|^J$|^SK$/';
 		$noneadditions = '/^MM$|^AM$/';
 
 		# First check if the call is in the proper format, A/B/C where A and C
@@ -130,7 +130,7 @@ class Dxcc {
 				if (preg_match($lidadditions, $b)) {        # check if $b is a lid-addition
 					$b = $a;
 					$a = null;                              # $a goes to $b, delete lid-add
-				} elseif ((preg_match('/\d[A-Z]+$/', $a)) && (preg_match('/\d$/', $b))) {   # check for call in $a
+				} elseif ((preg_match('/\d[A-Z]+$/', $a)) && (preg_match('/\d$/', $b) || preg_match('/^[A-Z]\d[A-Z]$/', $b))) {   # check for call in $a
 					$temp = $b;
 					$b = $a;
 					$a = $temp;


### PR DESCRIPTION
While playing around, I noticed two callsign that would not id as Bahamas (WJ7R/C6A and 9H5G/C6A).
I added some variants to my calltester, which assists in testing.

This PR fixes this problem, and also adds a few extra additions to callsigns, that should be ignore, namelig /J /L /SK.

