### PR TITLE
Last modified should not be shown if not configured at all

### DIFF
--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -126,7 +126,7 @@
             \"qth\":{\"show\":\"true\"},
             \"frequency\":{\"show\":\"true\"},
             \"dcl\":{\"show\":\"true\"},
-            \"last_modification\":{\"show\":\"true\"},
+            \"last_modification\":{\"show\":\"false\"},
         }";
     }
     $current_opts = json_decode($options);
@@ -236,7 +236,7 @@
         echo "\nuser_options={...user_options, ...o_template};";
     }
     if (!isset($current_opts->last_modification)) {
-        echo "\nvar o_template = { last_modification: {show: 'true'}};";
+        echo "\nvar o_template = { last_modification: {show: 'false'}};";
         echo "\nuser_options={...user_options, ...o_template};";
     }
 
@@ -874,7 +874,7 @@ $options = json_decode($options);
                     <?php if (($options->datetime->show ?? "true") == "true") {
                         echo '<th>' . __("Date/Time") . '</th>';
                     } ?>
-                    <?php if (($options->last_modification->show ?? "true") == "true") {
+                    <?php if (($options->last_modification->show ?? "false") == "true") {
                         echo '<th>' . __("Last modified") . '</th>';
                     } ?>
                     <?php if (($options->de->show ?? "true") == "true") {

--- a/application/views/logbookadvanced/useroptions.php
+++ b/application/views/logbookadvanced/useroptions.php
@@ -192,7 +192,7 @@
 		</tr>
 		<tr>
       <td><span title="<?= __("This is meant for debugging purposes only and not designed to be displayed by default"); ?>"><?= __("Last modified"); ?> <small id="debug_last_modified" class="badge text-bg-danger"><?= __("For debugging only"); ?></small></span></td>
-			<td><div class="form-check"><input class="form-check-input" name="last_modification" type="checkbox" <?php if (($options->last_modification->show ?? "true") == "true") { echo 'checked'; } ?>></div></td>
+			<td><div class="form-check"><input class="form-check-input" name="last_modification" type="checkbox" <?php if (($options->last_modification->show ?? "false") == "true") { echo 'checked'; } ?>></div></td>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
Relates to https://github.com/wavelog/wavelog/pull/2758. The column should not be shown if not configured at all.