### PR TITLE
Disable Auto-Websocket

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -1312,20 +1312,6 @@ $(document).ready(function() {
             // Start standard polling
             CATInterval = setInterval(updateFromCAT, CAT_CONFIG.POLL_INTERVAL);
 
-            // --- PR ADDITION: Auto-enable WebSocket for local CAT URLs ---
-            // Fetch radio details to check if we should also start WebSocket
-            $.getJSON(base_url + 'index.php/radio/json/' + selectedRadioId, function(data) {
-                if (data.cat_url) {
-                    const url = data.cat_url.toLowerCase();
-                    if (url.includes('127.0.0.1') || url.includes('localhost')) {
-                        console.log("CAT: Local CAT URL detected (" + data.cat_url + "). Initializing WebSocket...");
-                        websocketIntentionallyClosed = false;
-                        initializeWebSocketConnection();
-                    }
-                }
-            });
-            // -------------------------------------------------------------
-
             if ((window.CAT_COMPACT_MODE === 'ultra-compact' || window.CAT_COMPACT_MODE === 'icon-only') && typeof window.isCatTrackingEnabled !== 'undefined' && !window.isCatTrackingEnabled) {
                 displayOfflineStatus('cat_disabled');
             }

--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -1286,7 +1286,7 @@ $(document).ready(function() {
             $('#toggleCatTracking').removeClass('btn-success').addClass('btn-secondary');
             // Display offline status when no radio selected
             displayOfflineStatus('no_radio');
-        } else if (selectedRadioId == 'ws' || (websocketEnabled && websocket !== null)) {
+        } else if (selectedRadioId == 'ws') {
             websocketIntentionallyClosed = false; // Reset flag when opening WebSocket
             reconnectAttempts = 0; // Reset reconnect attempts
             hasTriedWsFallback = false; // Reset WSS failover state - try WSS first again


### PR DESCRIPTION
I am sure that the “Automatic connection to Websocket” feature #2878 was implemented with the best of intentions.
However, not everyone uses Websocket clients. There are many people who do not have a Websocket client.

And the feature keeps trying to connect to the Websocket, even if “None” is selected as an option.

Give people the option to choose whether they want to use “Websocket” or not.