### PR TITLE
Don't set DCL received when just updating the DOK

### DIFF
--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5715,7 +5715,6 @@ class Logbook_model extends CI_Model {
 	function set_dok($key, $dok) {
 		$data = array(
 			'COL_DARC_DOK' => $dok,
-			'COL_DCL_QSL_RCVD ' => 'Y',
 		);
 
 		$this->db->where(array('COL_PRIMARY_KEY' => $key));

--- a/application/views/adif/dcl_success.php
+++ b/application/views/adif/dcl_success.php
@@ -23,7 +23,7 @@
        </div>
     <?php if($dcl_errors) { ?>
       <h3><?= __("DOK Errors")?></h3>
-      <p><?= __("There is different data for DOK in your log compared to DCL")?></p>
+      <p><?= __("There is different data for DOK in your log compared to DCL or updates where not done because QSOs are not confirmed in DCL.")?></p>
       <table width="100%">
          <tr class="titles">
             <td><?= __("Date"); ?></td>

--- a/application/views/adif/import.php
+++ b/application/views/adif/import.php
@@ -339,7 +339,7 @@
                         </div>
                     <?php } ?>
 
-                    <p class="card-text"><?= sprintf(__("Go to %s and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put 'DL' into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info."), "<a href='http://dcl.darc.de/dml/export_adif_form.php' target='_blank'>" . __("DARC DCL") . "</a>") ?></p>
+                    <p class="card-text"><?= sprintf(__("Go to %s and export your logbook with confirmed DOKs. To speed up the process you can select only DL QSOs to download (i.e. put 'DL' into Prefix List). The downloaded ADIF file can be uploaded here in order to update QSOs with DOK info."), "<a href='http://dcl.darc.de/dml/export_adif_form.php' target='_blank'>" . __("DARC DCL") . "</a>") ?> <?= sprintf(__("More information regarding the confirmation status in DCL can be found on the %sDCL Confluence page%s."), '<a target="_blank" href="https://confluence.darc.de/pages/viewpage.action?pageId=21037270">', '</a>'); ?></p>
                     <form class="form" action="<?php echo site_url('adif/dcl'); ?>" method="post" enctype="multipart/form-data">
 
                         <div class="mb-3 row">

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -22,7 +22,7 @@
 			<optgroup label="<?= __("Awards"); ?>">
 				<option value="continent"><?= __("Continent"); ?></option>
 				<option value="cqz"><?= __("CQ Zone"); ?></option>
-				<option value="dok"><?= __("DOK"); ?></option>
+				<option value="dok"><?= __("DARC DOK"); ?></option>
 				<option value="dxcc"><?= __("DXCC"); ?></option>
 				<option value="gridsquare"><?= __("Gridsquare"); ?></option>
 				<option value="iota"><?= __("IOTA"); ?></option>


### PR DESCRIPTION
The current code sets DCL received when it updated the DOK value. This should only be done if the QSO really is confirmed in DCL. The confirmation status is set separately. So we should not update the DCL_RCVD status upon setting the DOK. As this is separat we just removed the update of DCL_RCVD from `set_dok` function.

Test: Import a DCL ADIF with QSOs containing a QSO but not confirmed on DCL.