### PR TITLE
feat: prevent user select lotw badge when copy

### DIFF
--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -261,7 +261,7 @@ function echoQrbCalcLink($mygrid, $grid, $vucc, $isVisitor = false) {
                        } elseif ($diff > 7) {
                           $lotw_hint = ' lotw_info_yellow';
                        }
-                       $timestamp = strtotime($row->lastupload); echo ($row->callsign == '' ? '' : ' <a id="lotw_badge" style="float: right;" href="https://lotw.arrl.org/lotwuser/act?act='.$row->COL_CALL.'" target="_blank"><small id="lotw_info" class="badge text-bg-success'.$lotw_hint.'" data-bs-toggle="tooltip" title="LoTW User. Last upload was '.date($custom_date_format." H:i", $timestamp).'">L</small></a>');
+                       $timestamp = strtotime($row->lastupload); echo ($row->callsign == '' ? '' : ' <a id="lotw_badge" style="float: right; user-select: none;" href="https://lotw.arrl.org/lotwuser/act?act='.$row->COL_CALL.'" target="_blank"><small id="lotw_info" class="badge text-bg-success'.$lotw_hint.'" data-bs-toggle="tooltip" title="LoTW User. Last upload was '.date($custom_date_format." H:i", $timestamp).'">L</small></a>');
                     }
                  ?>
             </td>

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1419,3 +1419,8 @@ svg text.month { fill: #AAA; }
 .tooltip {
     z-index: 9999 !important;
 }
+
+.qso_icons {
+	user-select: none;
+}
+


### PR DESCRIPTION
When I try to copy contact information to a friend, or copy an entire row to Excel, an extra "L" always appears after the callsign. This is because the callsign and the LoTW badge are in the same cell. Adding this style prevents the user from selecting the LoTW badge.

Like this.
<img width="1502" height="160" alt="image" src="https://github.com/user-attachments/assets/029ac3bb-1153-4863-bc29-9c6531ea4f4a" />
2026-01-07	05:26	VK9DXL	FT8	+01	+02	15m	Norfolk Island
