### PR TITLE
Catch LoTW download rate limit and log accordingly

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -766,7 +766,7 @@ class Lotw extends CI_Controller {
 						break;
 					}
 					continue;
-				} else if(str_contains($content,"Username/password incorrect</I>")) {
+				} else if(str_contains(substr($content,0 , 2000),"Username/password incorrect</I>")) {
 					$result = "LoTW download failed for user ".$user->user_lotw_name.": Username/password incorrect";
 					log_message('error', 'LoTW download failed for user '.$user->user_name.': Username/password incorrect');
 					if ($this->Lotw_model->remove_lotw_credentials($user->user_id)) {
@@ -775,7 +775,7 @@ class Lotw extends CI_Controller {
 						log_message('error', 'Deleting LoTW credentials for user '.$user->user_name.' failed');
 					}
 					continue;
-				} else if (str_contains($content,"Page Request Limit!</B>")) {
+				} else if (str_contains(substr($content, 0, 2000),"Page Request Limit!</B>")) {
 					$result = "LoTW download hit a rate limit for user ".$user->user_lotw_name;
 					log_message('error', 'LoTW download hit a rate limit for user '.$user->user_name);
 					continue;


### PR DESCRIPTION
Just distinguish this rate limit error from generic error message saying that the report was invalid. In case of the rate limit we just don't get any kind of report at all. This should be logged accordingly. Option: Delete LoTW credentials as well to prevent further polling. This needs some more investigation of how this rate limit is reached and how to release the root cause. So this is left out of this PR for now but may be added later.