### PR TITLE
[Winkey] Trigger visibility if mode is set by cat

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -132,7 +132,7 @@ $(document).ready(function() {
                 reconnectAttempts = 0;
                 websocketEnabled = true;
                 activeWebSocketProtocol = protocol; // Remember which protocol worked
-                
+
                 // Debug log if connected in Hybrid/Auto mode
                 if (isHybridMode) {
                     console.log("CAT: Hybrid WebSocket connected successfully.");
@@ -1098,6 +1098,11 @@ $(document).ready(function() {
 
         cat2UI($mode,newMode,false,false);
 
+        // Update winkey visibility directly
+        if (typeof updateWinkeyVisibility === 'function') {
+            updateWinkeyVisibility(newMode);
+        }
+
         // Update RST fields when mode changes
         // Check if mode was actually updated (catValue changed after cat2UI call)
         var currentMode = $mode.data('catValue');
@@ -1295,7 +1300,7 @@ $(document).ready(function() {
             reconnectAttempts = 0; // Reset reconnect attempts
             hasTriedWsFallback = false; // Reset WSS failover state - try WSS first again
             isHybridMode = false; // Explicitly NOT hybrid
-            
+
             // Set DX Waterfall CAT state to websocket if variable exists
             if (typeof dxwaterfall_cat_state !== 'undefined') {
                 dxwaterfall_cat_state = "websocket";
@@ -1314,7 +1319,7 @@ $(document).ready(function() {
                 dxwaterfall_cat_state = "polling";
             }
             $('#toggleCatTracking').prop('disabled', false).removeClass('disabled');
-            
+
             // Start standard polling
             CATInterval = setInterval(updateFromCAT, CAT_CONFIG.POLL_INTERVAL);
 
@@ -1325,7 +1330,7 @@ $(document).ready(function() {
             reconnectAttempts = 0;
             hasTriedWsFallback = false;
             isHybridMode = true; // Activate Hybrid Mode restrictions (limited retries, no UI errors)
-            
+
             initializeWebSocketConnection();
 
             if ((window.CAT_COMPACT_MODE === 'ultra-compact' || window.CAT_COMPACT_MODE === 'icon-only') && typeof window.isCatTrackingEnabled !== 'undefined' && !window.isCatTrackingEnabled) {
@@ -1343,7 +1348,7 @@ $(document).ready(function() {
 	/**
      * Broadcast Callsign Lookup Result via WebSocket
      * Triggered when Wavelog completes a callsign lookup.
-     * 
+     *
      * @param {object} data - The lookup data object
      */
     window.broadcastLookupResult = function(data) {
@@ -1381,5 +1386,5 @@ $(document).ready(function() {
         } catch (error) {
             console.warn('Failed to broadcast lookup result:', error);
         }
-    };	
+    };
 });

--- a/assets/js/winkey.js
+++ b/assets/js/winkey.js
@@ -9,24 +9,22 @@ $(document).ready(function() {
 		$('#winkey').hide(); // Hide the CW buttons
 	}
 
-	if (ModeSelected.value == 'CW') {
-		// Show the CW buttons
-		$('#winkey').show();
-	} else {
-		// Hide the CW buttons
-		$('#winkey').hide();
-	}
-
-	ModeSelected.addEventListener('change', (event) => {
-
-		if (event.target.value == 'CW') {
-			// Show the CW buttons
+	// Function to update winkey visibility based on mode
+	// Can be called directly from other scripts (e.g., cat.js)
+	window.updateWinkeyVisibility = function(mode) {
+		if (mode == 'CW') {
 			$('#winkey').show();
-
 		} else {
-			// Hide the CW buttons
 			$('#winkey').hide();
 		}
+	};
+
+	// Initial check
+	updateWinkeyVisibility(ModeSelected.value);
+
+	// Listen for manual changes from dropdown
+	ModeSelected.addEventListener('change', (event) => {
+		updateWinkeyVisibility(event.target.value);
 	});
 
 	$('#winkeycwspeed').change(function (event) {


### PR DESCRIPTION
Before:
Visibility for the Winkey UI is only triggered by mode dropdown.
If mode is changed by CAT, the change listener is not triggered.

After:
Visibility is checked and toggled regardless if mode is set in UI or by CAT.