### PR TITLE
Add band_mode_matrix and recent_contacts API endpoints

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -1218,6 +1218,308 @@ class API extends CI_Controller {
 		echo json_encode(['status' => 'successful', 'message' => 'Export successful', 'statistics' => $data]);
 	}
 
+	/*
+	 *
+	 *	Function: band_mode_matrix
+	 *	Task: Returns a matrix of worked/confirmed status for all band/mode combinations for a callsign
+	 *	Use case: External applications needing full worked status display (e.g., HamRig portal)
+	 *
+	 */
+	function band_mode_matrix() {
+		header('Content-type: application/json');
+
+		$raw_input = json_decode(file_get_contents("php://input"), true);
+		$user_id = '';
+
+		$this->load->model('user_model');
+		if (!($this->user_model->authorize($this->config->item('auth_mode')))) {
+			$no_auth = true;
+			$this->load->model('api_model');
+			if (!((isset($raw_input['key'])) && ($this->api_model->authorize($raw_input['key']) > 0))) {
+				$no_auth = true;
+			} else {
+				$no_auth = false;
+				$user_id = $this->api_model->key_userid($raw_input['key']);
+			}
+			if ($no_auth) {
+				http_response_code(401);
+				echo json_encode(['status' => 'failed', 'reason' => "missing api key or session"]);
+				die();
+			}
+		} else {
+			$user_id = $this->session->userdata('user_id');
+		}
+
+		$this->load->model('stations');
+		$all_station_ids = $this->stations->all_station_ids_of_user($user_id);
+
+		if ((array_key_exists('station_ids', $raw_input)) && (is_array($raw_input['station_ids']))) {
+			$a_station_ids = [];
+			foreach ($raw_input['station_ids'] as $stationid) {
+				if ($this->stations->check_station_against_user($stationid, $user_id)) {
+					$a_station_ids[] = $stationid;
+				}
+			}
+			$station_ids = implode(', ', $a_station_ids);
+		} else {
+			$station_ids = $all_station_ids;
+		}
+
+		if ($station_ids == '') {
+			http_response_code(200);
+			echo json_encode(['status' => 'failed', 'reason' => "no station_profiles are matching the User with this API-Key"]);
+			die();
+		}
+
+		$lookup_callsign = strtoupper($raw_input['callsign'] ?? '');
+		if ($lookup_callsign == '') {
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "callsign to lookup not given"]);
+			return;
+		}
+
+		$this->load->model("logbook_model");
+
+		// Get user's default confirmation preference
+		$userdata = $this->user_model->get_by_id($user_id);
+		$default_confirmation = $userdata->row()->user_default_confirmation ?? '';
+
+		// Define standard bands and modes
+		$bands = ['160m', '80m', '60m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '6m', '4m', '2m', '70cm', '23cm'];
+		$modes = ['SSB', 'CW', 'FT8', 'FT4', 'RTTY', 'FM', 'AM', 'DIGI'];
+
+		// Build the matrix
+		$matrix = [];
+
+		// Query all QSOs with this callsign
+		$this->db->select('COL_BAND, COL_MODE, COL_SUBMODE, COL_QSL_RCVD, COL_LOTW_QSL_RCVD, COL_EQSL_QSL_RCVD, COL_TIME_ON');
+		$this->db->from($this->config->item('table_name'));
+		$this->db->where('COL_CALL', $lookup_callsign);
+		$this->db->where_in('station_id', explode(', ', $station_ids));
+		$query = $this->db->get();
+
+		// Process results into matrix
+		foreach ($bands as $band) {
+			$matrix[$band] = [];
+			foreach ($modes as $mode) {
+				$matrix[$band][$mode] = [
+					'worked' => false,
+					'confirmed' => false,
+					'qso_count' => 0,
+					'last_qso' => null
+				];
+			}
+		}
+
+		if ($query->num_rows() > 0) {
+			foreach ($query->result() as $qso) {
+				$band = $qso->COL_BAND;
+
+				// Map detailed mode to general mode category
+				$mode = $this->map_mode_to_category($qso->COL_MODE, $qso->COL_SUBMODE ?? '');
+
+				if (isset($matrix[$band]) && isset($matrix[$band][$mode])) {
+					$matrix[$band][$mode]['worked'] = true;
+					$matrix[$band][$mode]['qso_count']++;
+
+					// Check if confirmed based on user's default confirmation preference
+					$is_confirmed = false;
+					if (strpos($default_confirmation, 'L') !== false && $qso->COL_LOTW_QSL_RCVD == 'Y') {
+						$is_confirmed = true;
+					}
+					if (strpos($default_confirmation, 'Q') !== false && $qso->COL_QSL_RCVD == 'Y') {
+						$is_confirmed = true;
+					}
+					if (strpos($default_confirmation, 'E') !== false && $qso->COL_EQSL_QSL_RCVD == 'Y') {
+						$is_confirmed = true;
+					}
+					// If no preference set, check any confirmation
+					if ($default_confirmation == '') {
+						if ($qso->COL_LOTW_QSL_RCVD == 'Y' || $qso->COL_QSL_RCVD == 'Y' || $qso->COL_EQSL_QSL_RCVD == 'Y') {
+							$is_confirmed = true;
+						}
+					}
+
+					if ($is_confirmed) {
+						$matrix[$band][$mode]['confirmed'] = true;
+					}
+
+					// Track most recent QSO
+					if ($matrix[$band][$mode]['last_qso'] === null || $qso->COL_TIME_ON > $matrix[$band][$mode]['last_qso']) {
+						$matrix[$band][$mode]['last_qso'] = $qso->COL_TIME_ON;
+					}
+				}
+			}
+		}
+
+		// Get DXCC info
+		$date = date("Y-m-d");
+		$dxcc_info = $this->logbook_model->dxcc_lookup($lookup_callsign, $date);
+
+		$return = [
+			'status' => 'success',
+			'callsign' => $lookup_callsign,
+			'dxcc_id' => $dxcc_info['adif'] ?? '',
+			'dxcc' => $dxcc_info['entity'] ?? '',
+			'bands' => $bands,
+			'modes' => $modes,
+			'matrix' => $matrix,
+			'total_qsos' => $query->num_rows()
+		];
+
+		http_response_code(200);
+		echo json_encode($return, JSON_PRETTY_PRINT);
+	}
+
+	/*
+	 *
+	 *	Function: recent_contacts
+	 *	Task: Returns the most recent QSOs with a specific callsign
+	 *	Use case: External applications showing recent contact history (e.g., HamRig portal)
+	 *
+	 */
+	function recent_contacts() {
+		header('Content-type: application/json');
+
+		$raw_input = json_decode(file_get_contents("php://input"), true);
+		$user_id = '';
+
+		$this->load->model('user_model');
+		if (!($this->user_model->authorize($this->config->item('auth_mode')))) {
+			$no_auth = true;
+			$this->load->model('api_model');
+			if (!((isset($raw_input['key'])) && ($this->api_model->authorize($raw_input['key']) > 0))) {
+				$no_auth = true;
+			} else {
+				$no_auth = false;
+				$user_id = $this->api_model->key_userid($raw_input['key']);
+			}
+			if ($no_auth) {
+				http_response_code(401);
+				echo json_encode(['status' => 'failed', 'reason' => "missing api key or session"]);
+				die();
+			}
+		} else {
+			$user_id = $this->session->userdata('user_id');
+		}
+
+		$this->load->model('stations');
+		$all_station_ids = $this->stations->all_station_ids_of_user($user_id);
+
+		if ((array_key_exists('station_ids', $raw_input)) && (is_array($raw_input['station_ids']))) {
+			$a_station_ids = [];
+			foreach ($raw_input['station_ids'] as $stationid) {
+				if ($this->stations->check_station_against_user($stationid, $user_id)) {
+					$a_station_ids[] = $stationid;
+				}
+			}
+			$station_ids = implode(', ', $a_station_ids);
+		} else {
+			$station_ids = $all_station_ids;
+		}
+
+		if ($station_ids == '') {
+			http_response_code(200);
+			echo json_encode(['status' => 'failed', 'reason' => "no station_profiles are matching the User with this API-Key"]);
+			die();
+		}
+
+		$lookup_callsign = strtoupper($raw_input['callsign'] ?? '');
+		if ($lookup_callsign == '') {
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "callsign to lookup not given"]);
+			return;
+		}
+
+		// Limit parameter (default 10, max 50)
+		$limit = isset($raw_input['limit']) ? min(intval($raw_input['limit']), 50) : 10;
+
+		$this->load->model("logbook_model");
+
+		// Query recent QSOs with this callsign
+		$this->db->select('COL_PRIMARY_KEY, COL_CALL, COL_TIME_ON, COL_TIME_OFF, COL_BAND, COL_FREQ, COL_MODE, COL_SUBMODE, COL_RST_SENT, COL_RST_RCVD, COL_NAME, COL_QTH, COL_GRIDSQUARE, COL_COMMENT, COL_QSL_RCVD, COL_QSL_SENT, COL_LOTW_QSL_RCVD, COL_LOTW_QSL_SENT, COL_EQSL_QSL_RCVD, COL_EQSL_QSL_SENT, station_id');
+		$this->db->from($this->config->item('table_name'));
+		$this->db->where('COL_CALL', $lookup_callsign);
+		$this->db->where_in('station_id', explode(', ', $station_ids));
+		$this->db->order_by('COL_TIME_ON', 'DESC');
+		$this->db->limit($limit);
+		$query = $this->db->get();
+
+		$contacts = [];
+		if ($query->num_rows() > 0) {
+			foreach ($query->result() as $qso) {
+				$contacts[] = [
+					'id' => $qso->COL_PRIMARY_KEY,
+					'callsign' => $qso->COL_CALL,
+					'datetime' => $qso->COL_TIME_ON,
+					'datetime_off' => $qso->COL_TIME_OFF,
+					'band' => $qso->COL_BAND,
+					'frequency' => $qso->COL_FREQ,
+					'mode' => $qso->COL_MODE,
+					'submode' => $qso->COL_SUBMODE,
+					'rst_sent' => $qso->COL_RST_SENT,
+					'rst_rcvd' => $qso->COL_RST_RCVD,
+					'name' => $qso->COL_NAME,
+					'qth' => $qso->COL_QTH,
+					'gridsquare' => $qso->COL_GRIDSQUARE,
+					'comment' => $qso->COL_COMMENT,
+					'qsl' => [
+						'paper_sent' => $qso->COL_QSL_SENT,
+						'paper_rcvd' => $qso->COL_QSL_RCVD,
+						'lotw_sent' => $qso->COL_LOTW_QSL_SENT,
+						'lotw_rcvd' => $qso->COL_LOTW_QSL_RCVD,
+						'eqsl_sent' => $qso->COL_EQSL_QSL_SENT,
+						'eqsl_rcvd' => $qso->COL_EQSL_QSL_RCVD
+					],
+					'station_id' => $qso->station_id
+				];
+			}
+		}
+
+		// Get DXCC info
+		$date = date("Y-m-d");
+		$dxcc_info = $this->logbook_model->dxcc_lookup($lookup_callsign, $date);
+
+		$return = [
+			'status' => 'success',
+			'callsign' => $lookup_callsign,
+			'dxcc_id' => $dxcc_info['adif'] ?? '',
+			'dxcc' => $dxcc_info['entity'] ?? '',
+			'total_found' => $query->num_rows(),
+			'limit' => $limit,
+			'contacts' => $contacts
+		];
+
+		http_response_code(200);
+		echo json_encode($return, JSON_PRETTY_PRINT);
+	}
+
+	/*
+	 *	Helper function to map detailed modes to general categories
+	 */
+	private function map_mode_to_category($mode, $submode = '') {
+		$mode = strtoupper($mode);
+		$submode = strtoupper($submode);
+
+		// Digital modes mapping
+		$digi_modes = ['PSK31', 'PSK63', 'PSK125', 'OLIVIA', 'JT65', 'JT9', 'JS8', 'MFSK', 'WSPR', 'HELL', 'THOR', 'DOMINO', 'ROS', 'SSTV', 'FAX', 'PACKET', 'PACTOR', 'AMTOR', 'WINMOR', 'ARDOP', 'VARA', 'FSK441', 'MSK144', 'ISCAT', 'Q65'];
+
+		if ($mode == 'FT8' || $submode == 'FT8') return 'FT8';
+		if ($mode == 'FT4' || $submode == 'FT4') return 'FT4';
+		if ($mode == 'SSB' || $mode == 'USB' || $mode == 'LSB') return 'SSB';
+		if ($mode == 'CW') return 'CW';
+		if ($mode == 'RTTY' || $mode == 'FSK' || $submode == 'RTTY') return 'RTTY';
+		if ($mode == 'FM' || $mode == 'NFM' || $mode == 'WFM') return 'FM';
+		if ($mode == 'AM') return 'AM';
+		if (in_array($mode, $digi_modes) || in_array($submode, $digi_modes)) return 'DIGI';
+
+		// Default to DIGI for unknown digital modes
+		if ($mode == 'MFSK' || $mode == 'DATA' || $mode == 'PKT' || strpos($mode, 'DIGITAL') !== false) return 'DIGI';
+
+		// For unknown modes, return as-is but it won't match the standard matrix
+		return $mode;
+	}
+
 	/**
 	 * Sanitize and validate callback URL
 	 * @param string $url The URL to sanitize

--- a/docs/API_ADDITIONS.md
+++ b/docs/API_ADDITIONS.md
@@ -1,0 +1,200 @@
+# Wavelog API Additions - Band/Mode Matrix and Recent Contacts
+
+## Overview
+
+This pull request adds two new API endpoints to support external applications that need comprehensive worked-before information:
+
+1. **`band_mode_matrix`** - Returns a full matrix of worked/confirmed status across all band/mode combinations
+2. **`recent_contacts`** - Returns the most recent QSOs with a specific callsign
+
+These endpoints complement the existing `private_lookup` endpoint, which only returns boolean values for a single band/mode combination at a time.
+
+## Use Case
+
+External logging portals (like HamRig) need to display comprehensive worked-before information similar to what Wavelog shows in its own interface. Currently, `private_lookup` only returns:
+- `call_worked` (boolean)
+- `call_worked_band` (boolean for ONE specified band)
+- `call_worked_band_mode` (boolean for ONE specified band/mode)
+
+This requires multiple API calls to build a complete picture. The new endpoints solve this by returning all data in a single request.
+
+---
+
+## New Endpoint: `band_mode_matrix`
+
+### URL
+```
+POST /index.php/api/band_mode_matrix
+```
+
+### Request Body
+```json
+{
+    "key": "your-api-key",
+    "callsign": "W1ABC",
+    "station_ids": [1, 2]  // Optional: filter to specific stations
+}
+```
+
+### Response
+```json
+{
+    "status": "success",
+    "callsign": "W1ABC",
+    "dxcc_id": "291",
+    "dxcc": "United States",
+    "bands": ["160m", "80m", "60m", "40m", "30m", "20m", "17m", "15m", "12m", "10m", "6m", "4m", "2m", "70cm", "23cm"],
+    "modes": ["SSB", "CW", "FT8", "FT4", "RTTY", "FM", "AM", "DIGI"],
+    "matrix": {
+        "20m": {
+            "SSB": {
+                "worked": true,
+                "confirmed": true,
+                "qso_count": 3,
+                "last_qso": "2024-01-15 14:30:00"
+            },
+            "CW": {
+                "worked": false,
+                "confirmed": false,
+                "qso_count": 0,
+                "last_qso": null
+            },
+            "FT8": {
+                "worked": true,
+                "confirmed": false,
+                "qso_count": 1,
+                "last_qso": "2024-01-10 08:15:00"
+            }
+            // ... other modes
+        }
+        // ... other bands
+    },
+    "total_qsos": 4
+}
+```
+
+### Features
+- Returns worked/confirmed status for every band/mode combination
+- Respects user's default confirmation preference (LoTW, Paper QSL, eQSL)
+- Includes QSO count and most recent QSO date for each combination
+- Mode categorization maps detailed modes to general categories (e.g., USB/LSB → SSB)
+
+---
+
+## New Endpoint: `recent_contacts`
+
+### URL
+```
+POST /index.php/api/recent_contacts
+```
+
+### Request Body
+```json
+{
+    "key": "your-api-key",
+    "callsign": "W1ABC",
+    "limit": 10,            // Optional: max 50, default 10
+    "station_ids": [1, 2]   // Optional: filter to specific stations
+}
+```
+
+### Response
+```json
+{
+    "status": "success",
+    "callsign": "W1ABC",
+    "dxcc_id": "291",
+    "dxcc": "United States",
+    "total_found": 5,
+    "limit": 10,
+    "contacts": [
+        {
+            "id": 12345,
+            "callsign": "W1ABC",
+            "datetime": "2024-01-15 14:30:00",
+            "datetime_off": "2024-01-15 14:45:00",
+            "band": "20m",
+            "frequency": "14.230",
+            "mode": "SSB",
+            "submode": null,
+            "rst_sent": "59",
+            "rst_rcvd": "59",
+            "name": "John",
+            "qth": "Boston, MA",
+            "gridsquare": "FN42",
+            "comment": "Great signal",
+            "qsl": {
+                "paper_sent": "Y",
+                "paper_rcvd": "Y",
+                "lotw_sent": "Y",
+                "lotw_rcvd": "Y",
+                "eqsl_sent": null,
+                "eqsl_rcvd": null
+            },
+            "station_id": 1
+        }
+        // ... more contacts
+    ]
+}
+```
+
+### Features
+- Returns detailed information for recent QSOs
+- Ordered by date descending (most recent first)
+- Includes full QSL status for all methods
+- Configurable limit (max 50 to prevent abuse)
+
+---
+
+## Authentication
+
+Both endpoints use the same authentication as other Wavelog API endpoints:
+- Requires a valid API key with at least read permissions
+- Key is passed in the JSON body as `"key": "your-api-key"`
+- Session-based auth also works for logged-in users
+
+---
+
+## Mode Categorization
+
+The `band_mode_matrix` endpoint maps detailed modes to these general categories:
+
+| Category | Included Modes |
+|----------|----------------|
+| SSB | SSB, USB, LSB |
+| CW | CW |
+| FT8 | FT8 |
+| FT4 | FT4 |
+| RTTY | RTTY, FSK |
+| FM | FM, NFM, WFM |
+| AM | AM |
+| DIGI | PSK31, PSK63, JT65, JT9, JS8, OLIVIA, MFSK, WSPR, etc. |
+
+This allows consistent display across different logging styles while preserving the actual mode in `recent_contacts`.
+
+---
+
+## Backward Compatibility
+
+These additions are fully backward compatible:
+- New endpoints only, no changes to existing endpoints
+- `private_lookup` continues to work exactly as before
+- No database schema changes required
+
+---
+
+## Example Usage (curl)
+
+### Band/Mode Matrix
+```bash
+curl -X POST https://your-wavelog.com/index.php/api/band_mode_matrix \
+  -H "Content-Type: application/json" \
+  -d '{"key":"your-api-key","callsign":"W1ABC"}'
+```
+
+### Recent Contacts
+```bash
+curl -X POST https://your-wavelog.com/index.php/api/recent_contacts \
+  -H "Content-Type: application/json" \
+  -d '{"key":"your-api-key","callsign":"W1ABC","limit":5}'
+```


### PR DESCRIPTION
## Summary

This PR adds two new API endpoints to support external applications that need comprehensive worked-before information:

1. **`band_mode_matrix`** - Returns a full matrix of worked/confirmed status across all band/mode combinations for a callsign
2. **`recent_contacts`** - Returns the most recent QSOs with a specific callsign

## Use Case

External logging portals need to display comprehensive worked-before information similar to what Wavelog shows in its own interface. Currently, `private_lookup` only returns:
- `call_worked` (boolean)
- `call_worked_band` (boolean for ONE specified band)
- `call_worked_band_mode` (boolean for ONE specified band/mode)

This requires multiple API calls to build a complete picture. The new endpoints solve this by returning all data in a single request.

## New Endpoints

### `POST /index.php/api/band_mode_matrix`

**Request:**
```json
{
    "key": "your-api-key",
    "callsign": "W1ABC",
    "station_ids": [1, 2]  // Optional
}
```

**Response:**
```json
{
    "status": "success",
    "callsign": "W1ABC",
    "dxcc_id": "291",
    "dxcc": "United States",
    "bands": ["160m", "80m", ...],
    "modes": ["SSB", "CW", "FT8", ...],
    "matrix": {
        "20m": {
            "SSB": {"worked": true, "confirmed": true, "qso_count": 3, "last_qso": "2024-01-15 14:30:00"},
            "CW": {"worked": false, "confirmed": false, "qso_count": 0, "last_qso": null}
        }
    },
    "total_qsos": 4
}
```

### `POST /index.php/api/recent_contacts`

**Request:**
```json
{
    "key": "your-api-key",
    "callsign": "W1ABC",
    "limit": 10  // Optional, max 50
}
```

**Response:**
```json
{
    "status": "success",
    "callsign": "W1ABC",
    "total_found": 5,
    "contacts": [
        {
            "id": 12345,
            "datetime": "2024-01-15 14:30:00",
            "band": "20m",
            "mode": "SSB",
            "rst_sent": "59",
            "rst_rcvd": "59",
            "name": "John",
            "qth": "Boston, MA",
            "gridsquare": "FN42",
            "qsl": {"lotw_rcvd": "Y", "paper_rcvd": "Y", ...}
        }
    ]
}
```

## Features

- Respects user's default confirmation preference (LoTW, Paper QSL, eQSL)
- Mode categorization maps detailed modes to general categories (USB/LSB → SSB, etc.)
- Station filtering via optional `station_ids` parameter
- Configurable limit on recent contacts (max 50)

## Backward Compatibility

- New endpoints only, no changes to existing endpoints
- `private_lookup` continues to work exactly as before
- No database schema changes required

## Testing

Both endpoints tested with HamRig portal integration - see `docs/API_ADDITIONS.md` for full documentation.

73 de DH5DAX