### PR TITLE
Hint for wrongly entered single grid into VUCC_GRIDS

### DIFF
--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -187,6 +187,7 @@
                            }
                            echo $row->COL_VUCC_GRIDS;
                            if (!str_contains($row->COL_VUCC_GRIDS, ',')) {
+                              echo " <i class='fa fa-question-circle' aria-hidden='true' data-bs-toggle='tooltip' title='".__("A single gridsquare was entered into the VUCC gridsquares field which should contain two or four gridsquares instead of a single grid.")."'></i>";
                               echo "</span>";
                            }
                            echo " <a href='javascript:spawnQrbCalculator('".$row->station_gridsquare."\',\'".$row->COL_VUCC_GRIDS.")'><i class='fas fa-globe'></i></a>";


### PR DESCRIPTION
Entering a single maidenhead grid into the VUCC_GRIDS field leads to the QSO view failing to load:

<img width="1843" height="1269" alt="image" src="https://github.com/user-attachments/assets/36bc1637-c606-41a6-a6be-60362b48b39a" />

We should catch this.

Also we show this as a hint to the user in QSO view by coloring the grid:

<img width="333" height="95" alt="image" src="https://github.com/user-attachments/assets/a146ad2c-d8f6-4457-80f9-0412fdf59772" />
