### PR TITLE
Check returned array properly

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -620,7 +620,7 @@ class API extends CI_Controller {
 					// Get associated station locations for mysql queries
 					$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
-					if ($logbooks_locations_array[0] == -1) {
+					if ($logbooks_locations_array[0] === -1) {
 						// Logbook not found
 						http_response_code(404);
 						echo json_encode(['status' => 'failed', 'reason' => "Empty Logbook"]);
@@ -706,7 +706,7 @@ class API extends CI_Controller {
 					// Get associated station locations for mysql queries
 					$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
-					if ($logbooks_locations_array[0] == -1) {
+					if ($logbooks_locations_array[0] === -1) {
 						// Logbook not found
 						http_response_code(404);
 						echo json_encode(['status' => 'failed', 'reason' => "Empty Logbook"]);
@@ -795,7 +795,7 @@ class API extends CI_Controller {
 			}
 			if ($this->logbooks_model->exists_logbook_id($logbook_id) != false) {
 				$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
-				if ($logbooks_locations_array[0] == -1) {
+				if ($logbooks_locations_array[0] === -1) {
 					http_response_code(404);
 					echo json_encode(['status' => 'failed', 'reason' => "logbook with ID ".$logbook_id." has no associated station locations"]);
 					die();

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -925,7 +925,7 @@ class Awards extends CI_Controller {
 
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -1889,7 +1889,7 @@ class Awards extends CI_Controller {
 	    $this->load->model('logbooks_model');
 	    $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-	    if ($logbooks_locations_array[0] == -1) {
+	    if ($logbooks_locations_array[0] === -1) {
 		    return null;
 	    }
 

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -34,7 +34,7 @@ class Dashboard extends CI_Controller {
 			$data['active_not_linked']=false;
 		}
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			$data['linkedCount']=0;
 		} else {
 			$data['linkedCount']=sizeof($logbooks_locations_array);

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -262,7 +262,7 @@ class Logbook extends CI_Controller {
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		$user_default_confirmation = $this->session->userdata('user_default_confirmation');
 
-		if($logbooks_locations_array[0] != -1) {
+		if($logbooks_locations_array[0] !== -1) {
 			$extrawhere='';
 			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'Q') !== false) {
 				$extrawhere="COL_QSL_RCVD='Y'";
@@ -337,7 +337,7 @@ class Logbook extends CI_Controller {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if($logbooks_locations_array[0] != -1) {
+		if($logbooks_locations_array[0] !== -1) {
 			if($band == "SAT") {
 				$this->db->where('COL_PROP_MODE', 'SAT');
 			} else {
@@ -475,7 +475,7 @@ class Logbook extends CI_Controller {
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		$this->load->model('logbook_model');
 
-		if($logbooks_locations_array[0] != -1) {
+		if($logbooks_locations_array[0] !== -1) {
 			if($type == "SAT") {
 				$this->db->where('COL_PROP_MODE', 'SAT');
 			} else {
@@ -579,7 +579,7 @@ class Logbook extends CI_Controller {
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		$this->load->model('logbook_model');
 
-		if($logbooks_locations_array[0] != -1) {
+		if($logbooks_locations_array[0] !== -1) {
 			if($type == "SAT") {
 				$this->db->where('COL_PROP_MODE', 'SAT');
 			} else {
@@ -717,7 +717,7 @@ class Logbook extends CI_Controller {
 			$satellites[$sat->name] = $sat->displayname;
 		}
 
-		if($logbooks_locations_array[0] != -1) {
+		if($logbooks_locations_array[0] !== -1) {
 			$station_ids = implode(',', array_map(function($id) { return (int)$id; }, $logbooks_locations_array));
 
 			$bindings = [

--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -167,7 +167,7 @@ class Oqrs extends CI_Controller {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] != -1) {
+		if ($logbooks_locations_array[0] !== -1) {
 			$location_list = "'".implode("','",$logbooks_locations_array)."'";
 		} else {
 			$location_list = null;

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -72,7 +72,7 @@ class Visitor extends CI_Controller {
                     // Get associated station locations for mysql queries
                     $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
-					if ($logbooks_locations_array[0] == -1) {
+					if ($logbooks_locations_array[0] === -1) {
 						show_404(__("Empty Logbook"));
 					}
 
@@ -167,7 +167,7 @@ class Visitor extends CI_Controller {
             // Get associated station locations for mysql queries
             $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
-			if ($logbooks_locations_array[0] == -1) {
+			if ($logbooks_locations_array[0] === -1) {
 				show_404(__("Empty Logbook"));
 			}
         } else {
@@ -202,7 +202,7 @@ class Visitor extends CI_Controller {
 				// Get associated station locations for mysql queries
 				$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
-				if ($logbooks_locations_array[0] == -1) {
+				if ($logbooks_locations_array[0] === -1) {
 					show_404(__("Empty Logbook"));
 				}
 			} else {
@@ -470,7 +470,7 @@ class Visitor extends CI_Controller {
             // Get associated station locations for mysql queries
             $logbooks_locations_array = $this->stationsetup_model->get_container_relations($logbook_id);
 
-			if ($logbooks_locations_array[0] == -1) {
+			if ($logbooks_locations_array[0] === -1) {
 				show_404(__("Empty Logbook"));
 			}
         } else {

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -60,7 +60,7 @@ class Widgets extends CI_Controller {
 				// Get associated station locations for mysql queries
 				$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
 
-				if ($logbooks_locations_array[0] == -1) {
+				if ($logbooks_locations_array[0] === -1) {
 					show_404(__("Empty Logbook"));
 				}
 			} else {

--- a/application/libraries/DxclusterCache.php
+++ b/application/libraries/DxclusterCache.php
@@ -105,7 +105,7 @@ class DxclusterCache {
 		$logbook_ids = $this->CI->logbooks_model->list_logbook_relationships($active_logbook);
 		$confirmation_prefs = $this->CI->session->userdata('user_default_confirmation') ?? '';
 
-		if ($logbook_ids[0] == -1) return null;
+		if ($logbook_ids[0] === -1) return null;
 
 		return $this->get_logbook_key($user_id, $logbook_ids, $confirmation_prefs);
 	}

--- a/application/models/Accumulate_model.php
+++ b/application/models/Accumulate_model.php
@@ -7,7 +7,7 @@ class Accumulate_model extends CI_Model
         $this->load->model('logbooks_model');
         $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return array();
         }
 

--- a/application/models/Activated_gridmap_model.php
+++ b/application/models/Activated_gridmap_model.php
@@ -7,7 +7,7 @@ class Activated_gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -59,7 +59,7 @@ class Activated_gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -110,7 +110,7 @@ class Activated_gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -163,7 +163,7 @@ class Activated_gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -256,7 +256,7 @@ class Activated_gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Activators_model.php
+++ b/application/models/Activators_model.php
@@ -12,7 +12,7 @@ class Activators_model extends CI_Model
 			$mincount = 2;
 		}
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -119,7 +119,7 @@ class Activators_model extends CI_Model
       $this->load->model('logbooks_model');
       $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-      if ($logbooks_locations_array[0] == -1) {
+      if ($logbooks_locations_array[0] === -1) {
          return array();
       }
 

--- a/application/models/Counties.php
+++ b/application/models/Counties.php
@@ -27,7 +27,7 @@ class Counties extends CI_Model
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 
@@ -87,7 +87,7 @@ class Counties extends CI_Model
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 

--- a/application/models/Dayswithqso_model.php
+++ b/application/models/Dayswithqso_model.php
@@ -8,7 +8,7 @@ class Dayswithqso_model extends CI_Model
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 
@@ -167,7 +167,7 @@ class Dayswithqso_model extends CI_Model
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 
@@ -186,7 +186,7 @@ class Dayswithqso_model extends CI_Model
 	    $this->load->model('logbooks_model');
 	    $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-	    if ($logbooks_locations_array[0] == -1) {
+	    if ($logbooks_locations_array[0] === -1) {
 		    return null;
 	    }
 
@@ -211,7 +211,7 @@ class Dayswithqso_model extends CI_Model
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 
@@ -233,7 +233,7 @@ class Dayswithqso_model extends CI_Model
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 

--- a/application/models/Distancerecords_model.php
+++ b/application/models/Distancerecords_model.php
@@ -17,7 +17,7 @@ class Distancerecords_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 		$sql = 'SELECT t1.sat, displayname AS sat_displayname, t1.distance, t2.COL_TIME_ON AS time, t2.COL_CALL AS callsign, t2.COL_GRIDSQUARE AS grid, t2.COL_MODE AS mode, t2.COL_PRIMARY_KEY AS primarykey, t2.station_gridsquare AS mygrid
@@ -51,7 +51,7 @@ class Distancerecords_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 		// First get max distance per sat

--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -11,7 +11,7 @@ class Distances_model extends CI_Model
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			header('Content-Type: application/json');
 			echo json_encode(array('Error' => 'No QSOs found to plot.'));
 			return;

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -44,7 +44,7 @@ class Eqsl_images extends CI_Model {
 	function count_eqsl_qso_list() {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return;
 		}
 		$this->db->join($this->config->item('table_name'), 'qso_id = COL_PRIMARY_KEY', 'left outer');
@@ -56,7 +56,7 @@ class Eqsl_images extends CI_Model {
 	function eqsl_qso_list($limit = null, $offset = null) {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return;
 		}
 		$this->db->select('COL_PRIMARY_KEY, qso_id, COL_CALL, COL_MODE, COL_SUBMODE, COL_TIME_ON, COL_BAND, COL_PROP_MODE, COL_SAT_NAME, COL_QSLMSG_RCVD, COL_EQSL_QSLRDATE, image_file');

--- a/application/models/Gridmap_model.php
+++ b/application/models/Gridmap_model.php
@@ -8,7 +8,7 @@ class Gridmap_model extends CI_Model {
 			$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		}
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
         }
 
@@ -95,7 +95,7 @@ class Gridmap_model extends CI_Model {
 			$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		}
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
         }
 
@@ -178,7 +178,7 @@ class Gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -255,7 +255,7 @@ class Gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -368,7 +368,7 @@ class Gridmap_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Helvetia_model.php
+++ b/application/models/Helvetia_model.php
@@ -12,7 +12,7 @@ class helvetia_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -89,7 +89,7 @@ class helvetia_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3314,7 +3314,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3333,7 +3333,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3465,7 +3465,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3629,7 +3629,7 @@ class Logbook_model extends CI_Model {
 			$logbooks_locations_array = $StationLocationsArray;
 		}
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return [
 				'total' => 0,
 				'today' => 0,
@@ -3694,7 +3694,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 		$mode[] = 'SSB';
@@ -3720,7 +3720,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3743,7 +3743,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3782,7 +3782,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3805,7 +3805,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3827,7 +3827,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3850,7 +3850,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3877,7 +3877,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -3899,7 +3899,7 @@ class Logbook_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Pota.php
+++ b/application/models/Pota.php
@@ -6,7 +6,7 @@ class Pota extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -183,7 +183,7 @@ class Qsl_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Rac.php
+++ b/application/models/Rac.php
@@ -12,7 +12,7 @@ class rac extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -89,7 +89,7 @@ class rac extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -42,7 +42,7 @@ class Satellite_model extends CI_Model {
 	function get_last_worked_sat() {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 		$location_list = "'" . implode("','", $logbooks_locations_array) . "'";

--- a/application/models/Seven3on73.php
+++ b/application/models/Seven3on73.php
@@ -6,7 +6,7 @@ class Seven3on73 extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Sig.php
+++ b/application/models/Sig.php
@@ -7,7 +7,7 @@ class Sig extends CI_Model {
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 
@@ -28,7 +28,7 @@ class Sig extends CI_Model {
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
             return null;
         }
 

--- a/application/models/Sota.php
+++ b/application/models/Sota.php
@@ -6,7 +6,7 @@ class Sota extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Stats.php
+++ b/application/models/Stats.php
@@ -238,7 +238,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -299,7 +299,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -322,7 +322,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -383,7 +383,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -405,7 +405,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -425,7 +425,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -445,7 +445,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -467,7 +467,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -489,7 +489,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -509,7 +509,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -549,7 +549,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -570,7 +570,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 		  return null;
 		}
 
@@ -744,7 +744,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		$binding=[];
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -776,7 +776,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		$binding=[];
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -809,7 +809,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -831,7 +831,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -849,7 +849,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -874,7 +874,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -910,7 +910,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -940,7 +940,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -971,7 +971,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -1018,7 +1018,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -1101,7 +1101,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -1135,7 +1135,7 @@
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -6,7 +6,7 @@ class Timeline_model extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Timeplotter_model.php
+++ b/application/models/Timeplotter_model.php
@@ -9,7 +9,7 @@ class Timeplotter_model extends CI_Model
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-        if ($logbooks_locations_array[0] == -1) {
+        if ($logbooks_locations_array[0] === -1) {
             header('Content-Type: application/json');
             $data['error'] = 'No QSOs found to plot!';
             echo json_encode($data);

--- a/application/models/Wae.php
+++ b/application/models/Wae.php
@@ -34,7 +34,7 @@ class WAE extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] != -1) {
+		if ($logbooks_locations_array[0] !== -1) {
 			// Create the location_list string
 			$this->location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 		} else {

--- a/application/models/Wap.php
+++ b/application/models/Wap.php
@@ -14,7 +14,7 @@ class wap extends CI_Model {
 		$CI->load->model('logbooks_model');
 		$logbooks_locations_array = $CI->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -91,7 +91,7 @@ class wap extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Was.php
+++ b/application/models/Was.php
@@ -11,7 +11,7 @@ class was extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 
@@ -90,7 +90,7 @@ class was extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/models/Wpx.php
+++ b/application/models/Wpx.php
@@ -12,7 +12,7 @@ class WPX extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 		$this->load->model('bands');
@@ -335,7 +335,7 @@ class WPX extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 		$location_list = "'".implode("','",$logbooks_locations_array)."'";

--- a/application/models/Wwff.php
+++ b/application/models/Wwff.php
@@ -6,7 +6,7 @@ class Wwff extends CI_Model {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-		if ($logbooks_locations_array[0] == -1) {
+		if ($logbooks_locations_array[0] === -1) {
 			return null;
 		}
 

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -494,7 +494,7 @@
 
 								<?php
 								$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-								if ($logbooks_locations_array[0] != -1) {
+								if ($logbooks_locations_array[0] !== -1) {
 									$location_list = "'" . implode("','", $logbooks_locations_array) . "'";
 								} else {
 									$location_list = null;


### PR DESCRIPTION
During working on https://github.com/wavelog/wavelog/pull/3068 we found an issue with the return value of `list_logbook_relationships`. In https://github.com/wavelog/wavelog/commit/f6ddbe1a69bfbadc25233dc1ed81dd6c7a57c377 the return value was changed so that an array is returned also in case of failure. But the check for the returned value in the API controller was not adjusted accordingly.