### PR TITLE
Use same filter criteria for update as for check

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -1476,8 +1476,6 @@ class Logbookadvanced_model extends CI_Model {
 			SET col_cont = dxcc_entities.cont
 			WHERE (COALESCE(" . $this->config->item('table_name') . ".col_cont, '') = ''  or " . $this->config->item('table_name') . ".col_cont not in ('AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA'))
 			AND station_profile.user_id = ?
-			AND col_dxcc is not null
-			AND col_dxcc != ''
 			AND col_dxcc != 0";
 
 		$query = $this->db->query($sql, array($this->session->userdata('user_id')));
@@ -1572,8 +1570,6 @@ class Logbookadvanced_model extends CI_Model {
 			join station_profile on " . $this->config->item('table_name') . ".station_id = station_profile.station_id
 			where user_id = ?
 			and (coalesce(col_cont, '') = '' or col_cont not in ('AF', 'AN', 'AS', 'EU', 'NA', 'OC', 'SA'))
-			and col_dxcc is not null
-			and col_dxcc != ''
 			and col_dxcc != 0";
 
 		$bindings[] = [$this->session->userdata('user_id')];


### PR DESCRIPTION
Found a glitch in update of continents via DBtools. The SQL query for updating continents is less specific as the one for counting the rows to update. This results in:

<img width="604" height="250" alt="image" src="https://github.com/user-attachments/assets/7069599b-fac4-48b9-859f-130f2452744b" />

vs.

<img width="604" height="250" alt="image" src="https://github.com/user-attachments/assets/05a5a3bf-7e9b-43cf-b36c-32e897e06952" />