### PR TITLE
Don't stop upload if end of QSO-Date was reached

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -257,10 +257,6 @@ class Lotw extends CI_Controller {
 					echo $data['lotw_cert_info']->callsign.": QSO start date of LoTW certificate not reached yet!<br>";
 					continue;
 				}
-				if ($current_date > $data['lotw_cert_info']->qso_end_date) {
-					echo $data['lotw_cert_info']->callsign.": QSO end date of LoTW certificate exceeded!<br>";
-					continue;
-				}
 				if ($current_date < $data['lotw_cert_info']->date_created) {
 					echo $data['lotw_cert_info']->callsign.": LoTW certificate not valid yet!<br>";
 					continue;


### PR DESCRIPTION
Situation / e.g.:
- LoTw-Cert with QSO-End Date for 10.02.2026 // Valid till 31.12.2026
- Wavelog uploads QSOs if the sync is triggered till 10.02.2026 23:59.
- If User uploads QSOs for - e.g. - 09.02.2026 on the 11th of Feb - the QSOs won't be uploaded (because routine checks current_date instead of QSO-Date)

Patch:
- remove check for current_date > lotw->qso_end_date

everything else: left. because current_date has still to be AFTER lotw->qso_start_date and current_date has also to be between cert->start and cert->end.

Friendly Usertest ongoing atm