### PR TITLE
Fix wrong comparison in installation pre-checks

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -10,6 +10,18 @@ DJ7NT - Docker Readiness - April 2024
 HB9HIL - Big UX and backend upgrade - July 2024
 */
 require_once('includes/install_config/install_lib.php');
+
+function convertToBytes(string $value): int {
+	$value = trim($value);
+	$num = (int) $value;
+	$unit = strtoupper(substr($value, -1));
+	switch ($unit) {
+		case 'G': return $num * 1024 * 1024 * 1024;
+		case 'M': return $num * 1024 * 1024;
+		case 'K': return $num * 1024;
+		default:  return $num;
+	}
+}
 $http_scheme = is_https() ? "https" : "http";
 
 $directory = ltrim(str_replace('/install', '', dirname($_SERVER['SCRIPT_NAME'])), '/');
@@ -171,7 +183,7 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 													<td>
 														<?php
 														$maxUploadFileSize = ini_get('upload_max_filesize');
-														$maxUploadFileSizeBytes = (int)($maxUploadFileSize) * (1024 * 1024); // convert to bytes
+														$maxUploadFileSizeBytes = convertToBytes($maxUploadFileSize);
 														if ($maxUploadFileSizeBytes >= ($upload_max_filesize * 1024 * 1024)) { // compare with given value in bytes
 														?>
 															<span class="badge text-bg-success"><?php echo $maxUploadFileSize; ?></span>
@@ -190,7 +202,7 @@ if (!file_exists('.lock') && !file_exists('../application/config/config.php') &&
 													<td>
 														<?php
 														$maxUploadFileSize = ini_get('post_max_size');
-														$maxUploadFileSizeBytes = (int)($maxUploadFileSize) * (1024 * 1024); // convert to bytes
+														$maxUploadFileSizeBytes = convertToBytes($maxUploadFileSize);
 														if ($maxUploadFileSizeBytes >= ($post_max_size * 1024 * 1024)) { // compare with given value in bytes
 														?>
 															<span class="badge text-bg-success"><?php echo $maxUploadFileSize; ?></span>


### PR DESCRIPTION
## Summary
- Fixes the incorrect comparison of PHP ini values like `upload_max_filesize` and `post_max_size` during installation pre-checks
- Added a `convertToBytes()` helper function that properly parses PHP shorthand notation (`K`, `M`, `G`) into bytes before comparing
- Previously `2048K` was incorrectly treated as `2048M` because the unit suffix was ignored when casting to int

## Problem
When `upload_max_filesize = 2048K` and comparing against `8M`, the old code did:
```php
(int)("2048K") * 1024 * 1024 = 2048 * 1024 * 1024 = 2147483648 (2G)
```
This made `2048K` appear greater than `8M`, showing a green badge when it should be a warning.

## Fix
The new `convertToBytes()` function correctly handles the suffix:
```php
convertToBytes("2048K") = 2048 * 1024 = 2097152 (2M)
convertToBytes("8M")    = 8 * 1024 * 1024 = 8388608 (8M)
```

Fixes #3085