### PR TITLE
Make LoTW login test code more bullet-proof

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -847,8 +847,8 @@ class Lotw extends CI_Controller {
 			$ch = curl_init();
 			curl_setopt($ch, CURLOPT_URL, $lotw_url);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 20);
 			$content = curl_exec($ch);
 			if(curl_errno($ch)) {
 				$ret['status']='failed';


### PR DESCRIPTION
Based on https://github.com/wavelog/wavelog/issues/2707 we reworked the LoTW code a little. If curl fails (because of SSL issues for example) $content will be empty and the user sees the misleading error message that LoTW is not available. This is just wrong in this case. Instead it is an issue with local SSL installation in this case for example.
Also adds some debug log output in case connection fails.