### PR TITLE
feat: sstv signal report

### DIFF
--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -64,6 +64,9 @@ function setRst(mode) {
 	} else if (mode == 'CW' || mode == 'RTTY' || mode == 'PSK31' || mode == 'PSK63') {
 		$('#rst_sent').val('599');
 		$('#rst_rcvd').val('599');
+	} else if (mode == 'SSTV' || mode == 'ATV') {
+		$('#rst_sent').val('595');
+		$('#rst_rcvd').val('595');
 	} else {
 		$('#rst_sent').val('59');
 		$('#rst_rcvd').val('59');


### PR DESCRIPTION
Change the default signal report for SSTV/ATV to 595.
<img width="890" height="622" alt="image" src="https://github.com/user-attachments/assets/5cca9e05-4d23-4fed-84c8-c108e13fe672" />
[Add QSO]

Reference: https://www.wa9tt.com/tutorial/SSTV_signal_report.pdf