### PR TITLE
Install php-redis-extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends cron
 RUN install-php-extensions \
         mysqli \
         zip \
-	redis \
+        redis \
         gd; \
     \
     a2enmod rewrite; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN install-php-extensions \
         mysqli \
         zip \
         redis \
+        memcached \
+        apcu \
+        wincache \
         gd; \
     \
     a2enmod rewrite; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends cron
 RUN install-php-extensions \
         mysqli \
         zip \
+	redis \
         gd; \
     \
     a2enmod rewrite; \


### PR DESCRIPTION
Since CI supports REDIS as Cache for sessions (coming more),
we should add at least the php-redis extension to the dockerfile.

So one is able to use his existing redis-installation for Wavelog.

Later we can add valkey itself to the compose-example and configs, when using docker.