### PR TITLE
Allow for more than one satellite without LoTW name

### DIFF
--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -123,6 +123,7 @@ class Satellite_model extends CI_Model {
 		}
 
 		$this->db->where('name', xss_clean($this->input->post('name', true)));
+		$this->db->where('displayname', xss_clean($this->input->post('displayname', true)));
 		$result = $this->db->get('satellite');
 
 		if ($result->num_rows() == 0) {
@@ -139,6 +140,8 @@ class Satellite_model extends CI_Model {
 			);
 
 			$this->db->insert('satellitemode', $data);
+		} else {
+			log_message('error', 'Duplicate satellite to be added: '.$data['displayname'].' - '.$data['name']);
 		}
 
 	}


### PR DESCRIPTION
Adding more than one satellite without LoTW name silently fails because the add function checks if there is a satellite with that (empty) (LoTW) name and if there is skips.

Patch: Check for name **and** displayname and log an error message if a dupe is to be added

Test: Add satellites without LoTW name. First one goes ok. Upon adding the second one nothing happens in the GUI.