### PR TITLE
Check for cURL before using it

### DIFF
--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -39,10 +39,12 @@ class Debug extends CI_Controller
 		$data['latest_release'] = $this->optionslib->get_option('latest_release');
 
 		$data['newer_version_available'] = false;
-		if (!$this->config->item('disable_version_check') ?? false) {
-			$this->Update_model->update_check(true);
-			if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
-				$data['newer_version_available'] = true;
+		if (function_exists('curl_version')) {
+			if (!$this->config->item('disable_version_check') ?? false) {
+				$this->Update_model->update_check(true);
+				if ($data['latest_release'] && version_compare($data['latest_release'], $data['running_version'], '>')) {
+					$data['newer_version_available'] = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
If cURL is not installed and update check is enabled the debug page fails to load so user cannot check/see if cURL is installed / working. So we should check if cURL is installed before using it to check Wavelog version.

Test: Uninstall php-curl and call debug page.