### PR TITLE
[ADIF import] Fix some minor annoyances

### DIFF
--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -385,7 +385,9 @@ class adif extends CI_Controller {
 					while($record = $this->adif_parser->get_record()) {
 
 						// Handle slashed zeros
-						$record['call'] = str_replace('Ø', "0", $record['call']);
+						if (isset($record['call'])) {
+							$record['call'] = str_replace('Ø', "0", $record['call']);
+						}
 						if (($record['operator'] ?? '') != '') {
 							$record['operator'] = str_replace('Ø', "0", $record['operator']);
 						}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4717,7 +4717,7 @@ class Logbook_model extends CI_Model {
 
 		if (($band ?? '') == '') {
 			log_message("Error", "Trying to import QSO without Band for station_id " . $station_id . ". QSO Date/Time: " . $time_on . " at ".($record['freq'] ?? 'N/A')." Mode: " . ($record['mode'] ?? '') . " Call: " . ($record['call'] ?? ''));
-			$returner['error']=sprintf(__("QSO on %s: You tried to import a QSO without any given Band. This QSO wasn't imported. It's invalid"), $time_on);
+			$returner['error']=sprintf(__("QSO on %s: You tried to import a QSO without any given Band. This QSO wasn't imported. It's invalid"), $time_on) . '<br>';
 
 			return($returner);
 		}


### PR DESCRIPTION
The PR fixes 2 minor things.

1. A line break is added for this message:
QSO on 1992-06-05 11:08:00: You tried to import a QSO without any given Band. This QSO wasn't imported. It's invalid
QSO on 1992-06-05 11:25:00: You tried to import a QSO without any given Band. This QSO wasn't imported. It's invalid
Easier to read for the user instead of having it all on one line.

2. Runs an isset on $record['call'] to stop this error:
A PHP Error was encountered
Severity: Warning

Message: Undefined array key "call"

Filename: controllers/Adif.php

Line Number: 388

A PHP Error was encountered
    Severity: Deprecated

Message: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

Filename: controllers/Adif.php

Line Number: 388
