### PR TITLE
Fetch callbook for api private_lookup if requested

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -843,7 +843,7 @@ class API extends CI_Controller {
 			$user_id=$this->session->userdata('user_id');
 		}
 
-		if (($raw_input['qrz'] ?? '' == 'true') && (($raw_input['callsign'] ?? '') != '')) {
+		if (($raw_input['callbook'] ?? '' == 'true') && (($raw_input['callsign'] ?? '') != '')) {
 			$this->load->library('callbook');
 			$this->load->model('logbook_model');
 			$lookupcall = $this->callbook->get_plaincall($raw_input['callsign']);


### PR DESCRIPTION
This one adds an optional parameter to the [private_lookup API ](https://github.com/wavelog/wavelog/wiki/API#apiprivate_lookup)called "callbook". if set to true, the endpoint delivers the callbookinformation along with the worked/cnf-informations

Should help at #2782 

Testing (with and without qrz-field):

`curl -X POST -H "Content-Type: application/json" -d '{"key":"[WL_KEY]","callsign":"DJ7NT","callbook":"true"}' https://[YOUR_WL]/index.php/api/private_lookup`

expected result (with callbook=true and a bit patience):
```
{
    ...
    "callbook": {redacted}
    }
}
```