### PR TITLE
Take References from QSO-Table

### DIFF
--- a/application/controllers/Labels.php
+++ b/application/controllers/Labels.php
@@ -297,12 +297,12 @@ class Labels extends CI_Controller {
 				'sat_band_rx' => ($qso->COL_BAND_RX ?? ''),
 				'qsl_recvd' => $qso->COL_QSL_RCVD,
 				'mycall' => $qso->COL_STATION_CALLSIGN,
-				'sig' => $qso->station_sig ?? '',
-				'sig_info' => $qso->station_sig_info ?? '',
-				'sota' => $qso->station_sota ?? '',
-				'iota' => $qso->station_iota ?? '',
-				'pota' => $qso->station_pota ?? '',
-				'wwff' => $qso->station_wwff ?? '',
+				'sig' => $qso->{'COL_MY_SIG'} ?? '',
+				'sig_info' => $qso->{'COL_MY_SIG_INFO'} ?? '',
+				'sota' => $qso->{'COL_MY_SOTA_REF'} ?? '',
+				'iota' => $qso->{'COL_MY_IOTA'} ?? '',
+				'pota' => $qso->{'COL_MY_POTA_REF'} ?? '',
+				'wwff' => $qso->{'COL_MY_WWFF_REF'} ?? '',
 				'qslmsg' => $qso->COL_QSLMSG  ?? '',
 
 			];

--- a/application/libraries/AdifHelper.php
+++ b/application/libraries/AdifHelper.php
@@ -205,13 +205,13 @@ class AdifHelper {
 			$line .= $this->getAdifFieldLine("MY_GRIDSQUARE", $qso->station_gridsquare);
 		}
 
-		$line .= $this->getAdifFieldLine("MY_IOTA", $qso->station_iota);
+		$line .= $this->getAdifFieldLine("MY_IOTA", $qso->{'COL_MY_IOTA'});
 
-		$line .= $this->getAdifFieldLine("MY_SOTA_REF", $qso->station_sota);
+		$line .= $this->getAdifFieldLine("MY_SOTA_REF", $qso->{'COL_MY_SOTA_REF'});
 
-		$line .= $this->getAdifFieldLine("MY_WWFF_REF", $qso->station_wwff);
+		$line .= $this->getAdifFieldLine("MY_WWFF_REF", $qso->{'COL_MY_WWFF_REF'});
 
-		$line .= $this->getAdifFieldLine("MY_POTA_REF", $qso->station_pota);
+		$line .= $this->getAdifFieldLine("MY_POTA_REF", $qso->{'COL_MY_POTA_REF'});
 
 		$line .= $this->getAdifFieldLine("MY_CQ_ZONE", $qso->station_cq);
 
@@ -237,8 +237,8 @@ class AdifHelper {
 
 		$line .= $this->getAdifFieldLine("MY_CNTY", $county);
 
-		$line .= $this->getAdifFieldLine("MY_SIG", $qso->station_sig);
-		$line .= $this->getAdifFieldLine("MY_SIG_INFO", $qso->station_sig_info);
+		$line .= $this->getAdifFieldLine("MY_SIG", $qso->{'COL_MY_SIG'});
+		$line .= $this->getAdifFieldLine("MY_SIG_INFO", $qso->{'COL_MY_SIG_INFO'});
 
 		$line .= $this->getAdifFieldLine("SIG", $qso->{'COL_SIG'});
 		$line .= $this->getAdifFieldLine("SIG_INFO", $qso->{'COL_SIG_INFO'});

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -728,43 +728,43 @@
                     </tr>
                     <?php } ?>
 
-                    <?php if($row->station_iota) { ?>
+                    <?php if($row->{'COL_MY_IOTA'}) { ?>
                     <tr>
                         <td><?= __("Station") . ' ' . __("IOTA Reference"); ?></td>
-                        <td><?php echo $row->station_iota; ?></td>
+                        <td><?php echo $row->{'COL_MY_IOTA'}; ?></td>
                     </tr>
                     <?php } ?>
 
-                    <?php if($row->station_sota) { ?>
+                    <?php if($row->{'COL_MY_SOTA_REF'}) { ?>
                     <tr>
                         <td><?= __("Station") . ' ' . __("SOTA Reference"); ?></td>
-                        <td><?php echo $row->station_sota; ?></td>
+                        <td><?php echo $row->{'COL_MY_SOTA_REF'}; ?></td>
                     </tr>
                     <?php } ?>
 
-                    <?php if($row->station_wwff) { ?>
+                    <?php if($row->{'COL_MY_WWFF_REF'}) { ?>
                     <tr>
                         <td><?= __("Station") . ' ' . __("WWFF Reference"); ?></td>
-                        <td><?php echo $row->station_wwff; ?></td>
+                        <td><?php echo $row->{'COL_MY_WWFF_REF'}; ?></td>
                     </tr>
                     <?php } ?>
 
-                    <?php if($row->station_pota) { ?>
+                    <?php if($row->{'COL_MY_POTA_REF'}) { ?>
                     <tr>
                         <td><?= __("Station") . ' ' . __("POTA Reference(s)"); ?></td>
-                        <td><?php echo $row->station_pota; ?></td>
+                        <td><?php echo $row->{'COL_MY_POTA_REF'}; ?></td>
                     </tr>
                     <?php } ?>
 
-                    <?php if($row->station_sig) { ?>
+                    <?php if($row->{'COL_MY_SIG'}) { ?>
                     <tr>
                         <td><?= __("Station") . ' ' . __("SIG"); ?></td>
-                        <td><?php echo $row->station_sig; ?></td>
+                        <td><?php echo $row->{'COL_MY_SIG'}; ?></td>
                     </tr>
 
                     <tr>
                         <td><?= __("Station") . ' ' . __("SIG Info"); ?></td>
-                        <td><?php echo $row->station_sig_info; ?></td>
+                        <td><?php echo $row->{'COL_MY_SIG_INFO'}; ?></td>
                     </tr>
                     <?php } ?>
             </table>

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -212,12 +212,12 @@ class QSO
 		$this->address = $data['COL_ADDRESS'] ?? '';
 
 		$this->deGridsquare = $data['station_gridsquare'] ?? '';
-		$this->deIOTA = $data['station_iota'] ?? '';
-		$this->deSig = $data['station_sig'] ?? '';
-		$this->deSigInfo = $data['station_sig_info'] ?? '';
+		$this->deIOTA = $data['COL_MY_IOTA'] ?? '';
+		$this->deSig = $data['COL_MY_SIG'] ?? '';
+		$this->deSigInfo = $data['COL_MY_SIG_INFO'] ?? '';
 		$this->deIOTAIslandID = $data['COL_MY_IOTA_ISLAND_ID'] ?? '';
-		$this->deSOTAReference = $data['station_sota'] ?? '';
-		$this->deWWFFReference = $data['station_wwff'] ?? '';
+		$this->deSOTAReference = $data['COL_MY_SOTA_REF'] ?? '';
+		$this->deWWFFReference = $data['COL_MY_WWFF_REF'] ?? '';
 
 		$this->deVUCCGridsquares = $data['COL_MY_VUCC_GRIDS'] ?? '';
 


### PR DESCRIPTION
With this patch (discussable) the logic for retrieving specific MY-Informations slightly changes. 

Before patch: Everything was taken from profile, even if QSO-Table has different information.

With Patch:

From QSO table:
  - MY_IOTA, MY_SOTA_REF, MY_WWFF_REF, MY_POTA_REF, MY_SIG, MY_SIG_INFO

 Still from station_profile join:
  - STATION_CALLSIGN → station_callsign
  - MY_CITY → station_city
  - MY_COUNTRY → station_country
  - MY_DXCC → station_dxcc
  - MY_GRIDSQUARE / MY_VUCC_GRIDS → station_gridsquare
  - MY_CQ_ZONE → station_cq
  - MY_ITU_ZONE → station_itu
  - MY_STATE → state
  - MY_CNTY → station_cnty

----
Testing:
- Log a couple of QSOs
- Change - e.g. - IOTA in your station_location
- Add more QSOs

- Have a look at them at QSO-Table.
- Have a look at them at detail-view.
- Export them.

compare dev to this.