### PR TITLE
Automatically enrich qso on import or added via api

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -29,6 +29,10 @@ $config['callbook'] = 'hamqth';
 
 $config['datadir'] = null; // default to install directory
 
+// If true every added qso will be automatically enriched with data from configured callbook(s)
+// Applies for adif imports as well as added qso via api
+$config['always_enrich_qso'] = false;
+
 /*
 |--------------------------------------------------------------------------
 | Logbook Options

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5535,6 +5535,13 @@ class Logbook_model extends CI_Model {
 				'COL_MORSE_KEY_TYPE' => (!empty($record['morse_key_type'])) ? $record['morse_key_type'] : '',
 			);
 
+			if($this->config->item('always_enrich_qso')) {
+				$this->load->model('logbookadvanced_model');
+				$callbook = $this->loadCallBook($record['call'], $this->config->item('use_fullname'));
+				$enrichedQso = $this->logbookadvanced_model->enrichQsoWithCallbookInfo($record, $callbook, true, $station_profile->station_gridsquare);
+				$data = [...$data, ...$enrichedQso];
+			}
+
 			// Collect field information from the station profile table thats required for the QSO.
 			if ($station_id != "0") {
 				if (!(array_key_exists($station_id, $this->station_result))) {

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -863,6 +863,11 @@ class Logbookadvanced_model extends CI_Model {
 	}
 
 	public function updateQsoWithCallbookInfo($qsoID, $qso, $callbook, $gridsquareAccuracyCheck, $station_gridsquare = null) {
+		$updatedData = $this->enrichQsoWithCallbookInfo($qso, $callbook, $gridsquareAccuracyCheck, $station_gridsquare);
+  		return $this->updateQsoWithCallbookInfoInDb($qsoID, $updatedData);
+  	}
+
+	public function enrichQsoWithCallbookInfo($qso, $callbook, $gridsquareAccuracyCheck, $station_gridsquare = null) {
 		$updatedData = array();
 		$updated = false;
 		if (!empty($callbook['name']) && empty($qso['COL_NAME'])) {
@@ -957,10 +962,14 @@ class Logbookadvanced_model extends CI_Model {
 		}
 
 		//Also set QRZ.com status to modified
-		if($updated == true && $qso['COL_QRZCOM_QSO_UPLOAD_STATUS'] == 'Y') {
+		if($updated == true && array_key_exists('COL_QRZCOM_QSO_UPLOAD_STATUS', $qso) && $qso['COL_QRZCOM_QSO_UPLOAD_STATUS'] == 'Y') {
 			$updatedData['COL_QRZCOM_QSO_UPLOAD_STATUS'] = 'M';
 		}
 
+		return $updatedData;
+    }
+
+	public function updateQsoWithCallbookInfoInDb($qsoID, $updatedData) {
 		if (count($updatedData) > 0) {
 			$this->db->where('COL_PRIMARY_KEY', $qsoID);
 			$this->db->update($this->config->item('table_name'), $updatedData);

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -29,6 +29,10 @@ $config['callbook'] = '%callbook%';
 
 $config['datadir'] = null; // default to install directory
 
+// If true every added qso will be automatically enriched with data from configured callbook(s)
+// Applies for adif imports as well as added qso via api
+$config['always_enrich_qso'] = false;
+
 /*
 |--------------------------------------------------------------------------
 | Logbook Options


### PR DESCRIPTION
Add logic and config item $config['always_enrich_qso'] (default: false) to automatically enrich qso upon import or added via api with data from configured callbook(s)