### PR TITLE
Prevent 500s when trying to access api with key=null

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -204,9 +204,9 @@ class API extends CI_Controller {
 		}
 	}
 
-	function check_auth($key) {
+	function check_auth($key = '') {
 		$this->load->model('api_model');
-		if($this->api_model->access($key) == "No Key Found" || $this->api_model->access($key) == "Key Disabled") {
+		if($this->api_model->access($key ?? '') == "No Key Found" || $this->api_model->access($key ?? '') == "Key Disabled") {
 			// set the content type as json
 			header("Content-type: application/json");
 
@@ -222,7 +222,7 @@ class API extends CI_Controller {
 			// set the http response code to 200
 			http_response_code(200);
 			// return the json
-			echo json_encode(['status' => 'valid', 'rights' => $this->api_model->access($key)]);
+			echo json_encode(['status' => 'valid', 'rights' => $this->api_model->access($key ?? '')]);
 		}
 	}
 

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -98,7 +98,7 @@ class API_Model extends CI_Model {
 	function access($key = '') {
 
 		// No key = no access, mate
-		if (!$key) {
+		if ((!$key) || ($key == '')) {
 			return $status = "No Key Found";
 		}
 

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -34,7 +34,7 @@ class API_Model extends CI_Model {
 		return $this->db->query($sql, $binding);
 	}
 
-	function key_description($key) {
+	function key_description($key = '') {
 		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('key', $key);
 		$query = $this->db->get('api');
@@ -42,14 +42,14 @@ class API_Model extends CI_Model {
 		return $query->result_array()[0];
 	}
 
-	function key_userid($key) {
+	function key_userid($key = '') {
 		$this->db->where('key', $key);
 		$query = $this->db->get('api');
 
 		return $query->result_array()[0]['user_id'];
 	}
 
-	function key_created_by($key) {
+	function key_created_by($key = '') {
 		$this->db->where('key', $key);
 		$query = $this->db->get('api');
 
@@ -68,7 +68,7 @@ class API_Model extends CI_Model {
 	}
 
 
-	function delete_key($key) {
+	function delete_key($key = '') {
 		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('key', xss_clean($key));
 		$this->db->delete('api');
@@ -95,7 +95,7 @@ class API_Model extends CI_Model {
 		}
 	}
 
-	function access($key) {
+	function access($key = '') {
 
 		// No key = no access, mate
 		if (!$key) {
@@ -119,7 +119,7 @@ class API_Model extends CI_Model {
 		}
 	}
 
-	function authorize($key) {
+	function authorize($key = '') {
 		$r = $this->access($key);
 		if ($r == "rw") {
 			return 2;


### PR DESCRIPTION
When calling API-Endpoints without a key, the application throws a 500, because null isn't catched.
this one fixes it.

testing-hints:

`curl -v https://[yourWL]/index.php/api/check_auth` --> 500 on dev / 401 with patch