### PR TITLE
[DBTools] Removed unused code + tweaks

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -895,30 +895,6 @@ class Logbookadvanced extends CI_Controller {
 		$this->load->view('logbookadvanced/showStateQsos', $data);
 	}
 
-	public function fixMissingDxcc() {
-		if(!clubaccess_check(9)) return;
-
-		$all = $this->input->post('all', true);
-		$this->load->model('logbookadvanced_model');
-        $result = $this->logbookadvanced_model->check_missing_dxcc_id($all);
-
-		$data['result'] = $result;
-		$data['all'] = $all;
-		$data['type'] = 'dxcc';
-
-		$this->load->view('logbookadvanced/showUpdateResult', $data);
-	}
-
-	public function openMissingDxccList() {
-		if(!clubaccess_check(9)) return;
-
-		$this->load->model('logbookadvanced_model');
-
-		$data['qsos'] = $this->logbookadvanced_model->getMissingDxccQsos();
-
-		$this->load->view('logbookadvanced/showMissingDxccQsos', $data);
-	}
-
 	public function batchFix() {
 		if(!clubaccess_check(9)) return;
 

--- a/application/views/logbookadvanced/checkresult.php
+++ b/application/views/logbookadvanced/checkresult.php
@@ -8,22 +8,12 @@ if($this->session->userdata('user_date_format')) {
 	$custom_date_format = $this->config->item('qso_date_format');
 }
 
-
 switch ($type) {
 	case 'checkdistance':
 		check_missing_distance($result);
 		break;
 	case 'checkcontinent':
 		check_qsos_missing_continent($result);
-		break;
-	case 'checkmissingdxcc':
-		check_missing_dxcc($result);
-		break;
-	case 'checkcqzones':
-		check_missing_cq_zones($result);
-		break;
-	case 'checkituzones':
-		check_missing_itu_zones($result);
 		break;
 	case 'checkgrids':
 		check_missing_grids($result);
@@ -77,40 +67,6 @@ function check_qsos_missing_continent($result) { ?>
 	<?php }
 }
 
-function check_missing_dxcc($result) { ?>
-	<h5><?= __("DXCC Check Results") ?></h5>
-	<?= __("QSOs to update found:"); ?> <?php echo $result[0]->count; ?>
-	<?php if ($result[0]->count > 0) { ?>
-	<br/>
-	<button type="button" class="mt-2 btn btn-sm btn-primary ld-ext-right" id="fixMissingDxccBtn" onclick="fixMissingDxcc(false)">
-		<?= __("Run fix") ?><div class="ld ld-ring ld-spin"></div>
-	</button>
-	<button id="openMissingDxccListBtn" onclick="openMissingDxccList()" class="btn btn-sm btn-success mt-2 btn btn-sm ld-ext-right"><i class="fas fa-search"></i><div class="ld ld-ring ld-spin"></div></button>
-	<?php }
-}
-
-function check_missing_cq_zones($result) { ?>
-	<h5><?= __("CQ Zone Check Results") ?></h5>
-	<?= __("QSOs to update found:"); ?> <?php echo $result[0]->count; ?>
-	<?php if ($result[0]->count > 0) { ?>
-	<br/>
-	<button type="button" class="mt-2 btn btn-sm btn-primary ld-ext-right" id="updateCqZonesBtn" onclick="fixMissingCqZones()">
-		<?= __("Update now") ?><div class="ld ld-ring ld-spin"></div>
-	</button>
-	<?php }
-}
-
-function check_missing_itu_zones($result) { ?>
-	<h5><?= __("ITU Zone Check Results") ?></h5>
-	<?= __("QSOs to update found:"); ?> <?php echo $result[0]->count; ?>
-	<?php if ($result[0]->count > 0) { ?>
-	<br/>
-	<button type="button" class="mt-2 btn btn-sm btn-primary ld-ext-right" id="updateItuZonesBtn" onclick="fixMissingItuZones()">
-		<?= __("Update now") ?><div class="ld ld-ring ld-spin"></div>
-	</button>
-	<?php }
-}
-
 function check_missing_grids($result) { ?>
 	<h5><?= __("Gridsquare Check Results") ?></h5>
 	<?= __("QSOs to update found:"); ?> <?php echo count($result); ?>
@@ -146,7 +102,7 @@ function check_dxcc($result, $custom_date_format) { ?>
 							<th class="select-filter" scope="col"><?= __("LoTW"); ?></th>
 							<th class="select-filter" scope="col"><?= __("Station Profile"); ?></th>
 							<th class="select-filter" scope="col"><?= __("Existing DXCC"); ?></th>
-							<th><?= __("Result DXCC"); ?></th>
+							<th class="select-filter" scope="col"><?= __("Result DXCC"); ?></th>
 						</tr>
 					</thead>
 					<tbody>

--- a/application/views/logbookadvanced/showUpdateResult.php
+++ b/application/views/logbookadvanced/showUpdateResult.php
@@ -1,9 +1,6 @@
 <?php
 
 switch ($type) {
-	case 'dxcc':
-		showDxccUpdateResult($result, $all);
-		break;
 	case 'state':
 		showStateUpdateResult($result, $country);
 		break;
@@ -13,70 +10,12 @@ switch ($type) {
 	case 'distance':
 		showDistanceUpdateResult($result);
 		break;
-	case 'cqzones':
-		showCqzoneUpdateResult($result);
-		break;
-	case 'ituzones':
-		showItuzoneUpdateResult($result);
-		break;
 	case 'grids':
 		showGridUpdateResult($result);
 		break;
 	default:
 		// Invalid type
 		break;
-}
-
-function showDxccUpdateResult($result, $all) {
-	echo '<h5>' . __("Results for DXCC update:") . '</h5>';
-	if ($result['count'] == 0) {
-		if ($all == 'false') {
-			echo '<div class="alert alert-danger" role="alert">' . __("The number of QSOs updated for missing DXCC IDs was") .': ' . $result['count'] . '</div>';
-		} else {
-			echo '<div class="alert alert-danger" role="alert">' . __("The number of QSOs re-checked for DXCC was") .': ' . $result['count'] . '</div>';
-		}
-	} else {
-		if ($all == 'false') {
-			echo '<div class="alert alert-success" role="alert">' . __("The number of QSOs updated for missing DXCC IDs was") .': ' . $result['count'] . '</div>';
-		} else {
-			echo '<div class="alert alert-success" role="alert">' . __("The number of QSOs re-checked for DXCC was") .': ' . $result['count'] . '</div>';
-		}
-	}
-
-	if ($result) {
-		$details = [];
-		foreach ($result as $r) {
-			if (is_array($r)) {
-				$details[] = $r;
-			}
-		}
-
-		if (!empty($details)) { ?>
-			<?php echo __("These QSOs could not be updated:"); ?>
-			<div class="table-responsive mt-3">
-			<table class="table table-sm table-striped table-hover">
-				<thead>
-					<tr>
-						<th> <?php echo __("Callsign"); ?> </th>
-						<th> <?php echo __("Reason"); ?> </th>
-						<th> <?php echo __("Station location"); ?> </th>
-					</tr>
-				</thead>
-				<tbody>
-
-				<?php foreach ($details as $r) { ?>
-					<tr>
-						<td><a id="edit_qso" href="javascript:displayQso(<?php echo $r['id']; ?>)"><?php echo htmlspecialchars($r['callsign']); ?></a></td>
-						<td> <?php echo htmlspecialchars($r['reason']); ?> </td>
-						<td> <?php echo htmlspecialchars($r['location']); ?> </td>
-					</tr>
-				<?php } ?>
-
-				</tbody>
-			</table>
-			</div>
-		<?php }
-	}
 }
 
 function showStateUpdateResult($result, $country) {
@@ -134,16 +73,6 @@ function showContinentUpdateResult($result) {
 function showDistanceUpdateResult($result) {
 	echo '<h5>' . __("Results for distance update:") . '</h5>';
 	echo '<div class="alert alert-' . ($result == 0 ? 'danger' : 'success') . '" role="alert">' . sprintf(__("The number of QSOs updated for distance is") . ': %d', $result) . '</div>';
-}
-
-function showCqzoneUpdateResult($result) {
-	echo '<h5>' . __("Results for CQ zone update:") . '</h5>';
-	echo '<div class="alert alert-' . ($result == 0 ? 'danger' : 'success') . '" role="alert">' . sprintf(__("The number of QSOs updated for CQ zone is") . ': %d', $result) . '</div>';
-}
-
-function showItuzoneUpdateResult($result) {
-	echo '<h5>' . __("Results for ITU zone update:") . '</h5>';
-	echo '<div class="alert alert-' . ($result == 0 ? 'danger' : 'success') . '" role="alert">' . sprintf(__("The number of QSOs updated for ITU zone is") . ': %d', $result) . '</div>';
 }
 
 function showGridUpdateResult($result) {

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -2061,39 +2061,6 @@ function saveOptions() {
 		});
 	}
 
-	function checkMissingDxcc() {
-		$('#checkMissingDxccsBtn').prop("disabled", true).addClass("running");
-		$('#closeButton').prop("disabled", true);
-
-		$.ajax({
-			url: base_url + 'index.php/logbookadvanced/checkDb',
-			data: {
-				type: 'checkmissingdxcc'
-			},
-			type: 'POST',
-			success: function(response) {
-				$('#checkMissingDxccsBtn').prop("disabled", false).removeClass("running");
-				$('#closeButton').prop("disabled", false);
-				$('.result').html(response);
-			},
-			error: function(xhr, status, error) {
-				$('#checkMissingDxccsBtn').prop('disabled', false).text('<?= __("Check") ?>');
-				$('#closeButton').prop('disabled', false);
-
-				let errorMsg = 'Error checking DXCC information';
-				if (xhr.responseJSON && xhr.responseJSON.message) {
-					errorMsg += ': ' + xhr.responseJSON.message;
-				}
-
-				BootstrapDialog.alert({
-					title: 'Error',
-					message: errorMsg,
-					type: BootstrapDialog.TYPE_DANGER
-				});
-			}
-		});
-	}
-
 	function checkFixContinent() {
 		$('#checkFixContinentBtn').prop("disabled", true).addClass("running");
 		$('#closeButton').prop("disabled", true);
@@ -2285,65 +2252,6 @@ function saveOptions() {
 		});
 	}
 
-	function fixMissingDxcc(all) {
-		if (all === true) {
-			$('#updateDxccBtn').prop("disabled", true).addClass("running");
-			BootstrapDialog.confirm({
-				title: lang_general_word_danger,
-				message: lang_gen_advanced_logbook_confirm_fix_missing_dxcc,
-				type: BootstrapDialog.TYPE_DANGER,
-				closable: true,
-				draggable: true,
-				btnOKClass: 'btn-danger',
-				callback: function(result) {
-					if(result) {
-						$('#closeButton').prop("disabled", true);
-						$.ajax({
-							url: base_url + 'index.php/logbookadvanced/fixMissingDxcc',
-							type: 'post',
-							data: {
-								all: all
-							},
-							success: function(data) {
-								$('#updateDxccBtn').prop("disabled", false).removeClass("running");
-								$('#closeButton').prop("disabled", false);
-								$('.result').html(data);
-							},
-							error: function(xhr, status, error) {
-								$('#updateDxccBtn').prop("disabled", false).removeClass("running");
-								$('#closeButton').prop("disabled", false);
-								$('.result').html(error);
-							}
-						})
-					} else {
-						$('#updateDxccBtn').prop("disabled", false).removeClass("running");
-					}
-
-				},
-			});
-		} else {
-			$('#fixMissingDxccBtn').prop("disabled", true).addClass("running");
-			$('#closeButton').prop("disabled", true);
-			$.ajax({
-				url: base_url + 'index.php/logbookadvanced/fixMissingDxcc',
-				type: 'post',
-				data: {
-					all: all
-				},
-				success: function(data) {
-					$('#fixMissingDxccBtn').prop("disabled", false).removeClass("running");
-					$('#closeButton').prop("disabled", false);
-					$('.result').html(data);
-				},
-				error: function(xhr, status, error) {
-					$('#fixMissingDxccBtn').prop("disabled", false).removeClass("running");
-					$('#closeButton').prop("disabled", false);
-					$('.result').html(error);
-				}
-			})
-		}
-	}
-
 	function runUpdateDistancesFix(dialogItself) {
 		$('#updateDistanceButton').prop("disabled", true).addClass("running");
 		$('#closeButton').prop("disabled", true);
@@ -2369,40 +2277,6 @@ function saveOptions() {
 		});
 	}
 
-	function openMissingDxccList() {
-		$('#openMissingDxccListBtn').prop("disabled", true).addClass("running");
-
-		$.ajax({
-			url: base_url + 'index.php/logbookadvanced/openMissingDxccList',
-			type: 'post',
-			success: function (response) {
-				$('#openMissingDxccListBtn').prop("disabled", false).removeClass("running");
-				BootstrapDialog.show({
-					title: 'QSO List',
-					size: BootstrapDialog.SIZE_WIDE,
-					cssClass: 'options',
-					nl2br: false,
-					message: response,
-					buttons: [
-					{
-						label: lang_admin_close,
-						cssClass: 'btn-sm btn-secondary',
-						id: 'closeButton',
-						action: function (dialogItself) {
-							dialogItself.close();
-						}
-					}],
-					onhide: function(dialogRef){
-						return;
-					},
-				});
-			},
-			error: function () {
-				$('#openMissingDxccListBtn').prop("disabled", false).removeClass("running");
-			}
-		});
-	}
-
 	function runContinentFix(dialogItself) {
 		$('#updateContinentButton').prop("disabled", true).addClass("running");
 		$('#closeButton').prop("disabled", true);
@@ -2421,50 +2295,6 @@ function saveOptions() {
 				$('#updateContinentButton').prop("disabled", false).removeClass("running");
 				$('.result').html(error);
 				$('#closeButton').prop("disabled", false);
-			}
-		});
-	}
-
-	function fixMissingCqZones() {
-		$('#updateCqZonesBtn').prop("disabled", true).addClass("running");
-		$('#closeButton').prop("disabled", true);
-		$.ajax({
-			url: base_url + 'index.php/logbookadvanced/batchFix',
-			data: {
-				type: 'cqzones'
-			},
-			type: 'POST',
-			success: function (response) {
-				$('#updateCqZonesBtn').prop("disabled", false).removeClass("running");
-				$('#closeButton').prop("disabled", false);
-				$('.result').html(response);
-			},
-			error: function(xhr, status, error) {
-				$('#updateCqZonesBtn').prop("disabled", false).removeClass("running");
-				$('#closeButton').prop("disabled", false);
-				$('.result').html(error);
-			}
-		});
-	}
-
-	function fixMissingItuZones() {
-		$('#updateItuZonesBtn').prop("disabled", true).addClass("running");
-		$('#closeButton').prop("disabled", true);
-		$.ajax({
-			url: base_url + 'index.php/logbookadvanced/batchFix',
-			data: {
-				type: 'ituzones'
-			},
-			type: 'POST',
-			success: function (response) {
-				$('#updateItuZonesBtn').prop("disabled", false).removeClass("running");
-				$('#closeButton').prop("disabled", false);
-				$('.result').html(response);
-			},
-			error: function(xhr, status, error) {
-				$('#updateItuZonesBtn').prop("disabled", false).removeClass("running");
-				$('#closeButton').prop("disabled", false);
-				$('.result').html(error);
 			}
 		});
 	}
@@ -2532,7 +2362,7 @@ function saveOptions() {
 				$('#dxccCheckTable').DataTable({
 					"pageLength": 25,
 					responsive: false,
-					ordering: false,
+					ordering: true,
 					"scrollY": "510px",
 					"scrollCollapse": true,
 					"paging": false,


### PR DESCRIPTION
This PR mainly removes code that was leftover after removing some functionality in dbtools.
That was missing dxcc, cq zone and itu zone, since the current tools shows the same, but with more information and control.

The tweaks done are in the incorrect dxcc part:

- memory limit
- sorting in table
- filter for result dxcc