### PR TITLE
[CQ Award] Make confirmed behave like before (hide W)

### DIFF
--- a/application/models/Cq.php
+++ b/application/models/Cq.php
@@ -132,7 +132,9 @@ class CQ extends CI_Model{
 					$summary['confirmed'][$cq->col_band]++;
 				}
 			} else {
-				$bandCq[$cq->col_cqz][$cq->col_band] = '<div class="bg-danger awardsBgWarning"><a href=\'javascript:displayContacts("' . str_replace("&", "%26", $cq->col_cqz) . '","' . $cq->col_band . '","All", "All","'. $postdata['mode'] . '","CQZone","")\'>W</a></div>';
+				if ($postdata['worked'] != NULL) {
+					$bandCq[$cq->col_cqz][$cq->col_band] = '<div class="bg-danger awardsBgWarning"><a href=\'javascript:displayContacts("' . str_replace("&", "%26", $cq->col_cqz) . '","' . $cq->col_band . '","All", "All","'. $postdata['mode'] . '","CQZone","")\'>W</a></div>';
+				}
 			}
 
 			// Track worked zones for summary


### PR DESCRIPTION
As a side effect of new logic, the behavior was changed.
Choosing only confirmed, now hides ALL worked stuff, even though ALL as band is chosen.
