### PR TITLE
DXCC-Lookup (API) accidently overwrites DXCC with previous QSOs

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -1146,8 +1146,6 @@ class API extends CI_Controller {
 				$return['qsl_manager'] = $call_lookup_results->COL_QSL_VIA;
 				$return['state'] = $call_lookup_results->COL_STATE;
 				$return['us_county'] = $call_lookup_results->COL_CNTY;
-				$return['dxcc_id'] = $call_lookup_results->COL_DXCC;
-				$return['cont'] = $call_lookup_results->COL_CONT;
 				$return['workedBefore'] = true;
 
 				if ($return['gridsquare'] != "") {


### PR DESCRIPTION
e.g.:

log AU7RS BEFORE 10th of Feb. 2026.
it's DXCC is india in that case.

now log it while it is in "LAKSHADWEEP ISLANDS" (ID: 142) (Between 10.02. and 18.02.).
DXCC is correct derived (exception) to "LAKSHADWEEP ISLANDS", but instantly overwritten by previous QSO which was "INDIA" with ID: 324. Extra-F**k-Up: DXCC-Name will still be "LAKSHADWEEP ISLANDS" for the new QSO, but ID is wrong

This patch fixes it.