### PR TITLE
make sure $call is always uppercase to make regex pattern work

### DIFF
--- a/src/Dxcc/Dxcc.php
+++ b/src/Dxcc/Dxcc.php
@@ -22,6 +22,9 @@ class Dxcc {
 	}
 
 	public function dxcc_lookup($call, $date) {
+		// Ensure callsign is uppercase for pattern matching
+		$call = strtoupper($call);
+		
 		if (array_key_exists($call, $this->dxccexceptions)) {
 			$exceptions = $this->dxccexceptions[$call];
 


### PR DESCRIPTION
If the $call is lowercase the whole dxcc class does not work properly due to the case sensitive regex. Instead fixing all kind of regex we just can make sure the $call is always uppercase