### PR TITLE
Fix multicallbook configuration

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -952,7 +952,9 @@ class Logbook extends CI_Controller {
 			if (is_array($source_callbooks)) {
 				$callsigninfo['error'] = '<b>'.__('All callbook lookups failed or provided no results.').'</b>';
 				foreach($source_callbooks as $source) {
-					$callsigninfo['error'] .= "<br />".$callsigninfo['callsign']['error_'.$source.'_name'].': '.$callsigninfo['callsign']['error_'.$source];
+					if (isset($callsigninfo['callsign']['error_'.$source]) && isset($callsigninfo['callsign']['error_'.$source.'_name'])) {
+						$callsigninfo['error'] .= "<br />".$callsigninfo['callsign']['error_'.$source.'_name'].': '.$callsigninfo['callsign']['error_'.$source];
+					}
 				}
 			} else {
 				if (isset($callsigninfo['callsign']['error'])) {


### PR DESCRIPTION
if a callbook query was successful on the first attempt there are no  error arraykeys. Currently this produces this error and prevents the qso logging

```php
DEBUG - 2026-02-01 21:04:43 --> Callbook lookup for DF2ET using hamqth: Success
ERROR - 2026-02-01 21:04:43 --> Severity: Warning --> Undefined array key "error_hamqth_name" /var/www/wavelog/application/controllers/Logbook.php 955
ERROR - 2026-02-01 21:04:43 --> Severity: Warning --> Undefined array key "error_hamqth" /var/www/wavelog/application/controllers/Logbook.php 955
ERROR - 2026-02-01 21:04:43 --> Severity: Warning --> Undefined array key "error_qrz_name" /var/www/wavelog.worktrees/upstream-dev/application/controllers/Logbook.php 955
ERROR - 2026-02-01 21:04:43 --> Severity: Warning --> Undefined array key "error_qrz" /var/www/wavelog/application/controllers/Logbook.php 955

```

this was my config:

```php
$config['callbook'] = ['hamqth', 'qrz'];
```