### PR TITLE
[Advanced Logbook] Fetch all modes for edit

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -653,7 +653,7 @@ class Logbookadvanced extends CI_Controller {
 
 		$data['stateDxcc'] = $this->logbookadvanced_model->getPrimarySubdivisonsDxccs();
 
-		$data['modes'] = $this->modes->active();
+		$data['modes'] = $this->modes->all();
 		$data['bands'] = $this->bands->get_user_bands_for_qso_entry();
 		$data['contests'] = $this->contesting_model->getActivecontests();
 		$this->load->view('logbookadvanced/edit', $data);


### PR DESCRIPTION
As DK1BOU pointed out, edit doesn't contain all modes in the Advanced Logbook. Instead, only the active ones was fetched. I changed this to fetch all the available modes instead.

The regular QSO edit fetches all the modes, regardless if they are active or not. With this PR, the batch edit does the same.