### PR TITLE
Relax fetch of DX Cluster data

### DIFF
--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -99,6 +99,8 @@ class Dxcluster_model extends CI_Model {
 			curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 			curl_setopt($ch, CURLOPT_HEADER, false);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    		curl_setopt($ch, CURLOPT_MAXREDIRS, 3);
 			$jsonraw = curl_exec($ch);
 			$curl_error = curl_error($ch);
 			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
DX Cluster data is being fetched with a minimally-initialized cURL instance, and the parameters do not accept any redirects. I personally do some proxy trickery to get this to work and allowing a redirect or two would help make this work normally instead of having to default to exposing dxcache directly.