### PR TITLE
Optimize index-usage

### DIFF
--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -20,10 +20,10 @@ class adif_data extends CI_Model {
 		$this->db->order_by("COL_TIME_ON", "ASC");
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		if ($from) {
-			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) >= ", $from);
+			$this->db->where($this->config->item('table_name').".COL_TIME_ON >= ", $from . ' 00:00:00');
 		}
 		if ($to) {
-			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= ",$to);
+			$this->db->where($this->config->item('table_name').".COL_TIME_ON <= ", $to . ' 23:59:59');
 		}
 		if ($onlyop) {
 			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
@@ -62,10 +62,10 @@ class adif_data extends CI_Model {
 		$this->db->order_by("COL_TIME_ON", "ASC");
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		if ($from) {
-			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) >= ", $from);
+			$this->db->where($this->config->item('table_name').".COL_TIME_ON >= ", $from . ' 00:00:00');
 		}
 		if ($to) {
-			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= ",$to);
+			$this->db->where($this->config->item('table_name').".COL_TIME_ON <= ", $to . ' 23:59:59');
 		}
 		if ($onlyop) {
 			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
@@ -187,10 +187,10 @@ class adif_data extends CI_Model {
 
 		// Apply same filters as export_custom
 		if ($from) {
-			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) >= ", $from);
+			$this->db->where($this->config->item('table_name').".COL_TIME_ON >= ", $from . ' 00:00:00');
 		}
 		if ($to) {
-			$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= ",$to);
+			$this->db->where($this->config->item('table_name').".COL_TIME_ON <= ", $to . ' 23:59:59');
 		}
 		if ($onlyop) {
 			$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);
@@ -229,10 +229,10 @@ class adif_data extends CI_Model {
 
 			// If date is set, we format the date and add it to the where-statement
 			if ($from) {
-				$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) >= ", $from);
+				$this->db->where($this->config->item('table_name').".COL_TIME_ON >= ", $from . ' 00:00:00');
 			}
 			if ($to) {
-				$this->db->where("date(".$this->config->item('table_name').".COL_TIME_ON) <= ",$to);
+				$this->db->where($this->config->item('table_name').".COL_TIME_ON <= ", $to . ' 23:59:59');
 			}
 			if ($onlyop) {
 				$this->db->where("upper(".$this->config->item('table_name').".col_operator)",$onlyop);

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -325,12 +325,12 @@ class Contesting_model extends CI_Model {
 		if ($from != 0) {
 			$from = DateTime::createFromFormat('Y-m-d', $this->security->xss_clean($from));
 			$from = $from->format('Y-m-d');
-			$this->db->where("date(" . $this->config->item('table_name') . ".COL_TIME_ON) >= '" . $from . "'");
+			$this->db->where($this->config->item('table_name') . ".COL_TIME_ON >= '" . $from . " 00:00:00'");
 		}
 		if ($to != 0) {
 			$to = DateTime::createFromFormat('Y-m-d', $this->security->xss_clean($to));
 			$to = $to->format('Y-m-d');
-			$this->db->where("date(" . $this->config->item('table_name') . ".COL_TIME_ON) <= '" . $to . "'");
+			$this->db->where($this->config->item('table_name') . ".COL_TIME_ON <= '" . $to . " 23:59:59'");
 		}
 
 		// If band is set, we only load contacts for that band
@@ -436,13 +436,13 @@ class Contesting_model extends CI_Model {
 		$binding = [];
 		$sql = "select distinct COL_BAND band
 			from " . $this->config->item('table_name') . "
-			where date(" . $this->config->item('table_name') . ".COL_TIME_ON) >= ?
-			and date(" . $this->config->item('table_name') . ".COL_TIME_ON) <= ?
+			where COL_TIME_ON >= ?
+			and COL_TIME_ON <= ?
 			and station_id = ? and COL_CONTEST_ID = ?";
 
-		//add data to bindings
-		$binding[] = $from;
-		$binding[] = $to;
+		//add data to bindings - convert dates to datetime for index usage
+		$binding[] = $from . ' 00:00:00';
+		$binding[] = $to . ' 23:59:59';
 		$binding[] = $station_id;
 		$binding[] = $contestid;
 

--- a/application/models/Cq.php
+++ b/application/models/Cq.php
@@ -83,13 +83,13 @@ class CQ extends CI_Model{
 		}
 
 			if ($postdata['datefrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['datefrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['datefrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateto'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateto'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateto'] . ' 23:59:59';
 		}
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$bindings);
@@ -105,13 +105,13 @@ class CQ extends CI_Model{
 		}
 
 		if ($postdata['datefrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['datefrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['datefrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateto'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateto'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateto'] . ' 23:59:59';
 		}
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$bindings);
@@ -141,13 +141,13 @@ class CQ extends CI_Model{
 		}
 
 		if ($postdata['datefrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['datefrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['datefrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateto'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateto'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateto'] . ' 23:59:59';
 		}
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$bindings);
@@ -211,13 +211,13 @@ class CQ extends CI_Model{
 		}
 
 		if ($postdata['datefrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['datefrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['datefrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateto'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateto'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateto'] . ' 23:59:59';
 		}
 
 		$query = $this->db->query($sql,$bindings);
@@ -256,13 +256,13 @@ class CQ extends CI_Model{
 		}
 
 		if ($postdata['datefrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['datefrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['datefrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateto'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateto'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateto'] . ' 23:59:59';
 		}
 
 		$sql .= $this->genfunctions->addQslToQuery($postdata);

--- a/application/models/Csv_model.php
+++ b/application/models/Csv_model.php
@@ -69,12 +69,12 @@ class Csv_model extends CI_Model
 
 		// If date is set, we format the date and add it to the where-statement
 		if ($fromdate != "") {
-			$sql .= " and date(COL_TIME_ON) >= ?";
-			$binds[]=$fromdate;
+			$sql .= " and COL_TIME_ON >= ?";
+			$binds[]=$fromdate . ' 00:00:00';
 		}
 		if ($todate != "") {
-			$sql .= " and date(COL_TIME_ON) <= ?"; 
-			$binds[]=$todate;
+			$sql .= " and COL_TIME_ON <= ?";
+			$binds[]=$todate . ' 23:59:59';
 		}
 
 		$sql .= ' and station_profile.user_id = ?';

--- a/application/models/Dxatlas_model.php
+++ b/application/models/Dxatlas_model.php
@@ -159,12 +159,12 @@ class Dxatlas_model extends CI_Model
 
 		// If date is set, we format the date and add it to the where-statement
 		if ($fromdate != "") {
-			$sql .= " and date(COL_TIME_ON) >= ?";
-			$bindings[] = $fromdate;
+			$sql .= " and COL_TIME_ON >= ?";
+			$bindings[] = $fromdate . ' 00:00:00';
 		}
 		if ($todate != "") {
-			$sql .= " and date(COL_TIME_ON) <= ?";
-			$bindings[] = $todate;
+			$sql .= " and COL_TIME_ON <= ?";
+			$bindings[] = $todate . ' 23:59:59';
 		}
 
 		$sql .= ' and station_profile.user_id = ?';

--- a/application/models/Dxcc.php
+++ b/application/models/Dxcc.php
@@ -172,13 +172,13 @@ class DXCC extends CI_Model {
 		$sql .= $this->genfunctions->addQslToQuery($postdata);
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 		$sql .= " group by col_dxcc
@@ -221,13 +221,13 @@ class DXCC extends CI_Model {
 		}
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 		$sql .= $this->addOrbitToQuery($postdata,$bindings);
@@ -280,13 +280,13 @@ class DXCC extends CI_Model {
 			}
 
 			if ($postdata['dateFrom'] != NULL) {
-				$sql .= " and date(col_time_on) >= ?";
-				$bindings[]=$postdata['dateFrom'];
+				$sql .= " and col_time_on >= ?";
+				$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 			}
 
 			if ($postdata['dateTo'] != NULL) {
-				$sql .= " and date(col_time_on) <= ?";
-				$bindings[]=$postdata['dateTo'];
+				$sql .= " and col_time_on <= ?";
+				$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 			}
 
 			if ($postdata['mode'] != 'All') {
@@ -343,13 +343,13 @@ class DXCC extends CI_Model {
 		}
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 		$sql .= " and not exists (select 1 from ".$this->config->item('table_name')." where station_id in (". $location_list .") and col_dxcc = thcv.col_dxcc and col_dxcc > 0";
@@ -366,13 +366,13 @@ class DXCC extends CI_Model {
 		}
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 
@@ -408,13 +408,13 @@ class DXCC extends CI_Model {
 		    ") and col_dxcc > 0";
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 		$sql .= $this->genfunctions->addBandToQuery($postdata['band'],$bindings);
@@ -548,13 +548,13 @@ class DXCC extends CI_Model {
 		}
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 		if ($postdata['mode'] != 'All') {
@@ -618,13 +618,13 @@ class DXCC extends CI_Model {
 		}
 
 		if ($postdata['dateFrom'] != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$bindings[]=$postdata['dateFrom'];
+			$sql .= " and col_time_on >= ?";
+			$bindings[]=$postdata['dateFrom'] . ' 00:00:00';
 		}
 
 		if ($postdata['dateTo'] != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$bindings[]=$postdata['dateTo'];
+			$sql .= " and col_time_on <= ?";
+			$bindings[]=$postdata['dateTo'] . ' 23:59:59';
 		}
 
 		if ($postdata['mode'] != 'All') {

--- a/application/models/Gridmap_model.php
+++ b/application/models/Gridmap_model.php
@@ -69,13 +69,13 @@ class Gridmap_model extends CI_Model {
 		}
 
 		if ($datefrom != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$binding[] = $datefrom;
+			$sql .= " and col_time_on >= ?";
+			$binding[] = $datefrom . ' 00:00:00';
 		}
 
 		if ($dateto != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$binding[] = $dateto;
+			$sql .= " and col_time_on <= ?";
+			$binding[] = $dateto . ' 23:59:59';
 		}
 
 		if ($dxcc != 'All') {
@@ -151,13 +151,13 @@ class Gridmap_model extends CI_Model {
 		}
 
 		if ($datefrom != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$binding[] = $datefrom;
+			$sql .= " and col_time_on >= ?";
+			$binding[] = $datefrom . ' 00:00:00';
 		}
 
 		if ($dateto != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$binding[] = $dateto;
+			$sql .= " and col_time_on <= ?";
+			$binding[] = $dateto . ' 23:59:59';
 		}
 
 		if ($orbit != 'All') {
@@ -234,13 +234,13 @@ class Gridmap_model extends CI_Model {
 		}
 
 		if ($datefrom != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$binding[] = $datefrom;
+			$sql .= " and col_time_on >= ?";
+			$binding[] = $datefrom . ' 00:00:00';
 		}
 
 		if ($dateto != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$binding[] = $dateto;
+			$sql .= " and col_time_on <= ?";
+			$binding[] = $dateto . ' 23:59:59';
 		}
 
 		if ($orbit != 'All') {
@@ -305,13 +305,13 @@ class Gridmap_model extends CI_Model {
 		}
 
 		if ($datefrom != NULL) {
-			$sql .= " and date(col_time_on) >= ?";
-			$binding[] = $datefrom;
+			$sql .= " and col_time_on >= ?";
+			$binding[] = $datefrom . ' 00:00:00';
 		}
 
 		if ($dateto != NULL) {
-			$sql .= " and date(col_time_on) <= ?";
-			$binding[] = $dateto;
+			$sql .= " and col_time_on <= ?";
+			$binding[] = $dateto . ' 23:59:59';
 		}
 
 		if ($mode != 'All') {

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -693,10 +693,10 @@ class Logbook_model extends CI_Model {
 		}
 
 		if ($datefrom != null) {
-			$this->db->where('date(COL_TIME_ON) >=', $datefrom);
+			$this->db->where('COL_TIME_ON >=', $datefrom . ' 00:00:00');
 		}
 		if ($dateto != null) {
-			$this->db->where('date(COL_TIME_ON) <=', $dateto);
+			$this->db->where('COL_TIME_ON <=', $dateto . ' 23:59:59');
 		}
 		$this->db->order_by("COL_TIME_ON", "desc");
 		$this->db->order_by("COL_PRIMARY_KEY", "desc");
@@ -3375,10 +3375,10 @@ class Logbook_model extends CI_Model {
 
 		// If date is set, we add it to the where-statement
 		if ($fromdate != "") {
-			$this->db->where("date(" . $this->config->item('table_name') . ".COL_TIME_ON) >=", $fromdate);
+			$this->db->where($this->config->item('table_name') . ".COL_TIME_ON >=", $fromdate . ' 00:00:00');
 		}
 		if ($todate != "") {
-			$this->db->where("date(" . $this->config->item('table_name') . ".COL_TIME_ON) <=", $todate);
+			$this->db->where($this->config->item('table_name') . ".COL_TIME_ON <=", $todate . ' 23:59:59');
 		}
 
 		$query = $this->db->get($this->config->item('table_name'));
@@ -3429,12 +3429,12 @@ class Logbook_model extends CI_Model {
 					FROM " . $this->config->item('table_name') . "
 					WHERE station_id IN ($location_list)";
 			if (!empty($dateFrom)) {
-				$sql .= " AND DATE(COL_TIME_ON) >= ?";
-				$params[] = $dateFrom;
+				$sql .= " AND COL_TIME_ON >= ?";
+				$params[] = $dateFrom . ' 00:00:00';
 			}
 			if (!empty($dateTo)) {
-				$sql .= " AND DATE(COL_TIME_ON) <= ?";
-				$params[] = $dateTo;
+				$sql .= " AND COL_TIME_ON <= ?";
+				$params[] = $dateTo . ' 23:59:59';
 			}
 			$sql .= " GROUP BY DATE_FORMAT(COL_TIME_ON, '%m')
 					ORDER BY month ASC";
@@ -3683,10 +3683,10 @@ class Logbook_model extends CI_Model {
 
 	private function where_date_range($dateFrom, $dateTo) {
 		if (!empty($dateFrom)) {
-			$this->db->where('DATE(COL_TIME_ON) >=', $dateFrom);
+			$this->db->where('COL_TIME_ON >=', $dateFrom . ' 00:00:00');
 		}
 		if (!empty($dateTo)) {
-			$this->db->where('DATE(COL_TIME_ON) <=', $dateTo);
+			$this->db->where('COL_TIME_ON <=', $dateTo . ' 23:59:59');
 		}
 	}
 

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -175,13 +175,13 @@ class Logbookadvanced_model extends CI_Model {
 
         if ($searchCriteria['dateFrom'] !== '') {
             $from = $searchCriteria['dateFrom'];
-			$conditions[] = "date(COL_TIME_ON) >= ?";
-			$binding[] = $from;
+			$conditions[] = "COL_TIME_ON >= ?";
+			$binding[] = $from . ' 00:00:00';
 		}
         if ($searchCriteria['dateTo'] !== '') {
             $to = $searchCriteria['dateTo'];
-			$conditions[] = "date(COL_TIME_ON) <= ?";
-			$binding[] = $to;
+			$conditions[] = "COL_TIME_ON <= ?";
+			$binding[] = $to . ' 23:59:59';
 		}
 		if ($searchCriteria['de'] !== 'All' && $searchCriteria['qsoids'] === '') {
 			if ($searchCriteria['de'] == '') {

--- a/application/models/Stats.php
+++ b/application/models/Stats.php
@@ -74,10 +74,10 @@
 	// Helper method for date range filtering
 	private function filter_date_range($dateFrom, $dateTo) {
 		if (!empty($dateFrom)) {
-			$this->db->where('DATE(COL_TIME_ON) >=', $dateFrom);
+			$this->db->where('COL_TIME_ON >=', $dateFrom . ' 00:00:00');
 		}
 		if (!empty($dateTo)) {
-			$this->db->where('DATE(COL_TIME_ON) <=', $dateTo);
+			$this->db->where('COL_TIME_ON <=', $dateTo . ' 23:59:59');
 		}
 	}
 
@@ -758,12 +758,12 @@
 		from " . $this->config->item('table_name') . "
 		where station_id in (". implode(',', $logbooks_locations_array) .")";
 		if (!empty($dateFrom)) {
-			$sql.=" and DATE(COL_TIME_ON) >= ? ";
-			$binding[]=$dateFrom;
+			$sql.=" and COL_TIME_ON >= ? ";
+			$binding[]=$dateFrom . ' 00:00:00';
 		}
 		if (!empty($dateTo)) {
-			$sql.=" and DATE(COL_TIME_ON) <= ? ";
-			$binding[]=$dateTo;
+			$sql.=" and COL_TIME_ON <= ? ";
+			$binding[]=$dateTo . ' 23:59:59';
 		}
 		$sql.=" and col_prop_mode <> 'SAT'
 		group by lower(col_band), col_mode, coalesce(col_submode, '')";
@@ -790,12 +790,12 @@
 		from " . $this->config->item('table_name') . "
 		where station_id in (". implode(',', $logbooks_locations_array) .")";
 		if (!empty($dateFrom)) {
-			$sql.=" and DATE(COL_TIME_ON) >= ? ";
-			$binding[]=$dateFrom;
+			$sql.=" and COL_TIME_ON >= ? ";
+			$binding[]=$dateFrom . ' 00:00:00';
 		}
 		if (!empty($dateTo)) {
-			$sql.=" and DATE(COL_TIME_ON) <= ? ";
-			$binding[]=$dateTo;
+			$sql.=" and COL_TIME_ON <= ? ";
+			$binding[]=$dateTo . ' 23:59:59';
 		}
 		$sql.=" and col_prop_mode = 'SAT'
 		and coalesce(col_sat_name, '') <> ''
@@ -996,12 +996,12 @@
 		LEFT JOIN satellite ON satellite.name = ".$this->config->item('table_name').".COL_SAT_NAME
 		where station_id in (" . implode(',',$logbooks_locations_array) . ") and coalesce(col_ant_el, '') <> ''";
 		if (!empty($dateFrom)) {
-			$sql.=" and DATE(COL_TIME_ON) >= ? ";
-			$binding[]=$dateFrom;
+			$sql.=" and COL_TIME_ON >= ? ";
+			$binding[]=$dateFrom . ' 00:00:00';
 		}
 		if (!empty($dateTo)) {
-			$sql.=" and DATE(COL_TIME_ON) <= ? ";
-			$binding[]=$dateTo;
+			$sql.=" and COL_TIME_ON <= ? ";
+			$binding[]=$dateTo . ' 23:59:59';
 		}
 		$sql.=" $where
 		group by round(col_ant_el)
@@ -1057,12 +1057,12 @@
 		where station_id in (" . implode(',',$logbooks_locations_array) . ")
 		and coalesce(col_ant_az, '') <> ''";
 		if (!empty($dateFrom)) {
-			$sql.=" and DATE(COL_TIME_ON) >= ? ";
-			$binding[]=$dateFrom;
+			$sql.=" and COL_TIME_ON >= ? ";
+			$binding[]=$dateFrom . ' 00:00:00';
 		}
 		if (!empty($dateTo)) {
-			$sql.=" and DATE(COL_TIME_ON) <= ? ";
-			$binding[]=$dateTo;
+			$sql.=" and COL_TIME_ON <= ? ";
+			$binding[]=$dateTo . ' 23:59:59';
 		}
 		$sql.=" $where
 		group by round(col_ant_az)

--- a/application/models/Visitor_model.php
+++ b/application/models/Visitor_model.php
@@ -13,9 +13,11 @@ class Visitor_model extends CI_Model {
 
 		if ($day != '') {
 			if ($day == 'today') {
-				$this->db->where('DATE('.$this->config->item('table_name').'.COL_TIME_ON) = CURDATE()');
+				$this->db->where($this->config->item('table_name').'.COL_TIME_ON >= CURDATE()');
+				$this->db->where($this->config->item('table_name').'.COL_TIME_ON < CURDATE() + INTERVAL 1 DAY');
 			} elseif ($day == 'yesterday') {
-				$this->db->where('DATE('.$this->config->item('table_name').'.COL_TIME_ON) = CURDATE() - INTERVAL 1 DAY');
+				$this->db->where($this->config->item('table_name').'.COL_TIME_ON >= CURDATE() - INTERVAL 1 DAY');
+				$this->db->where($this->config->item('table_name').'.COL_TIME_ON < CURDATE()');
 			}
 		} else {
 			if ($start_date != '') {


### PR DESCRIPTION
We already have an index at Logbook-Table which is a combined one of station_id and col_time_on.

but:
a lot of queries which use `DATE(COL_TIME_ON)` on the left side of the where. this leads into the fact, that the potential of index isn't used completly.

this PR refactors all occurences of `DATE(COL_TIME_ON)` within code to use the index.