### PR TITLE
Use HamQTH-DOK lookup as well for "Update from Callbook"

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -947,6 +947,10 @@ class Logbookadvanced_model extends CI_Model {
 			$updatedData['COL_CQZ'] = $callbook['cqz'];
 			$updated = true;
 		}
+		if (!empty($callbook['darc_dok']) && empty($qso['COL_DARC_DOK'])) {
+			$updatedData['COL_DARC_DOK'] = strtoupper($callbook['darc_dok']);
+			$updated = true;
+		}
 		if (empty($qso['COL_CONT'])) {
 			$updatedData['COL_CONT'] = $this->logbook_model->getContinent($callbook['dxcc']);
 			$updated = true;

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -254,6 +254,11 @@ function single_callbook_update() {
             fill_if_empty('#qsl-via', data.qsl_manager);
             fill_if_empty('select[name="input_state_edit"]', data.callsign_state);
             fill_if_empty('#stationCntyInputEdit', data.callsign_us_county);
+            if (data.callsign_darc_dok && $('#darc_dok_edit').val() == '') {
+                var dok_selectize = $('#darc_dok_edit')[0].selectize;
+                dok_selectize.addOption({ name: data.callsign_darc_dok });
+                dok_selectize.setValue(data.callsign_darc_dok, false);
+            }
 
             $('#update_from_callbook').prop("disabled", false).removeClass("running");
         },


### PR DESCRIPTION
#2981 introduced DOK-Lookup from HamQTH.
While it works wonderful during logging, the issue-owner states: "Doesn't work for Logbookadvanced or Edit". See #2977 

This patch adds the functionality to "Edit" and Logbookadanced, too.