### PR TITLE
Default ft8 rprt

### DIFF
--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -61,7 +61,15 @@ function setRst(mode) {
 	} else if (mode == 'FSK441' || mode == 'JT6M') {
 		$('#rst_sent').val('26');
 		$('#rst_rcvd').val('26');
-	} else if (mode == 'CW' || mode == 'RTTY' || mode == 'PSK31' || mode == 'PSK63') {
+	} else if (mode == 'CW') {
+		if ($('#selectPropagation :selected').val() == 'AUR') {
+			$('#rst_sent').val('59A');
+			$('#rst_rcvd').val('59A');
+		} else {
+			$('#rst_sent').val('599');
+			$('#rst_rcvd').val('599');
+		}
+	} else if (mode == 'RTTY' || mode == 'PSK31' || mode == 'PSK63') {
 		$('#rst_sent').val('599');
 		$('#rst_rcvd').val('599');
 	} else if (mode == 'SSTV' || mode == 'ATV') {


### PR DESCRIPTION
This changes two default reports in common.js:

1. Default values for FT8 stuff are now two decimal digits (i.e. -05 instead of -5)
2. Default reports for CW QSOs via AUR are now 59A instead of 599