### PR TITLE
if RX and TX are same (split) show only one QRG

### DIFF
--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -88,6 +88,8 @@ class Radio extends CI_Controller {
 					echo "<td>- / -</td>";
 				} elseif (empty($row->frequency_rx) || $row->frequency_rx == "0") {
 					echo "<td>" . $this->frequency->qrg_conversion($row->frequency) . "</td>";
+				} elseif ($this->frequency->frequencies_are_equal($row->frequency, $row->frequency_rx)) {
+					echo "<td>" . $this->frequency->qrg_conversion($row->frequency) . "</td>";
 				} else {
 					echo "<td>" . $this->frequency->qrg_conversion($row->frequency_rx) . " / " . $this->frequency->qrg_conversion($row->frequency) . "</td>";
 				}

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -502,6 +502,14 @@ class Widgets extends CI_Controller {
 			$mode_string = empty($cat_data->mode) ? "" : $cat_data->mode;
 
 			return trim(sprintf("%s %s", $tx_frequency, $mode_string));
+		} elseif ($this->frequency->frequencies_are_equal($cat_data->frequency, $cat_data->frequency_rx)) {
+			// Frequencies are equal, show only one
+			$tx_frequency = $this->frequency->qrg_conversion(
+				$cat_data->frequency, $r_option, $source_unit, $target_unit
+			);
+			$mode_string = empty($cat_data->mode) ? "" : $cat_data->mode;
+
+			return trim(sprintf("%s %s", $tx_frequency, $mode_string));
 		} else {
 			$rx_frequency = $this->frequency->qrg_conversion(
 				$cat_data->frequency_rx, $r_option, $source_unit, $target_unit

--- a/application/libraries/Frequency.php
+++ b/application/libraries/Frequency.php
@@ -337,5 +337,25 @@ class Frequency {
 		}
 		return $unit;
 	}
+
+	/**
+	 * Check if two frequencies are equal (handles different formats and empty values)
+	 *
+	 * @param mixed $freq1 First frequency (TX)
+	 * @param mixed $freq2 Second frequency (RX)
+	 * @return bool True if frequencies are equal or if one is empty/zero
+	 */
+	function frequencies_are_equal($freq1, $freq2) {
+		// Treat empty, null, or zero as "not set"
+		if (empty($freq1) || $freq1 === '0' || $freq1 === 0) {
+			return true;
+		}
+		if (empty($freq2) || $freq2 === '0' || $freq2 === 0) {
+			return true;
+		}
+
+		// Compare as floats to handle different string representations
+		return (float)$freq1 === (float)$freq2;
+	}
 }
 /* End of file Frequency.php */

--- a/application/views/qslprint/qsolist.php
+++ b/application/views/qslprint/qsolist.php
@@ -41,8 +41,24 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\'>'; $timestamp = strtotime($qsl->COL_TIME_ON); echo date($custom_date_format, $timestamp); echo '</td>';
 		echo '<td style=\'text-align: center\'>'; $timestamp = strtotime($qsl->COL_TIME_ON); echo date('H:i', $timestamp); echo '</td>';
 		echo '<td style=\'text-align: center\'>'; echo $qsl->COL_SUBMODE==null?$qsl->COL_MODE:$qsl->COL_SUBMODE; echo '</td>';
-		echo '<td style=\'text-align: center\'>'; if($qsl->COL_SAT_NAME != null) { echo __("SAT") . ' ' . $qsl->COL_SAT_NAME . ' '. strtolower($qsl->COL_BAND) . '/' . strtolower($qsl->COL_BAND_RX); } else { echo strtolower($qsl->COL_BAND); }; echo '</td>';
-		echo '<td style=\'text-align: center\'>'; if($qsl->COL_SAT_NAME != null) { echo __("SAT") . ' ' . $qsl->COL_SAT_NAME . ' ' . $this->frequency->qrg_conversion($qsl->COL_FREQ) . '/' . $this->frequency->qrg_conversion($qsl->COL_FREQ_RX); } else { echo $this->frequency->qrg_conversion($qsl->COL_FREQ); }; echo '</td>';
+		echo '<td style=\'text-align: center\'>'; if($qsl->COL_SAT_NAME != null) {
+			$band_rx = strtolower($qsl->COL_BAND_RX ?? '');
+			$band = strtolower($qsl->COL_BAND);
+			if ($band_rx && $band && $band_rx != $band) {
+				echo __("SAT") . ' ' . $qsl->COL_SAT_NAME . ' ' . $band . '/' . $band_rx;
+			} else {
+				echo __("SAT") . ' ' . $qsl->COL_SAT_NAME . ' ' . $band;
+			}
+		} else { echo strtolower($qsl->COL_BAND); }; echo '</td>';
+		echo '<td style=\'text-align: center\'>'; if($qsl->COL_SAT_NAME != null) {
+			$freq_rx = $qsl->COL_FREQ_RX ?? 0;
+			$freq = $qsl->COL_FREQ ?? 0;
+			if ($freq_rx && $freq && !$this->frequency->frequencies_are_equal($freq, $freq_rx)) {
+				echo __("SAT") . ' ' . $qsl->COL_SAT_NAME . ' ' . $this->frequency->qrg_conversion($freq) . '/' . $this->frequency->qrg_conversion($freq_rx);
+			} else {
+				echo __("SAT") . ' ' . $qsl->COL_SAT_NAME . ' ' . $this->frequency->qrg_conversion($freq);
+			}
+		} else { echo $this->frequency->qrg_conversion($qsl->COL_FREQ); }; echo '</td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_RST_SENT . '</td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_RST_RCVD . '</td>';
 		echo '<td style=\'text-align: center\'><span class="badge text-bg-light">' . $qsl->station_callsign . '</span></td>';

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -1426,9 +1426,12 @@ class QSO
 		}
 
 		if ($this->frequencyRX && $this->frequency) {
-			$converted_rx = $this->CI->frequency->qrg_conversion($this->frequencyRX);
-			if ($converted_rx) {
-				$label .= "/" . $converted_rx;
+			// Only show RX frequency if it's different from TX
+			if (!$this->CI->frequency->frequencies_are_equal($this->frequency, $this->frequencyRX)) {
+				$converted_rx = $this->CI->frequency->qrg_conversion($this->frequencyRX);
+				if ($converted_rx) {
+					$label .= "/" . $converted_rx;
+				}
 			}
 		}
 


### PR DESCRIPTION
If - for whatever reason - ADIF or CAT tells a Split-QSO with same Frequencies, show only ONE frequency in:
- Widget
- Overview
- Labels
- Logbook-Advanced

Detail-View is still the same, No data is touched. only UI.

Should resolve #3035 