### PR TITLE
feat: broadcast callsign lookup results via WebSocket

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1453,6 +1453,29 @@ $("#callsign").on("focusout", function () {
 				// Reset QSO fields
 				resetDefaultQSOFields();
 
+				// --- Added for WebSocket Integration (Rotators / External Displays) ---
+				if (typeof window.broadcastLookupResult === 'function') {
+					const broadcastData = {
+						callsign: result.callsign,
+						dxcc_id: result.dxcc.adif,
+						name: result.callsign_name,
+						gridsquare: result.callsign_qra,
+						city: result.callsign_qth,
+						iota: result.callsign_iota,
+						state: result.callsign_state,
+						us_county: result.callsign_us_county,
+						bearing: result.bearing,
+						distance: result.callsign_distance,
+						lotw_member: result.lotw_member,
+						lotw_days: result.lotw_days,
+						eqsl_member: result.eqsl_member,
+						qsl_manager: result.qsl_manager,
+						slot_confirmed: result.dxcc_confirmed_on_band_mode
+					};
+					window.broadcastLookupResult(broadcastData);
+				}
+				// ---------------------------------------------------------
+
 				// Set qso icon
 				get_note_status(result.callsign);
 


### PR DESCRIPTION
This PR implements a global WebSocket broadcast whenever a callsign lookup occurs in the QSO window. It enables external hardware and software (rotators, external displays, and integrators) to react instantly to the station being logged.

Key changes:
- Added 'broadcastLookupResult' to assets/js/cat.js.
- Implemented automatic WebSocket initialization if a local CAT-URL (127.0.0.1/localhost) is detected.
- Triggered broadcast from assets/js/sections/qso.js upon successful lookup, including full metadata (Azimuth, LoTW status, US County, Slot confirmation, etc.).