### PR TITLE
[Advanced Logbook] Fix error 500 if unit is set to mi or nmi

### DIFF
--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -1317,6 +1317,8 @@ class QSO
 	{
 		if ($this->distance === null) return '';
 
+		$distanceValue = floatval($this->distance); // Convert string to float
+
 		switch ($this->measurement_base) {
 			case 'M':
 				$unit = "mi";
@@ -1329,16 +1331,16 @@ class QSO
 				break;
 			default:
 				$unit = "km";
-			}
+		}
 
 		if ($unit == 'mi') {
-			$this->distance = round($this->distance * 0.621371, 1);
+			$distanceValue = round($distanceValue * 0.621371, 1);
 		}
 		if ($unit == 'nmi') {
-			$this->distance = round($this->distance * 0.539957, 1);
+			$distanceValue = round($distanceValue * 0.539957, 1);
 		}
 
-		return $this->distance . ' ' . $unit;
+		return $distanceValue . ' ' . $unit;
 	}
 
 	private function getFormattedMyDok(): string


### PR DESCRIPTION
Since the QSO class uses strict types, we need to cast when converting distance to other units.
Thanks to @int2001 for the heads up.