### PR TITLE
API function to pull all worked / confirmed callsigns from Logbook

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -806,7 +806,64 @@ class API extends CI_Controller {
 				}
 			}
 		}
+	}
 
+	// API function to get all worked callsigns for a band and confirmation method
+	function logbook_get_worked_callsigns() {
+		$arr = array();
+		header('Content-type: application/json');
+		$this->load->model('api_model');
+		$obj = json_decode(file_get_contents("php://input"), true);
+		if ($obj === NULL) {
+		    echo json_encode(['status' => 'failed', 'reason' => "wrong JSON"]);
+		    die();
+		}
+		// Check rate limit
+		$identifier = isset($obj['key']) ? $obj['key'] : null;
+		$this->check_rate_limit('logbook_get_worked_callsigns', $identifier);
+
+		if(!isset($obj['key']) || $this->api_model->authorize($obj['key']) == 0) {
+		   http_response_code(401);
+		   echo json_encode(['status' => 'failed', 'reason' => "missing api key"]);
+		   die();
+		}
+		$api_user_id = $this->api_model->key_userid($obj['key']);
+		if(!isset($obj['logbook_id'])) {
+		   http_response_code(400);
+		   echo json_encode(['status' => 'failed', 'reason' => "missing fields"]);
+			return;
+		}
+		if($obj['logbook_id'] != "") {
+			$logbook_id = $obj['logbook_id'];
+			if(isset($obj['band'])) {
+				$band = $obj['band'];
+			} else {
+				$band = null;
+			}
+			if(isset($obj['cnfm'])) {
+				$cnfm = $obj['cnfm'];
+			} else {
+				$cnfm = null;
+			}
+			$this->load->model('logbooks_model');
+			if(!$this->logbooks_model->logbook_id_belongs_to_user($logbook_id, $api_user_id)) {
+				http_response_code(403);
+				echo json_encode(['status' => 'failed', 'reason' => "logbook does not belong to this API key or logbook ID not found"]);
+				die();
+			}
+			if ($this->logbooks_model->exists_logbook_id($logbook_id) != false) {
+				$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
+				if ($logbooks_locations_array[0] === -1) {
+					http_response_code(404);
+					echo json_encode(['status' => 'failed', 'reason' => "logbook with ID ".$logbook_id." has no associated station locations"]);
+					die();
+				} else {
+					$arr = $this->api_model->get_callsigns_worked_in_logbook($logbooks_locations_array, $band, $cnfm);
+					http_response_code(201);
+					echo json_encode($arr);
+				}
+			}
+		}
 	}
 
 	/* ENDPOINT for Rig Control */

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -242,4 +242,49 @@ class API_Model extends CI_Model {
 		sort ($grid_array);
 		return $grid_array;
 	}
+
+	function get_callsigns_worked_in_logbook($StationLocationsArray = null, $band = null, $cnfm = null) {
+		$grid_array = [];
+		if ($StationLocationsArray == null) {
+			$this->load->model('logbooks_model');
+			$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+		} else {
+			$logbooks_locations_array = $StationLocationsArray;
+		}
+
+		$bindings = [];
+		$subsql = '';
+		$band = ($band == 'All') ? null : $band;
+		if ($band != null && $band != 'SAT') {
+			$subsql .= ' AND COL_BAND = ? AND COL_PROP_MODE != "SAT"';
+			$bindings[] = $band;
+		} else if ($band == 'SAT') {
+			$subsql .= ' AND COL_SAT_NAME != ""';
+		}
+		switch ($cnfm) {
+			case 'qsl':
+				$subsql .= ' AND COL_QSL_RCVD = "Y"';
+				break;
+			case 'lotw':
+				$subsql .= ' AND COL_LOTW_QSL_RCVD = "Y"';
+				break;
+			case 'eqsl':
+				$subsql .= ' AND COL_EQSL_QSL_RCVD = "Y"';
+				break;
+		}
+
+		$ids = array_map('intval', $logbooks_locations_array);
+		$sql = 'SELECT DISTINCT UPPER(COL_CALL) AS callsign FROM ' . $this->config->item('table_name') . ' thcv ';
+		$sql .= ' WHERE COL_CALL <> ""';
+		$sql .= ' AND station_id IN (' . implode(',', $ids) . ')';
+		$sql .= $subsql;
+		$sql .= ' ORDER BY callsign ASC;';
+		$query = $this->db->query($sql,$bindings);
+		$callsign_array = array();
+		foreach($query->result() as $line) {
+			$callsign_array[] = $line->callsign;
+		}
+		sort($callsign_array);
+		return $callsign_array;
+	}
 }

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -244,7 +244,7 @@ class API_Model extends CI_Model {
 	}
 
 	function get_callsigns_worked_in_logbook($StationLocationsArray = null, $band = null, $cnfm = null) {
-		$grid_array = [];
+		$callsign_array = [];
 		if ($StationLocationsArray == null) {
 			$this->load->model('logbooks_model');
 			$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
@@ -280,7 +280,6 @@ class API_Model extends CI_Model {
 		$sql .= $subsql;
 		$sql .= ' ORDER BY callsign ASC;';
 		$query = $this->db->query($sql,$bindings);
-		$callsign_array = array();
 		foreach($query->result() as $line) {
 			$callsign_array[] = $line->callsign;
 		}


### PR DESCRIPTION
Same as https://github.com/wavelog/wavelog/pull/2987 but allows for getting a list of all worked callsigns per band. 

Example cURL:

```
$ curl -X POST https://<WAVELOG_URL>/index.php/api/logbook_get_worked_grids -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\", \"logbook_id\":\"<LOGBOOK_ID>\",\"band\":\"SAT\"}"

$ curl -X POST https://<WAVELOG_URL>/index.php/api/logbook_get_worked_grids -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\", \"logbook_id\":\"<LOGBOOK_ID>\",\"band\":\"20M\"}"

$ curl -X POST https://<WAVELOG_URL>/index.php/api/logbook_get_worked_grids -H "Content-Type: application/json" -H "Accept: application/json" -d "{\"key\":\"<API_KEY>\", \"logbook_id\":\"<LOGBOOK_ID>\",\"band\":\"SAT\",\"cnfm\":\"lotw\"}"
```