### PR TITLE
Fix Presetcalculation of Dateranges

### DIFF
--- a/assets/js/sections/cqmap.js
+++ b/assets/js/sections/cqmap.js
@@ -249,28 +249,28 @@ function onClick2(e) {
                 break;
 
             case 'thismonth':
-                const firstDayOfMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 1);
+                const firstDayOfMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
                 dateFrom.value = formatDate(firstDayOfMonth);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastmonth':
-                const firstDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth() - 1, 1);
-                const lastDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 0);
+                const firstDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 1, 1));
+                const lastDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
                 dateFrom.value = formatDate(firstDayOfLastMonth);
                 dateTo.value = formatDate(lastDayOfLastMonth);
                 break;
 
             case 'thisyear':
-                const firstDayOfYear = new Date(today.getUTCFullYear(), 0, 1);
+                const firstDayOfYear = new Date(Date.UTC(today.getUTCFullYear(), 0, 1));
                 dateFrom.value = formatDate(firstDayOfYear);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastyear':
                 const lastYear = today.getUTCFullYear() - 1;
-                const firstDayOfLastYear = new Date(lastYear, 0, 1);
-                const lastDayOfLastYear = new Date(lastYear, 11, 31);
+                const firstDayOfLastYear = new Date(Date.UTC(lastYear, 0, 1));
+                const lastDayOfLastYear = new Date(Date.UTC(lastYear, 11, 31));
                 dateFrom.value = formatDate(firstDayOfLastYear);
                 dateTo.value = formatDate(lastDayOfLastYear);
                 break;

--- a/assets/js/sections/dxccmap.js
+++ b/assets/js/sections/dxccmap.js
@@ -260,28 +260,28 @@ function onClick(e) {
                 break;
 
             case 'thismonth':
-                const firstDayOfMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 1);
+                const firstDayOfMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
                 dateFrom.value = formatDate(firstDayOfMonth);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastmonth':
-                const firstDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth() - 1, 1);
-                const lastDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 0);
+                const firstDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 1, 1));
+                const lastDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
                 dateFrom.value = formatDate(firstDayOfLastMonth);
                 dateTo.value = formatDate(lastDayOfLastMonth);
                 break;
 
             case 'thisyear':
-                const firstDayOfYear = new Date(today.getUTCFullYear(), 0, 1);
+                const firstDayOfYear = new Date(Date.UTC(today.getUTCFullYear(), 0, 1));
                 dateFrom.value = formatDate(firstDayOfYear);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastyear':
                 const lastYear = today.getUTCFullYear() - 1;
-                const firstDayOfLastYear = new Date(lastYear, 0, 1);
-                const lastDayOfLastYear = new Date(lastYear, 11, 31);
+                const firstDayOfLastYear = new Date(Date.UTC(lastYear, 0, 1));
+                const lastDayOfLastYear = new Date(Date.UTC(lastYear, 11, 31));
                 dateFrom.value = formatDate(firstDayOfLastYear);
                 dateTo.value = formatDate(lastDayOfLastYear);
                 break;

--- a/assets/js/sections/gridmap.js
+++ b/assets/js/sections/gridmap.js
@@ -437,20 +437,20 @@ $(document).ready(function(){
                 break;
 
             case 'thismonth':
-                const firstDayOfMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 1);
+                const firstDayOfMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
                 dateFrom.value = formatDate(firstDayOfMonth);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastmonth':
-                const firstDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth() - 1, 1);
-                const lastDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 0);
+                const firstDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 1, 1));
+                const lastDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
                 dateFrom.value = formatDate(firstDayOfLastMonth);
                 dateTo.value = formatDate(lastDayOfLastMonth);
                 break;
 
             case 'thisyear':
-                const firstDayOfYear = new Date(today.getUTCFullYear(), 0, 1);
+                const firstDayOfYear = new Date(Date.UTC(today.getUTCFullYear(), 0, 1));
                 dateFrom.value = formatDate(firstDayOfYear);
                 dateTo.value = formatDate(today);
                 break;

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -1929,28 +1929,28 @@ function saveOptions() {
                 break;
 
             case 'thismonth':
-                const firstDayOfMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 1);
+                const firstDayOfMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
                 dateFrom.value = formatDate(firstDayOfMonth);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastmonth':
-                const firstDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth() - 1, 1);
-                const lastDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 0);
+                const firstDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 1, 1));
+                const lastDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
                 dateFrom.value = formatDate(firstDayOfLastMonth);
                 dateTo.value = formatDate(lastDayOfLastMonth);
                 break;
 
             case 'thisyear':
-                const firstDayOfYear = new Date(today.getUTCFullYear(), 0, 1);
+                const firstDayOfYear = new Date(Date.UTC(today.getUTCFullYear(), 0, 1));
                 dateFrom.value = formatDate(firstDayOfYear);
                 dateTo.value = formatDate(today);
                 break;
 
             case 'lastyear':
                 const lastYear = today.getUTCFullYear() - 1;
-                const firstDayOfLastYear = new Date(lastYear, 0, 1);
-                const lastDayOfLastYear = new Date(lastYear, 11, 31);
+                const firstDayOfLastYear = new Date(Date.UTC(lastYear, 0, 1));
+                const lastDayOfLastYear = new Date(Date.UTC(lastYear, 11, 31));
                 dateFrom.value = formatDate(firstDayOfLastYear);
                 dateTo.value = formatDate(lastDayOfLastYear);
                 break;

--- a/assets/js/sections/statistics.js
+++ b/assets/js/sections/statistics.js
@@ -45,28 +45,28 @@ function applyPreset(preset) {
 			break;
 
 		case 'thismonth':
-			const firstDayOfMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 1);
+			const firstDayOfMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
 			dateFrom.value = formatDate(firstDayOfMonth);
 			dateTo.value = formatDate(today);
 			break;
 
 		case 'lastmonth':
-			const firstDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth() - 1, 1);
-			const lastDayOfLastMonth = new Date(today.getUTCFullYear(), today.getUTCMonth(), 0);
+			const firstDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 1, 1));
+			const lastDayOfLastMonth = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
 			dateFrom.value = formatDate(firstDayOfLastMonth);
 			dateTo.value = formatDate(lastDayOfLastMonth);
 			break;
 
 		case 'thisyear':
-			const firstDayOfYear = new Date(today.getUTCFullYear(), 0, 1);
+			const firstDayOfYear = new Date(Date.UTC(today.getUTCFullYear(), 0, 1));
 			dateFrom.value = formatDate(firstDayOfYear);
 			dateTo.value = formatDate(today);
 			break;
 
 		case 'lastyear':
 			const lastYear = today.getUTCFullYear() - 1;
-			const firstDayOfLastYear = new Date(lastYear, 0, 1);
-			const lastDayOfLastYear = new Date(lastYear, 11, 31);
+			const firstDayOfLastYear = new Date(Date.UTC(lastYear, 0, 1));
+			const lastDayOfLastYear = new Date(Date.UTC(lastYear, 11, 31));
 			dateFrom.value = formatDate(firstDayOfLastYear);
 			dateTo.value = formatDate(lastDayOfLastYear);
 			break;


### PR DESCRIPTION
Before patch (e.g. "Last Year")

Affects:
Date Presets for:
- Last Year
- This Year
- Last Month
- This Month

Hope i catched every page, where presets are shown

<img width="736" height="224" alt="image" src="https://github.com/user-attachments/assets/deb68254-b7c7-43c6-a3a2-124094b4fda8" />

After Patch:
<img width="771" height="249" alt="image" src="https://github.com/user-attachments/assets/960f3afb-5720-4895-9ded-e6b916d0b929" />
