### PR TITLE
Implement a fallback in case tqsl repo fails

### DIFF
--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -645,7 +645,7 @@ class Update_model extends CI_Model {
 		$xml = @simplexml_load_string($response);
 
 		if ($xml === false) {
-			log_message('error', 'vuccgrids.dat upadte from primary location failed.');
+			log_message('error', 'vuccgrids.dat update from primary location failed.');
 
 			// Try our own mirror in case upstream fails
 			$url = 'https://raw.githubusercontent.com/wavelog/dxcc_data/refs/heads/master/vuccgrids.dat';
@@ -655,7 +655,7 @@ class Update_model extends CI_Model {
 			$response = curl_exec($curl);
 			$xml = @simplexml_load_string($response);
 			if ($xml === false) {
-				log_message('error', 'vuccgrids.dat upadte from backup location failed.');
+				log_message('error', 'vuccgrids.dat update from backup location failed.');
 				return "Failed to parse TQSL VUCC grid file XML.";
 			}
 		}


### PR DESCRIPTION
Not exactly knowing whats going on in https://github.com/wavelog/wavelog/issues/2585 but it might be a good idea to have a backup here (also for dev purposes) as sourceforge is damn slow at times.