### PR TITLE
Add Monthly stats to Analytics

### DIFF
--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -65,6 +65,28 @@ class Statistics extends CI_Controller {
 		echo json_encode($yearstats);
 	}
 
+	public function get_year_month() {
+		$this->load->model('logbook_model');
+
+		$yr = xss_clean($this->input->post('yr')) ?? 'All';
+
+		// get data
+		$totals_month = $this->logbook_model->totals_year_month($yr);
+
+		$monthstats = array();
+
+		$i = 0;
+		if ($totals_month) {
+			foreach($totals_month->result() as $qso_numbers) {
+				$monthstats[$i]['month'] = intval($qso_numbers->month);
+				$monthstats[$i++]['total'] = $qso_numbers->total;
+			}
+		}
+
+		header('Content-Type: application/json');
+		echo json_encode($monthstats);
+	}
+
 	public function get_mode() {
 		$this->load->model('logbook_model');
 		$yr = xss_clean($this->input->post('yr')) ?? 'All';

--- a/application/views/statistics/index.php
+++ b/application/views/statistics/index.php
@@ -12,16 +12,35 @@
 <script>
 		// General Language
 		var lang_statistics_years = "<?= __("Years")?>";
+		var lang_statistics_months = "<?= __("Months")?>";
 		var lang_statistics_modes = "<?= __("Mode")?>";
 		var lang_statistics_bands = "<?= __("Bands")?>";
 		var lang_statistics_operators = "<?= __("Operators")?>";
 		var lang_statistics_number_of_qso_worked_each_year = "<?= __("Number of QSOs worked each year")?>";
+		var lang_statistics_number_of_qso_worked_each_month = "<?= __("Number of QSOs worked each month")?>";
 		var lang_statistics_year = "<?= __("Year")?>";
+		var lang_statistics_month = "<?= __("Month")?>";
 		var lang_statistics_number_of_qso_worked = "<?= __("# of QSOs worked")?>";
 		var lang_gen_hamradio_mode = "<?= __("Mode")?>";
 		var lang_gen_hamradio_band = "<?= __("Band")?>";
 		var lang_gen_hamradio_operator = "<?= __("Operator")?>";
 		var lang_gen_satellite = "<?= __("Satellite")?>";
+
+		// Month names for translation
+		var monthNames = {
+			"01": "<?= __("January")?>",
+			"02": "<?= __("February")?>",
+			"03": "<?= __("March")?>",
+			"04": "<?= __("April")?>",
+			"05": "<?= __("May")?>",
+			"06": "<?= __("June")?>",
+			"07": "<?= __("July")?>",
+			"08": "<?= __("August")?>",
+			"09": "<?= __("September")?>",
+			"10": "<?= __("October")?>",
+			"11": "<?= __("November")?>",
+			"12": "<?= __("December")?>"
+		};
 </script>
 
 <div class="container statistics">
@@ -61,6 +80,9 @@
 							<a class="nav-link active" id="years-tab" data-bs-toggle="tab" href="#yearstab" role="tab" aria-controls="yearstab" aria-selected="true"><?= __("Years"); ?></a>
 						</li>
 						<li class="nav-item">
+							<a class="nav-link" id="months-tab" data-bs-toggle="tab" href="#monthstab" role="tab" aria-controls="monthstab" aria-selected="false"><?= __("Months"); ?></a>
+						</li>
+						<li class="nav-item">
 							<a class="nav-link" id="mode-tab" data-bs-toggle="tab" href="#modetab" role="tab" aria-controls="modetab" aria-selected="false"><?= __("Mode"); ?></a>
 						</li>
 						<li class="nav-item">
@@ -79,6 +101,10 @@
 				<div class="tab-content">
 					<div class="tab-pane fade show active" id="yearstab" role="tabpanel" aria-labelledby="years-tab">
 						<div class="years" style="margin-top: 20px;">
+						</div>
+					</div>
+					<div class="tab-pane fade" id="monthstab" role="tabpanel" aria-labelledby="months-tab">
+						<div class="months" style="margin-top: 20px;">
 						</div>
 					</div>
 					<div class="tab-pane fade" id="modetab" role="tabpanel" aria-labelledby="mode-tab">


### PR DESCRIPTION
It's that time of the Year:

Monthly Stats as new Stat-Page for Analytics:

<img width="1366" height="1056" alt="image" src="https://github.com/user-attachments/assets/a535539d-05b4-4fab-840a-a89988f82afe" />

If "All" is selected it accumulates all QSOs (for all years) and groups them by month