### PR TITLE
Only take SAT as PROP_MODE into account during matching

### DIFF
--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -643,7 +643,6 @@ class Update_model extends CI_Model {
 		$response = curl_exec($curl);
 
 		$xml = @simplexml_load_string($response);
-      $xml = false;
 
 		if ($xml === false) {
 			log_message('error', 'vuccgrids.dat update from primary location failed.');


### PR DESCRIPTION
LoTW confirmation matching is too strict. As per https://lotw.arrl.org/lotw-help/key-concepts/#confirmation LoTW only takes PROP_MODE = SAT into account during matching whereas we match *all* PROP_MODEs while looking for a matching QSO. This leads to the following issue (test scenario):

- Log a QSO with a prop mode unlike SAT e.g. TR
- Let Wavelog sync/upload the QSO to LoTW (with PROP_MODE set to TR)
- After QSO is uploaded remove PROP_MODE from QSO
- Wait for DX station to upload to LoTW
- After that is done LoTW import will fail finding a match because the downloaded report will contain PROP_MODE set to TR as it was uploaded initially

The problematic part is that this QSO is a match on LoTW regardless of which PROP_MODE was set by the DX station during upload. So on LoTW this QSO matches but Wavelog will not find a match.

As per the link above the QSO matching code must be a little less strict and only take PROP_MODE into account if it is set to SAT.