### PR TITLE
Emit Az/Ele - when working SAT - via Websocket

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -510,6 +510,54 @@ $(document).ready(function() {
     window.sendQSOViaWebSocket = sendQSOViaWebSocket;
 
     /**
+     * Send real-time satellite position (azimuth/elevation) via WebSocket
+     * Only sends when using WebSocket CAT and working satellite
+     * @param {string} satName - Satellite name
+     * @param {number} azimuth - Antenna azimuth in decimal degrees
+     * @param {number} elevation - Antenna elevation in decimal degrees
+     * @returns {boolean} - true if sent via WebSocket, false otherwise
+     */
+    function sendSatellitePositionViaWebSocket(satName, azimuth, elevation) {
+        // Only send if WebSocket is connected and enabled
+        if (!websocket || !websocketEnabled || websocket.readyState !== WebSocket.OPEN) {
+            return false;
+        }
+
+        // Only send for WebSocket radio ('ws')
+        if ($(".radios option:selected").val() != 'ws') {
+            return false;
+        }
+
+        // Only send if satellite name is provided
+        if (!satName || satName === '') {
+            return false;
+        }
+
+        try {
+            // Prepare satellite position message with standard format
+            const satMessage = {
+                type: 'satellite_position',
+                timestamp: new Date().toISOString(),
+                data: {
+                    sat_name: satName,
+                    azimuth: azimuth,
+                    elevation: elevation
+                }
+            };
+
+            // Send via WebSocket
+            websocket.send(JSON.stringify(satMessage));
+            return true;
+        } catch (error) {
+            console.warn('Failed to send satellite position via WebSocket:', error);
+            return false;
+        }
+    }
+
+    // Expose sendSatellitePositionViaWebSocket globally so it can be called from qso.js
+    window.sendSatellitePositionViaWebSocket = sendSatellitePositionViaWebSocket;
+
+    /**
      * Display radio status in the UI
      * @param {string} state - One of 'success', 'error', 'timeout', 'not_logged_in'
      * @param {object|string} data - Radio data object (success) or radio name string (error/timeout/not_logged_in)

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -981,6 +981,14 @@ function start_az_ele_ticker(tle) {
 			let el=(satellite.radiansToDegrees(lookAngles.elevation).toFixed(2));
 			$("#ant_az").val(parseFloat(az).toFixed(1));
 			$("#ant_el").val(parseFloat(el).toFixed(1));
+
+			// Send real-time azimuth/elevation via WebSocket if using WebSocket CAT and working satellite
+			if (typeof sendSatellitePositionViaWebSocket === 'function') {
+				var satName = $("#sat_name").val();
+				if (satName && satName !== '') {
+					sendSatellitePositionViaWebSocket(satName, parseFloat(az).toFixed(1), parseFloat(el).toFixed(1));
+				}
+			}
 		} catch(e) {
 			$("#ant_az").val('');
 			$("#ant_el").val('');


### PR DESCRIPTION
This PR implements pushing Az/Ele, when working a SAT, via Websocket.

Testing:
- Enable Websocket (Needs WavelogGate or WavelogStoat running)
- Chose a SAT in QSO-Window
- Inspect Websocket-Data
- Should stop, if CAT is disabled or SAT is removed from QSO

it's preparation for Rotator-Control.
i'll add the same for HF / Beamdirection in another PR.

todo's (outside this PR): Catch data in Stoat/Gate and forward it to rotctld