### PR TITLE
feat: implement silent hybrid websocket connection and simplify labels

### DIFF
--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -237,7 +237,7 @@
 		<small class="text-muted me-1 flex-shrink-0 d-none d-md-inline"><?= __("TRX:"); ?></small>
 		<select class="form-select form-select-sm radios flex-shrink-0" id="radio" name="radio" style="width: auto;">
 			<option value="0" selected="selected"><?= __("None"); ?></option>
-			<option value="ws"<?php if ($this->session->userdata('radio') == 'ws') { echo ' selected="selected"'; } ?>><?= __("Live - ") . __("WebSocket (Requires WLGate>=1.1.10)"); ?></option>
+			<option value="ws"<?php if ($this->session->userdata('radio') == 'ws') { echo ' selected="selected"'; } ?>><?= __("Live - WebSocket"); ?></option>
 			<?php foreach ($radios->result() as $row) { ?>
 				<option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?= __("Polling - ") . $row->radio; ?><?php if ($radio_last_updated->id == $row->id) { echo " (".__("last updated").")"; } else { echo ''; } ?></option>
 			<?php } ?>

--- a/application/views/contesting/index.php
+++ b/application/views/contesting/index.php
@@ -157,7 +157,7 @@
                                 <label for="inputRadio"><?= __("Radio"); ?></label>
                                 <select class="form-select form-select-sm radios" id="radio" name="radio">
                                     <option value="0" selected="selected"><?= __("None"); ?></option>
-				    <option value="ws"<?php if ($this->session->userdata('radio') == 'ws') { echo ' selected="selected"'; } ?>><?= __("WebSocket (Requires WLGate>1.1.10)"); ?></option>
+                                    <option value="ws"<?php if ($this->session->userdata('radio') == 'ws') { echo ' selected="selected"'; } ?>><?= __("Live - WebSocket"); ?></option>
                                         <?php foreach ($radios->result() as $row) { ?>
                                         <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id) { echo "selected=\"selected\""; } ?>><?php echo $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "(".__("last updated").")"; } else { echo ''; } ?></option>
                                         <?php } ?>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -408,7 +408,7 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
               <label for="radio"><?= __("Radio"); ?></label>
               <select class="form-select radios" id="radio" name="radio">
                 <option value="0" selected="selected"><?= __("None"); ?></option>
-		            <option value="ws"<?php if ($this->session->userdata('radio') == 'ws' && $manual_mode == '0') { echo ' selected="selected"'; } ?>><?= __("Live - ") . __("WebSocket (Requires WLGate>=1.1.10)"); ?></option>
+		            <option value="ws"<?php if ($this->session->userdata('radio') == 'ws' && $manual_mode == '0') { echo ' selected="selected"'; } ?>><?= __("Live - WebSocket"); ?></option>
                 <?php foreach ($radios->result() as $row) { ?>
                   <option value="<?php echo $row->id; ?>" <?php if($this->session->userdata('radio') == $row->id && $manual_mode == '0') { echo "selected=\"selected\""; } ?>><?= __("Polling - ") . $row->radio; ?> <?php if ($radio_last_updated->id == $row->id) { echo "(".__("last updated").")"; } else { echo ''; } ?></option>
                 <?php } ?>


### PR DESCRIPTION
Relates to proposal #2899

Hi @int2001 and @HB9HIL!

This PR implements the changes discussed and agreed upon in issue #2899 regarding the "Hybrid" WebSocket workflow and UI labels.

### 1. Hybrid WebSocket Connection (`cat.js`)
*   **Logic:** Implemented the "Single-Shot Silent Attempt". When a standard Radio Profile is selected (via API), Wavelog will now attempt to establish a local WebSocket connection (`ws://127.0.0.1:54322/54323`).
*   **Behavior:**
    *   It uses a restricted retry limit (`HYBRID_WS_MAX_RETRIES = 1`) to minimize console noise.
    *   Failures are silent (no UI error alerts).
    *   This enables integrators (like Wave-Flex and WLGate) to broadcast metadata (lookup results, bearing, etc.) to the frontend even when the user is in "Polling" mode for frequency updates.

### 2. UI Label Simplification (Views)
*   Updated the radio dropdown labels in `bandmap/list.php`, `contesting/index.php`, and `qso/index.php`.
*   Changed: `WebSocket (Requires WLGate>=1.1.10)`
*   To: `Live - WebSocket`
*   *Reasoning:* As discussed with @HB9HIL, this makes the label tool-agnostic and less confusing for users.

Tested and verified here to be non-intrusive for users without a local WS server.