### PR TITLE
[Labels] Added option for my call, to split grid and my call

### DIFF
--- a/application/controllers/Labels.php
+++ b/application/controllers/Labels.php
@@ -146,10 +146,11 @@ class Labels extends CI_Controller {
 		$qslmsg = $this->input->post('qslmsg') === "true" ? 1 : 0;
 		$tnxmsg = $this->input->post('tnxmsg') === "true" ? 1 : 0;
 		$reference = $this->input->post('reference') == "true" ? 1 : 0;
+		$mycall = $this->input->post('mycall') == "true" ? 1 : 0;
 		$this->load->model('labels_model');
 		$result = $this->labels_model->export_printrequestedids($ids);
 
-		$this->prepareLabel($result, true, $offset, $grid, $via, $reference, $qslmsg, $tnxmsg);
+		$this->prepareLabel($result, true, $offset, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 	}
 
 	public function print($station_id) {
@@ -160,21 +161,21 @@ class Labels extends CI_Controller {
 		$qslmsg = xss_clean($this->input->post('qslmsg') ?? 0);
 		$tnxmsg = xss_clean($this->input->post('tnxmsg') ?? 0);
 		$reference = xss_clean($this->input->post('reference') ?? 0);
+		$mycall = $this->input->post('mycall') ?? 0;
 		$this->load->model('stations');
 		if ($this->stations->check_station_is_accessible($station_id)) {
 			$this->load->model('labels_model');
 			$result = $this->labels_model->export_printrequested($clean_id);
 
-			$this->prepareLabel($result, false, $offset, $grid, $via, $reference, $qslmsg, $tnxmsg);
+			$this->prepareLabel($result, false, $offset, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 		} else {
 			redirect('labels');
 		}
 	}
 
-	function prepareLabel($qsos, $jscall = false, $offset = 1, $grid = false, $via = false, $reference = false, $qslmsg = false, $tnxmsg = true) {
+	function prepareLabel($qsos, $jscall = false, $offset = 1, $grid = false, $via = false, $reference = false, $qslmsg = false, $tnxmsg = true, $mycall = false) {
 		$this->load->model('labels_model');
 		$label = $this->labels_model->getDefaultLabel();
-
 
 		try {
 			if ($label) {
@@ -247,9 +248,9 @@ class Labels extends CI_Controller {
 
 		if ($qsos->num_rows() > 0) {
 			if ($label->qsos == 1) {
-				$this->makeMultiQsoLabel($qsos->result(), $pdf, 1, $offset, $ptype->orientation, $grid, $via, $reference, $qslmsg, $tnxmsg);
+				$this->makeMultiQsoLabel($qsos->result(), $pdf, 1, $offset, $ptype->orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 			} else {
-				$this->makeMultiQsoLabel($qsos->result(), $pdf, $label->qsos, $offset, $ptype->orientation, $grid, $via, $reference, $qslmsg, $tnxmsg);
+				$this->makeMultiQsoLabel($qsos->result(), $pdf, $label->qsos, $offset, $ptype->orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 			}
 		} else {
 			$this->session->set_flashdata('message', __('0 QSOs found for print!'));
@@ -258,7 +259,7 @@ class Labels extends CI_Controller {
 		$pdf->Output();
 	}
 
-	function makeMultiQsoLabel($qsos, $pdf, $numberofqsos, $offset, $orientation, $grid, $via, $reference, $qslmsg, $tnxmsg) {
+	function makeMultiQsoLabel($qsos, $pdf, $numberofqsos, $offset, $orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall) {
 		$text = '';
 		$current_callsign = '';
 		$current_sat = '';
@@ -275,7 +276,7 @@ class Labels extends CI_Controller {
 			( ($qso->COL_BAND_RX !== $current_sat_bandrx) && ($this->pretty_sat_mode($qso->COL_SAT_MODE) !== '')) ) {
 			   // ((($qso->COL_SAT_NAME ?? '' !== $current_sat) || ($qso->COL_CALL !== $current_callsign)) && ($qso->COL_SAT_NAME ?? '' !== '') && ($col->COL_BAND_RX ?? '' !== $current_sat_bandrx))) {
 				if (!empty($qso_data)) {
-					$this->finalizeData($pdf, $current_callsign, $qso_data, $numberofqsos, $orientation, $grid, $via, $reference, $qslmsg, $tnxmsg);
+					$this->finalizeData($pdf, $current_callsign, $qso_data, $numberofqsos, $orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 					$qso_data = [];
 				}
 				$current_callsign = $qso->COL_CALL;
@@ -307,7 +308,7 @@ class Labels extends CI_Controller {
 			];
 		}
 		if (!empty($qso_data)) {
-			$this->finalizeData($pdf, $current_callsign, $qso_data, $numberofqsos, $orientation, $grid, $via, $reference, $qslmsg, $tnxmsg);
+			$this->finalizeData($pdf, $current_callsign, $qso_data, $numberofqsos, $orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 		}
 	}
 	// New begin
@@ -315,7 +316,7 @@ class Labels extends CI_Controller {
 		return(strlen($sat_mode ?? '') == 2 ? (strtoupper($sat_mode[0]).'/'.strtoupper($sat_mode[1])) : strtoupper($sat_mode ?? ''));
 	}
 
-	function finalizeData($pdf, $current_callsign, &$preliminaryData, $qso_per_label,$orientation, $grid, $via, $reference, $qslmsg, $tnxmsg) {
+	function finalizeData($pdf, $current_callsign, &$preliminaryData, $qso_per_label,$orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall) {
 
 		$tableData = [];
 		$count_qso = 0;
@@ -333,9 +334,8 @@ class Labels extends CI_Controller {
 			$tableData[] = $rowData;
 			$count_qso++;
 
-
 			if($count_qso == $qso_per_label){
-				$this->generateLabel($pdf, $current_callsign, $tableData,$count_qso,$qso,$orientation, $grid, $via, $reference, $qslmsg, $tnxmsg);
+				$this->generateLabel($pdf, $current_callsign, $tableData,$count_qso,$qso,$orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 				$tableData = []; // reset the data
 				$count_qso = 0;  // reset the counter
 			}
@@ -343,12 +343,12 @@ class Labels extends CI_Controller {
 		}
 		// generate label for remaining QSOs
 		if($count_qso > 0){
-			$this->generateLabel($pdf, $current_callsign, $tableData,$count_qso,$qso,$orientation, $grid, $via, $reference, $qslmsg, $tnxmsg);
+			$this->generateLabel($pdf, $current_callsign, $tableData,$count_qso,$qso,$orientation, $grid, $via, $reference, $qslmsg, $tnxmsg, $mycall);
 			$preliminaryData = []; // reset the data
 		}
 	}
 
-	function generateLabel($pdf, $current_callsign, $tableData,$numofqsos,$qso,$orientation,$grid=true, $via=false, $reference = false, $qslmsg = false, $tnxmsg = true){
+	function generateLabel($pdf, $current_callsign, $tableData,$numofqsos,$qso,$orientation,$grid=true, $via=false, $reference = false, $qslmsg = false, $tnxmsg = true, $mycall = false){
 		$builder = new \AsciiTable\Builder();
 		$builder->addRows($tableData);
 			$toradio = "To Radio: ";
@@ -372,7 +372,11 @@ class Labels extends CI_Controller {
 			}
 		}
 		$text.="\n";
-		if ($grid) { $text .= "My call: ".$qso['mycall']." Grid: ".$qso['mygrid']."\n"; }
+		if ($mycall) { $text .= "My call: ".$qso['mycall'] . ' '; }
+		if ($mycall && !$grid) {
+			$text .= "\n";
+		}
+		if ($grid) { $text .= "Grid: ".$qso['mygrid']."\n"; }
 		if ($reference) {
 			$ref_text = "";
 			$ref_avail = false;

--- a/application/views/labels/index.php
+++ b/application/views/labels/index.php
@@ -1,6 +1,7 @@
 <script language="javascript">
-	var lang_mark_qsl_as_printed="<?= __("Mark QSL as printed"); ?>";
-	var lang_print_queue="<?= __("Print"); ?>";
+	let lang_mark_qsl_as_printed = "<?= __("Mark QSL as printed"); ?>";
+	let lang_print_queue = "<?= __("Print"); ?>";
+	let lang_label_print_options = "<?= __("Label Print Options"); ?>";
 </script>
 <div class="container">
 

--- a/application/views/labels/startatform.php
+++ b/application/views/labels/startatform.php
@@ -1,39 +1,103 @@
+<style>
+    .option-item {
+        display: grid;
+        grid-template-columns: 32px 1fr auto;
+        align-items: start;
+        gap: 0.5rem;
+    }
+    .option-item .switch-container {
+        margin-top: -0.25rem;
+    }
+</style>
+
 <form method="post" id="pform" class="col-md" action="<?php echo site_url('labels/print/' . $stationid) ?>" target="_blank">
     <input type="hidden" name="sid2print" id="sid2print" value="<?php echo $stationid; ?>">
-    <div class="mb-3 row">
-        <label for="grid"><?= __("Include Grid?"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="grid" id="grid">
+
+        <div class="card-body">
+            <div class="option-item mb-3">
+                <i class="fas fa-broadcast-tower text-primary mt-1"></i>
+                <div>
+                    <label for="mycall" class="form-label fw-bold mb-0">
+                        <?= __("Include my call?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="mycall" id="mycall" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-map-marker-alt text-success mt-1"></i>
+                <div>
+                    <label for="grid" class="form-label fw-bold mb-0">
+                        <?= __("Include Grid?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="grid" id="grid" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-mountain text-info mt-1"></i>
+                <div>
+                    <label for="reference" class="form-label fw-bold mb-0">
+                        <?= __("Include reference? (SIG, SOTA, POTA, IOTA, WWFF; If available in location)"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="reference" id="reference" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-share-alt text-warning mt-1"></i>
+                <div>
+                    <label for="via" class="form-label fw-bold mb-0">
+                        <?= __("Include Via (if filled)?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="via" id="via" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-envelope text-danger mt-1"></i>
+                <div>
+                    <label for="qslmsg" class="form-label fw-bold mb-0">
+                        <?= __("Include QSLMSG (if filled)?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="qslmsg" id="qslmsg" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-heart text-danger mt-1"></i>
+                <div>
+                    <label for="tnxmsg" class="form-label fw-bold mb-0">
+                        <?= __("Include TNX message?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="tnxmsg" id="tnxmsg" checked style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <hr class="my-4">
+
+            <div class="mb-3">
+                <label for="startat" class="form-label fw-bold d-flex align-items-center">
+                    <i class="fas fa-hashtag me-2 text-secondary" style="width: 20px;"></i>
+                    <?= __("Start printing at?"); ?>
+                </label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="fas fa-sort-numeric-up"></i></span>
+                    <input class="form-control" type="number" id="startat" name="startat" value="1" min="1">
+                </div>
+                <small class="form-text text-muted"><?= __("Enter the starting position for label printing"); ?></small>
+            </div>
         </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="reference"><?= __("Include reference? (SIG, SOTA, POTA, IOTA, WWFF; If available in location)"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="reference" id="reference">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="via"><?= __("Include Via (if filled)?"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="via" id="via">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="qslmsg"><?= __("Include QSLMSG (if filled)?"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="qslmsg" id="qslmsg">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="tnxmsg"><?= __("Include TNX message?"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="tnxmsg" id="tnxmsg" checked>
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="startat"><?= __("Start printing at?"); ?></label>
-        <div class="d-flex align-items-center">
-            <input class="form-control input-group-sm" type="number" id="startat" name="startat" value="1">
-        </div>
-    </div>
 </form>

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -79,6 +79,7 @@
 
 	let lang_gen_advanced_logbook_confirmedLabel = '<?= __("Gridsquares for"); ?>';
 	let lang_gen_advanced_logbook_workedLabel = '<?= __("Non DXCC matching gridsquare"); ?>';
+	let lang_label_print_options = "<?= __("Label Print Options"); ?>";
 
     let homegrid ='<?php echo strtoupper($homegrid[0]); ?>';
     <?php

--- a/application/views/logbookadvanced/startatform.php
+++ b/application/views/logbookadvanced/startatform.php
@@ -1,44 +1,115 @@
+<style>
+    .option-item {
+        display: grid;
+        grid-template-columns: 32px 1fr auto;
+        align-items: start;
+        gap: 0.5rem;
+    }
+    .option-item .switch-container {
+        margin-top: -0.25rem;
+    }
+</style>
+
 <form method="post" class="col-md">
-    <div class="mb-3 row">
-        <label for="gridlabel"><?= __("Include Grid?"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="gridlabel" id="gridlabel">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="reference"><?= __("Include reference? (SIG, SOTA, POTA, IOTA, WWFF; If available in location)"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="reference" id="reference">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="via"><?= __("Include Via"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="via" id="via">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="qslmsg"><?= __("Include QSLMSG"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="qslmsg" id="qslmsg">
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="tnxmsg"><?= __("Include TNX message"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="tnxmsg" id="tnxmsg" checked>
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label for="startat"><?= __("Start printing at?"); ?></label>
-        <div class="d-flex align-items-center">
-            <input class="form-control input-group-sm" type="number" id="startat" name="startat" value="1">
-        </div>
-    </div>
-	<div class="mb-3 row">
-        <label for="markprinted"><?= __("Mark QSL as printed"); ?></label>
-        <div class="form-check-inline">
-            <input class="form-check-input" type="checkbox" name="markprinted" id="markprinted">
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <div class="option-item mb-3">
+                <i class="fas fa-broadcast-tower text-primary mt-1"></i>
+                <div>
+                    <label for="mycall" class="form-label fw-bold mb-0">
+                        <?= __("Include my call?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="mycall" id="mycall" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-map-marker-alt text-success mt-1"></i>
+                <div>
+                    <label for="gridlabel" class="form-label fw-bold mb-0">
+                        <?= __("Include Grid?"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="gridlabel" id="gridlabel" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-mountain text-info mt-1"></i>
+                <div>
+                    <label for="reference" class="form-label fw-bold mb-0">
+                        <?= __("Include reference? (SIG, SOTA, POTA, IOTA, WWFF; If available in location)"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="reference" id="reference" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-share-alt text-warning mt-1"></i>
+                <div>
+                    <label for="via" class="form-label fw-bold mb-0">
+                        <?= __("Include Via"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="via" id="via" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-envelope text-danger mt-1"></i>
+                <div>
+                    <label for="qslmsg" class="form-label fw-bold mb-0">
+                        <?= __("Include QSLMSG"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="qslmsg" id="qslmsg" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-heart text-danger mt-1"></i>
+                <div>
+                    <label for="tnxmsg" class="form-label fw-bold mb-0">
+                        <?= __("Include TNX message"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="tnxmsg" id="tnxmsg" checked style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <div class="option-item mb-3">
+                <i class="fas fa-check-circle text-success mt-1"></i>
+                <div>
+                    <label for="markprinted" class="form-label fw-bold mb-0">
+                        <?= __("Mark QSL as printed"); ?>
+                    </label>
+                </div>
+                <div class="form-check form-switch switch-container">
+                    <input class="form-check-input" type="checkbox" name="markprinted" id="markprinted" style="width: 3em; height: 1.5em;">
+                </div>
+            </div>
+
+            <hr class="my-4">
+
+            <div class="mb-3">
+                <label for="startat" class="form-label fw-bold d-flex align-items-center">
+                    <i class="fas fa-hashtag me-2 text-secondary" style="width: 20px;"></i>
+                    <?= __("Start printing at?"); ?>
+                </label>
+                <div class="input-group">
+                    <span class="input-group-text"><i class="fas fa-sort-numeric-up"></i></span>
+                    <input class="form-control" type="number" id="startat" name="startat" value="1" min="1">
+                </div>
+                <small class="form-text text-muted"><?= __("Enter the starting position for label printing"); ?></small>
+            </div>
         </div>
     </div>
 </form>

--- a/assets/js/sections/labels.js
+++ b/assets/js/sections/labels.js
@@ -39,7 +39,7 @@ function printat(stationid) {
 		data: {'stationid': stationid},
 		success: function (html) {
 			BootstrapDialog.show({
-				title: 'Start printing at which label?',
+				title: '<i class="fas fa-print me-2"></i>'+lang_label_print_options,
 				size: BootstrapDialog.SIZE_NORMAL,
 				cssClass: 'qso-dialog',
 				nl2br: false,
@@ -51,20 +51,21 @@ function printat(stationid) {
 				{
 					label: lang_print_queue,
 					id: "button1id",
-					cssClass: "btn btn-primary",
-					action: function() { 
+					cssClass: "btn btn-primary btn-sm me-3",
+					action: function() {
 						$('#button_markprint').removeClass("disabled");
 						$('#button_markprint').attr("disabled", false);
-						$("#pform").submit(); 
+						$("#pform").submit();
 					}
 				},
 				{
 					label: lang_mark_qsl_as_printed+'<div class="ld ld-ring ld-spin"></div>',
-					cssClass: "btn btn-secondary me-3 ld-ext-right",
+					cssClass: "btn btn-secondary btn-sm me-3 ld-ext-right",
 					id: "button_markprint"
 				},
 				{
 					label: lang_admin_close,
+					cssClass: "btn btn-secondary btn-sm me-3",
 					action: function (dialogItself) {
 						dialogItself.close();
 						location.reload(); 	// Refresh Mainpage, because labels could have been marked as sent

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -831,7 +831,7 @@ $(document).ready(function () {
 					buttons: [
 					{
 						label: lang_admin_close,
-						cssClass: 'btn-sm btn-secondary',
+						cssClass: 'btn btn-sm btn-secondary',
 						id: 'closeButton',
 						action: function (dialogItself) {
 							dialogItself.close();
@@ -839,7 +839,7 @@ $(document).ready(function () {
 					},
 					{
 						label: 'Update',
-						cssClass: 'btn-sm btn-primary',
+						cssClass: 'btn btn-sm btn-primary',
 						id: 'updateButton',
 						action: function (dialogItself) {
 							startProcessingCallbook(nElements, $('[name="gridsquareaccuracycheck"]').is(":checked"));
@@ -1620,7 +1620,7 @@ $(document).ready(function () {
 			type: 'post',
 			success: function (html) {
 				BootstrapDialog.show({
-					title: lang_gen_advanced_logbook_start_printing_at_which_label,
+					title: '<i class="fas fa-print me-2"></i>'+lang_label_print_options,
 					size: BootstrapDialog.SIZE_NORMAL,
 					cssClass: 'qso-dialog',
 					nl2br: false,
@@ -1629,7 +1629,7 @@ $(document).ready(function () {
 					},
 					buttons: [{
 						label: 'Print',
-						cssClass: 'btn-primary btn-sm',
+						cssClass: 'btn btn-primary btn-sm',
 						action: function (dialogItself) {
 							printlabel(id_list);
 							dialogItself.close();
@@ -1637,6 +1637,7 @@ $(document).ready(function () {
 					},
 						{
 						label: lang_admin_close,
+						cssClass: 'btn btn-secondary btn-sm',
 						action: function (dialogItself) {
 							$('#printLabel').prop("disabled", false);
 							dialogItself.close();
@@ -1764,7 +1765,8 @@ function printlabel(id_list) {
 				'via': $('#via')[0].checked,
 				'tnxmsg': $('#tnxmsg')[0].checked,
 				'qslmsg': $('#qslmsg')[0].checked,
-				'reference': $('#reference')[0].checked
+				'reference': $('#reference')[0].checked,
+				'mycall': $('#mycall')[0].checked
 			},
 		xhr:function(){
 			var xhr = new XMLHttpRequest();


### PR DESCRIPTION
In response to #2856.
<img width="525" height="547" alt="image" src="https://github.com/user-attachments/assets/fe1aa91e-ee65-4fb4-bc7f-2422ccf28640" />

An extra option was added to split my call and grid.
Same option exists from the advanced logbook when printing labels there, and in the normal label print.
