### PR TITLE
Sec keyhandling

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -83,14 +83,23 @@ class API extends CI_Controller {
 
 	}
 
-	function generate($rights) {
+	function generate() {
+		// CSRF mitigation: reject non-POST requests
+		if ($this->input->method() !== 'post') {
+			$this->session->set_flashdata('error', __("Invalid request method"));
+			redirect('api');
+			return;
+		}
+
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
+
+		$rights = $this->input->post('rights', TRUE);
 
 		if ($rights !== "r" && $rights !== "rw") {
 			$this->session->set_flashdata('error', __("Invalid API rights"));
 			redirect('api');
-			exit;
+			return;
 		}
 
 		$this->load->model('api_model');
@@ -109,10 +118,23 @@ class API extends CI_Controller {
 		redirect('api');
 	}
 
-	function delete($key) {
+	function delete() {
+		// CSRF mitigation: reject non-POST requests
+		if ($this->input->method() !== 'post') {
+			$this->session->set_flashdata('error', __("Invalid request method"));
+			redirect('api');
+			return;
+		}
+
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
+		$key = $this->input->post('key', TRUE);
+		if (empty($key)) {
+			$this->session->set_flashdata('error', __("Invalid API Key"));
+			redirect('api');
+			return;
+		}
 
 		$this->load->model('api_model');
 

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -217,6 +217,14 @@ class QSO extends CI_Controller {
 	 * Returns JSON
 	 */
 	public function saveqso() {
+		// CSRF mitigation: this endpoint is AJAX-only; reject plain form submissions
+		if ($this->input->server('HTTP_X_REQUESTED_WITH') !== 'XMLHttpRequest') {
+			$this->output->set_status_header(403)
+			             ->set_content_type('application/json')
+			             ->set_output(json_encode(['error' => 'Forbidden']));
+			return;
+		}
+
 		$this->load->model('logbook_model');
 
 		$qso_data = [
@@ -563,7 +571,20 @@ class QSO extends CI_Controller {
 	}
 
 	/* Delete QSO */
-	function delete($id) {
+	function delete() {
+		// CSRF mitigation: reject non-POST requests
+		if ($this->input->method() !== 'post') {
+			$this->session->set_flashdata('error', __("Invalid request method"));
+			redirect('dashboard');
+			return;
+		}
+
+		$id = $this->input->post('id', TRUE);
+		if (empty($id)) {
+			redirect('dashboard');
+			return;
+		}
+
 		$this->load->model('logbook_model');
 
 		if ($this->logbook_model->check_qso_is_accessible($id)) {

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -66,21 +66,16 @@ class Station extends CI_Controller
 			$data['oqrs'] = $this->input->post('oqrs');
 			$data['oqrsemail'] = $this->input->post('oqrsemail');
 			$data['oqrstext'] = $this->input->post('oqrstext');
-			$csrf_token = bin2hex(random_bytes(32));
-			$this->session->set_userdata('csrf_station_create', $csrf_token);
-			$data['csrf_token'] = $csrf_token;
+			$data['csrf_token'] = $this->paths->csrf_generate('csrf_station_create');
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('station_profile/create', $data);
 			$this->load->view('interface_assets/footer');
 		} else {
-			$submitted = $this->input->post('csrf_token', TRUE);
-			$stored    = $this->session->userdata('csrf_station_create');
-			if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+			if (!$this->paths->csrf_verify('csrf_station_create')) {
 				$this->session->set_flashdata('error', __("Invalid security token"));
 				redirect('station/create');
 				return;
 			}
-			$this->session->set_userdata('csrf_station_create', bin2hex(random_bytes(32)));
 			$this->stations->add();
 			redirect('stationsetup');
 		}
@@ -96,21 +91,16 @@ class Station extends CI_Controller
 			$this->form_validation->set_rules('dxcc', 'DXCC', 'required');
 			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator');
 			if ($this->form_validation->run() == FALSE) {
-				$csrf_token = bin2hex(random_bytes(32));
-				$this->session->set_userdata('csrf_station_edit', $csrf_token);
-				$data['csrf_token'] = $csrf_token;
+				$data['csrf_token'] = $this->paths->csrf_generate('csrf_station_edit');
 				$this->load->view('interface_assets/header', $data);
 				$this->load->view('station_profile/edit', $data);
 				$this->load->view('interface_assets/footer');
 			} else {
-				$submitted = $this->input->post('csrf_token', TRUE);
-				$stored    = $this->session->userdata('csrf_station_edit');
-				if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+				if (!$this->paths->csrf_verify('csrf_station_edit')) {
 					$this->session->set_flashdata('error', __("Invalid security token"));
 					redirect('station/edit/' . $id);
 					return;
 				}
-				$this->session->set_userdata('csrf_station_edit', bin2hex(random_bytes(32)));
 
 				if ($this->stations->edit()) {
 					$data['notice'] = __("Station Location") . $this->security->xss_clean($this->input->post('station_profile_name', true)) . " Updated";

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -66,12 +66,12 @@ class Station extends CI_Controller
 			$data['oqrs'] = $this->input->post('oqrs');
 			$data['oqrsemail'] = $this->input->post('oqrsemail');
 			$data['oqrstext'] = $this->input->post('oqrstext');
-			$data['csrf_token'] = $this->paths->csrf_generate('csrf_station_create');
+			$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 			$this->load->view('interface_assets/header', $data);
-			$this->load->view('station_profile/create', $data);
+			$this->load->view('station_profile/create');
 			$this->load->view('interface_assets/footer');
 		} else {
-			if (!$this->paths->csrf_verify('csrf_station_create')) {
+			if (!$this->paths->csrf_verify($this->router->class.'_'.$this->router->method)) {
 				$this->session->set_flashdata('error', __("Invalid security token"));
 				redirect('station/create');
 				return;
@@ -91,12 +91,12 @@ class Station extends CI_Controller
 			$this->form_validation->set_rules('dxcc', 'DXCC', 'required');
 			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator');
 			if ($this->form_validation->run() == FALSE) {
-				$data['csrf_token'] = $this->paths->csrf_generate('csrf_station_edit');
+				$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 				$this->load->view('interface_assets/header', $data);
 				$this->load->view('station_profile/edit', $data);
 				$this->load->view('interface_assets/footer');
 			} else {
-				if (!$this->paths->csrf_verify('csrf_station_edit')) {
+				if (!$this->paths->csrf_verify($this->router->class.'_'.$this->router->method)) {
 					$this->session->set_flashdata('error', __("Invalid security token"));
 					redirect('station/edit/' . $id);
 					return;

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -66,10 +66,21 @@ class Station extends CI_Controller
 			$data['oqrs'] = $this->input->post('oqrs');
 			$data['oqrsemail'] = $this->input->post('oqrsemail');
 			$data['oqrstext'] = $this->input->post('oqrstext');
+			$csrf_token = bin2hex(random_bytes(32));
+			$this->session->set_userdata('csrf_station_create', $csrf_token);
+			$data['csrf_token'] = $csrf_token;
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('station_profile/create', $data);
 			$this->load->view('interface_assets/footer');
 		} else {
+			$submitted = $this->input->post('csrf_token', TRUE);
+			$stored    = $this->session->userdata('csrf_station_create');
+			if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+				$this->session->set_flashdata('error', __("Invalid security token"));
+				redirect('station/create');
+				return;
+			}
+			$this->session->set_userdata('csrf_station_create', bin2hex(random_bytes(32)));
 			$this->stations->add();
 			redirect('stationsetup');
 		}
@@ -85,10 +96,22 @@ class Station extends CI_Controller
 			$this->form_validation->set_rules('dxcc', 'DXCC', 'required');
 			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator');
 			if ($this->form_validation->run() == FALSE) {
+				$csrf_token = bin2hex(random_bytes(32));
+				$this->session->set_userdata('csrf_station_edit', $csrf_token);
+				$data['csrf_token'] = $csrf_token;
 				$this->load->view('interface_assets/header', $data);
-				$this->load->view('station_profile/edit');
+				$this->load->view('station_profile/edit', $data);
 				$this->load->view('interface_assets/footer');
 			} else {
+				$submitted = $this->input->post('csrf_token', TRUE);
+				$stored    = $this->session->userdata('csrf_station_edit');
+				if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+					$this->session->set_flashdata('error', __("Invalid security token"));
+					redirect('station/edit/' . $id);
+					return;
+				}
+				$this->session->set_userdata('csrf_station_edit', bin2hex(random_bytes(32)));
+
 				if ($this->stations->edit()) {
 					$data['notice'] = __("Station Location") . $this->security->xss_clean($this->input->post('station_profile_name', true)) . " Updated";
 				}

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -93,7 +93,7 @@ class Station extends CI_Controller
 			if ($this->form_validation->run() == FALSE) {
 				$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 				$this->load->view('interface_assets/header', $data);
-				$this->load->view('station_profile/edit', $data);
+				$this->load->view('station_profile/edit');
 				$this->load->view('interface_assets/footer');
 			} else {
 				if (!$this->paths->csrf_verify($this->router->class.'_'.$this->router->method)) {

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -1086,24 +1086,20 @@ class User extends CI_Controller {
 		$data = $query->row();
 		$data->page_title = __("Delete User");
 
-		if ($this->form_validation->run() == FALSE)
-		{
-			$data->csrf_token = $this->paths->csrf_generate('csrf_user_delete');
+		if ($this->form_validation->run() == FALSE) {
+			$data->csrf_token = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('user/delete');
 			$this->load->view('interface_assets/footer');
-		}
-		else
-		{
-			if (!$this->paths->csrf_verify('csrf_user_delete')) {
+		} else {
+			if (!$this->paths->csrf_verify($this->router->class.'_'.$this->router->method)) {
 				$this->session->set_flashdata('error', __("Invalid security token"));
 				redirect('user');
 				return;
 			}
 
-			if($this->user_model->delete($data->user_id))
-			{
+			if($this->user_model->delete($data->user_id)) {
 				$this->session->set_flashdata('notice', __("User deleted"));
 				redirect('user');
 			} else {

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -1088,9 +1088,7 @@ class User extends CI_Controller {
 
 		if ($this->form_validation->run() == FALSE)
 		{
-			$csrf_token = bin2hex(random_bytes(32));
-			$this->session->set_userdata('csrf_user_delete', $csrf_token);
-			$data->csrf_token = $csrf_token;
+			$data->csrf_token = $this->paths->csrf_generate('csrf_user_delete');
 
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('user/delete');
@@ -1098,14 +1096,11 @@ class User extends CI_Controller {
 		}
 		else
 		{
-			$submitted = $this->input->post('csrf_token', TRUE);
-			$stored    = $this->session->userdata('csrf_user_delete');
-			if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+			if (!$this->paths->csrf_verify('csrf_user_delete')) {
 				$this->session->set_flashdata('error', __("Invalid security token"));
 				redirect('user');
 				return;
 			}
-			$this->session->set_userdata('csrf_user_delete', bin2hex(random_bytes(32)));
 
 			if($this->user_model->delete($data->user_id))
 			{

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -192,6 +192,7 @@ class User extends CI_Controller {
 		if ($this->form_validation->run() == FALSE) {
 			$data['page_title'] = __("Add User");
 			$data['measurement_base'] = $this->config->item('measurement_base');
+			$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 
 			$this->load->view('interface_assets/header', $data);
 			if($this->input->post('user_name')) {
@@ -252,6 +253,12 @@ class User extends CI_Controller {
 			}
 			$this->load->view('interface_assets/footer', $footerData);
 		} else {
+			if (!$this->paths->csrf_verify($this->router->class.'_'.$this->router->method)) {
+				$this->session->set_flashdata('error', __("Invalid security token"));
+				redirect('user/add');
+				return;
+			}
+
 			switch($this->user_model->add($this->input->post('user_name'),
 				$this->input->post('user_password'),
 				$this->input->post('user_email'),
@@ -334,6 +341,7 @@ class User extends CI_Controller {
 					return;
 			}
 			$data['page_title'] = __("Users");
+			$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 
 			$this->load->view('interface_assets/header', $data);
 			$data['user_name'] = $this->input->post('user_name');
@@ -931,12 +939,19 @@ class User extends CI_Controller {
 			$data['on_air_widget_show_only_most_recent_radio'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'display_only_most_recent_radio'), $this->uri->segment(3))->row()->option_value ?? "true");
 			$data['on_air_widget_url'] = site_url('widgets/on_air/' . $q->slug);
 			$data['qso_widget_display_qso_time'] = ($this->user_options_model->get_options('widget', array('option_name'=>'qso', 'option_key' => 'display_qso_time'), $this->uri->segment(3))->row()->option_value ?? "false");
+			$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('user/edit', $data);
 			$this->load->view('interface_assets/footer', $footerData);
 		} else {
 			// Data was submitted for saving - save updated options in DB
+			if (!$this->paths->csrf_verify($this->router->class.'_'.$this->router->method)) {
+				$this->session->set_flashdata('error', __("Invalid security token"));
+				redirect('user/edit/'.$this->uri->segment(3));
+				return;
+			}
+
 			unset($data);
 			switch($this->user_model->edit($this->input->post())) {
 				// Check for errors
@@ -1000,6 +1015,7 @@ class User extends CI_Controller {
 					return;
 			}
 
+			$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
 			$this->load->view('interface_assets/header', $data);
 			$data['user_name'] = $this->input->post('user_name', true);
 			$data['user_email'] = $this->input->post('user_email', true);

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -1088,6 +1088,9 @@ class User extends CI_Controller {
 
 		if ($this->form_validation->run() == FALSE)
 		{
+			$csrf_token = bin2hex(random_bytes(32));
+			$this->session->set_userdata('csrf_user_delete', $csrf_token);
+			$data->csrf_token = $csrf_token;
 
 			$this->load->view('interface_assets/header', $data);
 			$this->load->view('user/delete');
@@ -1095,6 +1098,15 @@ class User extends CI_Controller {
 		}
 		else
 		{
+			$submitted = $this->input->post('csrf_token', TRUE);
+			$stored    = $this->session->userdata('csrf_user_delete');
+			if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+				$this->session->set_flashdata('error', __("Invalid security token"));
+				redirect('user');
+				return;
+			}
+			$this->session->set_userdata('csrf_user_delete', bin2hex(random_bytes(32)));
+
 			if($this->user_model->delete($data->user_id))
 			{
 				$this->session->set_flashdata('notice', __("User deleted"));

--- a/application/libraries/Paths.php
+++ b/application/libraries/Paths.php
@@ -33,6 +33,32 @@ class Paths
         return $datadir . "/" . $path;
 	}
 
+    /**
+     * Generate a CSRF token, store it in the session under $key, and return it
+     * for injection into view data.
+     */
+    function csrf_generate($key) {
+        $CI = &get_instance();
+        $token = bin2hex(random_bytes(32));
+        $CI->session->set_userdata($key, $token);
+        return $token;
+    }
+
+    /**
+     * Verify the submitted csrf_token POST field against the session value for
+     * $key. Rotates the token on success. Returns true on success, false on failure.
+     */
+    function csrf_verify($key) {
+        $CI = &get_instance();
+        $submitted = $CI->input->post('csrf_token', TRUE);
+        $stored    = $CI->session->userdata($key);
+        if (empty($submitted) || empty($stored) || !hash_equals($stored, $submitted)) {
+            return false;
+        }
+        $CI->session->set_userdata($key, bin2hex(random_bytes(32)));
+        return true;
+    }
+
     function cache_buster($filepath) {
         // make sure $filepath starts with a slash
         if (substr($filepath, 0, 1) !== '/') $filepath = '/' . $filepath;

--- a/application/views/api/index.php
+++ b/application/views/api/index.php
@@ -78,7 +78,13 @@
 										<?php
 											$cfnm_delete = sprintf(__("Are you sure you want delete the API Key %s?"), '&quot;'.($row->description ?? '<noname>').'&quot;');
 										?>
-										<a href="<?php echo site_url('api/delete/' . $api_key); ?>" class="btn btn-danger btn-sm" onclick="return confirm('<?php echo $cfnm_delete; ?>');"><?= __("Delete"); ?></a>
+										<form method="post" action="<?php echo site_url('api/delete'); ?>" style="display:inline;">
+											<input type="hidden" name="key" value="<?php echo $api_key; ?>">
+											<button type="submit" class="btn btn-danger btn-sm"
+												onclick="return confirm('<?php echo $cfnm_delete; ?>');">
+												<?= __("Delete"); ?>
+											</button>
+										</form>
 									<?php } ?>
 								</td>
 
@@ -93,8 +99,18 @@
 			<?php } ?>
 
 			<p>
-				<a href="<?php echo site_url('api/generate/rw'); ?>" class="btn btn-primary "><i class="fas fa-plus"></i> <?= __("Create a read & write key"); ?></a>
-				<a href="<?php echo site_url('api/generate/r'); ?>" class="btn btn-primary"><i class="fas fa-plus"></i> <?= __("Create a read-only key"); ?></a>
+				<form method="post" action="<?php echo site_url('api/generate'); ?>" style="display:inline;">
+					<input type="hidden" name="rights" value="rw">
+					<button type="submit" class="btn btn-primary">
+						<i class="fas fa-plus"></i> <?= __("Create a read & write key"); ?>
+					</button>
+				</form>
+				<form method="post" action="<?php echo site_url('api/generate'); ?>" style="display:inline;">
+					<input type="hidden" name="rights" value="r">
+					<button type="submit" class="btn btn-primary">
+						<i class="fas fa-plus"></i> <?= __("Create a read-only key"); ?>
+					</button>
+				</form>
 			</p>
 
 		</div>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -43,6 +43,7 @@ if ($dxcc_list->result() > 0) {
 	<?php } ?>
 
 	<form method="post" action="<?php echo site_url('station/create'); ?>" name="create_profile">
+	<input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>">
 
 	<div class="row">
 		<!-- Basic Station Info -->

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -54,6 +54,7 @@ if ($dxcc_list->result() > 0) {
 	?>
 		<form method="post" action="<?php echo site_url('station/edit/'); ?><?php echo $my_station_profile->station_id; ?>" name="create_profile">
 			<input type="hidden" name="station_id" value="<?php echo $my_station_profile->station_id; ?>">
+			<input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>">
 
 	<?php } else {
 		$form_action = __("Create");

--- a/application/views/user/delete.php
+++ b/application/views/user/delete.php
@@ -11,6 +11,7 @@
 
 	    <form method="post" action="<?php echo site_url('user/delete')."/".$this->uri->segment(3); ?>" name="users">
 	    <input type="hidden" name="id" value="<?php echo $this->uri->segment(3); ?>" />
+	    <input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>" />
 			<input class="btn btn-danger" type="submit" value="<?= __("Yes, delete this user"); ?>" /> <a href="<?php echo site_url('user'); ?>" class="btn btn-success"><?= __("No, do not delete this user"); ?></a>
 			</form>
 	  </div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -37,6 +37,7 @@
 	<?php $this->load->helper('form'); ?>
 
 	<form method="post" action="<?php echo $user_form_action; ?>" name="users" autocomplete="off">
+	<input type="hidden" name="csrf_token" value="<?php echo $csrf_token; ?>" />
 	<div class="accordion user_edit">
 		<!-- ZONE 1 / User General Information -->
 		<div class="accordion-item">


### PR DESCRIPTION
Minor SecFixes:
- Generate and delete API-Keys should only be possible when interacting with website. Refactor those two endpoints to POST instead of GET, because POST is checked via CORS-Policy // harder to attack.

- Add CSRF-Tokens for critical Actions:
  - Create / Edit / Delete Users
  - Create / Edit / Delete Station-profiles (Frontend)

Testing:
- Prepare Browser for action (Create/Edit/Delete User/Profile)
- prepare SECOND Tab with the same
- try to save at first tab - should fail, because wrong token.

This simulates a CSRF-Attack from outside