### PR TITLE
remove curl_close()

### DIFF
--- a/application/controllers/Contestcalendar.php
+++ b/application/controllers/Contestcalendar.php
@@ -139,7 +139,6 @@ class Contestcalendar extends CI_Controller {
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 			$rssRawData = curl_exec($ch);
-			curl_close($ch);
 
 			if ($rssRawData === FALSE) {
 				$msg = "Something went wrong with fetching the Contest Data";
@@ -148,8 +147,6 @@ class Contestcalendar extends CI_Controller {
 			}
 
 			$this->cache->save('RssRawContestCal', $rssRawData, (60 * 60 * 12)); // 12 hours cache time
-
-			curl_close($ch);
 		}
 
 		return $rssRawData;

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -116,7 +116,6 @@ class cron extends CI_Controller {
 							curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 						}
 						$crun = curl_exec($ch);
-						curl_close($ch);
 
 						if ($crun !== false) {
 							echo "CRON: " . $cron->id . " -> CURL Result: " . $crun . "\n";

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -374,7 +374,6 @@ class eqsl extends CI_Controller {
 			curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog-eQSL/1.0');
 			$file = curl_exec($ch);
 			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
 
 			if ($file === false || $http_code != 200) {
 				show_error(__('Failed to fetch eQSL image data'), 503);
@@ -412,7 +411,6 @@ class eqsl extends CI_Controller {
 				curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog-eQSL/1.0');
 				$content = curl_exec($ch);
 				$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-				curl_close($ch);
 
 				if ($content === false || $http_code != 200) {
 					show_error(__('Failed to download eQSL image'), 503);

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -42,7 +42,6 @@ class Qrz extends CI_Controller {
 		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
 		
 		$content = curl_exec($ch);
-		curl_close($ch);
 
 		if ($content){
 			if (stristr($content,'RESULT=OK')) {

--- a/application/libraries/Curl.php
+++ b/application/libraries/Curl.php
@@ -303,7 +303,6 @@ class Curl {
 			$this->error_code = curl_errno($this->session);
 			$this->error_string = curl_error($this->session);
 
-			curl_close($this->session);
 			$this->set_defaults();
 
 			return FALSE;
@@ -312,7 +311,6 @@ class Curl {
 		// Request successful
 		else
 		{
-			curl_close($this->session);
 			$response = $this->response;
 			$this->set_defaults();
 			return $response;

--- a/application/libraries/EqslBulkDownloader.php
+++ b/application/libraries/EqslBulkDownloader.php
@@ -213,7 +213,6 @@ class EqslBulkDownloader {
 			}
 
 			curl_multi_remove_handle($mh, $ch);
-			curl_close($ch);
 		}
 
 		curl_multi_close($mh);
@@ -319,7 +318,6 @@ class EqslBulkDownloader {
 			}
 
 			curl_multi_remove_handle($mh, $ch);
-			curl_close($ch);
 		}
 
 		curl_multi_close($mh);
@@ -403,7 +401,6 @@ class EqslBulkDownloader {
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog-eQSL/1.0');
 		$content = curl_exec($ch);
 		$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 
 		if ($content === false || $httpCode != 200) {
 			log_message('error', 'Failed to download image from: ' . $url);

--- a/application/libraries/EqslImporter.php
+++ b/application/libraries/EqslImporter.php
@@ -85,53 +85,48 @@ class EqslImporter
 		// Let's use cURL instead of file_get_contents
 		// begin script
 		$ch = curl_init();
-		try {
-			// basic curl options for all requests
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($ch, CURLOPT_HEADER, 1);
+		// basic curl options for all requests
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_HEADER, 1);
 
-			// use the URL and params we built
-			curl_setopt($ch, CURLOPT_URL, $eqsl_url);
-			curl_setopt($ch, CURLOPT_POST, 1);
-			curl_setopt($ch, CURLOPT_POSTFIELDS, $eqsl_params);
+		// use the URL and params we built
+		curl_setopt($ch, CURLOPT_URL, $eqsl_url);
+		curl_setopt($ch, CURLOPT_POST, 1);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $eqsl_params);
 
-			$input = curl_exec($ch);
-			$chi = curl_getinfo($ch);
+		$input = curl_exec($ch);
+		$chi = curl_getinfo($ch);
 
-			// "You have no log entries" -> Nothing else to do here
-			// "Your ADIF log file has been built" -> We've got an ADIF file we need to grab.
+		// "You have no log entries" -> Nothing else to do here
+		// "Your ADIF log file has been built" -> We've got an ADIF file we need to grab.
 
-			if ($chi['http_code'] == "200") {
-				if (stristr($input, "You have no log entries")) {
-					return $this->result('There are no QSLs waiting for download at eQSL.cc.'); // success
-				} else if (stristr($input, "Error: No such Username/Password found")) {
-					return $this->result('No such Username/Password found This could mean the wrong callsign or the wrong password, or the user does not exist.'); // warning
-				} else {
-					if (stristr($input, "Your ADIF log file has been built")) {
-						// Get all the links on the page and grab the URL for the ADI file.
-						$regexp = "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>";
-						if (preg_match_all("/$regexp/siU", $input, $matches)) {
-							foreach ($matches[2] as $match) {
-								// Look for the link that has the .adi file, and download it to $file
-								if (substr($match, -4, 4) == ".adi") {
-									file_put_contents($this->adif_file, file_get_contents("https://eqsl.cc/qslcard/" . $match));
-									return $this->import();
-								}
+		if ($chi['http_code'] == "200") {
+			if (stristr($input, "You have no log entries")) {
+				return $this->result('There are no QSLs waiting for download at eQSL.cc.'); // success
+			} else if (stristr($input, "Error: No such Username/Password found")) {
+				return $this->result('No such Username/Password found This could mean the wrong callsign or the wrong password, or the user does not exist.'); // warning
+			} else {
+				if (stristr($input, "Your ADIF log file has been built")) {
+					// Get all the links on the page and grab the URL for the ADI file.
+					$regexp = "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>";
+					if (preg_match_all("/$regexp/siU", $input, $matches)) {
+						foreach ($matches[2] as $match) {
+							// Look for the link that has the .adi file, and download it to $file
+							if (substr($match, -4, 4) == ".adi") {
+								file_put_contents($this->adif_file, file_get_contents("https://eqsl.cc/qslcard/" . $match));
+								return $this->import();
 							}
 						}
 					}
 				}
-			} else {
-				if ($chi['http_code'] == "500") {
-					return $this->result('eQSL.cc is experiencing issues. Please try importing QSOs later.'); // warning
-				}
 			}
-
-			return $this->result('It seems that the eQSL site has changed. Please open up an issue on GitHub.');
-		} finally {
-			// Close cURL handle
-			curl_close($ch);
+		} else {
+			if ($chi['http_code'] == "500") {
+				return $this->result('eQSL.cc is experiencing issues. Please try importing QSOs later.'); // warning
+			}
 		}
+
+		return $this->result('It seems that the eQSL site has changed. Please open up an issue on GitHub.');
 	}
 
 	// Read the ADIF file and set QSO confirmation status according to the settings

--- a/application/libraries/Hamqth.php
+++ b/application/libraries/Hamqth.php
@@ -20,7 +20,6 @@ class Hamqth {
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		$xml = curl_exec($ch);
-		curl_close($ch);
 		if(curl_errno($ch)) {
 			log_message('error', 'Hamqth query failed: '.curl_strerror(curl_errno($ch))." (".curl_errno($ch).")");
 			return false;
@@ -49,7 +48,6 @@ class Hamqth {
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -76,7 +74,6 @@ class Hamqth {
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
             curl_setopt($ch, CURLOPT_TIMEOUT, 10);
             $xml = curl_exec($ch);
-            curl_close($ch);
 
             // Create XML object
             $xml = simplexml_load_string($xml);

--- a/application/libraries/Pota.php
+++ b/application/libraries/Pota.php
@@ -58,9 +58,6 @@ class Pota
 
 		$summit_info = curl_exec($ch);
 
-		// Close cURL handle
-		curl_close($ch);
-
 		return $summit_info;
 	}
 }

--- a/application/libraries/Qrz.php
+++ b/application/libraries/Qrz.php
@@ -22,7 +22,6 @@ class Qrz {
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -48,7 +47,6 @@ class Qrz {
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -81,10 +79,8 @@ class Qrz {
 			if ($httpcode != 200) {
 				$message = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
 				log_message('debug', 'QRZ.com search for callsign: ' . $callsign . ' returned message: ' . $message . ' HTTP code: ' . $httpcode);
-				curl_close($ch);
 				return $data['error'] = 'Problems with qrz.com communication'; // Exit function if no 200. If request fails, 0 is returned
 			}
-			curl_close($ch);
 			// Create XML object
 			$xml = simplexml_load_string($xml);
 			if (!empty($xml->Session->Error)) {

--- a/application/libraries/Qrzcq.php
+++ b/application/libraries/Qrzcq.php
@@ -22,7 +22,6 @@ class Qrzcq {
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -55,7 +54,6 @@ class Qrzcq {
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -85,7 +83,6 @@ class Qrzcq {
 			curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 			$xml = curl_exec($ch);
 			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
 			if ($httpcode != 200) return $data['error'] = 'Problems with qrzcq.com communication'; // Exit function if no 200. If request fails, 0 is returned
 
 			// Create XML object

--- a/application/libraries/Qrzru.php
+++ b/application/libraries/Qrzru.php
@@ -22,7 +22,6 @@ class Qrzru {
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -48,7 +47,6 @@ class Qrzru {
 		curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 		$xml = curl_exec($ch);
-		curl_close($ch);
 
 		// Create XML object
 		$xml = simplexml_load_string($xml);
@@ -78,7 +76,6 @@ class Qrzru {
 			curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
 			$xml = curl_exec($ch);
 			$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
 
 			// Create XML object
 			$xml = simplexml_load_string($xml);

--- a/application/libraries/Sota.php
+++ b/application/libraries/Sota.php
@@ -58,9 +58,6 @@ class Sota
 
 		$summit_info = curl_exec($ch);
 
-		// Close cURL handle
-		curl_close($ch);
-
 		return $summit_info;
 	}
 }

--- a/application/libraries/Wwff.php
+++ b/application/libraries/Wwff.php
@@ -58,9 +58,6 @@ class Wwff
 
 		$summit_info = curl_exec($ch);
 
-		// Close cURL handle
-		curl_close($ch);
-
 		return $summit_info;
 	}
 }

--- a/application/models/Clublog_model.php
+++ b/application/models/Clublog_model.php
@@ -100,7 +100,6 @@ class Clublog_model extends CI_Model
 								if (curl_errno($request)) {
 									$return =  curl_error($request);
 								}
-								curl_close($request);
 
 								// If Clublog Accepts mark the QSOs
 								if (($httpcode == 200) || (preg_match('/\baccepted\b/', $response))) {
@@ -200,7 +199,6 @@ class Clublog_model extends CI_Model
 				$httpcode = curl_getinfo($request, CURLINFO_HTTP_CODE);
 				$c_err=curl_errno($request);
 				$c_errstring=curl_error($request);
-				curl_close($request);
 
 				if ($c_err) {
 					$log = $c_errstring."<br>";
@@ -445,7 +443,6 @@ class Clublog_model extends CI_Model
 		curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
 		$response = curl_exec($request);
 		$httpcode = curl_getinfo($request, CURLINFO_HTTP_CODE);
-		curl_close($request);
 
 		if (preg_match('/\bOK\b/', $response)) {
 			$returner['status'] = 'OK';

--- a/application/models/Dcl_model.php
+++ b/application/models/Dcl_model.php
@@ -65,7 +65,6 @@ class Dcl_model extends CI_Model {
 				curl_setopt($ch, CURLOPT_HEADER, false);
 				curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 				$rawdcldata = curl_exec($ch);
-				curl_close($ch);
 				if (strlen($rawdcldata)>100) {
 					$dcldata=json_decode($rawdcldata);
 					return $dcldata;

--- a/application/models/Dxcluster_model.php
+++ b/application/models/Dxcluster_model.php
@@ -102,7 +102,6 @@ class Dxcluster_model extends CI_Model {
 			$jsonraw = curl_exec($ch);
 			$curl_error = curl_error($ch);
 			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
 
 			// Check for curl errors
 			if ($curl_error || $jsonraw === false) {
@@ -554,7 +553,6 @@ class Dxcluster_model extends CI_Model {
 		    curl_setopt($ch, CURLOPT_HEADER, false);
 		    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		    $jsonraw = curl_exec($ch);
-		    curl_close($ch);
 		    $json = json_decode($jsonraw);
 
 			$date = date('Ymd', time());

--- a/application/models/Eqslmethods_model.php
+++ b/application/models/Eqslmethods_model.php
@@ -272,7 +272,6 @@ class Eqslmethods_model extends CI_Model {
 
 		$result = curl_exec($ch);
 		$chi = curl_getinfo($ch);
-		curl_close($ch);
 
 	/*  Time for some error handling
 			Things we might get back

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -1181,7 +1181,6 @@ class Logbook_model extends CI_Model {
 			$result['message'] = 'Curl error: ' . curl_errno($ch);
 			return $result;
 		}
-		curl_close($ch);
 	}
 
 	/*
@@ -1224,7 +1223,6 @@ class Logbook_model extends CI_Model {
 			$result['message'] = 'Curl error: ' . curl_errno($ch);
 			return $result;
 		}
-		curl_close($ch);
 	}
 
 	/*
@@ -1255,7 +1253,6 @@ class Logbook_model extends CI_Model {
 		$content = curl_exec($ch); // TODO: better error handling
 		$errors = curl_error($ch);
 		$response = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 		return $response === 200;
 	}
 

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -147,7 +147,6 @@ class Update_model extends CI_Model {
         curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $csv = curl_exec($ch);
-        curl_close($ch);
         if ($csv === FALSE) {
             return "Something went wrong with fetching the WWFF file";
         }
@@ -191,7 +190,6 @@ class Update_model extends CI_Model {
 	    curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 	    $contents = curl_exec($ch);
 	    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-	    curl_close($ch);
 
 	    if ($contents === FALSE || $http_code != 200) {
 		    return "Something went wrong with fetching the solarxml.xml file from HAMqsl website.";
@@ -226,7 +224,6 @@ class Update_model extends CI_Model {
         curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $csv = curl_exec($ch);
-        curl_close($ch);
         if ($csv === FALSE) {
             return "Something went wrong with fetching the POTA file";
         }
@@ -321,7 +318,6 @@ class Update_model extends CI_Model {
         curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
         curl_setopt($ch, CURLOPT_URL,$url);
         $result=curl_exec($ch);
-        curl_close($ch);
         $json = json_decode($result, true);
         $latest_tag = $json[0]['tag_name'] ?? 'Unknown';
         return $latest_tag;
@@ -417,7 +413,6 @@ class Update_model extends CI_Model {
 				}
 			}
 
-			curl_close($curl);
 
 			$mtime = microtime();
 			$mtime = explode(" ",$mtime);
@@ -427,7 +422,6 @@ class Update_model extends CI_Model {
 			return "This page was created in ".$totaltime." seconds <br />Records inserted: " . $count;
 
 		} else {
-			curl_close($curl);
 			return "Error: Received file was empty";
 		}
 	}
@@ -446,7 +440,6 @@ class Update_model extends CI_Model {
 			log_message('error', __('cURL error:').' '.curl_error($curl).' ('.curl_errno($curl).')');
 			return;
 		}
-		curl_close($curl);
 		$xmlstring = gzdecode($response);
 		if ($xmlstring === false) {
 			return;
@@ -559,7 +552,6 @@ class Update_model extends CI_Model {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		$response = curl_exec($ch);
 		$http_result = curl_getinfo($ch);
-		curl_close($ch);
 		if ($http_result['http_code'] == "200") {
 			$lines = explode("\n", $response);
 			if (count($lines) > 0) {	// Check if there was data, otherwise skip parsing / truncating the table and preserve whats there
@@ -699,8 +691,6 @@ class Update_model extends CI_Model {
 				$total_inserted += $rows;
 			}
 		}
-
-		curl_close($curl);
 
 		$mtime = microtime();
 		$mtime = explode(" ",$mtime);

--- a/install/includes/install_config/install_lib.php
+++ b/install/includes/install_config/install_lib.php
@@ -130,7 +130,6 @@ function detect_nginx_php_setting($http_scheme) {
    curl_setopt($ch, CURLOPT_HEADER, 0);
    $data = curl_exec($ch);
    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-   curl_close($ch);
    return $code;
 }
 

--- a/src/StaticMap/src/Image.php
+++ b/src/StaticMap/src/Image.php
@@ -306,8 +306,6 @@ class Image {
             throw new \Exception(\curl_error($curl));
         }
 
-        \curl_close($curl);
-
         if ($image === false) {
             return $this->resetFields();
         }


### PR DESCRIPTION
curl_close() is deprecated since php8.0 and is completely without effect. So we can remove it entirely. PHP <8 is not supported anymore.

Ref: https://www.php.net/manual/en/function.curl-close.php