### PR TITLE
Harmonize CAT-Display for RX/TX

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -296,7 +296,7 @@ $(document).ready(function() {
         } else if (qrgunit == 'GHz') {
             frequency_formatted=(freq / 1000000000);
         }
-        return frequency_formatted+''+qrgunit;
+        return frequency_formatted+' '+qrgunit;
     }
 
     /**
@@ -689,14 +689,14 @@ $(document).ready(function() {
         // Check if we have RX frequency (split operation)
         if(data.frequency_rx != null && data.frequency_rx != 0) {
             // Split operation: show TX and RX separately
-            freqLine = '<b>' + lang_cat_tx + ':</b> ' + data.frequency_formatted;
-            data.frequency_rx_formatted = format_frequency(data.frequency_rx);
-            if (data.frequency_rx_formatted) {
-                freqLine = freqLine + separator + '<b>' + lang_cat_rx + ':</b> ' + data.frequency_rx_formatted;
+            freqLine = '<b>' + lang_cat_tx + ':</b> ' + format_frequency(data.frequency);
+            var freq_rx_formatted = format_frequency(data.frequency_rx);
+            if (freq_rx_formatted) {
+                freqLine = freqLine + separator + '<b>' + lang_cat_rx + ':</b> ' + freq_rx_formatted;
             }
         } else {
             // Simplex operation: show TX/RX combined
-            freqLine = '<b>' + lang_cat_tx_rx + ':</b> ' + data.frequency_formatted;
+            freqLine = '<b>' + lang_cat_tx_rx + ':</b> ' + format_frequency(data.frequency);
         }
 
         // Add mode and power (only if we have valid frequency)
@@ -767,25 +767,20 @@ $(document).ready(function() {
 				var connectionType = $(".radios option:selected").val() == 'ws' ? lang_cat_live : lang_cat_polling;
 				tooltipContent = '<b>' + radioName + '</b> (' + connectionType + ')';
 
-				// Ensure frequency_formatted exists
-				var freqFormatted = data.frequency_formatted;
-				if (!freqFormatted || freqFormatted === 'undefined' || freqFormatted === 'nullkHz') {
-					freqFormatted = format_frequency(data.frequency);
-				}
-
 				// Add frequency info
+				var freqFormatted = format_frequency(data.frequency);
 				if(data.frequency_rx && data.frequency_rx != 0 && data.frequency_rx !== 'undefined') {
 					// Split operation: show TX and RX separately
-					if (freqFormatted && freqFormatted !== 'undefined') {
+					if (freqFormatted) {
 						tooltipContent += '<br><b>' + lang_cat_tx + ':</b> ' + freqFormatted;
 					}
 					var rxFormatted = format_frequency(data.frequency_rx);
-					if (rxFormatted && rxFormatted !== 'undefined') {
+					if (rxFormatted) {
 						tooltipContent += '<br><b>' + lang_cat_rx + ':</b> ' + rxFormatted;
 					}
 				} else {
 					// Simplex operation: show TX/RX combined
-					if (freqFormatted && freqFormatted !== 'undefined') {
+					if (freqFormatted) {
 						tooltipContent += '<br><b>' + lang_cat_tx_rx + ':</b> ' + freqFormatted;
 					}
 				}
@@ -858,25 +853,20 @@ $(document).ready(function() {
 			}
 			tooltipContent = '<b>' + radioName + '</b> (' + connectionType + ')';
 
-				// Ensure frequency_formatted exists
-				var freqFormatted = data.frequency_formatted;
-				if (!freqFormatted || freqFormatted === 'undefined' || freqFormatted === 'nullkHz') {
-					freqFormatted = format_frequency(data.frequency);
-				}
-
 				// Add frequency info
+				var freqFormatted = format_frequency(data.frequency);
 				if(data.frequency_rx && data.frequency_rx != 0 && data.frequency_rx !== 'undefined') {
 					// Split operation: show TX and RX separately
-					if (freqFormatted && freqFormatted !== 'undefined') {
+					if (freqFormatted) {
 						tooltipContent += '<br><b>' + lang_cat_tx + ':</b> ' + freqFormatted;
 					}
 					var rxFormatted = format_frequency(data.frequency_rx);
-					if (rxFormatted && rxFormatted !== 'undefined') {
+					if (rxFormatted) {
 						tooltipContent += '<br><b>' + lang_cat_rx + ':</b> ' + rxFormatted;
 					}
 				} else {
 					// Simplex operation: show TX/RX combined
-					if (freqFormatted && freqFormatted !== 'undefined') {
+					if (freqFormatted) {
 						tooltipContent += '<br><b>' + lang_cat_tx_rx + ':</b> ' + freqFormatted;
 					}
 				}


### PR DESCRIPTION
The issueowner at https://github.com/wavelog/wavelog/discussions/3062 raised an interesting point.
There were several issues with the CAT-Display in QSO-Log-Window.

1. A simple Space between the RX-QRG and the Unit was missing --> fixed
2. The frequencies itself were calculated differently. RX was formatted in JS, while TX was pre-formatted on serverside. This was leading into precision loss. Now both Frequencies are calculated in the same way on JS-Side

The whole PR is ONLY about the display for the status-bar.

B4 Patch:
<img width="1118" height="330" alt="image" src="https://github.com/user-attachments/assets/5dc9588b-2515-43c5-9c96-d9f5c11f3910" />


After patch:
<img width="2370" height="742" alt="image" src="https://github.com/user-attachments/assets/00b87480-ec17-4cf2-8196-e9625051a39f" />
