### PR TITLE
HamQSL widget frontend improvements

### DIFF
--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -488,6 +488,13 @@ function getDistance($distance) {
 				</td>
 			<tr>
 				<td colspan="10">
+					<?php
+					function bandcondition_dot($condition) {
+						$colors = ['Good' => 'text-success', 'Fair' => 'text-warning', 'Poor' => 'text-danger', 'n/a' => 'text-secondary'];
+						$color = $colors[$condition] ?? '';
+						return $condition ? '<span class="' . $color . '">&#9679;</span> ' . $condition : ($condition ?? '');
+					}
+					?>
 					<table class="table table-sm small text-center table-striped">
 						<tr>
 							<th width="20%">&nbsp;</th>
@@ -498,17 +505,17 @@ function getDistance($distance) {
 						</tr>
 						<tr>
 							<td>Day</td>
-							<td><?= $solar_bandconditions['80m-40m']['day'] ?></td>
-							<td><?= $solar_bandconditions['30m-20m']['day'] ?></td>
-							<td><?= $solar_bandconditions['17m-15m']['day'] ?></td>
-							<td><?= $solar_bandconditions['12m-10m']['day'] ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['80m-40m']['day'] ?: 'n/a') ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['30m-20m']['day'] ?: 'n/a') ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['17m-15m']['day'] ?: 'n/a') ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['12m-10m']['day'] ?: 'n/a') ?></td>
 						</tr>
 						<tr>
 							<td>Night</td>
-							<td><?= $solar_bandconditions['80m-40m']['night'] ?></td>
-							<td><?= $solar_bandconditions['30m-20m']['night'] ?></td>
-							<td><?= $solar_bandconditions['17m-15m']['night'] ?></td>
-							<td><?= $solar_bandconditions['12m-10m']['night'] ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['80m-40m']['night'] ?: 'n/a') ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['30m-20m']['night'] ?: 'n/a') ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['17m-15m']['night'] ?: 'n/a') ?></td>
+							<td><?= bandcondition_dot($solar_bandconditions['12m-10m']['night'] ?: 'n/a') ?></td>
 						</tr>
 					</table>
 				</td>
@@ -517,14 +524,14 @@ function getDistance($distance) {
 				<td colspan="10">
 					<table class="table table-sm small text-center table-striped">
 						<tr>
-							<th width="5%">Kp</th>
-							<th width="5%">A</th>
-							<th width="15%">SFI</th>
-							<th width="15%">SW</th>
-							<th width="15%">SS</th>
-							<th width="15%">X</th>
-							<th width="20%">Noise</th>
-							<th width="20%">Aurora</th>
+							<th width="5%" data-bs-toggle="tooltip" title="<?= __("K-index: Planetary geomagnetic activity (0-9)") ?>">Kp</th>
+							<th width="5%" data-bs-toggle="tooltip" title="<?= __("A-index: Daily geomagnetic activity index") ?>">A</th>
+							<th width="15%" data-bs-toggle="tooltip" title="<?= __("Solar Flux Index") ?>">SFI</th>
+							<th width="15%" data-bs-toggle="tooltip" title="<?= __("Solar Wind speed (km/s)") ?>">SW</th>
+							<th width="15%" data-bs-toggle="tooltip" title="<?= __("Signal Noise ratio") ?>">SS</th>
+							<th width="15%" data-bs-toggle="tooltip" title="<?= __("X-Ray solar flux level") ?>">X</th>
+							<th width="20%" data-bs-toggle="tooltip" title="<?= __("Sunspot Number") ?>">SSN</th>
+							<th width="20%" data-bs-toggle="tooltip" title="<?= __("Aurora activity level (Kp borealis)") ?>">Aurora</th>
 						</tr>
 						<tr>
 							<td><?= $solar_solardata['kindex'] ?></td>


### PR DESCRIPTION
<img width="557" height="260" alt="grafik" src="https://github.com/user-attachments/assets/3a464e2a-f139-4289-af44-2bfaeaf18dd9" />

Some small improvements to the propagation data widget on the dashboard.
- Change "Noise" to "SSN" which make the value more clear
- Added tooltips with a small description
- Added colored dot's based on the condition