### PR TITLE
Accept also single-stations on create_station

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -181,6 +181,11 @@ class API extends CI_Controller {
 				$this->output->set_status_header(400)->set_content_type('application/json')->set_output(json_encode(['status' => 'error', 'message' => 'Invalid JSON file']));
 				return;
 			}
+
+			// If a single station object is posted (not an array), wrap it in an array
+			if (isset($locations['station_callsign']) || isset($locations['station_profile_name'])) {
+				$locations = [$locations];
+			}
 		} catch (Exception $e) {
 			$this->output->set_status_header(500)->set_content_type('application/json')->set_output(json_encode(['status' => 'error', 'message' => 'Processing error: ' . $e->getMessage()]));
 		}

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -264,6 +264,9 @@ class Stationsetup_model extends CI_Model {
 			if ($imported >= 1000){
 				return (array('limit',$imported."locations imported. Maximum limit of 1000 locations reached.")); // Prevent importing more than 1000 locations at once
 			}
+			if (trim($loc['station_uuid'] ?? '') == '') {	// Make sure it's null, even if it's set to ''
+				$loc['station_uuid']=null;
+			}
 			// Data for station_profile
 			$dbdata = [
 				'station_active'        => 0,


### PR DESCRIPTION
Resolves #2876 

api accepts now single-stations (without array) as well as arrays.

Testing: See Wiki https://github.com/wavelog/wavelog/wiki/API#apicreate_station
Try with `[]` (as described in wiki) and without `[]` as a simple json-object. 

