### PR TITLE
Skip qrz update on DCL changes

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -1219,6 +1219,7 @@ class Logbookadvanced_model extends CI_Model {
 
 			$query = $this->db->query($sql, array($value, json_decode($ids, true), $this->session->userdata('user_id')));
 		} else if ($column == 'COL_DCL_QSL_SENT') {
+			$skipqrzupdate = true;
 
 			$sql = "UPDATE ".$this->config->item('table_name')." JOIN station_profile ON ". $this->config->item('table_name').".station_id = station_profile.station_id" .
 			" SET " . $this->config->item('table_name').".COL_DCL_QSL_SENT = ?, " . $this->config->item('table_name').".COL_DCL_QSLSDATE = now()" .
@@ -1226,6 +1227,7 @@ class Logbookadvanced_model extends CI_Model {
 
 			$query = $this->db->query($sql, array($value, json_decode($ids, true), $this->session->userdata('user_id')));
 		} else if ($column == 'COL_DCL_QSL_RCVD') {
+			$skipqrzupdate = true;
 
 			$sql = "UPDATE ".$this->config->item('table_name')." JOIN station_profile ON ". $this->config->item('table_name').".station_id = station_profile.station_id" .
 			" SET " . $this->config->item('table_name').".COL_DCL_QSL_RCVD = ?, " . $this->config->item('table_name').".COL_DCL_QSLRDATE = now()" .


### PR DESCRIPTION
Setting DCL rcvd/sent stati via LBA edit function triggers the QRZ sent status to be set to modified. As qrz.com does not care for DCL values (I guess) this should be prevented to skip uploading duplicate data.

Test: Mark some QSO in LBA and use its edit function to set DCL sent/rcvd state.