### PR TITLE
Decode HTML to display encoded translations correctly

### DIFF
--- a/assets/js/sections/user.js
+++ b/assets/js/sections/user.js
@@ -204,10 +204,10 @@ $(document).ready(function(){
 			success: function(res) {
 				if(res.status == 'OK') {
 					btn_div.addClass('alert-success').removeClass('running').prop('disabled', false);
-					msg_div.addClass('alert-success').text(res.details).show();
+					msg_div.addClass('alert-success').text(decodeHtml(res.details)).show();
 				} else {
 					btn_div.addClass('alert-danger').removeClass('running').prop('disabled', false);
-					msg_div.addClass('alert-danger').text('Error: '+res.details).show();
+					msg_div.addClass('alert-danger').text('Error: '+decodeHtml(res.details)).show();
 				}
 			},
 			error: function(res) {


### PR DESCRIPTION
Fix translations not being displayed correctly:

<img width="520" height="364" alt="image" src="https://github.com/user-attachments/assets/e5c52cb9-86e6-4417-b5b8-b5c154f73365" />

Seen in https://github.com/wavelog/wavelog/issues/2217#issuecomment-3684278859