### PR TITLE
Prevent populating unitialized distance-buckets

### DIFF
--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -172,7 +172,15 @@ class Distances_model extends CI_Model
 			echo json_encode(array('Error' => 'Error. There is a problem with the gridsquare ('.$stationgrid.') set in your profile!'));
 			exit;
 		} else {
-			// Making the array we will use for plotting, we save occurrences of the length of each qso in the array
+			// Build the chart buckets in 50-unit steps up to the max chart distance ($dist).
+			// Each bucket covers a 50-unit range, e.g. in km mode:
+			//   $dataarray[0]   => "0km - 50km"
+			//   $dataarray[1]   => "50km - 100km"
+			//   ...
+			//   $dataarray[399] => "19950km - 20000km"  (last valid index, since 20000/50 - 1 = 399)
+			// A QSO at 31,450 km would map to bucket index 629 (31450/50 = 629),
+			// which is never initialized here, causing "Undefined array key 629" warnings.
+			// The isset() guard further below skips any QSO whose distance exceeds this range.
 			$j = 0;
 			for ($i = 0; $j < $dist; $i++) {
 				$dataarray[$i]['dist'] =  $j . $unit . ' - ' . ($j + 50) . $unit;
@@ -204,6 +212,9 @@ class Distances_model extends CI_Model
 					$qrb['Distance'] = $bearingdistance;
 					$qrb['Callsign'] = $qso['callsign'];
 					$qrb['Grid'] = $qso['grid'];
+				}
+				if (!isset($dataarray[$arrayplacement])) {                              // QSO distance exceeds chart range, skip plotting
+					continue;
 				}
 				$dataarray[$arrayplacement]['count']++;                                               // Used for counting total qsos plotted
 				if ($dataarray[$arrayplacement]['callcount'] < 5) {                     // Used for tooltip in graph, set limit to 5 calls shown

--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -152,19 +152,19 @@ class Distances_model extends CI_Model
 		switch ($measurement_base) {
 		case 'M':
 			$unit = "mi";
-			$dist = '13000';
+			$dist = '26000';
 			break;
 		case 'K':
 			$unit = "km";
-			$dist = '20000';
+			$dist = '40050';
 			break;
 		case 'N':
 			$unit = "nmi";
-			$dist = '11000';
+			$dist = '22000';
 			break;
 		default:
 			$unit = "km";
-			$dist = '20000';
+			$dist = '40050';
 		}
 
 		if (!$this->valid_locator($stationgrid)) {
@@ -177,10 +177,7 @@ class Distances_model extends CI_Model
 			//   $dataarray[0]   => "0km - 50km"
 			//   $dataarray[1]   => "50km - 100km"
 			//   ...
-			//   $dataarray[399] => "19950km - 20000km"  (last valid index, since 20000/50 - 1 = 399)
-			// A QSO at 31,450 km would map to bucket index 629 (31450/50 = 629),
-			// which is never initialized here, causing "Undefined array key 629" warnings.
-			// The isset() guard further below skips any QSO whose distance exceeds this range.
+			//   till 40050 (longpath)
 			$j = 0;
 			for ($i = 0; $j < $dist; $i++) {
 				$dataarray[$i]['dist'] =  $j . $unit . ' - ' . ($j + 50) . $unit;


### PR DESCRIPTION
It looks like people are writing over-Longpath or Moonbounce-Distances to their QSOs.
our distance-chart creates a defined range of "buckets" at Analyze -> Distances.

With the above fact, WL tries to populate buckets which are far beyond our initialized once.
instead of extending the buckets (where should we stop? at Moon? at Mars? at Sun?), this preserves the distance at the QSO but doesn't plot them.

Trigger for this patch was:
```
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key 629 /var/www/html/application/models/Distances_model.php 208
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key "count" /var/www/html/application/models/Distances_model.php 208
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key "callcount" /var/www/html/application/models/Distances_model.php 209
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key "callcount" /var/www/html/application/models/Distances_model.php 210
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key "calls" /var/www/html/application/models/Distances_model.php 213
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key "callcount" /var/www/html/application/models/Distances_model.php 214
ERROR - 2026-03-05 21:30:23 --> Severity: Warning --> Undefined array key 481 /var/www/html/application/models/Distances_model.php 208
```