### PR TITLE
Emit ADIF to Websocket (if in qso) on logging

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -181,7 +181,7 @@ class QSO extends CI_Controller {
 			// Add QSO
 			// $this->logbook_model->add();
 			//change to create_qso function as add and create_qso duplicate functionality
-			$this->logbook_model->create_qso();
+			$adif = $this->logbook_model->create_qso();
 
 			$returner=[];
 			$actstation=$this->stations->find_active() ?? '';
@@ -190,6 +190,11 @@ class QSO extends CI_Controller {
 			$returner['activeStationTXPower'] = xss_clean($profile_info->station_power ?? '');
 			$returner['activeStationOP'] = xss_clean($this->session->userdata('operator_callsign'));
 			$returner['message']='success';
+
+			// Include ADIF for WebSocket transmission
+			if ($adif) {
+				$returner['adif'] = $adif;
+			}
 
 			// Get last 5 qsos
 			echo json_encode($returner);

--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -473,6 +473,43 @@ $(document).ready(function() {
     }
 
     /**
+     * Send QSO data via WebSocket when CAT is enabled via WebSocket
+     * This allows external systems (e.g., WLGate, external logging services) to receive logged QSOs in real-time
+     * @param {object} qsoData - QSO data object with fields from the QSO form
+     * @returns {boolean} - true if sent via WebSocket, false otherwise
+     */
+    function sendQSOViaWebSocket(qsoData) {
+        // Only send if WebSocket is connected and enabled
+        if (!websocket || !websocketEnabled || websocket.readyState !== WebSocket.OPEN) {
+            return false;
+        }
+
+        // Only send for WebSocket radio ('ws')
+        if ($(".radios option:selected").val() != 'ws') {
+            return false;
+        }
+
+        try {
+            // Prepare QSO message with standard format
+            const qsoMessage = {
+                type: 'qso_logged',
+                timestamp: new Date().toISOString(),
+                data: qsoData
+            };
+
+            // Send via WebSocket
+            websocket.send(JSON.stringify(qsoMessage));
+            return true;
+        } catch (error) {
+            console.warn('Failed to send QSO via WebSocket:', error);
+            return false;
+        }
+    }
+
+    // Expose sendQSOViaWebSocket globally so it can be called from qso.js
+    window.sendQSOViaWebSocket = sendQSOViaWebSocket;
+
+    /**
      * Display radio status in the UI
      * @param {string} state - One of 'success', 'error', 'timeout', 'not_logged_in'
      * @param {object|string} data - Radio data object (success) or radio name string (error/timeout/not_logged_in)


### PR DESCRIPTION
If CAT via Websocket is enabled, emit a logged QSO to Websocket (details and adif).
This one is for preparing more interfaces.

The UDP/2333-Standard for example. With a further development of WavelogGate or other tools it would be possible to emit QSOs as ADIF via UDP/2333 to other applications.

Testing Hints:
- Enable CAT/Websocket
- inspect (Debug-Console) network-tab / websocket message
- Log a QSO
- a meesage with the type "qso_logged" should appear. it includes a lot of informations about the QSO.
