### PR TITLE
Preserve precision in cluster

### DIFF
--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -1213,8 +1213,11 @@ $(function() {
 		// Band column: show band designation
 		data[0].push(single.band || '');
 
-		// Frequency column: convert kHz to MHz with 3 decimal places
-		let freqMHz = (single.frequency / 1000).toFixed(3);
+		// Frequency column: convert kHz to MHz, preserving the original precision from cluster
+	// Count decimal places in original kHz value, then add 3 for the /1000 conversion
+	const freqStr = single.frequency.toString();
+	const decimalPlaces = (freqStr.includes('.')) ? (freqStr.split('.')[1].length + 3) : 3;
+	let freqMHz = (single.frequency / 1000).toFixed(decimalPlaces);
 		data[0].push(freqMHz);
 
 	// Mode column: capitalize properly (API returns lowercase categories)
@@ -4259,7 +4262,10 @@ $(function() {
 		html += '</tr></thead><tbody>';
 
 		spots.forEach(spot => {
-			const freqMHz = (spot.frequency / 1000).toFixed(3);
+			// Convert kHz to MHz, preserving the original precision from cluster
+			const freqStr = spot.frequency.toString();
+			const decimalPlaces = (freqStr.includes('.')) ? (freqStr.split('.')[1].length + 3) : 3;
+			const freqMHz = (spot.frequency / 1000).toFixed(decimalPlaces);
 
 			// Color code callsign based on worked/confirmed status (matching bandmap table)
 			let callClass = '';


### PR DESCRIPTION
Before Patch:

Frequencies in spot were truncated to full kHz in Bandlist and on QSY

<img width="767" height="228" alt="image" src="https://github.com/user-attachments/assets/be5001dd-d2bc-4a5c-859d-208d11afe10e" />


After

Precision is preserved in display and QSY

<img width="701" height="207" alt="image" src="https://github.com/user-attachments/assets/2c6b980f-18f0-4c33-8519-46390d6bba27" />
