### PR TITLE
Cache Buster Log Flood

### DIFF
--- a/application/libraries/Paths.php
+++ b/application/libraries/Paths.php
@@ -37,11 +37,6 @@ class Paths
         // make sure $filepath starts with a slash
         if (substr($filepath, 0, 1) !== '/') $filepath = '/' . $filepath;
 
-        // These files are not existent on purpose and should not trigger error logs
-        $err_exceptions = [
-            '/assets/json/datatables_languages/en-US.json',
-        ];
-
         $CI = & get_instance();
 		$fullpath = empty($CI->config->item('directory')) ? $_SERVER['DOCUMENT_ROOT'] . $filepath : $_SERVER['DOCUMENT_ROOT'] . '/' . $CI->config->item('directory') . $filepath;
 
@@ -52,9 +47,7 @@ class Paths
         if (file_exists($fullpath)) {
             return base_url($filepath) . '?v=' . filemtime($fullpath);
         } else {
-            if (!in_array($filepath, $err_exceptions)) {
-                log_message('error', 'CACHE BUSTER: File does not exist: ' . $fullpath);
-            }
+            log_message('error', 'CACHE BUSTER: File does not exist: ' . $fullpath);
         }
         return base_url($filepath);
     }

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -180,32 +180,27 @@
 <!-- DATATABLES LANGUAGE -->
 <?php
 $local_code = $language['locale'];
-$lang_code = $language['code'];
-$file_path = $this->paths->cache_buster('/assets/json/datatables_languages/' . $local_code . '.json');
+$lang_code  = $language['code'];
 
-// Check if the file exists
-if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_languages/" . $local_code . ".json")) {
-    $datatables_language_url = '';
-} else {
-    $datatables_language_url = $file_path;
+$datatables_language_url = '';
+if ($lang_code !== 'en' && file_exists(FCPATH . "assets/json/datatables_languages/" . $local_code . ".json")) {
+    $datatables_language_url = $this->paths->cache_buster('/assets/json/datatables_languages/' . $local_code . '.json');
 }
 ?>
 
-<script type="text/javascript">
+<script>
     function getDataTablesLanguageUrl() {
-        locale = "<?php echo $local_code ?>";
-        lang_code = "<?php echo $lang_code; ?>";
-        datatables_language_url = "<?php echo $datatables_language_url; ?>";
+        const datatables_language_url = "<?php echo $datatables_language_url; ?>";
 
-        // if language is set to english we don't need to load any language files
-        if (lang_code != 'en') {
-            if (datatables_language_url !== '') {
-                return datatables_language_url;
-            } else {
-                console.error("Datatables language file does not exist for locale: " + locale);
-                return null;
-            }
+        if (datatables_language_url !== '') {
+            return datatables_language_url;
         }
+
+        <?php if ($lang_code !== 'en'): ?>
+        console.warn("Datatables language file does not exist for locale: <?php echo $local_code; ?>; Using english instead.");
+        <?php endif; ?>
+
+        return null;
     }
 </script>
 <!-- DATATABLES LANGUAGE END -->

--- a/application/views/visitor/layout/footer.php
+++ b/application/views/visitor/layout/footer.php
@@ -27,32 +27,27 @@
 <!-- DATATABLES LANGUAGE -->
 <?php
 $local_code = $language['locale'];
-$lang_code = $language['code'];
-$file_path = $this->paths->cache_buster('/assets/json/datatables_languages/' . $local_code . '.json');
+$lang_code  = $language['code'];
 
-// Check if the file exists
-if ($lang_code != 'en' && !file_exists(FCPATH . "assets/json/datatables_languages/" . $local_code . ".json")) {
-    $datatables_language_url = '';
-} else {
-    $datatables_language_url = $file_path;
+$datatables_language_url = '';
+if ($lang_code !== 'en' && file_exists(FCPATH . "assets/json/datatables_languages/" . $local_code . ".json")) {
+    $datatables_language_url = $this->paths->cache_buster('/assets/json/datatables_languages/' . $local_code . '.json');
 }
 ?>
 
-<script type="text/javascript">
+<script>
     function getDataTablesLanguageUrl() {
-        locale = "<?php echo $local_code ?>";
-        lang_code = "<?php echo $lang_code; ?>";
-        datatables_language_url = "<?php echo $datatables_language_url; ?>";
+        const datatables_language_url = "<?php echo $datatables_language_url; ?>";
 
-        // if language is set to english we don't need to load any language files
-        if (lang_code != 'en') {
-            if (datatables_language_url !== '') {
-                return datatables_language_url;
-            } else {
-                console.error("Datatables language file does not exist for locale: " + locale);
-                return null;
-            }
+        if (datatables_language_url !== '') {
+            return datatables_language_url;
         }
+
+        <?php if ($lang_code !== 'en'): ?>
+        console.warn("Datatables language file does not exist for locale: <?php echo $local_code; ?>; Using english instead.");
+        <?php endif; ?>
+
+        return null;
     }
 </script>
 <!-- DATATABLES LANGUAGE END -->


### PR DESCRIPTION
With the implementation of the cache buster in #2945 there were some changes how files get loaded. A little log flaw appeared in the datatables language loader. This was catched with an exception for the error log directly in the cache buster. However this did not solve the issue completely and in some cases in produces a lot of error logs. 

This solves this now by refactoring the datatables language url logic and removing the exception in the cache buster. 
