### PR TITLE
Fix some grammar issues and update links to point to new wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The Core-Dev-Team for Wavelog are (in Alphabetic order of the Call):
 * LA8AJA ([@AndreasK79](https://github.com/AndreasK79))
 
 ## Demo
-Test Wavelog and it's features!  
+Test Wavelog and its features!  
 https://demo.wavelog.org  
 
   Username: demo  
@@ -45,14 +45,14 @@ https://demo.wavelog.org
 * MySQL or MariaDB (MySQL 8 or higher // MariaDB 10.2 or higher)
 
 ### Alternative - Easy start with prebuilt Docker-image:
-* [Docker Support](https://github.com/wavelog/wavelog/wiki/Installation-via-Docker)
+* [Docker Support](https://docs.wavelog.org/getting-started/installation/docker/)
 
 Notes
 * If you want to log microwave QSOs you will need to use a 64bit operating system.
 
 ## Setup
 
-Installation information can be found on the [wiki](https://github.com/wavelog/wavelog/wiki).
+Installation information can be found on the [wiki](https://docs.wavelog.org/).
 
 ## WavelogGate 
 
@@ -74,9 +74,9 @@ Translators:
 
 [Ondřej Koloničný (OK1CDJ)](https://translate.wavelog.org/user/ok1cdj/), [Michael Skolsky (R1BLH)](https://translate.wavelog.org/user/R1BLH/), [Karuru (BG2ELG)](https://translate.wavelog.org/user/viola/), [Byt3](https://translate.wavelog.org/user/205er/), [BG6HJE](https://translate.wavelog.org/user/BG6HJE/), [Francisco (F4VSE)](https://translate.wavelog.org/user/kikosgc/), [Kim (DG9VH)](https://translate.wavelog.org/user/dg9vh/), [Casper van Lieburg (PA7DX)](https://translate.wavelog.org/user/pa7dx/), [Halil AYYILDIZ (TA2LG)](https://translate.wavelog.org/user/TA2LG/), [Michal Šiman](https://translate.wavelog.org/user/michalsiman/), [DN4BS](https://github.com/dn4bs), [Luca (IU2FRL)](https://translate.wavelog.org/user/iu2frl/), [Dragan Đorđević (4O4A)](https://translate.wavelog.org/user/4o4a/), [Dren Imeraj (Z63DRI)](https://translate.wavelog.org/user/Dren/), [Filip Melik (OK1GOD)](https://translate.wavelog.org/user/filipmelik/), [Petr (OK1PTR)](https://translate.wavelog.org/user/OK1PTR/), [Stefan (DB4SCW)](https://translate.wavelog.org/user/DB4SCW/), [F4JSU](https://translate.wavelog.org/user/F4JSU/), [Maciej](https://translate.wavelog.org/user/maciejla/), [imlonghao](https://translate.wavelog.org/user/imlonghao/), [Reiner Herrmann](https://translate.wavelog.org/user/reinerh/), [Jian ke (BG8IXZ)](https://translate.wavelog.org/user/bg8ixz/), [Fabian Franz](https://translate.wavelog.org/user/fabianfrz/), [Fatih Önder](https://translate.wavelog.org/user/cektor/), [Qing He(BD8DHF)](https://translate.wavelog.org/user/BD8DHF), [hellofinch](https://translate.wavelog.org/user/hellofinch/), [tviitkar (ES5TVI )](https://translate.wavelog.org/user/tviitkar/), [utkuyalcin](https://translate.wavelog.org/user/utkuyalcin/), [Plamen Panteleev (LZ1PPL)](https://translate.wavelog.org/user/lz1ppl/), [Bartek](https://translate.wavelog.org/user/atimias/), [Samir (DL4DCO)](https://translate.wavelog.org/user/DL4DCO/), [Stanisław Korzeń (SP5CRO)](https://translate.wavelog.org/user/sp5cro/), [wxy (BA7NID)](https://translate.wavelog.org/user/ba7nid/), [David Quental (CT1DRB)](https://translate.wavelog.org/user/ct1drb/), [Sebastian K.](https://translate.wavelog.org/user/sebket/), [Limes](https://translate.wavelog.org/user/limes-github/), [Ethan C. Edwards (AE4CE)](https://translate.wavelog.org/user/ethancedwards8/), [Simon Pribec](https://translate.wavelog.org/user/spribec/), [Christian Egger (HB9HJQ)](https://translate.wavelog.org/user/HB9HJQ/), [André Berends (PE1PQX)](https://translate.wavelog.org/user/PE1PQX/), [Alexander (PA8S)](https://translate.wavelog.org/user/pa8s/), [Jorgen Dahl (NU1T)](https://translate.wavelog.org/user/Jorgen/), [bel-pol](https://translate.wavelog.org/user/bel-pol/), [Mathias Regner (OE4BAM)](https://translate.wavelog.org/user/MatykoBr/), [remy56k](https://translate.wavelog.org/user/remy56k/), [YuanRetro (VA3LPZ/BI4LPZ)](https://translate.wavelog.org/user/yuanretro/), [李宇翔](https://translate.wavelog.org/user/vastsea-wuji/), [Pascal HB9HCG](https://translate.wavelog.org/user/hb9hcg/), [André Aubin](https://github.com/lambda2), [Tao Xu](https://translate.wavelog.org/user/tallcode/), [flothom](https://translate.wavelog.org/user/flothom/), [BH3HNI](https://translate.wavelog.org/user/BH3HNI/), [Lu Chang](https://translate.wavelog.org/user/ludoux/), [Alexey Khromov](https://translate.wavelog.org/user/zxalexis/), [BG8LNG](https://translate.wavelog.org/user/BG8LNG/), [Karim Malfi (F4CTJ)](https://translate.wavelog.org/user/F4CTJ/), [FengziLeo (BH7GZB)](https://translate.wavelog.org/user/BH7GZB/), [MiaoTony](https://translate.wavelog.org/user/miaotony/), [Aleksey Ubozhenko (R3DHX)](https://translate.wavelog.org/user/AleksdemSA/), [Stephane Tauziede (F4IZC)](https://translate.wavelog.org/user/F4IZC/), [S. NAKAO](https://translate.wavelog.org/user/NAKAO/), [Artur Greficz (SQ7ACP)](https://translate.wavelog.org/user/SQ7ACP/), [Matthias Jung](https://translate.wavelog.org/user/myzinsky/), [Erkin Mercan (TA4AQG/SP9AQG)](https://translate.wavelog.org/user/TA4AQG-SP9AQG/), [Fabian (EB1TR)](https://translate.wavelog.org/user/EB1TR/), [Szymon (SP9SPM)](https://translate.wavelog.org/user/sp9spm/), [Yoshida Kanae](translate.wavelog.org/user/xiaoxis654/), [notzaleewa](translate.wavelog.org/user/notzaleewa/), [F5MQU](translate.wavelog.org/user/F5MQU/), [ShenRQ(BH4FJN)](translate.wavelog.org/user/Jerryshen/), [JONCOUX Philippe](translate.wavelog.org/user/Garci80/), [Jerry](https://translate.wavelog.org/user/wohenbuguai/), [Viliam Petrik (OM0AAO)](https://translate.wavelog.org/user/om0aao/), [MCyiqiehuanying](https://translate.wavelog.org/user/MCyiqiehuanying/), [Dariusz Koryto (SQ7DK)](https://translate.wavelog.org/user/sq7dk/), [FATDEER](https://translate.wavelog.org/user/fatdeer/), [Jan Zeman (OK1IBW)](https://www.qrz.com/db/OK1IBW), [CS7AFM](https://translate.wavelog.org/user/sergio.t.mata@gmail.com/), [marin](https://translate.wavelog.org/user/marin/), [Juuso W. (OH1JW)](https://translate.wavelog.org/user/oh1jw/), [Juan Pablo Tamayo (HJ3KOS)](https://translate.wavelog.org/user/hj3kos/), [Miguel](https://translate.wavelog.org/user/micc/)
 
-If you would like to contribute in any way to Wavelog, it is most appreciated. This has been developed in free time, help coding new features or writing documentation is always useful.  
+If you would like to contribute in any way to Wavelog, it is most appreciated. This has been developed in free time, and help coding new features or writing documentation is always useful.  
 
-**For translations and language stuff you can refer to our [Wiki about Translations](https://github.com/wavelog/wavelog/wiki/Translations).**
+**For translations and language stuff you can refer to our [Wiki about Translations](https://docs.wavelog.org/developer/translations/).**
 
 Please note that Wavelog was built using [Codeigniter](https://www.codeigniter.com/userguide3/) version 3 and uses Bootstrap 5 for the user CSS framework documentation is available for this when building components.
 


### PR DESCRIPTION
Updates Wiki links to point to https://docs.wavelog.org/ and fixes some grammar issues