### PR TITLE
Combined sqls

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -837,10 +837,11 @@ class API extends CI_Controller {
 		$this->load->model('api_model');
 		if ((($key ?? '') != '') && ($this->api_model->authorize($key) != 0)) {
 			$this->load->model('logbook_model');
-			$data['todays_qsos'] = $this->logbook_model->todays_qsos(null, $key);
-			$data['total_qsos'] = $this->logbook_model->total_qsos(null, $key);
-			$data['month_qsos'] = $this->logbook_model->month_qsos(null, $key);
-			$data['year_qsos'] = $this->logbook_model->year_qsos(null, $key);
+			$qso_counts = $this->logbook_model->get_qso_counts(null, $key);
+			$data['todays_qsos'] = $qso_counts['today'];
+			$data['total_qsos'] = $qso_counts['total'];
+			$data['month_qsos'] = $qso_counts['month'];
+			$data['year_qsos'] = $qso_counts['year'];
 		} else { # for Downcompat
 			$data['todays_qsos'] = 0;
 			$data['total_qsos'] = 0;

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -111,38 +111,38 @@ class Dashboard extends CI_Controller {
 			$data['current_streak']=0;
 		}
 
-		// Load Countries Breakdown data into array (combined query)
-		$CountriesBreakdown = $this->logbook_model->total_countries_breakdown_batch($logbooks_locations_array);
+		// Load Dashboard stats (countries + QSL stats in one query)
+		$stats = $this->logbook_model->dashboard_stats_batch($logbooks_locations_array);
 
-		$data['total_countries'] = $CountriesBreakdown['Countries_Worked'];
-		$data['total_countries_confirmed_paper'] = $CountriesBreakdown['Countries_Worked_QSL'];
-		$data['total_countries_confirmed_eqsl'] = $CountriesBreakdown['Countries_Worked_EQSL'];
-		$data['total_countries_confirmed_lotw'] = $CountriesBreakdown['Countries_Worked_LOTW'];
-		$current = $CountriesBreakdown['Countries_Current'];
+		// Country stats
+		$data['total_countries'] = $stats['Countries_Worked'];
+		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
+		$data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
+		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
+		$current = $stats['Countries_Current'];
 
-		$QSLStatsBreakdownArray = $this->logbook_model->get_QSLStats($logbooks_locations_array);
+		// QSL stats
+		$data['total_qsl_sent'] = $stats['QSL_Sent'];
+		$data['total_qsl_rcvd'] = $stats['QSL_Received'];
+		$data['total_qsl_requested'] = $stats['QSL_Requested'];
+		$data['qsl_sent_today'] = $stats['QSL_Sent_today'];
+		$data['qsl_rcvd_today'] = $stats['QSL_Received_today'];
+		$data['qsl_requested_today'] = $stats['QSL_Requested_today'];
 
-		$data['total_qsl_sent'] = $QSLStatsBreakdownArray['QSL_Sent'];
-		$data['total_qsl_rcvd'] = $QSLStatsBreakdownArray['QSL_Received'];
-		$data['total_qsl_requested'] = $QSLStatsBreakdownArray['QSL_Requested'];
-		$data['qsl_sent_today'] = $QSLStatsBreakdownArray['QSL_Sent_today'];
-		$data['qsl_rcvd_today'] = $QSLStatsBreakdownArray['QSL_Received_today'];
-		$data['qsl_requested_today'] = $QSLStatsBreakdownArray['QSL_Requested_today'];
+		$data['total_eqsl_sent'] = $stats['eQSL_Sent'];
+		$data['total_eqsl_rcvd'] = $stats['eQSL_Received'];
+		$data['eqsl_sent_today'] = $stats['eQSL_Sent_today'];
+		$data['eqsl_rcvd_today'] = $stats['eQSL_Received_today'];
 
-		$data['total_eqsl_sent'] = $QSLStatsBreakdownArray['eQSL_Sent'];
-		$data['total_eqsl_rcvd'] = $QSLStatsBreakdownArray['eQSL_Received'];
-		$data['eqsl_sent_today'] = $QSLStatsBreakdownArray['eQSL_Sent_today'];
-		$data['eqsl_rcvd_today'] = $QSLStatsBreakdownArray['eQSL_Received_today'];
+		$data['total_lotw_sent'] = $stats['LoTW_Sent'];
+		$data['total_lotw_rcvd'] = $stats['LoTW_Received'];
+		$data['lotw_sent_today'] = $stats['LoTW_Sent_today'];
+		$data['lotw_rcvd_today'] = $stats['LoTW_Received_today'];
 
-		$data['total_lotw_sent'] = $QSLStatsBreakdownArray['LoTW_Sent'];
-		$data['total_lotw_rcvd'] = $QSLStatsBreakdownArray['LoTW_Received'];
-		$data['lotw_sent_today'] = $QSLStatsBreakdownArray['LoTW_Sent_today'];
-		$data['lotw_rcvd_today'] = $QSLStatsBreakdownArray['LoTW_Received_today'];
-
-		$data['total_qrz_sent'] = $QSLStatsBreakdownArray['QRZ_Sent'];
-		$data['total_qrz_rcvd'] = $QSLStatsBreakdownArray['QRZ_Received'];
-		$data['qrz_sent_today'] = $QSLStatsBreakdownArray['QRZ_Sent_today'];
-		$data['qrz_rcvd_today'] = $QSLStatsBreakdownArray['QRZ_Received_today'];
+		$data['total_qrz_sent'] = $stats['QRZ_Sent'];
+		$data['total_qrz_rcvd'] = $stats['QRZ_Received'];
+		$data['qrz_sent_today'] = $stats['QRZ_Sent_today'];
+		$data['qrz_rcvd_today'] = $stats['QRZ_Received_today'];
 
 		$data['last_qso_count'] = empty($this->session->userdata('dashboard_last_qso_count')) ? DASHBOARD_DEFAULT_QSOS_COUNT : $this->session->userdata('dashboard_last_qso_count');
 		$data['last_qsos_list'] = $this->logbook_model->get_last_qsos(

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -4,6 +4,7 @@ class Dashboard extends CI_Controller {
 
 	public function index()
 	{
+		$this->output->enable_profiler(TRUE);
 		// Check if users logged in
 		$this->load->model('user_model');
 		if ($this->user_model->validate_session() == 0) {
@@ -97,11 +98,11 @@ class Dashboard extends CI_Controller {
 
 		$data['radio_status'] = $this->cat->recent_status();
 
-		// Store info
-		$data['todays_qsos'] = $this->logbook_model->todays_qsos($logbooks_locations_array);
-		$data['total_qsos'] = $this->logbook_model->total_qsos($logbooks_locations_array);
-		$data['month_qsos'] = $this->logbook_model->month_qsos($logbooks_locations_array);
-		$data['year_qsos'] = $this->logbook_model->year_qsos($logbooks_locations_array);
+		$qso_counts = $this->logbook_model->get_qso_counts($logbooks_locations_array);
+		$data['todays_qsos'] = $qso_counts['today'];
+		$data['total_qsos'] = $qso_counts['total'];
+		$data['month_qsos'] = $qso_counts['month'];
+		$data['year_qsos'] = $qso_counts['year'];
 
 		$rawstreak=$this->dayswithqso_model->getAlmostCurrentStreak();
 		if (is_array($rawstreak)) {

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -111,13 +111,14 @@ class Dashboard extends CI_Controller {
 			$data['current_streak']=0;
 		}
 
-		// Load  Countries Breakdown data into array
-		$CountriesBreakdown = $this->logbook_model->total_countries_confirmed($logbooks_locations_array);
+		// Load Countries Breakdown data into array (combined query)
+		$CountriesBreakdown = $this->logbook_model->total_countries_breakdown_batch($logbooks_locations_array);
 
 		$data['total_countries'] = $CountriesBreakdown['Countries_Worked'];
 		$data['total_countries_confirmed_paper'] = $CountriesBreakdown['Countries_Worked_QSL'];
 		$data['total_countries_confirmed_eqsl'] = $CountriesBreakdown['Countries_Worked_EQSL'];
 		$data['total_countries_confirmed_lotw'] = $CountriesBreakdown['Countries_Worked_LOTW'];
+		$current = $CountriesBreakdown['Countries_Current'];
 
 		$QSLStatsBreakdownArray = $this->logbook_model->get_QSLStats($logbooks_locations_array);
 
@@ -156,8 +157,6 @@ class Dashboard extends CI_Controller {
 
 		$this->load->model('dxcc');
 		$dxcc = $this->dxcc->list_current();
-
-		$current = $this->logbook_model->total_countries_current($logbooks_locations_array);
 
 		$footerData['scripts'] = [
 			'assets/js/sections/dashboard.js?' . filemtime(realpath(__DIR__ . "/../../assets/js/sections/dashboard.js")),

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -4,7 +4,6 @@ class Dashboard extends CI_Controller {
 
 	public function index()
 	{
-		$this->output->enable_profiler(TRUE);
 		// Check if users logged in
 		$this->load->model('user_model');
 		if ($this->user_model->validate_session() == 0) {

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -105,29 +105,29 @@ class Visitor extends CI_Controller {
 
 				$data['user_map_custom'] = $this->optionslib->get_map_custom(true,$public_slug);
 
-                // Load  Countries Breakdown data into array (combined query)
-                $CountriesBreakdown = $this->logbook_model->total_countries_breakdown_batch($logbooks_locations_array);
+                // Load Dashboard stats (countries + QSL stats in one query)
+                $stats = $this->logbook_model->dashboard_stats_batch($logbooks_locations_array);
 
-                $data['total_countries'] = $CountriesBreakdown['Countries_Worked'];
-                $data['total_countries_confirmed_paper'] = $CountriesBreakdown['Countries_Worked_QSL'];
-                $data['total_countries_confirmed_eqsl'] = $CountriesBreakdown['Countries_Worked_EQSL'];
-                $data['total_countries_confirmed_lotw'] = $CountriesBreakdown['Countries_Worked_LOTW'];
-                $current = $CountriesBreakdown['Countries_Current'];
+                // Country stats
+                $data['total_countries'] = $stats['Countries_Worked'];
+                $data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
+                $data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
+                $data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
+                $current = $stats['Countries_Current'];
 
 				$dxcc = $this->dxcc->list_current();
                 $data['total_countries_needed'] = count($dxcc->result()) - $current;
 
-                $QSLStatsBreakdownArray =$this->logbook_model->get_QSLStats($logbooks_locations_array);
+                // QSL stats
+                $data['total_qsl_sent'] = $stats['QSL_Sent'];
+                $data['total_qsl_rcvd'] = $stats['QSL_Received'];
+                $data['total_qsl_requested'] = $stats['QSL_Requested'];
 
-                $data['total_qsl_sent'] = $QSLStatsBreakdownArray['QSL_Sent'];
-                $data['total_qsl_rcvd'] = $QSLStatsBreakdownArray['QSL_Received'];
-                $data['total_qsl_requested'] = $QSLStatsBreakdownArray['QSL_Requested'];
+                $data['total_eqsl_sent'] = $stats['eQSL_Sent'];
+                $data['total_eqsl_rcvd'] = $stats['eQSL_Received'];
 
-                $data['total_eqsl_sent'] = $QSLStatsBreakdownArray['eQSL_Sent'];
-                $data['total_eqsl_rcvd'] = $QSLStatsBreakdownArray['eQSL_Received'];
-
-                $data['total_lotw_sent'] = $QSLStatsBreakdownArray['LoTW_Sent'];
-                $data['total_lotw_rcvd'] = $QSLStatsBreakdownArray['LoTW_Received'];
+                $data['total_lotw_sent'] = $stats['LoTW_Sent'];
+                $data['total_lotw_rcvd'] = $stats['LoTW_Received'];
 
                 $data['results'] = $this->logbook_model->get_qsos($this->qso_per_page,$this->uri->segment(3),$logbooks_locations_array);
 

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -97,11 +97,11 @@ class Visitor extends CI_Controller {
 
 				$this->pagination->initialize($config);
 
-                // Store info
-                $data['todays_qsos'] = $this->logbook_model->todays_qsos($logbooks_locations_array);
-                $data['total_qsos'] = $this->logbook_model->total_qsos($logbooks_locations_array);
-                $data['month_qsos'] = $this->logbook_model->month_qsos($logbooks_locations_array);
-                $data['year_qsos'] = $this->logbook_model->year_qsos($logbooks_locations_array);
+                $qso_counts = $this->logbook_model->get_qso_counts($logbooks_locations_array);
+                $data['todays_qsos'] = $qso_counts['today'];
+                $data['total_qsos'] = $qso_counts['total'];
+                $data['month_qsos'] = $qso_counts['month'];
+                $data['year_qsos'] = $qso_counts['year'];
 
 				$data['user_map_custom'] = $this->optionslib->get_map_custom(true,$public_slug);
 

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -105,16 +105,16 @@ class Visitor extends CI_Controller {
 
 				$data['user_map_custom'] = $this->optionslib->get_map_custom(true,$public_slug);
 
-                // Load  Countries Breakdown data into array
-                $CountriesBreakdown = $this->logbook_model->total_countries_confirmed($logbooks_locations_array);
+                // Load  Countries Breakdown data into array (combined query)
+                $CountriesBreakdown = $this->logbook_model->total_countries_breakdown_batch($logbooks_locations_array);
 
                 $data['total_countries'] = $CountriesBreakdown['Countries_Worked'];
                 $data['total_countries_confirmed_paper'] = $CountriesBreakdown['Countries_Worked_QSL'];
                 $data['total_countries_confirmed_eqsl'] = $CountriesBreakdown['Countries_Worked_EQSL'];
                 $data['total_countries_confirmed_lotw'] = $CountriesBreakdown['Countries_Worked_LOTW'];
+                $current = $CountriesBreakdown['Countries_Current'];
 
 				$dxcc = $this->dxcc->list_current();
-                $current = $this->logbook_model->total_countries_current($logbooks_locations_array);
                 $data['total_countries_needed'] = count($dxcc->result()) - $current;
 
                 $QSLStatsBreakdownArray =$this->logbook_model->get_QSLStats($logbooks_locations_array);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4357,8 +4357,8 @@ class Logbook_model extends CI_Model {
 		}
 	}
 
-	/* Return combined countries breakdown: worked, confirmed (QSL/eQSL/LOTW), and current */
-	function total_countries_breakdown_batch($StationLocationsArray = null) {
+	/* Return combined countries breakdown + QSL stats in one query */
+	function dashboard_stats_batch($StationLocationsArray = null) {
 		if ($StationLocationsArray == null) {
 			$this->load->model('logbooks_model');
 			$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
@@ -4367,38 +4367,104 @@ class Logbook_model extends CI_Model {
 		}
 
 		if (!empty($logbooks_locations_array)) {
+			$todayStart = date('Y-m-d 00:00:00');
+			$tomorrowStart = date('Y-m-d 00:00:00', strtotime('+1 day'));
+			$todayStartSql = $this->db->escape($todayStart);
+			$tomorrowStartSql = $this->db->escape($tomorrowStart);
+
+			$location_list = "'" . implode("','", $logbooks_locations_array) . "'";
+
 			$sql = "SELECT
-				COUNT(DISTINCT t.COL_DXCC) as Countries_Worked,
-				COUNT(DISTINCT IF(t.COL_QSL_RCVD = 'Y', t.COL_DXCC, NULL)) as Countries_Worked_QSL,
-				COUNT(DISTINCT IF(t.COL_EQSL_QSL_RCVD = 'Y', t.COL_DXCC, NULL)) as Countries_Worked_EQSL,
-				COUNT(DISTINCT IF(t.COL_LOTW_QSL_RCVD = 'Y', t.COL_DXCC, NULL)) as Countries_Worked_LOTW,
-				COUNT(DISTINCT IF(d.end IS NULL AND d.adif != 0, t.COL_DXCC, NULL)) as Countries_Current
+				-- Country stats (COUNT DISTINCT - filtered to valid DXCC only)
+				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked,
+				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
+				COUNT(DISTINCT CASE WHEN t.COL_EQSL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_EQSL,
+				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
+				COUNT(DISTINCT CASE WHEN d.end IS NULL AND d.adif != 0 AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Current,
+				-- QSL stats (SUM - no filtering, all QSOs)
+				SUM(CASE WHEN t.COL_QSL_SENT = 'Y' THEN 1 ELSE 0 END) as QSL_Sent,
+				SUM(CASE WHEN t.COL_QSL_RCVD = 'Y' THEN 1 ELSE 0 END) as QSL_Received,
+				SUM(CASE WHEN t.COL_QSL_SENT IN ('Q', 'R') THEN 1 ELSE 0 END) as QSL_Requested,
+				SUM(CASE WHEN t.COL_EQSL_QSL_SENT = 'Y' THEN 1 ELSE 0 END) as eQSL_Sent,
+				SUM(CASE WHEN t.COL_EQSL_QSL_RCVD = 'Y' THEN 1 ELSE 0 END) as eQSL_Received,
+				SUM(CASE WHEN t.COL_LOTW_QSL_SENT = 'Y' THEN 1 ELSE 0 END) as LoTW_Sent,
+				SUM(CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' THEN 1 ELSE 0 END) as LoTW_Received,
+				SUM(CASE WHEN t.COL_QRZCOM_QSO_UPLOAD_STATUS = 'Y' THEN 1 ELSE 0 END) as QRZ_Sent,
+				SUM(CASE WHEN t.COL_QRZCOM_QSO_DOWNLOAD_STATUS = 'Y' THEN 1 ELSE 0 END) as QRZ_Received,
+				-- Today's stats (SUM - no filtering, all QSOs)
+				SUM(CASE WHEN t.COL_QSL_SENT = 'Y' AND t.COL_QSLSDATE >= " . $todayStartSql . " AND t.COL_QSLSDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as QSL_Sent_today,
+				SUM(CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_QSLRDATE >= " . $todayStartSql . " AND t.COL_QSLRDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as QSL_Received_today,
+				SUM(CASE WHEN t.COL_QSL_SENT IN ('Q', 'R') AND t.COL_QSLSDATE >= " . $todayStartSql . " AND t.COL_QSLSDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as QSL_Requested_today,
+				SUM(CASE WHEN t.COL_EQSL_QSL_SENT = 'Y' AND t.COL_EQSL_QSLSDATE >= " . $todayStartSql . " AND t.COL_EQSL_QSLSDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as eQSL_Sent_today,
+				SUM(CASE WHEN t.COL_EQSL_QSL_RCVD = 'Y' AND t.COL_EQSL_QSLRDATE >= " . $todayStartSql . " AND t.COL_EQSL_QSLRDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as eQSL_Received_today,
+				SUM(CASE WHEN t.COL_LOTW_QSL_SENT = 'Y' AND t.COL_LOTW_QSLSDATE >= " . $todayStartSql . " AND t.COL_LOTW_QSLSDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as LoTW_Sent_today,
+				SUM(CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_LOTW_QSLRDATE >= " . $todayStartSql . " AND t.COL_LOTW_QSLRDATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as LoTW_Received_today,
+				SUM(CASE WHEN t.COL_QRZCOM_QSO_UPLOAD_STATUS = 'Y' AND t.COL_QRZCOM_QSO_UPLOAD_DATE >= " . $todayStartSql . " AND t.COL_QRZCOM_QSO_UPLOAD_DATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as QRZ_Sent_today,
+				SUM(CASE WHEN t.COL_QRZCOM_QSO_DOWNLOAD_STATUS = 'Y' AND t.COL_QRZCOM_QSO_DOWNLOAD_DATE >= " . $todayStartSql . " AND t.COL_QRZCOM_QSO_DOWNLOAD_DATE < " . $tomorrowStartSql . " THEN 1 ELSE 0 END) as QRZ_Received_today
 				FROM " . $this->config->item('table_name') . " t
 				LEFT JOIN dxcc_entities d ON d.adif = t.col_dxcc
-				WHERE t.station_id IN (" . str_repeat('?,', count($logbooks_locations_array) - 1) . "?)
-					AND t.COL_COUNTRY != 'Invalid'
-					AND t.COL_DXCC > 0";
+				WHERE t.station_id IN (" . $location_list . ")";
 
-			$query = $this->db->query($sql, $logbooks_locations_array);
+			$query = $this->db->query($sql);
 
 			if ($query->num_rows() > 0) {
 				$row = $query->row();
 				return [
+					// Country stats
 					'Countries_Worked' => $row->Countries_Worked,
 					'Countries_Worked_QSL' => $row->Countries_Worked_QSL,
 					'Countries_Worked_EQSL' => $row->Countries_Worked_EQSL,
 					'Countries_Worked_LOTW' => $row->Countries_Worked_LOTW,
-					'Countries_Current' => $row->Countries_Current
+					'Countries_Current' => $row->Countries_Current,
+					// QSL stats
+					'QSL_Sent' => $row->QSL_Sent,
+					'QSL_Received' => $row->QSL_Received,
+					'QSL_Requested' => $row->QSL_Requested,
+					'eQSL_Sent' => $row->eQSL_Sent,
+					'eQSL_Received' => $row->eQSL_Received,
+					'LoTW_Sent' => $row->LoTW_Sent,
+					'LoTW_Received' => $row->LoTW_Received,
+					'QRZ_Sent' => $row->QRZ_Sent,
+					'QRZ_Received' => $row->QRZ_Received,
+					// Today's stats
+					'QSL_Sent_today' => $row->QSL_Sent_today,
+					'QSL_Received_today' => $row->QSL_Received_today,
+					'QSL_Requested_today' => $row->QSL_Requested_today,
+					'eQSL_Sent_today' => $row->eQSL_Sent_today,
+					'eQSL_Received_today' => $row->eQSL_Received_today,
+					'LoTW_Sent_today' => $row->LoTW_Sent_today,
+					'LoTW_Received_today' => $row->LoTW_Received_today,
+					'QRZ_Sent_today' => $row->QRZ_Sent_today,
+					'QRZ_Received_today' => $row->QRZ_Received_today
 				];
 			}
 		}
 
+		// Return zero values if no data
 		return [
 			'Countries_Worked' => 0,
 			'Countries_Worked_QSL' => 0,
 			'Countries_Worked_EQSL' => 0,
 			'Countries_Worked_LOTW' => 0,
-			'Countries_Current' => 0
+			'Countries_Current' => 0,
+			'QSL_Sent' => 0,
+			'QSL_Received' => 0,
+			'QSL_Requested' => 0,
+			'eQSL_Sent' => 0,
+			'eQSL_Received' => 0,
+			'LoTW_Sent' => 0,
+			'LoTW_Received' => 0,
+			'QRZ_Sent' => 0,
+			'QRZ_Received' => 0,
+			'QSL_Sent_today' => 0,
+			'QSL_Received_today' => 0,
+			'QSL_Requested_today' => 0,
+			'eQSL_Sent_today' => 0,
+			'eQSL_Received_today' => 0,
+			'LoTW_Sent_today' => 0,
+			'LoTW_Received_today' => 0,
+			'QRZ_Sent_today' => 0,
+			'QRZ_Received_today' => 0
 		];
 	}
 


### PR DESCRIPTION
At the moment there are 54 SQL-Queries for rendering the Dashboard.
a couple of the can be combined to boost performance.

e.g.:
- 4 Queries which count Grids will crawl the database and the QSOs 4 times
- One query - smart designed - only crawls one to gather the information.

Adjusted:
- [x] Year/Month/Day/Total breakdown
- [x] VUCC-Counters
- [x] Better fetching of QSL breakdown (by @HB9HIL)
- [x] Combine Country-Stat-SQL
- [x] Combine Timerange-Breakdown with QSL-Breakdown

