### PR TITLE
Outbound DX Cluster spotting from QSO entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ docker-compose.yml
 .demo
 .htaccess
 .user.ini
+*.patch

--- a/application/controllers/Dxcluster.php
+++ b/application/controllers/Dxcluster.php
@@ -78,4 +78,113 @@ class Dxcluster extends CI_Controller {
 			echo json_encode(['error' => 'not found'], JSON_PRETTY_PRINT);
 		}
 	}
+
+	public function spot() {
+		// Only allow POST
+		if (strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+			show_404();
+			return;
+		}
+
+		// Basic auth already handled in constructor
+		$this->load->library('optionslib');
+		$this->load->library('Dxcluster_spotter');
+
+		// Accept both form-encoded and JSON payloads
+		$payload = $this->input->post(NULL, TRUE);
+		$raw = file_get_contents('php://input');
+		if (is_string($raw) && strlen($raw) > 0 && ($raw[0] === '{' || $raw[0] === '[')) {
+			$json = json_decode($raw, true);
+			if (is_array($json)) {
+				$payload = array_merge($payload ?: [], $json);
+			}
+		}
+
+		$dxcall = strtoupper(trim($payload['dxcall'] ?? $payload['callsign'] ?? ''));
+		$comment = trim($payload['comment'] ?? $payload['info'] ?? '');
+		$mode = trim($payload['mode'] ?? '');
+
+		// Frequency: accept Hz or kHz
+		$freq_khz = null;
+		if (isset($payload['freq_khz'])) {
+			$freq_khz = floatval($payload['freq_khz']);
+		} elseif (isset($payload['frequency'])) {
+			$f = floatval($payload['frequency']);
+			$freq_khz = ($f > 100000) ? ($f / 1000.0) : $f;
+		} elseif (isset($payload['freq'])) {
+			$f = floatval($payload['freq']);
+			$freq_khz = ($f > 100000) ? ($f / 1000.0) : $f;
+		}
+
+		// Validate
+		if ($dxcall === '' || !preg_match('/^[A-Z0-9\\/]+$/', $dxcall)) {
+			$this->_spot_json(false, 'Invalid DX callsign.');
+			return;
+		}
+		if ($freq_khz === null || $freq_khz <= 0) {
+			$this->_spot_json(false, 'Missing or invalid frequency.');
+			return;
+		}
+
+		$spotter_call = strtoupper(trim($this->session->userdata('operator_callsign') ?: $this->session->userdata('user_callsign') ?: ''));
+		if ($spotter_call === '' || !preg_match('/^[A-Z0-9\\/]+$/', $spotter_call)) {
+			$this->_spot_json(false, 'Your user callsign is not set. Please set it in your profile.');
+			return;
+		}
+
+		// Load outbound config
+		$enabled = ($this->optionslib->get_option('dxcluster_out_enabled') ?? '0') === '1';
+		if (!$enabled) {
+			$this->_spot_json(false, 'Outbound spotting is disabled in Options → DXCluster.');
+			return;
+		}
+
+		$host = trim((string)($this->optionslib->get_option('dxcluster_out_host') ?? ''));
+		$port = intval($this->optionslib->get_option('dxcluster_out_port') ?? 0);
+		$timeout = intval($this->optionslib->get_option('dxcluster_out_timeout') ?? 5);
+		$password = (string)($this->optionslib->get_option('dxcluster_out_password') ?? '');
+
+		if ($host === '' || $port < 1 || $port > 65535) {
+			$this->_spot_json(false, 'DX Cluster host/port not configured in Options → DXCluster.');
+			return;
+		}
+		if ($timeout < 2) $timeout = 2;
+		if ($timeout > 30) $timeout = 30;
+
+		// Rate limit: 1 spot / 60s per session
+		$last = intval($this->session->userdata('dxcluster_last_spot_ts') ?? 0);
+		if ($last > 0 && (time() - $last) < 60) {
+			$this->_spot_json(false, 'Please wait a moment before sending another spot.');
+			return;
+		}
+
+		// Default comment
+		if ($comment === '' && $mode !== '') {
+			$comment = $mode;
+		}
+		if ($comment !== '') {
+			$comment = preg_replace('/[\\r\\n]+/', ' ', $comment);
+			$comment = substr($comment, 0, 60);
+		}
+
+		$err = '';
+		$ok = $this->dxcluster_spotter->send_spot($host, $port, $spotter_call, $dxcall, $freq_khz, $comment, $timeout, $password, $err);
+
+		if ($ok) {
+			$this->session->set_userdata('dxcluster_last_spot_ts', time());
+			$this->_spot_json(true, 'Spot sent.');
+		} else {
+			$this->_spot_json(false, $err !== '' ? $err : 'Failed to send spot.');
+		}
+	}
+
+	private function _spot_json($ok, $message) {
+		$this->output
+			->set_content_type('application/json')
+			->set_output(json_encode([
+				'ok' => (bool)$ok,
+				'message' => (string)$message,
+			]));
+	}
+
 }

--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -161,6 +161,10 @@ class Options extends CI_Controller {
 		$this->form_validation->set_rules('dxcache_url', 'URL of DXCache', 'valid_url');
 		$this->form_validation->set_rules('dxcluster_maxage', 'Max Age of Spots', 'required');
 		$this->form_validation->set_rules('dxcluster_decont', 'de continent', 'required');
+		$this->form_validation->set_rules('dxcluster_out_host', 'DX Cluster Host', 'trim');
+		$this->form_validation->set_rules('dxcluster_out_port', 'DX Cluster Port', 'integer');
+		$this->form_validation->set_rules('dxcluster_out_timeout', 'DX Cluster Timeout', 'integer');
+
 
 		if ($this->form_validation->run() == FALSE) {
 			$this->load->view('interface_assets/header', $data);
@@ -181,6 +185,15 @@ class Options extends CI_Controller {
 			if($dxcache_url_update == TRUE) {
 				$this->session->set_flashdata('success', __("DXCluster Cache URL changed to ").$this->input->post('dxcache_url'));
 			}
+
+			// Outbound DXCluster spotting options
+			$enabled = $this->input->post('dxcluster_out_enabled') ? '1' : '0';
+			$this->optionslib->update('dxcluster_out_enabled', $enabled, 'yes');
+			$this->optionslib->update('dxcluster_out_host', trim((string)$this->input->post('dxcluster_out_host')), 'yes');
+			$this->optionslib->update('dxcluster_out_port', (string)(int)$this->input->post('dxcluster_out_port'), 'yes');
+			$this->optionslib->update('dxcluster_out_timeout', (string)(int)$this->input->post('dxcluster_out_timeout'), 'yes');
+			$this->optionslib->update('dxcluster_out_password', (string)$this->input->post('dxcluster_out_password'), 'yes');
+
 			redirect('/options/dxcluster');
 		}
 	}

--- a/application/libraries/Dxcluster_spotter.php
+++ b/application/libraries/Dxcluster_spotter.php
@@ -1,0 +1,117 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Dxcluster_spotter {
+
+    /**
+     * Send a spot to a Telnet DX Cluster.
+     *
+     * @param string $host
+     * @param int $port
+     * @param string $spotter_call
+     * @param string $dxcall
+     * @param float $freq_khz
+     * @param string $comment
+     * @param int $timeout
+     * @param string $password
+     * @param string &$err
+     * @return bool
+     */
+    public function send_spot($host, $port, $spotter_call, $dxcall, $freq_khz, $comment, $timeout, $password, &$err) {
+        $err = '';
+        $host = trim($host);
+        $spotter_call = trim($spotter_call);
+        $dxcall = trim($dxcall);
+        $comment = trim($comment);
+
+        $addr = $host;
+        // Prefer IPv4 if hostname resolves to IPv6 but server can't use it
+        if (strpos($host, ':') !== false && $host[0] !== '[') {
+            $addr = '['.$host.']';
+        }
+
+        $errno = 0; $errstr = '';
+        $fp = @fsockopen($addr, $port, $errno, $errstr, $timeout);
+        if (!$fp) {
+            $err = "Connect failed: {$errstr} ({$errno})";
+            return false;
+        }
+
+        stream_set_timeout($fp, $timeout);
+        stream_set_blocking($fp, true);
+
+        // Read initial banner/prompt (non-fatal if empty)
+        $banner = $this->read_until_prompt($fp, $timeout);
+
+        // Some clusters show "login:" prompt; send callsign
+        $this->write_line($fp, $spotter_call);
+
+        // If password is required and server asks for it, send it.
+        if ($password !== '') {
+            $resp = $this->read_until_prompt($fp, $timeout);
+            if (stripos($resp, 'password') !== false) {
+                $this->write_line($fp, $password);
+            } else {
+                // keep resp for later
+            }
+        }
+
+        // Build spot command (DXSpider supports "DX <call> <freq> <comment>")
+        $freq_str = number_format($freq_khz, 1, '.', '');
+        $line = "DX {$dxcall} {$freq_str}";
+        if ($comment !== '') {
+            $line .= " {$comment}";
+        }
+        $this->write_line($fp, $line);
+
+        // Read response briefly to catch common rejections
+        $resp2 = $this->read_for_seconds($fp, 2);
+
+        fclose($fp);
+
+        // Heuristics: if response contains "not allowed" or "register", treat as fail
+        $lower = strtolower($resp2);
+        if (strpos($lower, 'not allowed') !== false || strpos($lower, 'register') !== false || strpos($lower, 'won\'t be able to upload') !== false) {
+            $err = trim($resp2) !== '' ? trim($resp2) : 'Cluster rejected spot.';
+            return false;
+        }
+
+        return true;
+    }
+
+    private function write_line($fp, $line) {
+        @fwrite($fp, rtrim($line, "\r\n") . "\n");
+    }
+
+    private function read_until_prompt($fp, $timeout) {
+        $out = '';
+        $start = time();
+        while (time() - $start < $timeout) {
+            $chunk = @fgets($fp, 4096);
+            if ($chunk === false) {
+                break;
+            }
+            $out .= $chunk;
+            // stop when we see a typical prompt
+            if (preg_match('/(login:|call:|password:|>\s*$)/i', $chunk)) {
+                break;
+            }
+        }
+        return $out;
+    }
+
+    private function read_for_seconds($fp, $seconds) {
+        $out = '';
+        $end = microtime(true) + $seconds;
+        while (microtime(true) < $end) {
+            $meta = stream_get_meta_data($fp);
+            $chunk = @fgets($fp, 4096);
+            if ($chunk !== false) {
+                $out .= $chunk;
+            } else {
+                // avoid busy loop
+                usleep(100000);
+            }
+        }
+        return $out;
+    }
+}

--- a/application/views/options/dxcluster.php
+++ b/application/views/options/dxcluster.php
@@ -63,6 +63,59 @@
                             <small id="dxcluster_decontHelp" class="form-text text-muted"><?= __("Only spots by spotters from this continent are shown"); ?></small>
                         </div>
  
+                        
+                        <hr class="my-4"/>
+
+                        <h5 class="mb-3"><?= __("Outbound Spotting (Telnet)"); ?></h5>
+                        <p class="text-muted mb-3">
+                            <?= __("Enable a manual 'Send to DX Cluster' button in the Live Log. This will connect to a Telnet DX Cluster and send a spot."); ?>
+                        </p>
+                        <div class="mb-3">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="1"
+                                       id="dxcluster_out_enabled" name="dxcluster_out_enabled"
+                                       <?php echo (($this->optionslib->get_option('dxcluster_out_enabled') ?? '0') == '1' ? 'checked' : ''); ?> />
+                                <label class="form-check-label" for="dxcluster_out_enabled">
+                                    <?= __("Enable outbound spotting"); ?>
+                                </label>
+                            </div>
+                            <small class="form-text text-muted">
+                                <?= __("If enabled, users can manually send a spot from the QSO entry screen. Note: Some DXSpider nodes require prior registration to accept spots (e.g., register@dxspider.co.uk)."); ?>
+                            </small>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-8 mb-3">
+                                <label for="dxcluster_out_host"><?= __("DX Cluster Host"); ?></label>
+                                <input type="text" name="dxcluster_out_host" class="form-control" id="dxcluster_out_host"
+                                       value="<?php echo $this->optionslib->get_option('dxcluster_out_host'); ?>"
+                                       placeholder="cluster.example.org">
+                                <small class="form-text text-muted"><?= __("Hostname or IP of the Telnet DX Cluster."); ?></small>
+                            </div>
+                            <div class="col-md-4 mb-3">
+                                <label for="dxcluster_out_port"><?= __("Port"); ?></label>
+                                <input type="number" name="dxcluster_out_port" class="form-control" id="dxcluster_out_port"
+                                       value="<?php echo $this->optionslib->get_option('dxcluster_out_port'); ?>"
+                                       placeholder="7300" min="1" max="65535">
+                            </div>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label for="dxcluster_out_timeout"><?= __("Connect timeout (seconds)"); ?></label>
+                                <input type="number" name="dxcluster_out_timeout" class="form-control" id="dxcluster_out_timeout"
+                                       value="<?php echo $this->optionslib->get_option('dxcluster_out_timeout') ?: 5; ?>"
+                                       min="2" max="30">
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <label for="dxcluster_out_password"><?= __("Password (optional)"); ?></label>
+                                <input type="password" name="dxcluster_out_password" class="form-control" id="dxcluster_out_password"
+                                       value="<?php echo $this->optionslib->get_option('dxcluster_out_password'); ?>"
+                                       autocomplete="new-password">
+                                <small class="form-text text-muted"><?= __("Only if your cluster requires it."); ?></small>
+                            </div>
+                        </div>
+
                         <!-- Save the Form -->
                         <input class="btn btn-primary" type="submit" value="<?= __("Save"); ?>" />
                     </form>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -763,15 +763,25 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
           <input size="20" id="country" type="hidden" name="country" value="" />
         </div>
 
-        <div class="btn-group" role="group">
-              <button tabindex="22" type="button" class="btn btn-secondary" id="btn_reset"><?= __("Clear"); ?></button>
-        <button id="btnGroupDrop1" type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"></button>
-        <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
-                <li><a class="dropdown-item" href="#" id="btn_fullreset"><?= __("Reset to Default"); ?></a></li>
-            </ul>
+        <div class="d-flex flex-nowrap align-items-center gap-2">
+          <div class="btn-group" role="group">
+              <button tabindex="22" type="button" class="btn btn-secondary btn-sm" id="btn_reset"><?= __("Clear"); ?></button>
+              <button id="btnGroupDrop1" type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false"></button>
+              <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+                  <li><a class="dropdown-item" href="#" id="btn_fullreset"><?= __("Reset to Default"); ?></a></li>
+              </ul>
+          </div>
+
+          <button tabindex="20" type="button" id="send_dxcluster_spot" class="btn btn-outline-primary btn-sm" data-bs-toggle="tooltip" title="<?= __("Send spot to DX Cluster"); ?>">
+              <i class="fas fa-bullhorn"></i><span class="d-none d-md-inline ms-1"><?= __("Send to DX Cluster"); ?></span>
+          </button>
+
+          <button tabindex="21" type="submit" id="saveQso" name="saveQso" class="btn btn-primary btn-sm">
+              <i class="fas fa-save"></i><span class="d-none d-md-inline ms-1"><?= __("Save QSO"); ?></span>
+          </button>
         </div>
-        <button tabindex="21" type="submit" id="saveQso" name="saveQso" class="btn btn-primary"><i class="fas fa-save"></i> <?= __("Save QSO"); ?></button>
-        <div class="alert alert-danger warningOnSubmit mt-3" style="display:none;"><span><i class="fas fa-times-circle"></i></span> <span class="warningOnSubmit_txt ms-1"><?= __("Error"); ?></span></div>
+
+<div class="alert alert-danger warningOnSubmit mt-3" style="display:none;"><span><i class="fas fa-times-circle"></i></span> <span class="warningOnSubmit_txt ms-1"><?= __("Error"); ?></span></div>
       </div>
     </form>
     </div>
@@ -937,3 +947,38 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
 <script>
 	var station_callsign = "<?php echo $station_callsign; ?>";
 </script>
+
+
+<!-- DXCluster Spot Modal -->
+<div class="modal fade" id="dxclusterSpotModal" tabindex="-1" aria-labelledby="dxclusterSpotModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="dxclusterSpotModalLabel"><?= __("Send spot to DX Cluster"); ?></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= __("Close"); ?>"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label class="form-label"><?= __("DX Callsign"); ?></label>
+          <input type="text" class="form-control uppercase" id="dxcluster_spot_dxcall" maxlength="20">
+        </div>
+        <div class="mb-3">
+          <label class="form-label"><?= __("Frequency (kHz)"); ?></label>
+          <input type="number" class="form-control" id="dxcluster_spot_freq" step="0.1" min="0">
+          <small class="form-text text-muted"><?= __("Will be taken from the current QSO frequency by default."); ?></small>
+        </div>
+        <div class="mb-3">
+          <label class="form-label"><?= __("Comment"); ?></label>
+          <input type="text" class="form-control" id="dxcluster_spot_comment" maxlength="60" placeholder="FT8 / CW / SSB ...">
+        </div>
+        <div class="alert alert-danger d-none" id="dxcluster_spot_error"></div>
+        <div class="alert alert-success d-none" id="dxcluster_spot_success"></div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?= __("Close"); ?></button>
+        <button type="button" class="btn btn-primary" id="dxcluster_spot_send_btn"><?= __("Send"); ?></button>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -3390,3 +3390,71 @@ $(document).ready(function () {
 	// everything loaded and ready 2 go
 	bc.postMessage('ready');
 });
+
+
+// Manual outbound DXCluster spot
+$("#send_dxcluster_spot").on("click", function () {
+    // Prefill callsign and frequency
+    $("#dxcluster_spot_error").addClass("d-none").text("");
+    $("#dxcluster_spot_success").addClass("d-none").text("");
+
+    var dxcall = ($("#callsign").val() || "").trim();
+    $("#dxcluster_spot_dxcall").val(dxcall);
+
+    // frequency hidden field is in Hz
+    var hz = parseFloat($("#frequency").val() || "0");
+    var khz = 0;
+    if (hz > 0) {
+        khz = hz / 1000.0;
+    } else {
+        // fallback to displayed field (kHz) if available
+        khz = parseFloat($("#freq_calculated").val() || "0");
+    }
+    if (khz > 0) {
+        $("#dxcluster_spot_freq").val(khz.toFixed(1));
+    }
+
+    var modal = new bootstrap.Modal(document.getElementById('dxclusterSpotModal'));
+    modal.show();
+});
+
+$("#dxcluster_spot_send_btn").on("click", function () {
+    $("#dxcluster_spot_error").addClass("d-none").text("");
+    $("#dxcluster_spot_success").addClass("d-none").text("");
+
+    var dxcall = ($("#dxcluster_spot_dxcall").val() || "").trim().toUpperCase();
+    var freq = parseFloat($("#dxcluster_spot_freq").val() || "0");
+    var comment = ($("#dxcluster_spot_comment").val() || "").trim();
+
+    if (dxcall === "" || freq <= 0) {
+        $("#dxcluster_spot_error").removeClass("d-none").text("Please enter DX callsign and a valid frequency.");
+        return;
+    }
+
+    $.ajax({
+        url: base_url + "index.php/dxcluster/spot",
+        method: "POST",
+        dataType: "json",
+        data: {
+            dxcall: dxcall,
+            freq_khz: freq,
+            comment: comment
+        },
+        success: function (res) {
+            if (res && res.ok) {
+                $("#dxcluster_spot_success").removeClass("d-none").text(res.message || "Spot sent");
+            } else {
+                $("#dxcluster_spot_error").removeClass("d-none").text((res && res.message) ? res.message : "Failed to send spot");
+            }
+        },
+        error: function (xhr) {
+            var msg = "Failed to send spot";
+            try {
+                var j = JSON.parse(xhr.responseText);
+                if (j && j.message) msg = j.message;
+            } catch(e) {}
+            $("#dxcluster_spot_error").removeClass("d-none").text(msg);
+        }
+    });
+});
+


### PR DESCRIPTION
### Summary
This PR adds a manual outbound DX Cluster spotting feature directly from the QSO entry screen (“Send to DX Cluster”).

### Key features
- New “Send to DX Cluster” action in the QSO entry UI (prominent next to “Save QSO”).
- Configurable outbound cluster connection in Options → DXCluster:
  - enable/disable
  - host, port
  - connect timeout
  - optional password
- Server-side Telnet/socket implementation (no external telnet binary required).
- Basic rate limiting to reduce accidental duplicate/rapid spots.

### Notes
- Some DX Cluster nodes require registration before they accept uploaded spots (e.g. G6NHU). A short hint is included in the options page.

### Files changed
- `application/controllers/Dxcluster.php`
- `application/libraries/Dxcluster_spotter.php` (new)
- `application/controllers/Options.php`
- `application/views/options/dxcluster.php`
- `application/views/qso/index.php`
- `assets/js/sections/qso.js`

### How to test
1. Go to Options → DXCluster and enable outbound spotting.
2. Set a DX cluster host/port (e.g. any Telnet-accessible node) and save.
3. Open QSO entry, click “Send to DX Cluster”, fill comment if desired, and submit.
4. Verify the spot is accepted by the cluster (or check the cluster banner/response if registration is required).

