### PR TITLE
Enable "Add sked partner" if at least one satellite is selected

### DIFF
--- a/assets/js/sections/satpasses.js
+++ b/assets/js/sections/satpasses.js
@@ -23,6 +23,11 @@ $(document).ready(function() {
 		// Then, select the stored locations
 		$('#satlist').multiselect('select', satelliteArray);
 	}
+
+	var countsats = $('#satlist').val().length;
+	if (countsats > 0) {
+		$('#addsked').prop('disabled', false);
+	}
 });
 
 function searchpasses() {


### PR DESCRIPTION
Function "Add sked partner" is disabled per default on page load independent of if or how many satellites are selected. It is enabled only after changing the selection:

<img width="912" height="351" alt="image" src="https://github.com/user-attachments/assets/af00ebfe-ec81-41aa-b41b-e7d72a502707" />

This PR changes the behavior so that the button is enabled if at least one satellite is selected on page load.

Test: Load sat pass page and find the button disabled.