### PR TITLE
Cookie Maintenance

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -547,7 +547,7 @@ $config['sess_gc_divisor'] = 1000;
 | 'cookie_domain'   = Set to .your-domain.com for site-wide cookies
 | 'cookie_path'     = Typically will be a forward slash
 | 'cookie_secure'   = Cookie will only be set if a secure HTTPS connection exists.
-| 'cookie_httponly' = Cookie will only be accessible via HTTP(S) (no javascript)
+| 'cookie_samesite' = Cookie SameSite attribute (None, Lax, Strict)
 |
 | Note: These settings (with the exception of 'cookie_prefix' and
 |       'cookie_httponly') will also affect sessions.
@@ -557,7 +557,7 @@ $config['cookie_prefix']	= '';
 $config['cookie_domain']	= '';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= FALSE;
-$config['cookie_httponly'] 	= FALSE;
+$config['cookie_samesite']  = 'Lax';
 
 /*
 |--------------------------------------------------------------------------

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -547,7 +547,7 @@ $config['sess_gc_divisor'] = 1000;
 | 'cookie_domain'   = Set to .your-domain.com for site-wide cookies
 | 'cookie_path'     = Typically will be a forward slash
 | 'cookie_secure'   = Cookie will only be set if a secure HTTPS connection exists.
-| 'cookie_httponly' = Cookie will only be accessible via HTTP(S) (no javascript)
+| 'cookie_samesite' = Cookie SameSite attribute (None, Lax, Strict)
 |
 | Note: These settings (with the exception of 'cookie_prefix' and
 |       'cookie_httponly') will also affect sessions.
@@ -557,7 +557,7 @@ $config['cookie_prefix']	= '';
 $config['cookie_domain']	= '';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= FALSE;
-$config['cookie_httponly'] 	= FALSE;
+$config['cookie_samesite']  = 'Lax';
 
 /*
 |--------------------------------------------------------------------------

--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -150,11 +150,14 @@ class CI_Session {
 			setcookie(
 				$this->_config['cookie_name'],
 				session_id(),
-				(empty($this->_config['cookie_lifetime']) ? 0 : time() + $this->_config['cookie_lifetime']),
-				$this->_config['cookie_path'],
-				$this->_config['cookie_domain'],
-				$this->_config['cookie_secure'],
-				TRUE
+				array(
+					'expires'  => empty($this->_config['cookie_lifetime']) ? 0 : time() + $this->_config['cookie_lifetime'],
+					'path'     => $this->_config['cookie_path'],
+					'domain'   => $this->_config['cookie_domain'],
+					'secure'   => $this->_config['cookie_secure'],
+					'httponly' => true, // Yes, this is intentional and not configurable for security reasons
+					'samesite' => $this->_config['cookie_samesite'],
+				)
 			);
 		}
 
@@ -272,14 +275,16 @@ class CI_Session {
 		isset($params['cookie_path']) OR $params['cookie_path'] = config_item('cookie_path');
 		isset($params['cookie_domain']) OR $params['cookie_domain'] = config_item('cookie_domain');
 		isset($params['cookie_secure']) OR $params['cookie_secure'] = (bool) config_item('cookie_secure');
+		isset($params['cookie_samesite']) OR $params['cookie_samesite'] = config_item('cookie_samesite') ?: 'Lax';
 
-		session_set_cookie_params(
-			$params['cookie_lifetime'],
-			$params['cookie_path'],
-			$params['cookie_domain'],
-			$params['cookie_secure'],
-			TRUE // HttpOnly; Yes, this is intentional and not configurable for security reasons
-		);
+		session_set_cookie_params(array(
+			'lifetime' => $params['cookie_lifetime'],
+			'path'     => $params['cookie_path'],
+			'domain'   => $params['cookie_domain'],
+			'secure'   => $params['cookie_secure'],
+			'httponly' => TRUE, // Yes, this is intentional and not configurable for security reasons
+			'samesite' => $params['cookie_samesite'],
+		));
 
 		if (empty($expiration))
 		{


### PR DESCRIPTION
- Updated the setcookie sytnax to the >php7.4 era 
- samesite ist now defaulted to 'Lax' but configurable in the config.php
- httponly is hardcoded to `true`, therefore the config option makes no sense and is unused