### PR TITLE
New UI for JCC award

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -427,7 +427,7 @@ class Awards extends CI_Controller {
 		$data['bands'] = $bands; // Used for displaying selected band(s) in the table in the view
 
 		// Query the database for JCC status
-		$jcc_entity_status = $this->jcc_model->query_entity_status($postdata, 'band');
+		$jcc_entity_status = $this->jcc_model->query_jcc_entity_status($postdata, 'band');
 		
 		$data['jcc_array'] = $this->jcc_model->get_jcc_array($bands, $postdata, $jcc_entity_status);
 		$data['jcc_summary'] = $this->jcc_model->get_jcc_summary($bands, $postdata, $jcc_entity_status);
@@ -1938,7 +1938,7 @@ class Awards extends CI_Controller {
 	    $postdata['mode'] = $this->input->post('mode', true) ?? 'All';
 	    $postdata['prop_mode'] = $this->input->post('prop_mode', true) ?? 'All';
 
-	    $jcc_entity_status = $this->jcc_model->query_entity_status($postdata, 'none');
+	    $jcc_entity_status = $this->jcc_model->query_jcc_entity_status($postdata, 'none');
 	    $jccs = $this->jcc_model->get_jcc_map_array($postdata, $jcc_entity_status);
 
 	    header('Content-Type: application/json');

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -376,7 +376,7 @@ class Awards extends CI_Controller {
 		$footerData = [];
 		$footerData['scripts'] = [
 			'assets/js/sections/jcc.js',
-			'assets/js/sections/jccmap.js'
+			'assets/js/sections/jccmap.js',
 		];
 
 		$this->load->helper('awards');
@@ -384,15 +384,12 @@ class Awards extends CI_Controller {
 		$this->load->model('modes');
 		$this->load->model('bands');
 
-		if($this->input->method() === 'post') {
+		if ($this->input->method() === 'post') {
 			$postdata['qsl'] = ($this->input->post('qsl', true) ?? 0) == 0 ? null : 1;
 			$postdata['lotw'] = ($this->input->post('lotw', true) ?? 0) == 0 ? null : 1;
 			$postdata['eqsl'] = ($this->input->post('eqsl', true) ?? 0) == 0 ? null : 1;
 			$postdata['qrz'] = ($this->input->post('qrz', true) ?? 0) == 0 ? null : 1;
 			$postdata['clublog'] = ($this->input->post('clublog', true) ?? 0) == 0 ? null : 1;
-			$postdata['worked'] = ($this->input->post('worked', true) ?? 0) == 0 ? null : 1;
-			$postdata['confirmed'] = ($this->input->post('confirmed', true) ?? 0) == 0 ? null : 1;
-			$postdata['notworked'] = ($this->input->post('notworked', true) ?? 0) == 0 ? null : 1;
 			$postdata['includedeleted'] = ($this->input->post('includedeleted', true) ?? 0) == 0 ? null : 1;
 			$postdata['band'] = $this->input->post('band', true) ?? 'All';
 			$postdata['mode'] = $this->input->post('mode', true) ?? 'All';
@@ -404,9 +401,6 @@ class Awards extends CI_Controller {
 			$postdata['eqsl'] = 1;
 			$postdata['qrz'] = null;
 			$postdata['clublog'] = null;
-			$postdata['worked'] = 1;
-			$postdata['confirmed'] = 1;
-			$postdata['notworked'] = null;
 			$postdata['includedeleted'] = null;
 			$postdata['band'] = 'All';
 			$postdata['mode'] = 'All';
@@ -418,21 +412,11 @@ class Awards extends CI_Controller {
 		$data['modes'] = $this->modes->active();
 		$data['user_map_custom'] = $this->optionslib->get_map_custom();
 
-		// If "All" is selected, show all bands that have been worked. Otherwise, just the selected band.
-		if ($postdata['band'] == 'All') {
-			$bands = $data['worked_bands'];
-		} else {
-			$bands = [$postdata['band']];
-		}
-		$data['bands'] = $bands; // Used for displaying selected band(s) in the table in the view
+		$jcc_entity_status = $this->jcc_model->query_jcc_entity_status($postdata, 'none');
+		$data['jcc_groups'] = $this->jcc_model->get_jcc_grouped_slot($postdata, $jcc_entity_status);
+		$data['jcc_summary'] = $this->jcc_model->get_jcc_summary($postdata, $jcc_entity_status);
+		$data['has_active_slots'] = ($data['jcc_summary']['worked'] ?? 0) > 0;
 
-		// Query the database for JCC status
-		$jcc_entity_status = $this->jcc_model->query_jcc_entity_status($postdata, 'band');
-		
-		$data['jcc_array'] = $this->jcc_model->get_jcc_array($bands, $postdata, $jcc_entity_status);
-		$data['jcc_summary'] = $this->jcc_model->get_jcc_summary($bands, $postdata, $jcc_entity_status);
-
-		// Render Page
 		$data['page_title'] = sprintf(__("Awards - %s"), __("JCC"));
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('awards/jcc/index');

--- a/application/helpers/awards_helper.php
+++ b/application/helpers/awards_helper.php
@@ -108,20 +108,18 @@ if (!function_exists('awards_render_jcc_grid_slot')) {
 	function awards_render_jcc_grid_slot($slot, $postdata) {
 		$classes = array(
 			'award-grid-slot',
-			'badge',
+			'btn',
 			'border',
 			'd-inline-flex',
 			'align-items-center',
 			'justify-content-center',
-			'fw-semibold',
-			'text-decoration-none',
 		);
 		if (($slot['status'] ?? '-') === 'C') {
-			$classes[] = 'text-bg-success';
+			$classes[] = 'btn-success';
 		} elseif (($slot['status'] ?? '-') === 'W') {
-			$classes[] = 'text-bg-danger';
+			$classes[] = 'btn-danger';
 		} else {
-			$classes[] = 'text-bg-light';
+			$classes[] = 'btn-light';
 		}
 		if (!empty($slot['deleted'])) {
 			$classes[] = 'award-grid-slot-deleted';

--- a/application/helpers/awards_helper.php
+++ b/application/helpers/awards_helper.php
@@ -96,3 +96,75 @@ if (!function_exists('awards_render_jcc_cell')) {
 		return '<div class="' . $class_name . '"><a href="' . html_escape($href) . '">' . $status . '</a></div>';
 	}
 }
+
+if (!function_exists('awards_render_jcc_grid_slot')) {
+	/**
+	 * Renders a slot for the grouped JCC demo grid.
+	 *
+	 * @param array $slot The slot metadata
+	 * @param array $postdata The postdata containing filter options
+	 * @return string The HTML string for the slot
+	 */
+	function awards_render_jcc_grid_slot($slot, $postdata) {
+		$classes = array(
+			'award-grid-slot',
+			'badge',
+			'border',
+			'd-inline-flex',
+			'align-items-center',
+			'justify-content-center',
+			'fw-semibold',
+			'text-decoration-none',
+		);
+		if (($slot['status'] ?? '-') === 'C') {
+			$classes[] = 'text-bg-success';
+		} elseif (($slot['status'] ?? '-') === 'W') {
+			$classes[] = 'text-bg-danger';
+		} else {
+			$classes[] = 'text-bg-light';
+		}
+		if (!empty($slot['deleted'])) {
+			$classes[] = 'award-grid-slot-deleted';
+		}
+
+		$tooltip_lines = array();
+		$title_parts = array();
+
+		if (!empty($slot['entity'])) {
+			$tooltip_lines[] = '<strong>' . html_escape($slot['entity']) . '</strong>';
+			$title_parts[] = $slot['entity'];
+		}
+		if (!empty($slot['name'])) {
+			$tooltip_lines[] = html_escape($slot['name']);
+			$title_parts[] = $slot['name'];
+		}
+		if (!empty($slot['deleted'])) {
+			$tooltip_lines[] = html_escape(__("Deleted"));
+			$title_parts[] = __("Deleted");
+		}
+
+		$tooltip_html = implode('<br>', $tooltip_lines);
+		$title = trim(implode(' - ', $title_parts));
+
+		$label = html_escape($slot['short_number'] ?? $slot['entity'] ?? '');
+		$class_name = html_escape(implode(' ', $classes));
+		$title_attr = html_escape($title);
+		$tooltip_attr = html_escape($tooltip_html);
+		$tooltip_data = ' data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" data-bs-title="' . $tooltip_attr . '" title="' . $title_attr . '"';
+
+		if (($slot['status'] ?? '-') === 'W' || ($slot['status'] ?? '-') === 'C') {
+			$qsl_string = ($slot['status'] ?? '-') === 'C' ? awards_build_qsl_string($postdata) : '';
+			$href = awards_build_display_contacts_href(
+				$slot['entity'] ?? '',
+				$postdata['band'] ?? 'All',
+				$postdata['mode'] ?? 'All',
+				'JCC',
+				$qsl_string,
+			);
+
+			return '<a class="' . $class_name . '" href="' . html_escape($href) . '"' . $tooltip_data . ' aria-label="' . $title_attr . '">' . $label . '</a>';
+		}
+
+		return '<span class="' . $class_name . '"' . $tooltip_data . ' aria-label="' . $title_attr . '">' . $label . '</span>';
+	}
+}

--- a/application/models/Japan_award_model.php
+++ b/application/models/Japan_award_model.php
@@ -1,0 +1,363 @@
+<?php
+
+class Japan_award_model extends CI_Model {
+
+	protected $location_list = null;
+
+	protected $ja_prefectures = null;
+	protected $ja_cities = null;
+	protected $ja_kus = null;
+	protected $ja_guns = null;
+
+	function __construct() {
+		$this->load->library('Genfunctions');
+		$this->load->model('logbooks_model');
+		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+		$this->location_list = "'" . implode("','", $logbooks_locations_array) . "'";
+	}
+
+	/**
+	 * Load Prefecture data from JSON file into $this->ja_cities
+	 */
+	protected function load_pref_data_from_json() {
+		$this->ja_prefectures = json_decode(file_get_contents(FCPATH . 'assets/json/japan_award/pref_list.json'), true);
+	}
+
+	/**
+	 * Load JCC data from JSON file into $this->ja_cities
+	 */
+	protected function load_jcc_data_from_json() {
+		$this->ja_cities = json_decode(file_get_contents(FCPATH . 'assets/json/japan_award/jcc_list.json'), true);
+	}
+
+	/**
+	 * Load KU data from JSON file into $this->ja_kus
+	 */
+	protected function load_ku_data_from_json() {
+		$this->ja_kus = json_decode(file_get_contents(FCPATH . 'assets/json/japan_award/ku_list.json'), true);
+	}
+
+	/**
+	 * Load JCG data from JSON file into $this->ja_guns
+	 */
+	protected function load_jcg_data_from_json() {
+		$this->ja_guns = json_decode(file_get_contents(FCPATH . 'assets/json/japan_award/jcg_list.json'), true);
+	}
+
+	/**
+	 * Get the display name for a Japanese prefecture code.
+	 *
+	 * @param string $prefecture_code The 2-digit prefecture code
+	 * @return string The prefecture name
+	 */
+	protected function get_ja_prefecture_name($prefecture_code) {
+		return $this->ja_prefectures[$prefecture_code]['name'] ?? $prefecture_code;
+	}
+
+	/**
+	 * Filters out entities(cities, guns or kus) that are marked as deleted
+	 *
+	 * @param array $entity_data The list of entities to filter
+	 * @param array $postdata The postdata containing filter options
+	 * @return array The filtered list of entities
+	 */
+	protected function filter_entity_data($entity_data, $postdata) {
+		if (($postdata['includedeleted'] ?? null) != null) {
+			return $entity_data;
+		}
+
+		return array_filter($entity_data, function ($entity) {
+			return !(isset($entity['deleted']) && $entity['deleted'] == true);
+		});
+	}
+
+	/**
+	 * Build SQL expression for key_col based on band
+	 *
+	 * SAT is treated as a separate "band" in wavelog award system
+	 *
+	 * @return string The SQL expression for key_col
+	 */
+	protected function build_band_key_expr() {
+		return "case
+			when col_prop_mode = 'SAT' then 'SAT'
+			else col_band
+		end";
+	}
+
+	/**
+	 * Build SQL expression for key_col based on mode
+	 *
+	 * Based on JARL supported mode endorsements
+	 *
+	 * @return string The SQL expression for key_col
+	 */
+	protected function build_mode_key_expr() {
+		return "case
+			when col_submode = 'DSTAR' then 'DSTAR'
+			when col_mode in ('AM', 'FM', 'CW', 'SSB', 'ATV', 'FAX', 'SSTV', 'DIGITALVOICE') then col_mode
+			else 'DIGITAL'
+		end";
+	}
+
+	/**
+	 * Build SQL condition for confirmation based on postdata
+	 *  cond1 OR cond2 OR cond3 ...
+	 *
+	 * @param array $postdata The postdata containing filter options
+	 * @return string The SQL condition expr
+	 */
+	protected function get_qsl_condition_sql($postdata) {
+		$qsl = array();
+		if (($postdata['qsl'] ?? null) == 1) {
+			$qsl[] = "col_qsl_rcvd = 'Y'";
+		}
+		if (($postdata['lotw'] ?? null) == 1) {
+			$qsl[] = "col_lotw_qsl_rcvd = 'Y'";
+		}
+		if (($postdata['eqsl'] ?? null) == 1) {
+			$qsl[] = "col_eqsl_qsl_rcvd = 'Y'";
+		}
+		if (($postdata['qrz'] ?? null) == 1) {
+			$qsl[] = "COL_QRZCOM_QSO_DOWNLOAD_STATUS = 'Y'";
+		}
+		if (($postdata['clublog'] ?? null) == 1) {
+			$qsl[] = "COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y'";
+		}
+
+		return count($qsl) > 0 ? implode(' or ', $qsl) : '1=0';
+	}
+
+	/**
+	 * Build SQL expression for confirmation based on postdata
+	 * 	CASE WHEN (cond1 OR cond2 OR cond3 ...) THEN 1 ELSE 0 END
+	 *
+	 * @param array $postdata The postdata containing filter options
+	 * @return string The SQL expression for confirmed
+	 */
+	protected function get_qsl_confirmed_expr($postdata) {
+		return 'case when (' . $this->get_qsl_condition_sql($postdata) . ') then 1 else 0 end';
+	}
+
+	/**
+	 * Build SQL for entity(cities, guns or kus) IN (list)
+	 * 	id1, id2, id3 ...
+	 *
+	 * @param array $entity_data The list of entities to build IN clause for
+	 * @return string The SQL string for IN clause
+	 */
+	protected function build_entity_in_list_sql($entity_data) {
+		$keys = array_map(function ($key) {
+			return $this->db->escape((string) $key);
+		}, array_keys($entity_data));
+
+		return implode(',', $keys);
+	}
+
+	/**
+	 * Build SQL WHERE clause for entity query based on postdata
+	 *
+	 * @param string $entity_cond Full condition SQL for entity matching,
+	 *   e.g. "col_dxcc in ('339') and col_cnty in (...)"
+	 * @param array $postdata The postdata containing filter options
+	 * @param bool $confirmed_only Whether to include only confirmed QSOs
+	 * @return array ['sql' => string, 'bindings' => array]
+	 */
+	protected function build_entity_query_where_sql($entity_cond, $postdata, $confirmed_only = false) {
+		$bindings = array();
+		$band = $postdata['band'] ?? 'All';
+		$mode = $postdata['mode'] ?? 'All';
+		$prop_mode = $postdata['prop_mode'] ?? 'All';
+
+		$where = array(
+			"(" . $entity_cond . ")",
+			"station_id in (" . $this->location_list . ")",
+		);
+		if ($band != 'All') {
+			if ($band === 'SAT') {
+				$where[] = "(col_prop_mode = ?)";
+				$bindings[] = $band;
+			} else {
+				$where[] = "(col_band = ?)";
+				$bindings[] = $band;
+			}
+		}
+		if ($mode != 'All') {
+			$where[] = "(col_mode = ? or col_submode = ?)";
+			$bindings[] = $mode;
+			$bindings[] = $mode;
+		}
+		if ($prop_mode != 'All') {
+			$where[] = "(col_prop_mode = ?)";
+			$bindings[] = $prop_mode;
+		}
+		if ($confirmed_only) {
+			$where[] = '(' . $this->get_qsl_condition_sql($postdata) . ')';
+		}
+
+		return [
+			'sql' => implode(" and ", $where),
+			'bindings' => $bindings,
+		];
+	}
+
+	/**
+	 * Build the base SQL query for entity status
+	 * The query turns eligible QSOs into rows of (entity, key_col and confirmed)
+	 *
+	 * @param string $entity_expr The SQL expression for entity, e.g. col_cnty or left(col_cnty, 4)
+	 * @param string $entity_cond Full condition SQL for entity matching
+	 * @param string $key_col The column to use as key_col: 'band', 'mode' or 'none'
+	 * @param array $postdata The postdata containing filter options
+	 * @return array ['sql' => string, 'bindings' => array]
+	 */
+	protected function build_entity_status_base_query($entity_expr, $entity_cond, $key_col, $postdata) {
+		$confirmed_expr = $this->get_qsl_confirmed_expr($postdata);
+
+		$select = array(
+			$entity_expr . ' as entity',
+			$confirmed_expr . ' as confirmed',
+		);
+		if ($key_col === 'band') {
+			$select[] = $this->build_band_key_expr() . ' as key_col';
+		} else if ($key_col === 'mode') {
+			$select[] = $this->build_mode_key_expr() . ' as key_col';
+		} else {
+			$select[] = "'All' as key_col";
+		}
+		$select_str = implode(", ", $select);
+
+		$from = $this->config->item('table_name') . " thcv";
+
+		$where = $this->build_entity_query_where_sql($entity_cond, $postdata);
+
+		return [
+			'sql' => "select " . $select_str . " from " . $from . " where " . $where['sql'],
+			'bindings' => $where['bindings'],
+		];
+	}
+
+	/**
+	 * Build SQL to group the base query by entity and key_col, and aggregate confirmed
+	 *
+	 * @param string $source_sql The SQL string for the source query
+	 * @return string The SQL string for the grouped and aggregated query
+	 */
+	protected function build_entity_status_max_confirmed_group_by_sql($source_sql) {
+		return "select entity, key_col, max(confirmed) as confirmed from (" . $source_sql . ") entity_status group by entity, key_col";
+	}
+
+	/**
+	 * Build UNION ALL of N query pairs
+	 *
+	 * @param array $queries Array of ['sql' => string, 'bindings' => array]
+	 * @return array ['sql' => string, 'bindings' => array]
+	 */
+	protected function build_union_all_sql($queries) {
+		$sqls = array();
+		$bindings = array();
+		foreach ($queries as $q) {
+			$sqls[] = $q['sql'];
+			$bindings = array_merge($bindings, $q['bindings']);
+		}
+		return [
+			'sql' => implode(" union all ", $sqls),
+			'bindings' => $bindings,
+		];
+	}
+
+	/**
+	 * Query the entity status from query groups
+	 * Return rows of (entity, key_col and confirmed)
+	 * The row exists if the slot is worked, and confirmed is 1 if the slot is confirmed
+	 *
+	 * @param array $query_groups Array of ['entity_expr' => string, 'entity_cond' => string]
+	 * @param string $key_col The column to use as key_col: 'band', 'mode' or 'none'
+	 * @param array $postdata The postdata containing filter options
+	 * @return array The result set as an array of rows
+	 */
+	function query_entity_status($query_groups, $key_col, $postdata) {
+		$group_queries = array();
+		foreach ($query_groups as $group) {
+			$base = $this->build_entity_status_base_query(
+				$group['entity_expr'], $group['entity_cond'], $key_col, $postdata
+			);
+			$group_sql = $this->build_entity_status_max_confirmed_group_by_sql($base['sql']);
+			$group_queries[] = ['sql' => $group_sql, 'bindings' => $base['bindings']];
+		}
+
+		$union = $this->build_union_all_sql($group_queries);
+		$final_sql = $this->build_entity_status_max_confirmed_group_by_sql($union['sql']);
+
+		$query = $this->db->query($final_sql, $union['bindings']);
+		return $query->result_array();
+	}
+
+	/**
+	 * Build the base SQL query for exporting QSOs for entities
+	 * The query selects eligible QSOs for further processing
+	 *
+	 * @param string $entity_expr The SQL expression for entity
+	 * @param string $entity_cond Full condition SQL for entity matching
+	 * @param string $key_col The column to use as key_col: 'band', 'mode' or 'none'
+	 * @param array $postdata The postdata containing filter options
+	 * @return array ['sql' => string, 'bindings' => array]
+	 */
+	protected function build_export_entity_source_query($entity_expr, $entity_cond, $key_col, $postdata) {
+		$select = array(
+			$entity_expr . ' as entity',
+			'COL_PRIMARY_KEY',
+			'COL_CALL',
+			'COL_TIME_ON',
+			'COL_BAND',
+			'COL_MODE',
+			'COL_PROP_MODE',
+		);
+		if ($key_col === 'band') {
+			$select[] = $this->build_band_key_expr() . ' as key_col';
+		} else if ($key_col === 'mode') {
+			$select[] = $this->build_mode_key_expr() . ' as key_col';
+		} else {
+			$select[] = "'All' as key_col";
+		}
+
+		$select_str = implode(", ", $select);
+
+		$from = $this->config->item('table_name') . " thcv";
+
+		$where = $this->build_entity_query_where_sql($entity_cond, $postdata, true);
+
+		return [
+			'sql' => 'select ' . $select_str . ' from ' . $from . ' where ' . $where['sql'],
+			'bindings' => $where['bindings'],
+		];
+	}
+
+	/**
+	 * Query export QSOs from query groups
+	 * Return first confirmed QSO for each entity (+ key_col if applicable)
+	 *
+	 * @param array $query_groups Array of ['entity_expr' => string, 'entity_cond' => string]
+	 * @param string $key_col The column to use as key_col: 'band', 'mode' or 'none'
+	 * @param array $postdata The postdata containing filter options
+	 * @return array The result set as an array of rows with QSO details
+	 */
+	function query_export_qsos($query_groups, $key_col, $postdata) {
+		$source_queries = array();
+		foreach ($query_groups as $group) {
+			$source_queries[] = $this->build_export_entity_source_query(
+				$group['entity_expr'], $group['entity_cond'], $key_col, $postdata
+			);
+		}
+
+		$source = $this->build_union_all_sql($source_queries);
+
+		$ranked_sql = 'select source.*, row_number() over (partition by entity, key_col order by COL_TIME_ON asc, COL_PRIMARY_KEY asc) as rn from (' . $source['sql'] . ') source';
+		$final_sql = 'select entity, key_col, COL_CALL, COL_TIME_ON, COL_BAND, COL_MODE, COL_PROP_MODE from (' . $ranked_sql . ') ranked where rn = 1 order by entity asc, key_col asc';
+
+		$query = $this->db->query($final_sql, $source['bindings']);
+		return $query->result_array();
+	}
+
+}
+?>

--- a/application/models/Japan_award_model.php
+++ b/application/models/Japan_award_model.php
@@ -147,11 +147,7 @@ class Japan_award_model extends CI_Model {
 	 * @return string The SQL string for IN clause
 	 */
 	protected function build_entity_in_list_sql($entity_data) {
-		$keys = array_map(function ($key) {
-			return $this->db->escape((string) $key);
-		}, array_keys($entity_data));
-
-		return implode(',', $keys);
+		return implode(',', array_keys($entity_data));
 	}
 
 	/**

--- a/application/models/Jcc_model.php
+++ b/application/models/Jcc_model.php
@@ -6,6 +6,7 @@ class Jcc_model extends Japan_award_model {
 
 	function __construct() {
 		parent::__construct();
+		$this->load_pref_data_from_json();
 		$this->load_jcc_data_from_json();
 		$this->load_ku_data_from_json();
 	}
@@ -59,117 +60,109 @@ class Jcc_model extends Japan_award_model {
 	}
 
 	/**
-	 * Get the JCC status array for display on the table
-	 * 	array[city][band] = 'C' if confirmed, 'W' if worked but not confirmed, '-' if not worked
+	 * Build grouped slot data for the JCC demo slot.
 	 *
-	 * @param array $bands The list of bands to include in the result
 	 * @param array $postdata The postdata containing filter options
 	 * @param array|null $entity_status The pre-query entity status to use
+	 * @return array Grouped slot data keyed by prefecture code
 	 */
-	function get_jcc_array($bands, $postdata, $entity_status = null) {
+	function get_jcc_grouped_slot($postdata, $entity_status = null) {
 		if ($entity_status === null) {
-			$entity_status = $this->query_jcc_entity_status($postdata, 'band');
+			$entity_status = $this->query_jcc_entity_status($postdata, 'none');
 		}
 
 		$jcc_list = $this->filter_entity_data($this->ja_cities, $postdata);
-
-		$cities = array();
-		// Initializing the array with all cities and bands
-		foreach ($jcc_list as $city => $city_data) {
-			$cities[$city]['Number'] = $city;
-			$cities[$city]['City'] = $city_data['name'];
-			$cities[$city]['count'] = 0;
-			foreach ($bands as $band) {
-				// Sets all to dash to indicate no result
-				$cities[$city][$band] = '-';
-			}
+		$slot_status = array();
+		foreach ($jcc_list as $entity => $city_data) {
+			$slot_status[$entity] = '-';
 		}
 
 		foreach ($entity_status as $row) {
+			$entity = $row['entity'];
+			$slot_status[$entity] = 'W';
 			if ($row['confirmed'] == 1) {
-				if ($postdata['confirmed'] != NULL) {
-					$cities[$row['entity']][$row['key_col']] = 'C';
-					$cities[$row['entity']]['count'] += 1;
-				}
-			} else {
-				if ($postdata['worked'] != NULL) {
-					$cities[$row['entity']][$row['key_col']] = 'W';
-					$cities[$row['entity']]['count'] += 1;
-				}
+				$slot_status[$entity] = 'C';
 			}
 		}
 
-		if ($postdata['notworked'] == NULL) {
-			foreach ($cities as $city => $city_data) {
-				if ($city_data['count'] == 0) {
-					unset($cities[$city]);
-				}
+		$groups = array();
+		foreach ($jcc_list as $entity => $city_data) {
+			$prefecture_code = substr((string) $entity, 0, 2);
+			if (!isset($groups[$prefecture_code])) {
+				$groups[$prefecture_code] = array(
+					'prefecture_code' => $prefecture_code,
+					'prefecture_name' => $this->get_ja_prefecture_name($prefecture_code),
+					'slots' => array(),
+				);
 			}
+
+			$status = $slot_status[$entity] ?? '-';
+
+			$groups[$prefecture_code]['slots'][] = array(
+				'entity' => $entity,
+				'short_number' => substr((string) $entity, 2),
+				'name' => $city_data['name'] ?? '',
+				'status' => $status,
+				'deleted' => !empty($city_data['deleted']),
+			);
 		}
 
-		if (!empty($cities)) {
-			return $cities;
-		} else {
-			return 0;
+		ksort($groups, SORT_STRING);
+		foreach ($groups as &$group) {
+			usort($group['slots'], function ($left, $right) {
+				return strcmp($left['entity'], $right['entity']);
+			});
 		}
+		unset($group);
+
+		return $groups;
 	}
 
-
 	/**
-	 * Get the JCC summary array for display on the table
-	 * 	array['worked'][band] = count of worked cities for the band
-	 * 	array['confirmed'][band] = count of confirmed cities for the band
+	 * Build the overall summary for the grouped JCC grid.
 	 *
-	 * @param array $bands The list of bands to include in the result
 	 * @param array $postdata The postdata containing filter options
 	 * @param array|null $entity_status The pre-query entity status to use
+	 * @return array The summary data for the grouped grid
 	 */
-	function get_jcc_summary($bands, $postdata, $entity_status = null) {
+	function get_jcc_summary($postdata, $entity_status = null) {
 		if ($entity_status === null) {
-			$entity_status = $this->query_jcc_entity_status($postdata, 'band');
+			$entity_status = $this->query_jcc_entity_status($postdata, 'none');
 		}
 
-		$summary = array(
-			'worked' => array(),
-			'confirmed' => array(),
-		);
-
-		// $worked_by_band = array();
-		// $confirmed_by_band = array();
-		foreach ($bands as $band) {
-			$summary['worked'][$band] = 0;
-			$summary['confirmed'][$band] = 0;
-		}
-
-		$worked_total = array();
-		$confirmed_total = array();
+		$jcc_list = $this->filter_entity_data($this->ja_cities, $postdata);
+		$worked_entities = array();
+		$confirmed_entities = array();
 
 		foreach ($entity_status as $row) {
-			$worked_total[$row['entity']] = true;
-			$summary['worked'][$row['key_col']] += 1;
+			$entity = $row['entity'];
+			$worked_entities[$entity] = true;
 			if ($row['confirmed'] == 1) {
-				$confirmed_total[$row['entity']] = true;
-				$summary['confirmed'][$row['key_col']] += 1;
+				$confirmed_entities[$entity] = true;
 			}
 		}
 
-		$summary['worked']['Total'] = count($worked_total);
-		$summary['confirmed']['Total'] = count($confirmed_total);
-
-		// make sure SAT is after Total
-		// I don't know why, but the origin design is such.
-		if (isset($summary['worked']['SAT']) && isset($summary['confirmed']['SAT'])) {
-			$summary_worked_sat = $summary['worked']['SAT'];
-			$summary_confirmed_sat = $summary['confirmed']['SAT'];
-
-			unset($summary['worked']['SAT']);
-			unset($summary['confirmed']['SAT']);
-
-			$summary['worked']['SAT'] = $summary_worked_sat;
-			$summary['confirmed']['SAT'] = $summary_confirmed_sat;
+		$total = count($jcc_list);
+		$deleted = 0;
+		foreach ($jcc_list as $city_data) {
+			if (!empty($city_data['deleted'])) {
+				$deleted += 1;
+			}
 		}
+		$worked = count($worked_entities);
+		$confirmed = count($confirmed_entities);
+		$worked_only = max(0, $worked - $confirmed);
 
-		return $summary;
+		return array(
+			'deleted' => $deleted,
+			'total' => $total,
+			'worked' => $worked,
+			'confirmed' => $confirmed,
+			'worked_only' => $worked_only,
+			'worked_percent' => $total > 0 ? round(($worked / $total) * 100, 1) : 0,
+			'confirmed_percent' => $total > 0 ? round(($confirmed / $total) * 100, 1) : 0,
+			'worked_only_percent' => $total > 0 ? round(($worked_only / $total) * 100, 1) : 0,
+		);
 	}
 
 	/**

--- a/application/models/Jcc_model.php
+++ b/application/models/Jcc_model.php
@@ -22,7 +22,7 @@ class Jcc_model extends Japan_award_model {
 	 */
 	private function build_jcc_query_groups($postdata) {
 		$jcc_data = $this->filter_entity_data($this->ja_cities, $postdata);
-		$ku_data = $this->filter_entity_data($this->ja_kus, $postdata);
+		$ku_data = $this->ja_kus;	// No need to filter deleted kus, as they could still count as its city
 		$jcc_in_list = $this->build_entity_in_list_sql($jcc_data);
 		$ku_in_list = $this->build_entity_in_list_sql($ku_data);
 

--- a/application/models/Jcc_model.php
+++ b/application/models/Jcc_model.php
@@ -1,291 +1,74 @@
 <?php
 
-class Jcc_model extends CI_Model {
+require_once(APPPATH . 'models/Japan_award_model.php');
 
+class Jcc_model extends Japan_award_model {
 
-	private $location_list=null;
 	function __construct() {
-		$this->load->library('Genfunctions');
-		$this->load->model('logbooks_model');
-		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-		$this->location_list = "'".implode("','",$logbooks_locations_array)."'";
+		parent::__construct();
 		$this->load_jcc_data_from_json();
 		$this->load_ku_data_from_json();
 	}
 
-	// The list of JCC cities and KU areas, loaded from JSON files in assets/json/japan_award/
-	public $ja_cities = array();
-	public $ja_kus = array();
-
 	/**
-	 * Load JCC data from JSON file into $this->ja_cities
-	 */
-	private function load_jcc_data_from_json() {
-		$this->ja_cities = json_decode(file_get_contents(FCPATH . 'assets/json/japan_award/jcc_list.json'), true);
-	}
-
-	/**
-	 * Load KU data from JSON file into $this->ja_kus
-	 */
-	private function load_ku_data_from_json() {
-		$this->ja_kus = json_decode(file_get_contents(FCPATH . 'assets/json/japan_award/ku_list.json'), true);
-	}
-
-	/**
-	 * Filters out entities(cities or kus) that are marked as deleted
-	 * 
-	 * @param array $entity_data The list of entities to filter, usually ja_cities, ja_guns or ja_kus
+	 * Build query groups for JCC award
+	 * JCC has 2 groups:
+	 *   1. Cities: match by col_cnty in jcc_list
+	 *   2. Designated city wards (kus): match by col_cnty in ku_list, entity = left(col_cnty, 4)
+	 *
 	 * @param array $postdata The postdata containing filter options
-	 * @return array The filtered list of entities
+	 * @return array Array of query groups
 	 */
-	private function filter_entity_data($entity_data, $postdata) {
-		if (($postdata['includedeleted'] ?? null) != null) {
-			return $entity_data;
-		}
-
-		return array_filter($entity_data, function ($entity) {
-			return !(isset($entity['deleted']) && $entity['deleted'] == true);
-		});
-	}
-
-	/**
-	 * Build SQL expression for key_col based on band
-	 * 
-	 * SAT is treated as a separate "band" in wavelog award system, which is a little strange
-	 * 
-	 * @return string The SQL expression for key_col
-	 */
-	private function build_band_key_expr() {
-		return "case
-			when col_prop_mode = 'SAT' then 'SAT'
-			else col_band
-		end";
-	}
-
-	/**
-	 * Build SQL expression for key_col based on mode
-	 * 
-	 * Based on JARL supported mode endorsements
-	 * Note: This function is not been used in current implementation.
-	 * 
-	 * @return string The SQL expression for key_col
-	 */
-	private function build_mode_key_expr() {
-		return "case
-			when col_submode = 'DSTAR' then 'DSTAR'
-			when col_mode in ('AM', 'FM', 'CW', 'SSB', 'ATV', 'FAX', 'SSTV', 'DIGITALVOICE') then col_mode
-			else 'DIGITAL'
-		end";
-	}
-
-	/**
-	 * Build SQL condition for confirmation based on postdata
-	 *  cond1 OR cond2 OR cond3 ...
-	 * 
-	 * Similar to Genfunctions->addQslToQuery, but without an 'AND' prefix
-	 * May be moved to Genfunctions in the future
-	 * 
-	 * @param array $postdata The postdata containing filter options
-	 * @return string The SQL condition expr
-	 */
-	private function get_qsl_condition_sql($postdata) {
-		$qsl = array();
-		if (($postdata['qsl'] ?? null) == 1) {
-			$qsl[] = "col_qsl_rcvd = 'Y'";
-		}
-		if (($postdata['lotw'] ?? null) == 1) {
-			$qsl[] = "col_lotw_qsl_rcvd = 'Y'";
-		}
-		if (($postdata['eqsl'] ?? null) == 1) {
-			$qsl[] = "col_eqsl_qsl_rcvd = 'Y'";
-		}
-		if (($postdata['qrz'] ?? null) == 1) {
-			$qsl[] = "COL_QRZCOM_QSO_DOWNLOAD_STATUS = 'Y'";
-		}
-		if (($postdata['clublog'] ?? null) == 1) {
-			$qsl[] = "COL_CLUBLOG_QSO_DOWNLOAD_STATUS = 'Y'";
-		}
-		if (($postdata['dcl'] ?? null) == 1) {
-			$qsl[] = "COL_DCL_QSL_RCVD = 'Y'";
-		}
-
-		return count($qsl) > 0 ? implode(' or ', $qsl) : '1=0';
-	}
-
-	/**
-	 * Build SQL expression for confirmation based on postdata
-	 * 	CASE WHEN (cond1 OR cond2 OR cond3 ...) THEN 1 ELSE 0 END
-	 * 
-	 * @param array $postdata The postdata containing filter options
-	 * @return string The SQL expression for confirmed
-	 */
-	private function get_qsl_confirmed_expr($postdata) {
-		return 'case when (' . $this->get_qsl_condition_sql($postdata) . ') then 1 else 0 end';
-	}
-
-	/**
-	 * Build SQL for entity(cities, guns or kus) IN (list)
-	 * 	id1, id2, id3 ...
-	 * 
-	 * @param array $entity_data The list of entities to build IN clause for
-	 * @return string The SQL string for IN clause
-	 */
-	private function build_entity_in_list_sql($entity_data) {
-		$keys = array_map(function ($key) {
-			return $this->db->escape((string) $key);
-		}, array_keys($entity_data));
-
-		return implode(',', $keys);
-	}
-
-	/**
-	 * Build SQL WHERE clause for entity status query based on postdata
-	 * 
-	 * @param string $entity_in_list_sql The SQL string for entity IN clause
-	 * @param array $postdata The postdata containing filter options
-	 * @param array $bindings The array to store query bindings for prepared statement
-	 * @param bool $confirmed_only Whether to include only confirmed QSOs in the condition
-	 * @return string The SQL string for WHERE clause
-	 */
-	private function build_entity_query_where_sql($entity_in_list_sql, $postdata, &$bindings, $confirmed_only = false) {
-		$band = $postdata['band'] ?? 'All';
-		$mode = $postdata['mode'] ?? 'All';
-		$prop_mode = $postdata['prop_mode'] ?? 'All';
-
-		$where = array(
-			"col_dxcc in ('339')",
-			"col_cnty in (" . $entity_in_list_sql . ")",
-			"station_id in (" . $this->location_list . ")",
-		);
-		if ($band != 'All') {
-			if ($band === 'SAT') {
-				$where[] = "(col_prop_mode = ?)";
-				$bindings[] = $band;
-			} else {
-				$where[] = "(col_band = ?)";
-				$bindings[] = $band;
-			}
-		}
-		if ($mode != 'All') {
-			$where[] = "(col_mode = ? or col_submode = ?)";
-			$bindings[] = $mode;
-			$bindings[] = $mode;
-		}
-		if ($prop_mode != 'All') {
-			$where[] = "(col_prop_mode = ?)";
-			$bindings[] = $prop_mode;
-		}
-		if ($confirmed_only) {
-			$where[] = '(' . $this->get_qsl_condition_sql($postdata) . ')';
-		}
-
-		return implode(" and ", $where);
-	}
-
-	/**
-	 * Build the base SQL query for entity status
-	 * The query turns eligible QSOs into rows of (entity, key_col and confirmed) for further group and aggregation
-	 * 
-	 * @param string $entity_expr The SQL expression for entity, e.g. col_cnty or left(col_cnty, 4)
-	 * @param string $entity_in_list_sql The SQL string for entity IN clause
-	 * @param string $key_col The column to use as key_col in the result, can be 'band', 'mode' or 'none'
-	 * @param array $postdata The postdata containing filter options
-	 * @param array $bindings The array to store query bindings for prepared statement
-	 * @return string The SQL string for the base query
-	 */
-	private function build_entity_status_base_query($entity_expr, $entity_in_list_sql, $key_col, $postdata, &$bindings) {
-		$confirmed_expr = $this->get_qsl_confirmed_expr($postdata);
-
-		$select = array(
-			$entity_expr . ' as entity',
-			$confirmed_expr . ' as confirmed',
-		);
-		if ($key_col === 'band') {
-			$select[] = $this->build_band_key_expr() . ' as key_col';
-		} else if ($key_col === 'mode') {
-			$select[] = $this->build_mode_key_expr() . ' as key_col';
-		} else {
-			$select[] = "'All' as key_col";
-			// No additional bindings needed since key_col is a constant in this case
-		}
-		$select_str = implode(", ", $select);
-
-		$from = $this->config->item('table_name') . " thcv";
-
-		$where_str = $this->build_entity_query_where_sql($entity_in_list_sql, $postdata, $bindings);
-
-		$sql = "select " . $select_str . " from " . $from . " where " . $where_str;
-
-		return $sql;
-	}
-
-	/**
-	 * Build SQL to group the base query by entity and key_col, and aggregate confirmed
-	 * 
-	 * @param string $source_sql The SQL string for the source query to group and aggregate
-	 * @return string The SQL string for the grouped and aggregated query
-	 */
-	private function build_entity_status_max_confirmed_group_by_sql($source_sql) {
-		return "select entity, key_col, max(confirmed) as confirmed from (" . $source_sql . ") entity_status group by entity, key_col";
-	}
-
-	/**
-	 * Build SQL to union all two entity status queries
-	 * 
-	 * @param string $left_sql The SQL string for the left query
-	 * @param string $right_sql The SQL string for the right query
-	 * @return string The SQL string for the union all query
-	 */
-	private function build_entity_status_union_all_sql($left_sql, $right_sql) {
-		return $left_sql . " union all " . $right_sql;
-	}
-
-	/**
-	 * Query the entity status based on postdata and key_col
-	 * Return rows of (entity, key_col and confirmed)
-	 * The row exists if the slot is worked, and confirmed is 1 if the slot is confirmed
-	 * 
-	 * @param array $postdata The postdata containing filter options
-	 * @param string $key_col The column to use as key_col in the result, can be 'band', 'mode' or 'none'
-	 * @return array The result set as an array of rows
-	 */
-	function query_entity_status($postdata, $key_col = "none") {
+	private function build_jcc_query_groups($postdata) {
 		$jcc_data = $this->filter_entity_data($this->ja_cities, $postdata);
 		$ku_data = $this->filter_entity_data($this->ja_kus, $postdata);
 		$jcc_in_list = $this->build_entity_in_list_sql($jcc_data);
 		$ku_in_list = $this->build_entity_in_list_sql($ku_data);
 
-		$bindings = array();
+		return array(
+			array(
+				'entity_expr' => 'col_cnty',
+				'entity_cond' => "col_dxcc in ('339') and col_cnty in (" . $jcc_in_list . ")",
+			),
+			array(
+				'entity_expr' => 'left(col_cnty, 4)',
+				'entity_cond' => "col_dxcc in ('339') and col_cnty in (" . $ku_in_list . ")",
+			),
+		);
+	}
 
-		// Query QSOs with any JCCs, group by city and key_col
-		$jcc_source_sql = $this->build_entity_status_base_query('col_cnty', $jcc_in_list, $key_col, $postdata, $bindings);
-		$jcc_group_sql = $this->build_entity_status_max_confirmed_group_by_sql($jcc_source_sql);
+	/**
+	 * Query JCC entity status
+	 *
+	 * @param array $postdata The postdata containing filter options
+	 * @param string $key_col The column to use as key_col: 'band', 'mode' or 'none'
+	 * @return array The result set as an array of rows
+	 */
+	function query_jcc_entity_status($postdata, $key_col = "none") {
+		return $this->query_entity_status($this->build_jcc_query_groups($postdata), $key_col, $postdata);
+	}
 
-		// Query QSOs with any Kus, classify to cities, group by city and key_col
-		$ku_source_sql = $this->build_entity_status_base_query('left(col_cnty, 4)', $ku_in_list, $key_col, $postdata, $bindings);
-		$ku_group_sql = $this->build_entity_status_max_confirmed_group_by_sql($ku_source_sql);
-
-		// Union the two queries, then group again
-		$union_sql = $this->build_entity_status_union_all_sql($jcc_group_sql, $ku_group_sql);
-		$final_sql = $this->build_entity_status_max_confirmed_group_by_sql($union_sql);
-
-		$query = $this->db->query($final_sql, $bindings);
-		$rows = $query->result_array();
-
-		return $rows;
+	/**
+	 * Query JCC export QSOs (first confirmed QSO per city)
+	 *
+	 * @param array $postdata The postdata containing filter options
+	 * @return array The result set as an array of rows
+	 */
+	function query_jcc_export_qsos($postdata) {
+		return $this->query_export_qsos($this->build_jcc_query_groups($postdata), 'none', $postdata);
 	}
 
 	/**
 	 * Get the JCC status array for display on the table
 	 * 	array[city][band] = 'C' if confirmed, 'W' if worked but not confirmed, '-' if not worked
-	 * 
+	 *
 	 * @param array $bands The list of bands to include in the result
 	 * @param array $postdata The postdata containing filter options
 	 * @param array|null $entity_status The pre-query entity status to use
 	 */
 	function get_jcc_array($bands, $postdata, $entity_status = null) {
 		if ($entity_status === null) {
-			$entity_status = $this->query_entity_status($postdata, 'band');
+			$entity_status = $this->query_jcc_entity_status($postdata, 'band');
 		}
 
 		$jcc_list = $this->filter_entity_data($this->ja_cities, $postdata);
@@ -336,14 +119,14 @@ class Jcc_model extends CI_Model {
 	 * Get the JCC summary array for display on the table
 	 * 	array['worked'][band] = count of worked cities for the band
 	 * 	array['confirmed'][band] = count of confirmed cities for the band
-	 * 
+	 *
 	 * @param array $bands The list of bands to include in the result
 	 * @param array $postdata The postdata containing filter options
 	 * @param array|null $entity_status The pre-query entity status to use
 	 */
 	function get_jcc_summary($bands, $postdata, $entity_status = null) {
 		if ($entity_status === null) {
-			$entity_status = $this->query_entity_status($postdata, 'band');
+			$entity_status = $this->query_jcc_entity_status($postdata, 'band');
 		}
 
 		$summary = array(
@@ -392,14 +175,14 @@ class Jcc_model extends CI_Model {
 	/**
 	 * Get the JCC map array for display on the map
 	 * 	array[city] = [worked, confirmed]
-	 * 
+	 *
 	 * @param array $postdata The postdata containing filter options
 	 * @param array|null $entity_status The pre-query entity status to use
 	 * @return array The JCC map array for display on the map
 	 */
 	function get_jcc_map_array($postdata, $entity_status = null) {
 		if ($entity_status === null) {
-			$entity_status = $this->query_entity_status($postdata, 'none');
+			$entity_status = $this->query_jcc_entity_status($postdata, 'none');
 		}
 
 		$jccs = array();
@@ -420,74 +203,14 @@ class Jcc_model extends CI_Model {
 	}
 
 	/**
-	 * Build the base SQL query for exporting QSOs for entities(cities or kus)
-	 * The query selects eligible QSOs for further processing
-	 * 
-	 * @param string $entity_expr The SQL expression for entity, e.g. col_cnty or left(col_cnty, 4)
-	 * @param string $entity_in_list_sql The SQL string for entity IN clause
-	 * @param array $postdata The postdata containing filter options
-	 * @param array $bindings The array to store query bindings for prepared statement
-	 * @return string The SQL string for the export query
-	 */
-	private function build_export_entity_source_query($entity_expr, $entity_in_list_sql, $postdata, &$bindings) {
-		$select = array(
-			$entity_expr . ' as entity',
-			'COL_PRIMARY_KEY',
-			'COL_CALL',
-			'COL_TIME_ON',
-			'COL_BAND',
-			'COL_MODE',
-			'COL_PROP_MODE',
-		);
-
-		$select_str = implode(", ", $select);
-
-		$from = $this->config->item('table_name') . " thcv";
-
-		$where_str = $this->build_entity_query_where_sql($entity_in_list_sql, $postdata, $bindings, true);
-
-		return 'select ' . $select_str . ' from ' . $from . ' where ' . $where_str;
-	}
-
-	/**
-	 * Export QSOs for entities(cities or kus) based on postdata
-	 * Return first confirmed QSO for each entity, with QSO details
-	 * 
-	 * @param array $postdata The postdata containing filter options
-	 * @return array The result set as an array of rows with QSO details
-	 */
-	function query_export_qsos($postdata) {
-		$jcc_data = $this->filter_entity_data($this->ja_cities, $postdata);
-		$ku_data = $this->filter_entity_data($this->ja_kus, $postdata);
-		$jcc_in_list = $this->build_entity_in_list_sql($jcc_data);
-		$ku_in_list = $this->build_entity_in_list_sql($ku_data);
-
-		$bindings = array();
-
-		// Query QSOs with any JCCs or Kus, then union the results
-		$jcc_source_sql = $this->build_export_entity_source_query('col_cnty', $jcc_in_list, $postdata, $bindings);
-		$ku_source_sql = $this->build_export_entity_source_query('left(col_cnty, 4)', $ku_in_list, $postdata, $bindings);
-		$source_sql = $this->build_entity_status_union_all_sql($jcc_source_sql, $ku_source_sql);
-
-		// Rank the QSOs for each entity by time and primary key, then select the first one for each entity
-		$ranked_sql = 'select source.*, row_number() over (partition by entity order by COL_TIME_ON asc, COL_PRIMARY_KEY asc) as rn from (' . $source_sql . ') source';
-		$final_sql = 'select entity, COL_CALL, COL_TIME_ON, COL_BAND, COL_MODE, COL_PROP_MODE from (' . $ranked_sql . ') ranked where rn = 1 order by entity asc';
-
-		$query = $this->db->query($final_sql, $bindings);
-		$rows = $query->result_array();
-
-		return $rows;
-	}
-
-	/**
 	 * Export QSOs for JCC award based on postdata
 	 * Return first confirmed QSO for each city, with QSO details and city name
-	 * 
+	 *
 	 * @param array $postdata The postdata containing filter options
 	 * @return array The result set as an array of rows with QSO details and city name
 	 */
 	function get_jcc_export($postdata) {
-		$rows = $this->query_export_qsos($postdata);
+		$rows = $this->query_jcc_export_qsos($postdata);
 
 		foreach ($rows as &$row) {
 			$row['entity_name'] = $this->ja_cities[$row['entity']]['name'] ?? '';

--- a/application/views/awards/jcc/index.php
+++ b/application/views/awards/jcc/index.php
@@ -1,72 +1,133 @@
 <script>
-	let tileUrl="<?php echo $this->optionslib->get_option('option_map_tile_server');?>"
-	let user_map_custom = JSON.parse('<?php echo $user_map_custom; ?>');
+    let tileUrl = "<?php echo $this->optionslib->get_option('option_map_tile_server'); ?>";
+    let user_map_custom = JSON.parse('<?php echo $user_map_custom; ?>');
 </script>
 <style>
     #jccmap {
        height: calc(100vh - 480px) !important;
        max-height: 900px !important;
     }
+
+    .award-grid-legend-swatch {
+        width: 1rem;
+        height: 1rem;
+        display: inline-block;
+    }
+
+    .award-grid-legend-swatch-deleted {
+        background-image: repeating-linear-gradient(135deg, rgba(0, 0, 0, 0.18) 0, rgba(0, 0, 0, 0.18) 2px, transparent 2px, transparent 6px);
+    }
+
+    .award-grid-prefecture {
+        min-width: 12rem;
+    }
+
+    .award-grid-slots {
+        align-content: flex-start;
+    }
+
+    .award-grid-slot {
+        --award-slot-hover-color: inherit;
+        --award-slot-hover-bg: transparent;
+        --award-slot-hover-border-color: currentColor;
+        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-secondary-rgb), 0.15);
+        width: 3rem;
+        height: 2rem;
+        padding: 0 0.5rem;
+        border-radius: 0.375rem;
+        font-size: 0.9rem;
+        line-height: 1;
+        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .award-grid-slot {
+            transition: none;
+        }
+    }
+
+    .award-grid-slot:hover {
+        background-color: var(--award-slot-hover-bg) !important;
+        border-color: var(--award-slot-hover-border-color) !important;
+        text-decoration: none;
+        box-shadow: none;
+    }
+
+    .award-grid-slot:focus-visible {
+        outline: 0;
+        box-shadow: var(--award-slot-focus-shadow);
+    }
+
+    .award-grid-slot.text-bg-success {
+        --award-slot-hover-bg: color-mix(in srgb, var(--bs-success) 85%, black);
+        --award-slot-hover-border-color: color-mix(in srgb, var(--bs-success) 80%, black);
+        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+    }
+
+    .award-grid-slot.text-bg-danger {
+        --award-slot-hover-bg: color-mix(in srgb, var(--bs-danger) 85%, black);
+        --award-slot-hover-border-color: color-mix(in srgb, var(--bs-danger) 80%, black);
+        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+    }
+
+    .award-grid-slot.text-bg-light {
+        --award-slot-hover-bg: color-mix(in srgb, var(--bs-light) 85%, black);
+        --award-slot-hover-border-color: color-mix(in srgb, var(--bs-light) 80%, black);
+        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-secondary-rgb), 0.15);
+    }
+
+    .award-grid-slot-deleted {
+        background-image: repeating-linear-gradient(135deg, rgba(0, 0, 0, 0.18) 0, rgba(0, 0, 0, 0.18) 2px, transparent 2px, transparent 6px);
+    }
+
+    .award-grid-progress {
+        height: 0.5rem;
+    }
+
+    @media (max-width: 991.98px) {
+        .award-grid-prefecture {
+            min-width: 0;
+        }
+    }
 </style>
+
 <div class="container">
-        <!-- Award Info Box -->
-        <br>
-        <div id="awardInfoButton">
-            <script>
-            var lang_awards_info_button = "<?= __("Award Info"); ?>";
-            var lang_award_info_ln1 = "<?= __("JCC - Japan Century Cities Award"); ?>";
-            var lang_award_info_ln2 = "<?= __("May be claimed for having contacted (heard) and received a QSL card from an amateur station located in each of at least 100 different cities of Japan."); ?>";
-            var lang_award_info_ln3 = "<?= __("JCC-200, 300, 400, 500, 600, 700 and 800 will be issued as separate awards. A list of QSL cards should be arranged in order of JCC reference number, however names of city may be omitted. An additional sticker will be issued at every 50 contacts like 150, 250, 350, 450, 550, 650, 750 cities."); ?>";
-            var lang_award_info_ln4 = "<?= sprintf(__("For more information, please visit: %s."), "<a href='https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm' target='_blank'>https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm</a>"); ?>";
-			var lang_award_info_ln5 = "<?= __("Fields taken for this Award: DXCC (Japan) and County (Must contain a valid reference!)"); ?>";
-            </script>
-            <h2><?php echo $page_title; ?></h2>
-            <button type="button" class="btn btn-sm btn-primary me-1" id="displayAwardInfo"><?= __("Award Info"); ?></button>
-        </div>
-        <!-- End of Award Info Box -->
+    <div id="awardInfoButton" class="py-3">
+        <script>
+        var lang_awards_info_button = "<?= __("Award Info"); ?>";
+        var lang_award_info_ln1 = "<?= __("JCC - Japan Century Cities Award"); ?>";
+        var lang_award_info_ln2 = "<?= __("May be claimed for having contacted (heard) and received a QSL card from an amateur station located in each of at least 100 different cities of Japan."); ?>";
+        var lang_award_info_ln3 = "<?= __("JCC-200, 300, 400, 500, 600, 700 and 800 will be issued as separate awards. A list of QSL cards should be arranged in order of JCC reference number, however names of city may be omitted. An additional sticker will be issued at every 50 contacts like 150, 250, 350, 450, 550, 650, 750 cities."); ?>";
+        var lang_award_info_ln4 = "<?= sprintf(__("For more information, please visit: %s."), "<a href='https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm' target='_blank'>https://www.jarl.org/English/4_Library/A-4-2_Awards/Award_Main.htm</a>"); ?>";
+        var lang_award_info_ln5 = "<?= __("Fields taken for this Award: DXCC (Japan) and County (Must contain a valid reference!)"); ?>";
+        </script>
+        <h2><?php echo $page_title; ?></h2>
+        <button type="button" class="btn btn-sm btn-primary me-1" id="displayAwardInfo"><?= __("Award Info"); ?></button>
+    </div>
 
     <form class="form" action="<?php echo site_url('awards/jcc'); ?>" method="post" enctype="multipart/form-data">
         <fieldset>
-
             <div class="mb-3 row">
-                <div class="col-md-2" for="checkboxes"><?= __("Worked / Confirmed"); ?></div>
+                <div class="col-md-2"><?= __("QSL Type"); ?></div>
                 <div class="col-md-10">
                     <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="worked" id="worked" value="1" <?php if ($this->input->post('worked') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
-                        <label class="form-check-label" for="worked"><?= __("Show worked"); ?></label>
-                    </div>
-                    <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="confirmed" id="confirmed" value="1" <?php if ($this->input->post('confirmed') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
-                        <label class="form-check-label" for="confirmed"><?= __("Show confirmed"); ?></label>
-                    </div>
-                    <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="notworked" id="notworked" value="1" <?php if ($this->input->post('notworked')) echo ' checked="checked"'; ?> >
-                        <label class="form-check-label" for="notworked"><?= __("Show not worked"); ?></label>
-                    </div>
-                </div>
-            </div>
-
-            <div class="mb-3 row">
-                <div class="col-md-2"><?= __("Show QSO with QSL Type"); ?></div>
-                <div class="col-md-10">
-                    <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="qsl" value="1" id="qsl" <?php if ($this->input->post('qsl') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
+                        <input class="form-check-input" type="checkbox" name="qsl" value="1" id="qsl" <?php if (($postdata['qsl'] ?? null) == 1) echo ' checked="checked"'; ?> >
                         <label class="form-check-label" for="qsl"><?= __("QSL"); ?></label>
                     </div>
                     <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="lotw" value="1" id="lotw" <?php if ($this->input->post('lotw') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
+                        <input class="form-check-input" type="checkbox" name="lotw" value="1" id="lotw" <?php if (($postdata['lotw'] ?? null) == 1) echo ' checked="checked"'; ?> >
                         <label class="form-check-label" for="lotw"><?= __("LoTW"); ?></label>
                     </div>
                     <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="eqsl" value="1" id="eqsl" <?php if ($this->input->post('eqsl') || $this->input->method() !== 'post') echo ' checked="checked"'; ?> >
+                        <input class="form-check-input" type="checkbox" name="eqsl" value="1" id="eqsl" <?php if (($postdata['eqsl'] ?? null) == 1) echo ' checked="checked"'; ?> >
                         <label class="form-check-label" for="eqsl"><?= __("eQSL"); ?></label>
                     </div>
                     <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="qrz" value="1" id="qrz" <?php if ($this->input->post('qrz')) echo ' checked="checked"'; ?> >
+                        <input class="form-check-input" type="checkbox" name="qrz" value="1" id="qrz" <?php if (($postdata['qrz'] ?? null) == 1) echo ' checked="checked"'; ?> >
                         <label class="form-check-label" for="qrz"><?= __("QRZ.com"); ?></label>
                     </div>
                     <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="clublog" value="1" id="clublog" <?php if ($this->input->post('clublog')) echo ' checked="checked"'; ?> >
+                        <input class="form-check-input" type="checkbox" name="clublog" value="1" id="clublog" <?php if (($postdata['clublog'] ?? null) == 1) echo ' checked="checked"'; ?> >
                         <label class="form-check-label" for="clublog"><?= __("Clublog"); ?></label>
                     </div>
                 </div>
@@ -76,7 +137,7 @@
                 <div class="col-md-2"><?= __("Deleted cities"); ?></div>
                 <div class="col-md-10">
                     <div class="form-check-inline">
-                        <input class="form-check-input" type="checkbox" name="includedeleted" value="1" id="includedeleted" <?php if ($this->input->post('includedeleted')) echo ' checked="checked"'; ?> >
+                        <input class="form-check-input" type="checkbox" name="includedeleted" value="1" id="includedeleted" <?php if (($postdata['includedeleted'] ?? null) == 1) echo ' checked="checked"'; ?> >
                         <label class="form-check-label" for="includedeleted"><?= __("Include deleted"); ?></label>
                     </div>
                 </div>
@@ -86,11 +147,13 @@
                 <label class="col-md-2 control-label" for="band2"><?= __("Band"); ?></label>
                 <div class="col-md-2">
                     <select id="band2" name="band" class="form-select form-select-sm">
-                        <option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("Every band"); ?></option>
-                        <?php foreach($worked_bands as $band) {
+                        <option value="All" <?php if (($postdata['band'] ?? 'All') == 'All') echo ' selected'; ?>><?= __("Every band"); ?></option>
+                        <?php foreach ($worked_bands as $band) {
                             echo '<option value="' . $band . '"';
-                            if ($this->input->post('band') == $band) echo ' selected';
-                            echo '>' . $band . '</option>'."\n";
+                            if (($postdata['band'] ?? 'All') == $band) {
+                                echo ' selected';
+                            }
+                            echo '>' . $band . '</option>' . "\n";
                         } ?>
                     </select>
                 </div>
@@ -99,22 +162,26 @@
             <div class="mb-3 row">
                 <label class="col-md-2 control-label" for="mode"><?= __("Mode"); ?></label>
                 <div class="col-md-2">
-                <select id="mode" name="mode" class="form-select form-select-sm">
-                    <option value="All" <?php if ($this->input->post('mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?>><?= __("All"); ?></option>
-                    <?php
-                    foreach($modes->result() as $mode){
-                        if ($mode->submode == null) {
-                            echo '<option value="' . $mode->mode . '"';
-                            if ($this->input->post('mode') == $mode->mode) echo ' selected';
-                            echo '>'. $mode->mode . '</option>'."\n";
-                        } else {
-                            echo '<option value="' . $mode->submode . '"';
-                            if ($this->input->post('mode') == $mode->submode) echo ' selected';
-                            echo '>' . $mode->submode . '</option>'."\n";
+                    <select id="mode" name="mode" class="form-select form-select-sm">
+                        <option value="All" <?php if (($postdata['mode'] ?? 'All') == 'All') echo ' selected'; ?>><?= __("All"); ?></option>
+                        <?php
+                        foreach ($modes->result() as $mode) {
+                            if ($mode->submode == null) {
+                                echo '<option value="' . $mode->mode . '"';
+                                if (($postdata['mode'] ?? 'All') == $mode->mode) {
+                                    echo ' selected';
+                                }
+                                echo '>' . $mode->mode . '</option>' . "\n";
+                            } else {
+                                echo '<option value="' . $mode->submode . '"';
+                                if (($postdata['mode'] ?? 'All') == $mode->submode) {
+                                    echo ' selected';
+                                }
+                                echo '>' . $mode->submode . '</option>' . "\n";
+                            }
                         }
-                    }
-                    ?>
-                </select>
+                        ?>
+                    </select>
                 </div>
             </div>
 
@@ -123,133 +190,116 @@
                 <div class="col-md-10">
                     <button id="button2id" type="reset" name="button2id" class="btn btn-sm btn-warning"><?= __("Reset"); ?></button>
                     <button id="button1id" type="submit" name="button1id" class="btn btn-sm btn-primary"><?= __("Show"); ?></button>
-                    <?php if ($jcc_array) {?>
                     <button type="button" onclick="load_jcc_map();" class="btn btn-info btn-sm"><i class="fas fa-globe-asia"></i> <?= __("Show JCC Map"); ?></button>
-					<button id="button3id" type="button" onclick="export_qsos();" name="button3id" class="btn btn-sm btn-info"><?= __("Export confirmed QSOs"); ?></button>
-                    <?php } ?>
+                    <button id="button3id" type="button" onclick="export_qsos();" name="button3id" class="btn btn-sm btn-info"<?php echo !$has_active_slots ? ' disabled' : ''; ?>><?= __("Export confirmed QSOs"); ?></button>
                 </div>
             </div>
-
         </fieldset>
     </form>
 
-    <ul class="nav nav-tabs" id="myTab" role="tablist">
-        <li class="nav-item">
-            <a class="nav-link active" id="table-tab" data-bs-toggle="tab" href="#table" role="tab" aria-controls="table" aria-selected="true"><?= __("Results"); ?></a>
+    <ul class="nav nav-tabs" id="jcc-tabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="jcc-results-tab" data-bs-toggle="tab" data-bs-target="#jcc-results" type="button" role="tab" aria-controls="jcc-results" aria-selected="true"><?= __("Results"); ?></button>
         </li>
-        <li class="nav-item">
-            <a class="nav-link" onclick="load_jcc_map();" id="map-tab" data-bs-toggle="tab" href="#jccmaptab" role="tab" aria-controls="home" aria-selected="false"><?= __("Map"); ?></a>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="jcc-map-tab" data-bs-toggle="tab" data-bs-target="#jcc-map-panel" type="button" role="tab" aria-controls="jcc-map-panel" aria-selected="false" onclick="load_jcc_map();"><?= __("Map"); ?></button>
         </li>
     </ul>
-    <br />
 
-    <div class="tab-content" id="myTabContent">
-        <div class="tab-pane fade" id="jccmaptab" role="tabpanel" aria-labelledby="home-tab">
-    <br />
+    <div class="tab-content" id="jcc-tab-content">
+        <div class="tab-pane fade show active" id="jcc-results" role="tabpanel" aria-labelledby="jcc-results-tab">
+            <div class="mt-4">
+                <div class="border rounded px-3 py-2 mb-3">
+                    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-start align-items-xl-center gap-3">
+                        <div class="d-flex flex-wrap align-items-center gap-3 gap-xl-4">
+                            <div class="d-inline-flex align-items-baseline gap-2">
+                                <span class="small text-body-secondary"><?= __("Confirmed"); ?></span>
+                                <span class="fs-5 fw-bold text-success"><?php echo $jcc_summary['confirmed']; ?></span>
+                                <span class="small text-body-secondary"><?php echo number_format($jcc_summary['confirmed_percent'], 1); ?>%</span>
+                            </div>
+                            <div class="d-inline-flex align-items-baseline gap-2">
+                                <span class="small text-body-secondary"><?= __("Worked"); ?></span>
+                                <span class="fs-5 fw-bold text-danger"><?php echo $jcc_summary['worked']; ?></span>
+                                <span class="small text-body-secondary"><?php echo number_format($jcc_summary['worked_percent'], 1); ?>%</span>
+                            </div>
+                            <div class="d-inline-flex align-items-baseline gap-2">
+                                <span class="small text-body-secondary"><?= __("Total"); ?></span>
+                                <span class="fs-5 fw-bold"><?php echo $jcc_summary['total']; ?></span>
+                            </div>
+                            <?php if (($postdata['includedeleted'] ?? null) == 1) { ?>
+                                <div class="d-inline-flex align-items-baseline gap-2">
+                                    <span class="small text-body-secondary"><?= __("Deleted"); ?></span>
+                                    <span class="fs-5 fw-bold text-body-secondary"><?php echo $jcc_summary['deleted']; ?></span>
+                                </div>
+                            <?php } ?>
+                        </div>
 
-    <div id="jccmap" class="map-leaflet" ></div>
+                        <div class="d-flex flex-wrap align-items-center gap-3 small text-body-secondary justify-content-xl-end flex-shrink-0">
+                            <div class="d-inline-flex align-items-center gap-2">
+                                <span class="award-grid-legend-swatch rounded border border-success text-bg-success"></span>
+                                <span><?= __("Confirmed"); ?></span>
+                            </div>
+                            <div class="d-inline-flex align-items-center gap-2">
+                                <span class="award-grid-legend-swatch rounded border border-danger text-bg-danger"></span>
+                                <span><?= __("Worked not confirmed"); ?></span>
+                            </div>
+                            <div class="d-inline-flex align-items-center gap-2">
+                                <span class="award-grid-legend-swatch rounded border text-bg-light"></span>
+                                <span><?= __("Not worked"); ?></span>
+                            </div>
+                            <?php if (($postdata['includedeleted'] ?? null) == 1) { ?>
+                                <div class="d-inline-flex align-items-center gap-2">
+                                    <span class="award-grid-legend-swatch award-grid-legend-swatch-deleted rounded border text-bg-light"></span>
+                                    <span><?= __("Deleted"); ?></span>
+                                </div>
+                            <?php } ?>
+                        </div>
+                    </div>
 
-    </div>
-
-        <div class="tab-pane fade show active" id="table" role="tabpanel" aria-labelledby="table-tab">
-
-    <?php
-    $i = 1;
-    if ($jcc_array) {
-        echo '
-                <table id="jccTable" style="width:100%" class="table-sm table table-bordered table-hover table-striped table-condensed text-center">
-                    <thead>
-                    <tr>
-						<td>' . __("Number") . '</td>
-						<td>' . __("City") . '</td>';
-
-        foreach($bands as $band) {
-            echo '<td>' . $band . '</td>';
-        }
-        echo '</tr>
-                    </thead>
-                    <tbody>';
-        foreach ($jcc_array as $jcc => $value) {      // Fills the table with the data
-            echo '<tr>';
-            echo '<td style="text-align: center">' . $value['Number'] . '</td>';
-            echo '<td style="text-align: center">' . $value['City'] . '</td>';
-            foreach ($bands as $band) {
-				echo '<td style="text-align: center">' . awards_render_jcc_cell($jcc, $band, $value[$band], $postdata) . '</td>';
-            }
-            echo '</tr>';
-        }
-        echo '</table>
-        <h2>' . __("Summary") . '</h2>
-
-        <table class="table-sm tablesummary table table-bordered table-hover table-striped table-condensed text-center">';
-        $sat = 0;
-        if (in_array('SAT', $bands)) {
-           $sat = 1;
-        }
-
-        echo '<thead><tr>';
-        if (count($bands) > 1) {
-           echo '<td></td>';
-
-           foreach($bands as $band) {
-               if ($band != 'SAT') {
-                   echo '<td>' . $band . '</td>';
-               }
-           }
-           echo '<td><b>' . __("Total") . '</b></td>';
-           if ($sat == 1) {
-              echo '<td>' . __("SAT") . '</td>';
-           }
-        } else {
-           echo '<td></td><td><b>'.$bands[0].'</b></td>';
-        }
-        echo '</tr></thead>';
-        echo '<tbody>
-
-        <tr><td>' . __("Total worked") . '</td>';
-
-        if (count($bands) > 2) {
-           $len_worked = count($jcc_summary['worked']);
-           $j = 0;
-           foreach ($jcc_summary['worked'] as $jcc) {      // Fills the table with the data
-               if ($j == $len_worked - 1 - $sat) {
-                  echo '<td style="text-align: center"><b>' . $jcc . '</b></td>';
-               } else {
-                  echo '<td style="text-align: center">' . $jcc . '</td>';
-               }
-               $j++;
-           }
-        } else {
-           echo '<td style="text-align: center"><b>' . $jcc_summary['worked']['Total'] . '</b></td>';
-        }
-
-        echo '</tr><tr>';
-
-        echo '<td>' . __("Total confirmed") . '</td>';
-        if (count($bands) > 2) {
-           $len_confirmed = count($jcc_summary['confirmed']);
-           $j = 0;
-           foreach ($jcc_summary['confirmed'] as $jcc) {      // Fills the table with the data
-               if ($j == $len_confirmed - 1 - $sat) {
-                  echo '<td style="text-align: center"><b>' . $jcc . '</b></td>';
-               } else {
-                  echo '<td style="text-align: center">' . $jcc . '</td>';
-               }
-               $j++;
-           }
-        } else {
-           echo '<td style="text-align: center"><b>' . $jcc_summary['confirmed']['Total'] . '</b></td>';
-        }
-
-        echo '</tr>
-        </table>
-        </div>';
-
-    }
-    else {
-        echo '<div class="alert alert-danger" role="alert">' . __("Nothing found!") . '</div>';
-    }
-    ?>
+                    <div class="progress award-grid-progress mt-2" role="progressbar" aria-label="<?= __("JCC progress"); ?>" aria-valuenow="<?php echo (int) round($jcc_summary['worked_percent']); ?>" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress-bar bg-success" style="width: <?php echo $jcc_summary['confirmed_percent']; ?>%"></div>
+                        <?php if (($jcc_summary['worked_only_percent'] ?? 0) > 0) { ?>
+                            <div class="progress-bar bg-danger" style="width: <?php echo $jcc_summary['worked_only_percent']; ?>%"></div>
+                        <?php } ?>
+                    </div>
                 </div>
+
+                <?php if (($postdata['includedeleted'] ?? null) == 1) { ?>
+                    <div class="alert alert-warning" role="alert">
+                        <?= __("Attention! Wavelog does not verify whether a QSO happened before the entity deletion date."); ?>
+                    </div>
+                <?php } ?>
+
+                <?php if (!$has_active_slots) { ?>
+                    <div class="alert alert-danger" role="alert">
+                        <?= __("No worked or confirmed JCC slots match the current filters."); ?>
+                    </div>
+                <?php } ?>
+
+                <div class="border-top">
+                    <?php foreach ($jcc_groups as $group) { ?>
+                        <section class="d-flex flex-column flex-lg-row gap-3 py-3 border-bottom">
+                            <div class="award-grid-prefecture flex-shrink-0">
+                                <div class="d-flex align-items-center flex-wrap gap-2 mb-1">
+                                    <span class="fs-5 fw-bold"><?php echo $group['prefecture_code']; ?></span>
+                                    <span class="fw-bold"><?php echo $group['prefecture_name']; ?></span>
+                                </div>
+                            </div>
+                            <div class="award-grid-slots d-flex flex-wrap gap-2">
+                                <?php foreach ($group['slots'] as $slot) {
+                                    echo awards_render_jcc_grid_slot($slot, $postdata);
+                                } ?>
+                            </div>
+                        </section>
+                    <?php } ?>
+                </div>
+            </div>
         </div>
+
+        <div class="tab-pane fade" id="jcc-map-panel" role="tabpanel" aria-labelledby="jcc-map-tab">
+            <div class="mt-4">
+                <div id="jccmap" class="map-leaflet"></div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/application/views/awards/jcc/index.php
+++ b/application/views/awards/jcc/index.php
@@ -14,80 +14,23 @@
         display: inline-block;
     }
 
-    .award-grid-legend-swatch-deleted {
-        background-image: repeating-linear-gradient(135deg, rgba(0, 0, 0, 0.18) 0, rgba(0, 0, 0, 0.18) 2px, transparent 2px, transparent 6px);
-    }
-
     .award-grid-prefecture {
         min-width: 12rem;
-    }
-
-    .award-grid-slots {
-        align-content: flex-start;
-    }
-
-    .award-grid-slot {
-        --award-slot-hover-color: inherit;
-        --award-slot-hover-bg: transparent;
-        --award-slot-hover-border-color: currentColor;
-        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-secondary-rgb), 0.15);
-        width: 3rem;
-        height: 2rem;
-        padding: 0 0.5rem;
-        border-radius: 0.375rem;
-        font-size: 0.9rem;
-        line-height: 1;
-        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        .award-grid-slot {
-            transition: none;
-        }
-    }
-
-    .award-grid-slot:hover {
-        background-color: var(--award-slot-hover-bg) !important;
-        border-color: var(--award-slot-hover-border-color) !important;
-        text-decoration: none;
-        box-shadow: none;
-    }
-
-    .award-grid-slot:focus-visible {
-        outline: 0;
-        box-shadow: var(--award-slot-focus-shadow);
-    }
-
-    .award-grid-slot.text-bg-success {
-        --award-slot-hover-bg: color-mix(in srgb, var(--bs-success) 85%, black);
-        --award-slot-hover-border-color: color-mix(in srgb, var(--bs-success) 80%, black);
-        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
-    }
-
-    .award-grid-slot.text-bg-danger {
-        --award-slot-hover-bg: color-mix(in srgb, var(--bs-danger) 85%, black);
-        --award-slot-hover-border-color: color-mix(in srgb, var(--bs-danger) 80%, black);
-        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
-    }
-
-    .award-grid-slot.text-bg-light {
-        --award-slot-hover-bg: color-mix(in srgb, var(--bs-light) 85%, black);
-        --award-slot-hover-border-color: color-mix(in srgb, var(--bs-light) 80%, black);
-        --award-slot-focus-shadow: 0 0 0 0.25rem rgba(var(--bs-secondary-rgb), 0.15);
-    }
-
-    .award-grid-slot-deleted {
-        background-image: repeating-linear-gradient(135deg, rgba(0, 0, 0, 0.18) 0, rgba(0, 0, 0, 0.18) 2px, transparent 2px, transparent 6px);
-    }
-
-    .award-grid-progress {
-        height: 0.5rem;
     }
 
     @media (max-width: 991.98px) {
         .award-grid-prefecture {
             min-width: 0;
         }
+    }
+
+    .award-grid-slot {
+        width: 3rem;
+        height: 2rem;
+    }
+
+    .award-grid-slot-deleted {
+        background-image: repeating-linear-gradient(135deg, rgba(0, 0, 0, 0.18) 0, rgba(0, 0, 0, 0.18) 2px, transparent 2px, transparent 6px);
     }
 </style>
 
@@ -249,7 +192,7 @@
                             </div>
                             <?php if (($postdata['includedeleted'] ?? null) == 1) { ?>
                                 <div class="d-inline-flex align-items-center gap-2">
-                                    <span class="award-grid-legend-swatch award-grid-legend-swatch-deleted rounded border text-bg-light"></span>
+                                    <span class="award-grid-legend-swatch award-grid-slot-deleted rounded border text-bg-light"></span>
                                     <span><?= __("Deleted"); ?></span>
                                 </div>
                             <?php } ?>
@@ -282,10 +225,10 @@
                             <div class="award-grid-prefecture flex-shrink-0">
                                 <div class="d-flex align-items-center flex-wrap gap-2 mb-1">
                                     <span class="fs-5 fw-bold"><?php echo $group['prefecture_code']; ?></span>
-                                    <span class="fw-bold"><?php echo $group['prefecture_name']; ?></span>
+                                    <span><?php echo $group['prefecture_name']; ?></span>
                                 </div>
                             </div>
-                            <div class="award-grid-slots d-flex flex-wrap gap-2">
+                            <div class="d-flex flex-wrap gap-2">
                                 <?php foreach ($group['slots'] as $slot) {
                                     echo awards_render_jcc_grid_slot($slot, $postdata);
                                 } ?>

--- a/assets/js/sections/jcc.js
+++ b/assets/js/sections/jcc.js
@@ -1,22 +1,3 @@
-$(document).ready(function () {
-	$('#jccTable').DataTable({
-        "pageLength": 25,
-        responsive: false,
-        ordering: false,
-        "scrollY":        "400px",
-        "scrollCollapse": true,
-        "paging":         false,
-        "scrollX": true,
-        "language": {
-            url: getDataTablesLanguageUrl(),
-        },
-        dom: 'Bfrtip',
-        buttons: [
-            'csv'
-        ]
-    });
-});
-
 function export_qsos() {
    $.ajax({
        url: base_url + 'index.php/awards/jcc_export',
@@ -54,3 +35,11 @@ function export_qsos() {
        },
    });
 }
+
+$(document).ready(function() {
+   $('[data-bs-toggle="tooltip"]').tooltip({
+      html: true,
+      placement: 'top',
+      boundary: 'window'
+   });
+});

--- a/assets/js/sections/jccmap.js
+++ b/assets/js/sections/jccmap.js
@@ -13,16 +13,17 @@ if (typeof(user_map_custom.unworked) !== 'undefined') {
 }
 
 function load_jcc_map() {
-    $('.nav-tabs a[href="#jccmaptab"]').tab('show');
+    const map_tab = document.getElementById('jcc-map-tab');
+    if (map_tab && typeof bootstrap !== 'undefined') {
+        bootstrap.Tab.getOrCreateInstance(map_tab).show();
+    }
+
     $.ajax({
         url: base_url + 'index.php/awards/jcc_map',
         type: 'post',
         data: {
             band: $('#band2').val(),
             mode: $('#mode').val(),
-            worked: +$('#worked').prop('checked'),
-            confirmed: +$('#confirmed').prop('checked'),
-            notworked: +$('#notworked').prop('checked'),
             qsl: +$('#qsl').prop('checked'),
             lotw: +$('#lotw').prop('checked'),
             qrz: +$('#qrz').prop('checked'),
@@ -31,7 +32,7 @@ function load_jcc_map() {
 			includedeleted: +$('#includedeleted').prop('checked'),
         },
         success: function(data) {
-            load_jcc_map2(data, worked, confirmed, notworked);
+			load_jcc_map2(data);
         },
         error: function() {
 
@@ -39,7 +40,8 @@ function load_jcc_map() {
     });
 }
 
-function load_jcc_map2(data, worked, confirmed, notworked) {
+function load_jcc_map2(data) {
+	const include_deleted = $('#includedeleted').prop('checked');
 
     // If map is already initialized
     var container = L.DomUtil.get('jccmap');
@@ -47,7 +49,7 @@ function load_jcc_map2(data, worked, confirmed, notworked) {
     if(container != null){
         container._leaflet_id = null;
         container.remove();
-        $("#jccmaptab").append('<div id="jccmap" class="map-leaflet" ></div>');
+        $("#jcc-map-panel").append('<div id="jccmap" class="map-leaflet" ></div>');
     }
 
     var map = new L.Map('jccmap', {
@@ -65,6 +67,10 @@ function load_jcc_map2(data, worked, confirmed, notworked) {
         }
     ).addTo(map);
 
+    const confirmed_layer = L.layerGroup().addTo(map);
+    const worked_layer = L.layerGroup().addTo(map);
+    const notworked_layer = L.layerGroup();
+
     var notworkedcount = 0;
     var confirmedcount = 0;
     var workednotconfirmedcount = 0;
@@ -76,6 +82,9 @@ function load_jcc_map2(data, worked, confirmed, notworked) {
        async: false,
        success: function(result) {
           for (var item in result) {
+             if (!include_deleted && result[item]['deleted']) {
+                continue;
+             }
              var name = item.toString();
              jccstuff[name] = [result[item]['name'], result[item]['lat'], result[item]['lon']];
           }
@@ -83,50 +92,54 @@ function load_jcc_map2(data, worked, confirmed, notworked) {
     });
     for (const [key, value] of Object.entries(jccstuff)) {
        var D = [];
+         let mapColor = null;
        if (key in data) {
-          if (confirmed.checked == true) {
-             if (data[key][1] == 1) {
-                mapColor = confirmedColor;
-                D['prefix'] = key;
-                D['name'] = value[0];
-                D['lat'] = value[1];
-                D['long'] = value[2];
-                addMarker(L, D, mapColor, map);
-                confirmedcount++;
-                continue;
-             }
-          }
-          if (worked.checked == true) {
-             mapColor = workedColor;
-             D['prefix'] = key;
-             D['name'] = value[0];
-             D['lat'] = value[1];
-             D['long'] = value[2];
-             addMarker(L, D, mapColor, map);
-             workednotconfirmedcount++;
-          }
+           if (data[key][1] == 1) {
+              mapColor = confirmedColor;
+              D['prefix'] = key;
+              D['name'] = value[0];
+              D['lat'] = value[1];
+              D['long'] = value[2];
+			  addMarker(L, D, mapColor, confirmed_layer);
+              confirmedcount++;
+              continue;
+           }
+
+           mapColor = workedColor;
+           D['prefix'] = key;
+           D['name'] = value[0];
+           D['lat'] = value[1];
+           D['long'] = value[2];
+           addMarker(L, D, mapColor, worked_layer);
+           workednotconfirmedcount++;
        } else {
-          if (notworked.checked == true) {
-             mapColor = unworkedColor;
-             D['prefix'] = key;
-             D['name'] = value[0];
-             D['lat'] = value[1];
-             D['long'] = value[2];
-             addMarker(L, D, mapColor, map);
-             notworkedcount++;
-          }
+           mapColor = unworkedColor;
+           D['prefix'] = key;
+           D['name'] = value[0];
+           D['lat'] = value[1];
+           D['long'] = value[2];
+           addMarker(L, D, mapColor, notworked_layer);
+           notworkedcount++;
        }
     };
 
-    /*Legend specific*/
-    var legend = L.control({ position: "topright" });
+    L.control.layers(null, {
+        [lang_general_word_confirmed + ' (' + confirmedcount + ')']: confirmed_layer,
+        [lang_general_word_worked_not_confirmed + ' (' + workednotconfirmedcount + ')']: worked_layer,
+        [lang_general_word_not_worked + ' (' + notworkedcount + ')']: notworked_layer,
+    }, {
+        collapsed: false,
+        position: 'topright',
+    }).addTo(map);
 
-    legend.onAdd = function(map) {
-        var div = L.DomUtil.create("div", "legend");
-        div.innerHTML += "<h4>" + lang_general_word_colors + "</h4>";
-        div.innerHTML += "<i style='background: " + confirmedColor + "'></i><span>" + lang_general_word_confirmed + " (" + confirmedcount + ")</span><br>";
-        div.innerHTML += "<i style='background: " + workedColor + "'></i><span>" + lang_general_word_worked_not_confirmed + " (" + workednotconfirmedcount + ")</span><br>";
-        div.innerHTML += "<i style='background: " + unworkedColor + "'></i><span>" + lang_general_word_not_worked + " (" + notworkedcount + ")</span><br>";
+    var legend = L.control({ position: 'bottomright' });
+
+    legend.onAdd = function() {
+        var div = L.DomUtil.create('div', 'legend');
+        div.innerHTML += '<h4>' + lang_general_word_colors + '</h4>';
+        div.innerHTML += "<i style='background: " + confirmedColor + "'></i><span>" + lang_general_word_confirmed + "</span><br>";
+        div.innerHTML += "<i style='background: " + workedColor + "'></i><span>" + lang_general_word_worked_not_confirmed + "</span><br>";
+        div.innerHTML += "<i style='background: " + unworkedColor + "'></i><span>" + lang_general_word_not_worked + "</span><br>";
         return div;
     };
 
@@ -135,7 +148,7 @@ function load_jcc_map2(data, worked, confirmed, notworked) {
     map.setView([37.460, 139.452], 5);
 }
 
-function addMarker(L, D, mapColor, map) {
+function addMarker(L, D, mapColor, layer) {
     var title = '<span><font style="color: ' +mapColor+ '; text-shadow: 1px 0 #fff, -1px 0 #fff, 0 1px #fff, 0 -1px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff;font-size: 14px; font-weight: 900;">' + D['prefix'] + '</font></span>';
     var myIcon = L.divIcon({className: 'my-div-icon', html: title});
 
@@ -163,7 +176,7 @@ function addMarker(L, D, mapColor, map) {
         prefix: D['prefix'],
         title: D['prefix'] + ' - ' + D['name'],
     }
-    ).addTo(map).on('click', onClick);
+    ).addTo(layer).on('click', onClick);
 
     L.marker(
         [D['lat'], D['long']], {
@@ -171,7 +184,7 @@ function addMarker(L, D, mapColor, map) {
             prefix: D['prefix'],
             title: D['prefix'] + ' - ' + D['name'],
         }
-        ).addTo(map).on('click', onClick);
+        ).addTo(layer).on('click', onClick);
 }
 
 function onClick(e) {

--- a/assets/json/japan_award/jcc_list.json
+++ b/assets/json/japan_award/jcc_list.json
@@ -5,7 +5,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.061936,
-    "lon": 141.3542924
+    "lon": 141.3542924,
+    "designated_city": true,
+    "designated_city_date": "1972-04-01"
   },
   "0102": {
     "name": "Asahikawa",
@@ -13,7 +15,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.7627501,
-    "lon": 142.3579263
+    "lon": 142.3579263,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0103": {
     "name": "Otaru",
@@ -21,7 +25,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.1906806,
-    "lon": 140.9946021
+    "lon": 140.9946021,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0104": {
     "name": "Hakodate",
@@ -29,7 +35,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 41.768793,
-    "lon": 140.729008
+    "lon": 140.729008,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0105": {
     "name": "Muroran",
@@ -37,7 +45,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.3152461,
-    "lon": 140.9740731
+    "lon": 140.9740731,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0106": {
     "name": "Kushiro",
@@ -45,7 +55,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.9906837,
-    "lon": 144.3820381
+    "lon": 144.3820381,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0107": {
     "name": "Obihiro",
@@ -53,7 +65,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.923809,
-    "lon": 143.1966324
+    "lon": 143.1966324,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0108": {
     "name": "Kitami",
@@ -61,7 +75,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.8029391,
-    "lon": 143.8946351
+    "lon": 143.8946351,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0109": {
     "name": "Yubari",
@@ -69,7 +85,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.0563455,
-    "lon": 141.9739081
+    "lon": 141.9739081,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0110": {
     "name": "Iwamizawa",
@@ -77,7 +95,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.1960638,
-    "lon": 141.7753595
+    "lon": 141.7753595,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0111": {
     "name": "Abashiri",
@@ -85,7 +105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 44.0206027,
-    "lon": 144.2732035
+    "lon": 144.2732035,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0112": {
     "name": "Rumoi",
@@ -93,7 +115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.941029,
-    "lon": 141.6368171
+    "lon": 141.6368171,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0113": {
     "name": "Tomakomai",
@@ -101,7 +125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.6340602,
-    "lon": 141.6055453
+    "lon": 141.6055453,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0114": {
     "name": "Wakkanai",
@@ -109,7 +135,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 45.4158108,
-    "lon": 141.6730309
+    "lon": 141.6730309,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0115": {
     "name": "Bibai",
@@ -117,7 +145,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.3325763,
-    "lon": 141.8537339
+    "lon": 141.8537339,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0116": {
     "name": "Ashibetsu",
@@ -125,7 +155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.518329,
-    "lon": 142.1898276
+    "lon": 142.1898276,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0117": {
     "name": "Ebetsu",
@@ -133,7 +165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.1037358,
-    "lon": 141.535894
+    "lon": 141.535894,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0118": {
     "name": "Akabira",
@@ -141,7 +175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.5578505,
-    "lon": 142.0440317
+    "lon": 142.0440317,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0119": {
     "name": "Mombetsu",
@@ -149,7 +185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 44.3565151,
-    "lon": 143.3545224
+    "lon": 143.3545224,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0120": {
     "name": "Shibetsu",
@@ -157,7 +195,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 44.1785114,
-    "lon": 142.4001645
+    "lon": 142.4001645,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0121": {
     "name": "Nayoro",
@@ -165,7 +205,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 44.3558063,
-    "lon": 142.4631619
+    "lon": 142.4631619,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0122": {
     "name": "Mikasa",
@@ -173,7 +215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2851844,
-    "lon": 139.6743413
+    "lon": 139.6743413,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0123": {
     "name": "Nemuro",
@@ -181,7 +225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.3301154,
-    "lon": 145.5829068
+    "lon": 145.5829068,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0124": {
     "name": "Chitose",
@@ -189,7 +235,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.8209335,
-    "lon": 141.6509612
+    "lon": 141.6509612,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0125": {
     "name": "Takikawa",
@@ -197,7 +245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.5577956,
-    "lon": 141.9103697
+    "lon": 141.9103697,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0126": {
     "name": "Sunagawa",
@@ -205,7 +255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.494928,
-    "lon": 141.9034816
+    "lon": 141.9034816,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0127": {
     "name": "Utashinai",
@@ -213,7 +265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.5213549,
-    "lon": 142.0345999
+    "lon": 142.0345999,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0128": {
     "name": "Fukagawa",
@@ -221,7 +275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.7234297,
-    "lon": 142.0540685
+    "lon": 142.0540685,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0129": {
     "name": "Furano",
@@ -229,7 +285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.3419744,
-    "lon": 142.383188
+    "lon": 142.383188,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0130": {
     "name": "Noboribetsu",
@@ -237,7 +295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.4127547,
-    "lon": 141.1064964
+    "lon": 141.1064964,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0131": {
     "name": "Eniwa",
@@ -245,15 +305,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.8827386,
-    "lon": 141.5775731
+    "lon": 141.5775731,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0132": {
     "name": "Kameda",
     "ja_name": "亀田",
     "deleted": true,
-    "deleted_date": "Nov.30,1973",
+    "deleted_date": "1973-11-30",
     "lat": 37.87718,
-    "lon": 139.108242
+    "lon": 139.108242,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0133": {
     "name": "Date",
@@ -261,7 +325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.4717601,
-    "lon": 140.8646839
+    "lon": 140.8646839,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0134": {
     "name": "Kitahiroshima",
@@ -269,7 +335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.9853877,
-    "lon": 141.5629536
+    "lon": 141.5629536,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0135": {
     "name": "Ishikari",
@@ -277,7 +345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.171677,
-    "lon": 141.3159605
+    "lon": 141.3159605,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0136": {
     "name": "Hokuto",
@@ -285,7 +355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 41.8240228,
-    "lon": 140.6529686
+    "lon": 140.6529686,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0201": {
     "name": "Aomori",
@@ -293,7 +365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.886943,
-    "lon": 140.590121
+    "lon": 140.590121,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0202": {
     "name": "Hirosaki",
@@ -301,7 +375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.6030543,
-    "lon": 140.4640389
+    "lon": 140.4640389,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0203": {
     "name": "Hachinohe",
@@ -309,7 +385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.5122388,
-    "lon": 141.4882959
+    "lon": 141.4882959,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0204": {
     "name": "Kuroishi",
@@ -317,7 +395,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.6423427,
-    "lon": 140.5951263
+    "lon": 140.5951263,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0205": {
     "name": "Goshogawara",
@@ -325,7 +405,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.8076098,
-    "lon": 140.4459462
+    "lon": 140.4459462,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0206": {
     "name": "Towada",
@@ -333,7 +415,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.6127405,
-    "lon": 141.206023
+    "lon": 141.206023,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0207": {
     "name": "Misawa",
@@ -341,7 +425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.6829377,
-    "lon": 141.3692113
+    "lon": 141.3692113,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0208": {
     "name": "Mutsu",
@@ -349,7 +435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 41.2928444,
-    "lon": 141.1831247
+    "lon": 141.1831247,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0209": {
     "name": "Tsugaru",
@@ -357,7 +445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.8087605,
-    "lon": 140.3803311
+    "lon": 140.3803311,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0210": {
     "name": "Hirakawa",
@@ -365,7 +455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.5837043,
-    "lon": 140.5671226
+    "lon": 140.5671226,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0301": {
     "name": "Morioka",
@@ -373,7 +465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.7021331,
-    "lon": 141.1545397
+    "lon": 141.1545397,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0302": {
     "name": "Kamaishi",
@@ -381,7 +475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.2757463,
-    "lon": 141.8858151
+    "lon": 141.8858151,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0303": {
     "name": "Miyako",
@@ -389,7 +485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.6395835,
-    "lon": 141.9461177
+    "lon": 141.9461177,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0304": {
     "name": "Ichinoseki",
@@ -397,7 +495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.9346961,
-    "lon": 141.126605
+    "lon": 141.126605,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0305": {
     "name": "Ofunato",
@@ -405,15 +505,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.0817727,
-    "lon": 141.7084037
+    "lon": 141.7084037,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0306": {
     "name": "Mizusawa",
     "ja_name": "水沢",
     "deleted": true,
-    "deleted_date": "Feb.19,2006",
+    "deleted_date": "2006-02-19",
     "lat": 39.1389814,
-    "lon": 141.1464938
+    "lon": 141.1464938,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0307": {
     "name": "Hanamaki",
@@ -421,7 +525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.3884038,
-    "lon": 141.1169618
+    "lon": 141.1169618,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0308": {
     "name": "Kitakami",
@@ -429,7 +535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.2866832,
-    "lon": 141.1135121
+    "lon": 141.1135121,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0309": {
     "name": "Kuji",
@@ -437,7 +545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.1904323,
-    "lon": 141.7756812
+    "lon": 141.7756812,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0310": {
     "name": "Tono",
@@ -445,7 +555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.3306091,
-    "lon": 141.5314591
+    "lon": 141.5314591,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0311": {
     "name": "Rikuzentakata",
@@ -453,15 +565,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.0204051,
-    "lon": 141.6331219
+    "lon": 141.6331219,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0312": {
     "name": "Esashi",
     "ja_name": "江刺",
     "deleted": true,
-    "deleted_date": "Feb.19,2006",
+    "deleted_date": "2006-02-19",
     "lat": 41.8690714,
-    "lon": 140.1272235
+    "lon": 140.1272235,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0313": {
     "name": "Ninohe",
@@ -469,7 +585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.2710819,
-    "lon": 141.304674
+    "lon": 141.304674,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0314": {
     "name": "Hachimantai",
@@ -477,7 +595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.9564706,
-    "lon": 141.0709451
+    "lon": 141.0709451,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0315": {
     "name": "Oshu",
@@ -485,7 +605,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.144275,
-    "lon": 141.1392382
+    "lon": 141.1392382,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0316": {
     "name": "Takizawa",
@@ -493,7 +615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.73477,
-    "lon": 141.0770901
+    "lon": 141.0770901,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0401": {
     "name": "Akita",
@@ -501,7 +625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.6898802,
-    "lon": 140.342608
+    "lon": 140.342608,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0402": {
     "name": "Noshiro",
@@ -509,7 +635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.2118417,
-    "lon": 140.0271517
+    "lon": 140.0271517,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0403": {
     "name": "Odate",
@@ -517,7 +645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.2716953,
-    "lon": 140.5652404
+    "lon": 140.5652404,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0404": {
     "name": "Yokote",
@@ -525,15 +655,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.3137847,
-    "lon": 140.5667433
+    "lon": 140.5667433,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0405": {
     "name": "Honjo",
     "ja_name": "本荘",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 36.2435937,
-    "lon": 139.1916278
+    "lon": 139.1916278,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0406": {
     "name": "Oga",
@@ -541,7 +675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.8866202,
-    "lon": 139.8473949
+    "lon": 139.8473949,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0407": {
     "name": "Yuzawa",
@@ -549,15 +685,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.1643018,
-    "lon": 140.4957467
+    "lon": 140.4957467,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0408": {
     "name": "Omagari",
     "ja_name": "大曲",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 39.4656823,
-    "lon": 140.479891
+    "lon": 140.479891,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0409": {
     "name": "Kazuno",
@@ -565,7 +705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.2157445,
-    "lon": 140.7882193
+    "lon": 140.7882193,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0410": {
     "name": "Yurihonjo",
@@ -573,7 +715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.3858771,
-    "lon": 140.0487402
+    "lon": 140.0487402,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0411": {
     "name": "Katagami",
@@ -581,7 +725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.8572974,
-    "lon": 140.0132252
+    "lon": 140.0132252,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0412": {
     "name": "Daisen",
@@ -589,7 +735,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.4530067,
-    "lon": 140.4757635
+    "lon": 140.4757635,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0413": {
     "name": "Kitaakita",
@@ -597,7 +745,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 40.2259431,
-    "lon": 140.3709149
+    "lon": 140.3709149,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0414": {
     "name": "Nikaho",
@@ -605,7 +755,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.2028587,
-    "lon": 139.9076665
+    "lon": 139.9076665,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0415": {
     "name": "Senboku",
@@ -613,7 +765,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 39.7000816,
-    "lon": 140.730767
+    "lon": 140.730767,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0501": {
     "name": "Yamagata",
@@ -621,7 +775,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.4746705,
-    "lon": 140.083237
+    "lon": 140.083237,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0502": {
     "name": "Yonezawa",
@@ -629,7 +785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.9222426,
-    "lon": 140.1166276
+    "lon": 140.1166276,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0503": {
     "name": "Tsuruoka",
@@ -637,7 +795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.7272187,
-    "lon": 139.8266292
+    "lon": 139.8266292,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0504": {
     "name": "Sakata",
@@ -645,7 +805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.9147229,
-    "lon": 139.8364101
+    "lon": 139.8364101,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0505": {
     "name": "Shinjo",
@@ -653,7 +815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.7648577,
-    "lon": 140.3021449
+    "lon": 140.3021449,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0506": {
     "name": "Sagae",
@@ -661,7 +825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.3808731,
-    "lon": 140.2759709
+    "lon": 140.2759709,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0507": {
     "name": "Kaminoyama",
@@ -669,7 +835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.1494956,
-    "lon": 140.2677993
+    "lon": 140.2677993,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0508": {
     "name": "Murayama",
@@ -677,7 +845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.4836471,
-    "lon": 140.3808616
+    "lon": 140.3808616,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0509": {
     "name": "Nagai",
@@ -685,7 +855,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.1074816,
-    "lon": 140.0403265
+    "lon": 140.0403265,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0510": {
     "name": "Tendo",
@@ -693,7 +865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.3624343,
-    "lon": 140.3772634
+    "lon": 140.3772634,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0511": {
     "name": "Higashine",
@@ -701,7 +875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.4312437,
-    "lon": 140.391304
+    "lon": 140.391304,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0512": {
     "name": "Obanazawa",
@@ -709,7 +885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.6006499,
-    "lon": 140.406101
+    "lon": 140.406101,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0513": {
     "name": "Nan'yo",
@@ -717,7 +895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.055081,
-    "lon": 140.1481134
+    "lon": 140.1481134,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0601": {
     "name": "Sendai",
@@ -725,7 +905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.2677554,
-    "lon": 140.8691498
+    "lon": 140.8691498,
+    "designated_city": true,
+    "designated_city_date": "1989-04-01"
   },
   "0602": {
     "name": "Ishinomaki",
@@ -733,7 +915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.4341281,
-    "lon": 141.3028087
+    "lon": 141.3028087,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0603": {
     "name": "Shiogama",
@@ -741,15 +925,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.3143384,
-    "lon": 141.0218221
+    "lon": 141.0218221,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0604": {
     "name": "Furukawa",
     "ja_name": "古川",
     "deleted": true,
-    "deleted_date": "Mar.30,2006",
+    "deleted_date": "2006-03-30",
     "lat": 38.5705529,
-    "lon": 140.9679338
+    "lon": 140.9679338,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0605": {
     "name": "Kesennuma",
@@ -757,7 +945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.9080078,
-    "lon": 141.5698223
+    "lon": 141.5698223,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0606": {
     "name": "Shiroishi",
@@ -765,7 +955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.0023671,
-    "lon": 140.6200214
+    "lon": 140.6200214,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0607": {
     "name": "Natori",
@@ -773,7 +965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.171499,
-    "lon": 140.8917335
+    "lon": 140.8917335,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0608": {
     "name": "Kakuda",
@@ -781,7 +975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.9770215,
-    "lon": 140.7820521
+    "lon": 140.7820521,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0609": {
     "name": "Tagajo",
@@ -789,15 +985,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.2938132,
-    "lon": 141.0042642
+    "lon": 141.0042642,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0610": {
     "name": "Izumi",
     "ja_name": "泉",
     "deleted": true,
-    "deleted_date": "Feb.29,1988",
+    "deleted_date": "1988-02-29",
     "lat": 34.43108,
-    "lon": 135.474789
+    "lon": 135.474789,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0611": {
     "name": "Iwanuma",
@@ -805,7 +1005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.1042874,
-    "lon": 140.8701494
+    "lon": 140.8701494,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0612": {
     "name": "Tome",
@@ -813,7 +1015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.6918037,
-    "lon": 141.1877688
+    "lon": 141.1877688,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0613": {
     "name": "Kurihara",
@@ -821,7 +1025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.73313,
-    "lon": 141.02326
+    "lon": 141.02326,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0614": {
     "name": "Higashimatsushima",
@@ -829,7 +1035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.4263868,
-    "lon": 141.2110467
+    "lon": 141.2110467,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0615": {
     "name": "Osaki",
@@ -837,7 +1045,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.5770889,
-    "lon": 140.955454
+    "lon": 140.955454,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0616": {
     "name": "Tomiya",
@@ -845,7 +1055,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.3998594,
-    "lon": 140.8953466
+    "lon": 140.8953466,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0701": {
     "name": "Fukushima",
@@ -853,7 +1065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.38158,
-    "lon": 140.22199
+    "lon": 140.22199,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0702": {
     "name": "Aizuwakamatsu",
@@ -861,7 +1075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.48043,
-    "lon": 139.942135
+    "lon": 139.942135,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0703": {
     "name": "Koriyama",
@@ -869,15 +1085,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.404937,
-    "lon": 140.333381
+    "lon": 140.333381,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0704": {
     "name": "Taira",
     "ja_name": "平",
     "deleted": true,
-    "deleted_date": "Sep.30,1966",
+    "deleted_date": "1966-09-30",
     "lat": 32.8719111,
-    "lon": 130.3089447
+    "lon": 130.3089447,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0705": {
     "name": "Shirakawa",
@@ -885,15 +1105,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.1263397,
-    "lon": 140.2107192
+    "lon": 140.2107192,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0706": {
     "name": "Haramachi",
     "ja_name": "原町",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 35.7003037,
-    "lon": 139.7235922
+    "lon": 139.7235922,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0707": {
     "name": "Sukagawa",
@@ -901,7 +1125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.2867857,
-    "lon": 140.37293
+    "lon": 140.37293,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0708": {
     "name": "Kitakata",
@@ -909,23 +1135,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.6508057,
-    "lon": 139.8749387
+    "lon": 139.8749387,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0709": {
     "name": "Joban",
     "ja_name": "常磐",
     "deleted": true,
-    "deleted_date": "Sep.30,1966",
+    "deleted_date": "1966-09-30",
     "lat": 37.3787847,
-    "lon": 140.9664217
+    "lon": 140.9664217,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0710": {
     "name": "Iwaki",
     "ja_name": "磐城",
     "deleted": true,
-    "deleted_date": "Sep.30,1966",
+    "deleted_date": "1966-09-30",
     "lat": 37.0504227,
-    "lon": 140.8876338
+    "lon": 140.8876338,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0711": {
     "name": "Soma",
@@ -933,23 +1165,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.7966579,
-    "lon": 140.9195032
+    "lon": 140.9195032,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0712": {
     "name": "Uchigo",
     "ja_name": "内郷",
     "deleted": true,
-    "deleted_date": "Sep.30,1966",
+    "deleted_date": "1966-09-30",
     "lat": 37.0357154,
-    "lon": 140.8547969
+    "lon": 140.8547969,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0713": {
     "name": "Nakoso",
     "ja_name": "勿来",
     "deleted": true,
-    "deleted_date": "Sep.30,1966",
+    "deleted_date": "1966-09-30",
     "lat": 36.8839897,
-    "lon": 140.7868497
+    "lon": 140.7868497,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0714": {
     "name": "Nihonmatsu",
@@ -957,7 +1195,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.5850396,
-    "lon": 140.4313889
+    "lon": 140.4313889,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0715": {
     "name": "Iwaki",
@@ -965,15 +1205,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.0504227,
-    "lon": 140.8876338
+    "lon": 140.8876338,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0716": {
     "name": "Wakamatsu",
     "ja_name": "若松",
     "deleted": true,
-    "deleted_date": "Dec.31,1954",
+    "deleted_date": "1954-12-31",
     "lat": 33.9009962,
-    "lon": 130.8060685
+    "lon": 130.8060685,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0717": {
     "name": "Tamura",
@@ -981,7 +1225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.4405603,
-    "lon": 140.5764547
+    "lon": 140.5764547,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0718": {
     "name": "Minamisoma",
@@ -989,7 +1235,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.6421923,
-    "lon": 140.9572649
+    "lon": 140.9572649,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0719": {
     "name": "Date",
@@ -997,7 +1245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 42.4717601,
-    "lon": 140.8646839
+    "lon": 140.8646839,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0720": {
     "name": "Motomiya",
@@ -1005,7 +1255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.5141768,
-    "lon": 140.3994933
+    "lon": 140.3994933,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0801": {
     "name": "Niigata",
@@ -1013,7 +1265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.6452283,
-    "lon": 138.7669125
+    "lon": 138.7669125,
+    "designated_city": true,
+    "designated_city_date": "2007-04-01"
   },
   "0802": {
     "name": "Nagaoka",
@@ -1021,15 +1275,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.446996,
-    "lon": 138.8512199
+    "lon": 138.8512199,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0803": {
     "name": "Takada",
     "ja_name": "高田",
     "deleted": true,
-    "deleted_date": "Apr.28,1971",
+    "deleted_date": "1971-04-28",
     "lat": 34.5162814,
-    "lon": 135.7446939
+    "lon": 135.7446939,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0804": {
     "name": "Sanjo",
@@ -1037,7 +1295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.6361174,
-    "lon": 138.9613971
+    "lon": 138.9613971,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0805": {
     "name": "Kashiwazaki",
@@ -1045,7 +1305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.3719095,
-    "lon": 138.5591406
+    "lon": 138.5591406,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0806": {
     "name": "Shibata",
@@ -1053,15 +1315,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.9478881,
-    "lon": 139.3271831
+    "lon": 139.3271831,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0807": {
     "name": "Niitsu",
     "ja_name": "新津",
     "deleted": true,
-    "deleted_date": "Mar.20,2005",
+    "deleted_date": "2005-03-20",
     "lat": 37.8000262,
-    "lon": 139.1209935
+    "lon": 139.1209935,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0808": {
     "name": "Ojiya",
@@ -1069,7 +1335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.3142715,
-    "lon": 138.7951327
+    "lon": 138.7951327,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0809": {
     "name": "Kamo",
@@ -1077,7 +1345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.6661851,
-    "lon": 139.04018
+    "lon": 139.04018,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0810": {
     "name": "Tokamachi",
@@ -1085,7 +1355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.1276085,
-    "lon": 138.755504
+    "lon": 138.755504,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0811": {
     "name": "Mitsuke",
@@ -1093,7 +1365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.53145,
-    "lon": 138.9126572
+    "lon": 138.9126572,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0812": {
     "name": "Murakami",
@@ -1101,7 +1375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.3144518,
-    "lon": 139.5751176
+    "lon": 139.5751176,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0813": {
     "name": "Tsubame",
@@ -1109,23 +1385,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.6730751,
-    "lon": 138.8825389
+    "lon": 138.8825389,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0814": {
     "name": "Naoetsu",
     "ja_name": "直江津",
     "deleted": true,
-    "deleted_date": "Apr.28,1971",
+    "deleted_date": "1971-04-28",
     "lat": 37.170264,
-    "lon": 138.2422616
+    "lon": 138.2422616,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0815": {
     "name": "Tochio",
     "ja_name": "栃尾",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 35.532446,
-    "lon": 135.4364781
+    "lon": 135.4364781,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0816": {
     "name": "Itoigawa",
@@ -1133,15 +1415,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.0433062,
-    "lon": 137.8617531
+    "lon": 137.8617531,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0817": {
     "name": "Arai",
     "ja_name": "新井",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 34.7578437,
-    "lon": 134.7936014
+    "lon": 134.7936014,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0818": {
     "name": "Gosen",
@@ -1149,31 +1435,39 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.7444474,
-    "lon": 139.1826005
+    "lon": 139.1826005,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0819": {
     "name": "Ryotsu",
     "ja_name": "両津",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 38.0810217,
-    "lon": 138.4374641
+    "lon": 138.4374641,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0820": {
     "name": "Shirone",
     "ja_name": "白根",
     "deleted": true,
-    "deleted_date": "Mar.20,2005",
+    "deleted_date": "2005-03-20",
     "lat": 37.776335,
-    "lon": 139.0245333
+    "lon": 139.0245333,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0821": {
     "name": "Toyosaka",
     "ja_name": "豊栄",
     "deleted": true,
-    "deleted_date": "Mar.20,2005",
+    "deleted_date": "2005-03-20",
     "lat": 37.9197443,
-    "lon": 139.2156646
+    "lon": 139.2156646,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0822": {
     "name": "Joetsu",
@@ -1181,7 +1475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.1478816,
-    "lon": 138.2359501
+    "lon": 138.2359501,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0823": {
     "name": "Agano",
@@ -1189,7 +1485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.8343618,
-    "lon": 139.2258539
+    "lon": 139.2258539,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0824": {
     "name": "Sado",
@@ -1197,7 +1495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.0182578,
-    "lon": 138.3683995
+    "lon": 138.3683995,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0825": {
     "name": "Uonuma",
@@ -1205,7 +1505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.2303274,
-    "lon": 138.9611531
+    "lon": 138.9611531,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0826": {
     "name": "Minamiuonuma",
@@ -1213,7 +1515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.0655723,
-    "lon": 138.8760989
+    "lon": 138.8760989,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0827": {
     "name": "Myoko",
@@ -1221,7 +1525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.0252467,
-    "lon": 138.253635
+    "lon": 138.253635,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0828": {
     "name": "Tainai",
@@ -1229,7 +1535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.0596893,
-    "lon": 139.4102658
+    "lon": 139.4102658,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0901": {
     "name": "Nagano",
@@ -1237,7 +1545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1143945,
-    "lon": 138.0319015
+    "lon": 138.0319015,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0902": {
     "name": "Matsumoto",
@@ -1245,7 +1555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2382047,
-    "lon": 137.9687141
+    "lon": 137.9687141,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0903": {
     "name": "Ueda",
@@ -1253,7 +1565,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.4021192,
-    "lon": 138.2490506
+    "lon": 138.2490506,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0904": {
     "name": "Okaya",
@@ -1261,7 +1575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.07853,
-    "lon": 138.049549
+    "lon": 138.049549,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0905": {
     "name": "Iida",
@@ -1269,7 +1585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5147101,
-    "lon": 137.8219519
+    "lon": 137.8219519,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0906": {
     "name": "Suwa",
@@ -1277,7 +1595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.03209,
-    "lon": 138.114118
+    "lon": 138.114118,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0907": {
     "name": "Suzaka",
@@ -1285,7 +1605,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.6510923,
-    "lon": 138.3071289
+    "lon": 138.3071289,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0908": {
     "name": "Komoro",
@@ -1293,7 +1615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3272526,
-    "lon": 138.4259718
+    "lon": 138.4259718,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0909": {
     "name": "Ina",
@@ -1301,7 +1625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.830452,
-    "lon": 137.954916
+    "lon": 137.954916,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0910": {
     "name": "Komagane",
@@ -1309,7 +1635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7296709,
-    "lon": 137.9389254
+    "lon": 137.9389254,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0911": {
     "name": "Nakano",
@@ -1317,7 +1645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.718123,
-    "lon": 139.664468
+    "lon": 139.664468,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0912": {
     "name": "Omachi",
@@ -1325,7 +1655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5029093,
-    "lon": 137.8508885
+    "lon": 137.8508885,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0913": {
     "name": "Iiyama",
@@ -1333,7 +1665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.8517629,
-    "lon": 138.3654364
+    "lon": 138.3654364,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0914": {
     "name": "Chino",
@@ -1341,7 +1675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.02598,
-    "lon": 138.24379
+    "lon": 138.24379,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0915": {
     "name": "Shiojiri",
@@ -1349,23 +1685,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.124957,
-    "lon": 137.952801
+    "lon": 137.952801,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0916": {
     "name": "Shinonoi",
     "ja_name": "篠ノ井",
     "deleted": true,
-    "deleted_date": "Oct.15,1966",
+    "deleted_date": "1966-10-15",
     "lat": 36.5774099,
-    "lon": 138.1382288
+    "lon": 138.1382288,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0917": {
     "name": "Koshoku",
     "ja_name": "更埴",
     "deleted": true,
-    "deleted_date": "Aug.31,2003",
+    "deleted_date": "2003-08-31",
     "lat": 36.5179021,
-    "lon": 138.0954697
+    "lon": 138.0954697,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0918": {
     "name": "Saku",
@@ -1373,7 +1715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2488014,
-    "lon": 138.4767695
+    "lon": 138.4767695,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0919": {
     "name": "Chikuma",
@@ -1381,7 +1725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5336984,
-    "lon": 138.120123
+    "lon": 138.120123,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0920": {
     "name": "Toumi",
@@ -1389,7 +1735,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3594225,
-    "lon": 138.3305353
+    "lon": 138.3305353,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "0921": {
     "name": "Azumino",
@@ -1397,15 +1745,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3044083,
-    "lon": 137.9054972
+    "lon": 137.9054972,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1001": {
     "name": "Tokyo 23-wards",
     "ja_name": "東京23区",
     "deleted": true,
-    "deleted_date": "Mar.31,2010",
+    "deleted_date": "2010-03-31",
     "lat": 35.6821936,
-    "lon": 139.762221
+    "lon": 139.762221,
+    "designated_city": true,
+    "designated_city_date": "1947-05-03"
   },
   "100101": {
     "name": "Chiyoda",
@@ -1413,7 +1765,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6938097,
-    "lon": 139.7532163
+    "lon": 139.7532163,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100102": {
     "name": "Chuo",
@@ -1421,7 +1775,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.666255,
-    "lon": 139.775565
+    "lon": 139.775565,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100103": {
     "name": "Minato",
@@ -1429,7 +1785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6432274,
-    "lon": 139.7400553
+    "lon": 139.7400553,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100104": {
     "name": "Shinjuku",
@@ -1437,7 +1795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6937632,
-    "lon": 139.7036319
+    "lon": 139.7036319,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100105": {
     "name": "Bunkyo",
@@ -1445,7 +1805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.71881,
-    "lon": 139.744732
+    "lon": 139.744732,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100106": {
     "name": "Taito",
@@ -1453,7 +1815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.71745,
-    "lon": 139.790859
+    "lon": 139.790859,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100107": {
     "name": "Sumida",
@@ -1461,7 +1825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7003789,
-    "lon": 139.8058673
+    "lon": 139.8058673,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100108": {
     "name": "Koto",
@@ -1469,7 +1835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6727747,
-    "lon": 139.8169621
+    "lon": 139.8169621,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100109": {
     "name": "Shinagawa",
@@ -1477,7 +1845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.599252,
-    "lon": 139.73891
+    "lon": 139.73891,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100110": {
     "name": "Meguro",
@@ -1485,7 +1855,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.62125,
-    "lon": 139.688014
+    "lon": 139.688014,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100111": {
     "name": "Ota",
@@ -1493,7 +1865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.561206,
-    "lon": 139.715843
+    "lon": 139.715843,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100112": {
     "name": "Setagaya",
@@ -1501,7 +1875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.646096,
-    "lon": 139.65627
+    "lon": 139.65627,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100113": {
     "name": "Shibuya",
@@ -1509,7 +1885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6645956,
-    "lon": 139.6987107
+    "lon": 139.6987107,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100114": {
     "name": "Nakano",
@@ -1517,7 +1895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.718123,
-    "lon": 139.664468
+    "lon": 139.664468,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100115": {
     "name": "Suginami",
@@ -1525,7 +1905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6994929,
-    "lon": 139.6362876
+    "lon": 139.6362876,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100116": {
     "name": "Toshima",
@@ -1533,7 +1915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.736156,
-    "lon": 139.714222
+    "lon": 139.714222,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100117": {
     "name": "Kita",
@@ -1541,7 +1925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.755838,
-    "lon": 139.736687
+    "lon": 139.736687,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100118": {
     "name": "Arakawa",
@@ -1549,7 +1935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.737529,
-    "lon": 139.78131
+    "lon": 139.78131,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100119": {
     "name": "Itabashi",
@@ -1557,7 +1945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.774143,
-    "lon": 139.681209
+    "lon": 139.681209,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100120": {
     "name": "Nerima",
@@ -1565,7 +1955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.74836,
-    "lon": 139.638735
+    "lon": 139.638735,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100121": {
     "name": "Adachi",
@@ -1573,7 +1965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.783703,
-    "lon": 139.795319
+    "lon": 139.795319,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100122": {
     "name": "Katsushika",
@@ -1581,7 +1975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.751733,
-    "lon": 139.863816
+    "lon": 139.863816,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "100123": {
     "name": "Edogawa",
@@ -1589,7 +1985,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.678278,
-    "lon": 139.871091
+    "lon": 139.871091,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1002": {
     "name": "Hachioji",
@@ -1597,7 +1995,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.655389,
-    "lon": 139.3394669
+    "lon": 139.3394669,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1003": {
     "name": "Tachikawa",
@@ -1605,7 +2005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.724463,
-    "lon": 139.404766
+    "lon": 139.404766,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1004": {
     "name": "Musashino",
@@ -1613,7 +2015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.712898,
-    "lon": 139.563534
+    "lon": 139.563534,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1005": {
     "name": "Mitaka",
@@ -1621,7 +2025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.685227,
-    "lon": 139.572916
+    "lon": 139.572916,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1006": {
     "name": "Ome",
@@ -1629,7 +2035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.803601,
-    "lon": 139.238128
+    "lon": 139.238128,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1007": {
     "name": "Fuchu",
@@ -1637,7 +2045,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5683141,
-    "lon": 133.2366327
+    "lon": 133.2366327,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1008": {
     "name": "Akishima",
@@ -1645,7 +2055,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.70248,
-    "lon": 139.350065
+    "lon": 139.350065,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1009": {
     "name": "Chofu",
@@ -1653,7 +2065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.660036,
-    "lon": 139.554815
+    "lon": 139.554815,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1010": {
     "name": "Machida",
@@ -1661,7 +2075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.564193,
-    "lon": 139.442839
+    "lon": 139.442839,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1011": {
     "name": "Koganei",
@@ -1669,7 +2085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7041083,
-    "lon": 139.5106759
+    "lon": 139.5106759,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1012": {
     "name": "Kodaira",
@@ -1677,7 +2095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.72522,
-    "lon": 139.476606
+    "lon": 139.476606,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1013": {
     "name": "Hino",
@@ -1685,7 +2105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.66314,
-    "lon": 139.39859
+    "lon": 139.39859,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1014": {
     "name": "Higashimurayama",
@@ -1693,7 +2115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.768929,
-    "lon": 139.484539
+    "lon": 139.484539,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1015": {
     "name": "Kokubunji",
@@ -1701,7 +2125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.709674,
-    "lon": 139.454224
+    "lon": 139.454224,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1016": {
     "name": "Kunitachi",
@@ -1709,23 +2135,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.681991,
-    "lon": 139.43624
+    "lon": 139.43624,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1017": {
     "name": "Hoya",
     "ja_name": "保谷",
     "deleted": true,
-    "deleted_date": "Jan.20,2001",
+    "deleted_date": "2001-01-20",
     "lat": 36.37353,
-    "lon": 138.1969
+    "lon": 138.1969,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1018": {
     "name": "Tanashi",
     "ja_name": "田無",
     "deleted": true,
-    "deleted_date": "Jan.20,2001",
+    "deleted_date": "2001-01-20",
     "lat": 35.7273146,
-    "lon": 139.5394387
+    "lon": 139.5394387,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1019": {
     "name": "Fussa",
@@ -1733,7 +2165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7423308,
-    "lon": 139.3278791
+    "lon": 139.3278791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1020": {
     "name": "Komae",
@@ -1741,7 +2175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.634023,
-    "lon": 139.575977
+    "lon": 139.575977,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1021": {
     "name": "Higashiyamato",
@@ -1749,7 +2185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.740869,
-    "lon": 139.428831
+    "lon": 139.428831,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1022": {
     "name": "Kiyose",
@@ -1757,7 +2195,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.785483,
-    "lon": 139.531253
+    "lon": 139.531253,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1023": {
     "name": "Higashikurume",
@@ -1765,7 +2205,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.752546,
-    "lon": 139.519089
+    "lon": 139.519089,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1024": {
     "name": "Musashimurayama",
@@ -1773,7 +2215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.756509,
-    "lon": 139.385637
+    "lon": 139.385637,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1025": {
     "name": "Tama",
@@ -1781,7 +2225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.63098,
-    "lon": 139.43983
+    "lon": 139.43983,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1026": {
     "name": "Inagi",
@@ -1789,15 +2235,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.638229,
-    "lon": 139.507776
+    "lon": 139.507776,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1027": {
     "name": "Akigawa",
     "ja_name": "秋川",
     "deleted": true,
-    "deleted_date": "Aug.31,1995",
+    "deleted_date": "1995-08-31",
     "lat": 35.728075,
-    "lon": 139.2866763
+    "lon": 139.2866763,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1028": {
     "name": "Hamura",
@@ -1805,7 +2255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.764833,
-    "lon": 139.307862
+    "lon": 139.307862,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1029": {
     "name": "Akiruno",
@@ -1813,7 +2265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.731042,
-    "lon": 139.217028
+    "lon": 139.217028,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1030": {
     "name": "Nishitokyo",
@@ -1821,7 +2275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.73546,
-    "lon": 139.550228
+    "lon": 139.550228,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1101": {
     "name": "Yokohama",
@@ -1829,7 +2285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4443947,
-    "lon": 139.6367727
+    "lon": 139.6367727,
+    "designated_city": true,
+    "designated_city_date": "1956-09-01"
   },
   "1102": {
     "name": "Yokosuka",
@@ -1837,7 +2295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2730564,
-    "lon": 139.6653829
+    "lon": 139.6653829,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1103": {
     "name": "Kawasaki",
@@ -1845,7 +2305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5305307,
-    "lon": 139.7028012
+    "lon": 139.7028012,
+    "designated_city": true,
+    "designated_city_date": "1972-04-01"
   },
   "1104": {
     "name": "Hiratsuka",
@@ -1853,7 +2315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.357674,
-    "lon": 139.318278
+    "lon": 139.318278,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1105": {
     "name": "Kamakura",
@@ -1861,7 +2325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.329564,
-    "lon": 139.54442
+    "lon": 139.54442,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1106": {
     "name": "Fujisawa",
@@ -1869,7 +2335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.364842,
-    "lon": 139.465077
+    "lon": 139.465077,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1107": {
     "name": "Odawara",
@@ -1877,7 +2345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.263676,
-    "lon": 139.150229
+    "lon": 139.150229,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1108": {
     "name": "Chigasaki",
@@ -1885,7 +2355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.329479,
-    "lon": 139.405371
+    "lon": 139.405371,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1109": {
     "name": "Zushi",
@@ -1893,7 +2365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3040672,
-    "lon": 139.5838447
+    "lon": 139.5838447,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1110": {
     "name": "Sagamihara",
@@ -1901,7 +2375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.56559,
-    "lon": 139.236215
+    "lon": 139.236215,
+    "designated_city": true,
+    "designated_city_date": "2010-04-01"
   },
   "1111": {
     "name": "Miura",
@@ -1909,7 +2385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1550499,
-    "lon": 139.6406823
+    "lon": 139.6406823,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1112": {
     "name": "Hadano",
@@ -1917,7 +2395,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3746619,
-    "lon": 139.2420729
+    "lon": 139.2420729,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1113": {
     "name": "Atsugi",
@@ -1925,7 +2405,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4433894,
-    "lon": 139.3783891
+    "lon": 139.3783891,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1114": {
     "name": "Yamato",
@@ -1933,7 +2415,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.699616,
-    "lon": 131.049859
+    "lon": 131.049859,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1115": {
     "name": "Isehara",
@@ -1941,7 +2425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4023968,
-    "lon": 139.2996106
+    "lon": 139.2996106,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1116": {
     "name": "Ebina",
@@ -1949,7 +2435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4527491,
-    "lon": 139.3909319
+    "lon": 139.3909319,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1117": {
     "name": "Zama",
@@ -1957,7 +2445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4865288,
-    "lon": 139.3877657
+    "lon": 139.3877657,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1118": {
     "name": "Minamiashigara",
@@ -1965,7 +2455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3205738,
-    "lon": 139.0992405
+    "lon": 139.0992405,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1119": {
     "name": "Ayase",
@@ -1973,7 +2465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4460475,
-    "lon": 139.430823
+    "lon": 139.430823,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1201": {
     "name": "Chiba",
@@ -1981,7 +2475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.549399,
-    "lon": 140.2647303
+    "lon": 140.2647303,
+    "designated_city": true,
+    "designated_city_date": "1992-04-01"
   },
   "1202": {
     "name": "Choshi",
@@ -1989,7 +2485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7345338,
-    "lon": 140.8272667
+    "lon": 140.8272667,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1203": {
     "name": "Ichikawa",
@@ -1997,7 +2495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.729412,
-    "lon": 139.928568
+    "lon": 139.928568,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1204": {
     "name": "Funabashi",
@@ -2005,7 +2505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.699997,
-    "lon": 139.988668
+    "lon": 139.988668,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1205": {
     "name": "Tateyama",
@@ -2013,7 +2515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9965304,
-    "lon": 139.8699838
+    "lon": 139.8699838,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1206": {
     "name": "Kisarazu",
@@ -2021,7 +2525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3810808,
-    "lon": 139.9247334
+    "lon": 139.9247334,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1207": {
     "name": "Matsudo",
@@ -2029,7 +2535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7879371,
-    "lon": 139.903177
+    "lon": 139.903177,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1208": {
     "name": "Noda",
@@ -2037,15 +2545,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9549076,
-    "lon": 139.8748667
+    "lon": 139.8748667,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1209": {
     "name": "Sawara",
     "ja_name": "佐原",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 35.8945456,
-    "lon": 140.4940774
+    "lon": 140.4940774,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1210": {
     "name": "Mobara",
@@ -2053,7 +2565,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4285094,
-    "lon": 140.2880753
+    "lon": 140.2880753,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1211": {
     "name": "Narita",
@@ -2061,7 +2575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7767683,
-    "lon": 140.3183376
+    "lon": 140.3183376,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1212": {
     "name": "Sakura",
@@ -2069,7 +2585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7234619,
-    "lon": 140.2240158
+    "lon": 140.2240158,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1213": {
     "name": "Togane",
@@ -2077,15 +2595,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5600309,
-    "lon": 140.3662589
+    "lon": 140.3662589,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1214": {
     "name": "Yokaichiba",
     "ja_name": "八日市場",
     "deleted": true,
-    "deleted_date": "Jan.22,2006",
+    "deleted_date": "2006-01-22",
     "lat": 35.6992256,
-    "lon": 140.5520936
+    "lon": 140.5520936,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1215": {
     "name": "Asahi",
@@ -2093,7 +2615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7204126,
-    "lon": 140.6464527
+    "lon": 140.6464527,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1216": {
     "name": "Narashino",
@@ -2101,7 +2625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.670572,
-    "lon": 140.018956
+    "lon": 140.018956,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1217": {
     "name": "Kashiwa",
@@ -2109,7 +2635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8676218,
-    "lon": 139.9756876
+    "lon": 139.9756876,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1218": {
     "name": "Katsuura",
@@ -2117,7 +2645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1521846,
-    "lon": 140.3207449
+    "lon": 140.3207449,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1219": {
     "name": "Ichihara",
@@ -2125,7 +2655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.497775,
-    "lon": 140.1156996
+    "lon": 140.1156996,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1220": {
     "name": "Nagareyama",
@@ -2133,7 +2665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8562314,
-    "lon": 139.9026259
+    "lon": 139.9026259,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1221": {
     "name": "Yachiyo",
@@ -2141,7 +2675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.722537,
-    "lon": 140.0995131
+    "lon": 140.0995131,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1222": {
     "name": "Abiko",
@@ -2149,7 +2685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.863999,
-    "lon": 140.0280653
+    "lon": 140.0280653,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1223": {
     "name": "Kamogawa",
@@ -2157,7 +2695,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1140584,
-    "lon": 140.098692
+    "lon": 140.098692,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1224": {
     "name": "Kimitsu",
@@ -2165,7 +2705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3302375,
-    "lon": 139.902551
+    "lon": 139.902551,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1225": {
     "name": "Kamagaya",
@@ -2173,7 +2715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7766455,
-    "lon": 140.0007147
+    "lon": 140.0007147,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1226": {
     "name": "Futtu",
@@ -2181,7 +2725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.22665,
-    "lon": 139.89873
+    "lon": 139.89873,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1227": {
     "name": "Urayasu",
@@ -2189,7 +2735,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6530518,
-    "lon": 139.9018495
+    "lon": 139.9018495,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1228": {
     "name": "Yotsukaido",
@@ -2197,7 +2745,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6696551,
-    "lon": 140.1679445
+    "lon": 140.1679445,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1229": {
     "name": "Sodegaura",
@@ -2205,7 +2755,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4296688,
-    "lon": 139.9544661
+    "lon": 139.9544661,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1230": {
     "name": "Yachimata",
@@ -2213,7 +2765,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6658607,
-    "lon": 140.3178646
+    "lon": 140.3178646,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1231": {
     "name": "Inzai",
@@ -2221,7 +2775,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8322582,
-    "lon": 140.1452981
+    "lon": 140.1452981,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1232": {
     "name": "Shiroi",
@@ -2229,7 +2785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7914538,
-    "lon": 140.0560632
+    "lon": 140.0560632,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1233": {
     "name": "Tomisato",
@@ -2237,7 +2795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7268876,
-    "lon": 140.3430548
+    "lon": 140.3430548,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1234": {
     "name": "Minamiboso",
@@ -2245,7 +2805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0387486,
-    "lon": 139.8371399
+    "lon": 139.8371399,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1235": {
     "name": "Sosa",
@@ -2253,7 +2815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.70794,
-    "lon": 140.5645144
+    "lon": 140.5645144,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1236": {
     "name": "Katori",
@@ -2261,7 +2825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8978273,
-    "lon": 140.4992787
+    "lon": 140.4992787,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1237": {
     "name": "Sanmu",
@@ -2269,7 +2835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.484561,
-    "lon": 140.540184
+    "lon": 140.540184,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1238": {
     "name": "Isumi",
@@ -2277,7 +2845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2539394,
-    "lon": 140.3849461
+    "lon": 140.3849461,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1239": {
     "name": "Oamishirasato",
@@ -2285,15 +2855,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5216038,
-    "lon": 140.3208929
+    "lon": 140.3208929,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1301": {
     "name": "Urawa",
     "ja_name": "浦和",
     "deleted": true,
-    "deleted_date": "Apr.30,2001",
+    "deleted_date": "2001-04-30",
     "lat": 35.8589883,
-    "lon": 139.6571882
+    "lon": 139.6571882,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1302": {
     "name": "Kawagoe",
@@ -2301,7 +2875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9251145,
-    "lon": 139.4856927
+    "lon": 139.4856927,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1303": {
     "name": "Kumagaya",
@@ -2309,7 +2885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1472472,
-    "lon": 139.3886141
+    "lon": 139.3886141,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1304": {
     "name": "Kawaguchi",
@@ -2317,15 +2895,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8078228,
-    "lon": 139.7241054
+    "lon": 139.7241054,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1305": {
     "name": "Omiya",
     "ja_name": "大宮",
     "deleted": true,
-    "deleted_date": "Apr.30,2001",
+    "deleted_date": "2001-04-30",
     "lat": 35.9063869,
-    "lon": 139.6243304
+    "lon": 139.6243304,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1306": {
     "name": "Gyoda",
@@ -2333,7 +2915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1386052,
-    "lon": 139.4559001
+    "lon": 139.4559001,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1307": {
     "name": "Chichibu",
@@ -2341,7 +2925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9914509,
-    "lon": 139.0857612
+    "lon": 139.0857612,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1308": {
     "name": "Tokorozawa",
@@ -2349,7 +2935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7994271,
-    "lon": 139.4687478
+    "lon": 139.4687478,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1309": {
     "name": "Hanno",
@@ -2357,7 +2945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8556902,
-    "lon": 139.3276436
+    "lon": 139.3276436,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1310": {
     "name": "Kazo",
@@ -2365,7 +2955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1308572,
-    "lon": 139.603225
+    "lon": 139.603225,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1311": {
     "name": "Honjo",
@@ -2373,7 +2965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2435937,
-    "lon": 139.1916278
+    "lon": 139.1916278,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1312": {
     "name": "Higashimatsuyama",
@@ -2381,15 +2975,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0421523,
-    "lon": 139.399796
+    "lon": 139.399796,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1313": {
     "name": "Iwatsuki",
     "ja_name": "岩槻",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.9500131,
-    "lon": 139.6943932
+    "lon": 139.6943932,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1314": {
     "name": "Kasukabe",
@@ -2397,7 +2995,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9757957,
-    "lon": 139.752019
+    "lon": 139.752019,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1315": {
     "name": "Sayama",
@@ -2405,7 +3005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8528971,
-    "lon": 139.4122999
+    "lon": 139.4122999,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1316": {
     "name": "Hanyu",
@@ -2413,7 +3015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1724023,
-    "lon": 139.5484797
+    "lon": 139.5484797,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1317": {
     "name": "Konosu",
@@ -2421,7 +3025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0657583,
-    "lon": 139.5221055
+    "lon": 139.5221055,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1318": {
     "name": "Fukaya",
@@ -2429,7 +3035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1915583,
-    "lon": 139.2810987
+    "lon": 139.2810987,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1319": {
     "name": "Ageo",
@@ -2437,15 +3045,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9774082,
-    "lon": 139.5930504
+    "lon": 139.5930504,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1320": {
     "name": "Yono",
     "ja_name": "与野",
     "deleted": true,
-    "deleted_date": "Apr.30,2001",
+    "deleted_date": "2001-04-30",
     "lat": 35.8843981,
-    "lon": 139.6391522
+    "lon": 139.6391522,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1321": {
     "name": "Soka",
@@ -2453,7 +3065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8262233,
-    "lon": 139.8061784
+    "lon": 139.8061784,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1322": {
     "name": "Koshigaya",
@@ -2461,7 +3075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8903993,
-    "lon": 139.7908633
+    "lon": 139.7908633,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1323": {
     "name": "Warabi",
@@ -2469,7 +3085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8263705,
-    "lon": 139.6791302
+    "lon": 139.6791302,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1324": {
     "name": "Toda",
@@ -2477,7 +3095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8175874,
-    "lon": 139.6778944
+    "lon": 139.6778944,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1325": {
     "name": "Iruma",
@@ -2485,15 +3105,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8358142,
-    "lon": 139.3909293
+    "lon": 139.3909293,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1326": {
     "name": "Hatogaya",
     "ja_name": "鳩ヶ谷",
     "deleted": true,
-    "deleted_date": "Oct.10,2011",
+    "deleted_date": "2011-10-10",
     "lat": 35.8309021,
-    "lon": 139.7362167
+    "lon": 139.7362167,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1327": {
     "name": "Asaka",
@@ -2501,7 +3125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7970861,
-    "lon": 139.593733
+    "lon": 139.593733,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1328": {
     "name": "Shiki",
@@ -2509,7 +3135,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8373892,
-    "lon": 139.5795684
+    "lon": 139.5795684,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1329": {
     "name": "Wako",
@@ -2517,7 +3145,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7817053,
-    "lon": 139.6058692
+    "lon": 139.6058692,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1330": {
     "name": "Niiza",
@@ -2525,7 +3155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7931194,
-    "lon": 139.5657258
+    "lon": 139.5657258,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1331": {
     "name": "Okegawa",
@@ -2533,7 +3165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0028937,
-    "lon": 139.5583422
+    "lon": 139.5583422,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1332": {
     "name": "Kuki",
@@ -2541,7 +3175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0618828,
-    "lon": 139.6667081
+    "lon": 139.6667081,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1333": {
     "name": "Kitamoto",
@@ -2549,7 +3185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0268711,
-    "lon": 139.5301389
+    "lon": 139.5301389,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1334": {
     "name": "Yashio",
@@ -2557,15 +3195,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8226404,
-    "lon": 139.8386867
+    "lon": 139.8386867,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1335": {
     "name": "Kamifukuoka",
     "ja_name": "上福岡",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 35.870999,
-    "lon": 139.51
+    "lon": 139.51,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1336": {
     "name": "Fujimi",
@@ -2573,7 +3215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9083257,
-    "lon": 138.2026202
+    "lon": 138.2026202,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1337": {
     "name": "Misato",
@@ -2581,7 +3225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8289993,
-    "lon": 139.8726811
+    "lon": 139.8726811,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1338": {
     "name": "Hasuda",
@@ -2589,7 +3235,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.994092,
-    "lon": 139.6632547
+    "lon": 139.6632547,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1339": {
     "name": "Sakado",
@@ -2597,7 +3245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9572312,
-    "lon": 139.4029048
+    "lon": 139.4029048,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1340": {
     "name": "Satte",
@@ -2605,7 +3255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0778827,
-    "lon": 139.7254086
+    "lon": 139.7254086,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1341": {
     "name": "Tsurugashima",
@@ -2613,7 +3265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9346812,
-    "lon": 139.3929735
+    "lon": 139.3929735,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1342": {
     "name": "Hidaka",
@@ -2621,7 +3275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9077667,
-    "lon": 139.3390385
+    "lon": 139.3390385,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1343": {
     "name": "Yoshikawa",
@@ -2629,7 +3285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8962831,
-    "lon": 139.854504
+    "lon": 139.854504,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1344": {
     "name": "Saitama",
@@ -2637,7 +3295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9754168,
-    "lon": 139.4160114
+    "lon": 139.4160114,
+    "designated_city": true,
+    "designated_city_date": "2003-04-01"
   },
   "1345": {
     "name": "Fujimino",
@@ -2645,7 +3305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8794749,
-    "lon": 139.5195441
+    "lon": 139.5195441,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1346": {
     "name": "Shiraoka",
@@ -2653,7 +3315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0186181,
-    "lon": 139.677099
+    "lon": 139.677099,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1401": {
     "name": "Mito",
@@ -2661,7 +3325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3659174,
-    "lon": 140.4731743
+    "lon": 140.4731743,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1402": {
     "name": "Hitachi",
@@ -2669,7 +3335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5991225,
-    "lon": 140.6504604
+    "lon": 140.6504604,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1403": {
     "name": "Tsuchiura",
@@ -2677,7 +3345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0786297,
-    "lon": 140.2045934
+    "lon": 140.2045934,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1404": {
     "name": "Koga",
@@ -2685,7 +3355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.178025,
-    "lon": 139.7553638
+    "lon": 139.7553638,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1405": {
     "name": "Ishioka",
@@ -2693,15 +3365,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1908398,
-    "lon": 140.2884101
+    "lon": 140.2884101,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1406": {
     "name": "Shimodate",
     "ja_name": "下館",
     "deleted": true,
-    "deleted_date": "Mar.27,2005",
+    "deleted_date": "2005-03-27",
     "lat": 36.3041016,
-    "lon": 139.9780655
+    "lon": 139.9780655,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1407": {
     "name": "Yuki",
@@ -2709,7 +3385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3052945,
-    "lon": 139.8771403
+    "lon": 139.8771403,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1408": {
     "name": "Ryugasaki",
@@ -2717,15 +3395,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9113158,
-    "lon": 140.181878
+    "lon": 140.181878,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1409": {
     "name": "Nakaminato",
     "ja_name": "那珂湊",
     "deleted": true,
-    "deleted_date": "Oct.31,1994",
+    "deleted_date": "1994-10-31",
     "lat": 36.3450819,
-    "lon": 140.5881169
+    "lon": 140.5881169,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1410": {
     "name": "Shimotsuma",
@@ -2733,15 +3415,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1843552,
-    "lon": 139.9672418
+    "lon": 139.9672418,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1411": {
     "name": "Mitsukaido",
     "ja_name": "水海道",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 36.0180569,
-    "lon": 139.9916513
+    "lon": 139.9916513,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1412": {
     "name": "Hitachiota",
@@ -2749,15 +3435,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5373021,
-    "lon": 140.5308393
+    "lon": 140.5308393,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1413": {
     "name": "Katsuta",
     "ja_name": "勝田",
     "deleted": true,
-    "deleted_date": "Oct.31,1994",
+    "deleted_date": "1994-10-31",
     "lat": 36.3944346,
-    "lon": 140.5242433
+    "lon": 140.5242433,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1414": {
     "name": "Takahagi",
@@ -2765,7 +3455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.7199765,
-    "lon": 140.7158414
+    "lon": 140.7158414,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1415": {
     "name": "Kitaibaraki",
@@ -2773,7 +3465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.8018507,
-    "lon": 140.7513188
+    "lon": 140.7513188,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1416": {
     "name": "Kasama",
@@ -2781,7 +3475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3452244,
-    "lon": 140.3042261
+    "lon": 140.3042261,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1417": {
     "name": "Toride",
@@ -2789,15 +3485,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9112034,
-    "lon": 140.0500352
+    "lon": 140.0500352,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1418": {
     "name": "Iwai",
     "ja_name": "岩井",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 35.0926346,
-    "lon": 139.8496343
+    "lon": 139.8496343,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1419": {
     "name": "Ushiku",
@@ -2805,7 +3505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9790551,
-    "lon": 140.1495982
+    "lon": 140.1495982,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1420": {
     "name": "Tsukuba",
@@ -2813,7 +3515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0833265,
-    "lon": 140.077279
+    "lon": 140.077279,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1421": {
     "name": "Hitachinaka",
@@ -2821,7 +3525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3961235,
-    "lon": 140.5353397
+    "lon": 140.5353397,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1422": {
     "name": "Kashima",
@@ -2829,7 +3535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9661164,
-    "lon": 140.6450292
+    "lon": 140.6450292,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1423": {
     "name": "Itako",
@@ -2837,7 +3545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9471731,
-    "lon": 140.5552819
+    "lon": 140.5552819,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1424": {
     "name": "Moriya",
@@ -2845,7 +3555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9510096,
-    "lon": 139.9754981
+    "lon": 139.9754981,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1425": {
     "name": "Hitachiomiya",
@@ -2853,7 +3565,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5429197,
-    "lon": 140.4116172
+    "lon": 140.4116172,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1426": {
     "name": "Naka",
@@ -2861,7 +3575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.457227,
-    "lon": 140.4871772
+    "lon": 140.4871772,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1427": {
     "name": "Chikusei",
@@ -2869,7 +3585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3051944,
-    "lon": 139.9790903
+    "lon": 139.9790903,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1428": {
     "name": "Bandou",
@@ -2877,7 +3595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.06639,
-    "lon": 139.88729
+    "lon": 139.88729,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1429": {
     "name": "Inashiki",
@@ -2885,7 +3605,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9720697,
-    "lon": 140.3033759
+    "lon": 140.3033759,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1430": {
     "name": "Kasumigaura",
@@ -2893,7 +3615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1552115,
-    "lon": 140.2353307
+    "lon": 140.2353307,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1431": {
     "name": "Sakuragawa",
@@ -2901,7 +3625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.327241,
-    "lon": 140.0903587
+    "lon": 140.0903587,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1432": {
     "name": "Kamisu",
@@ -2909,7 +3635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8898999,
-    "lon": 140.6645754
+    "lon": 140.6645754,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1433": {
     "name": "Namegata",
@@ -2917,7 +3645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9901895,
-    "lon": 140.4888826
+    "lon": 140.4888826,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1434": {
     "name": "Hokota",
@@ -2925,7 +3655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1585645,
-    "lon": 140.5165158
+    "lon": 140.5165158,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1435": {
     "name": "Joso",
@@ -2933,7 +3665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.0235685,
-    "lon": 139.9938714
+    "lon": 139.9938714,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1436": {
     "name": "Tsukubamirai",
@@ -2941,7 +3675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9627445,
-    "lon": 140.0377674
+    "lon": 140.0377674,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1437": {
     "name": "Omitama",
@@ -2949,7 +3685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2389756,
-    "lon": 140.3523684
+    "lon": 140.3523684,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1501": {
     "name": "Utsunomiya",
@@ -2957,7 +3695,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5549677,
-    "lon": 139.8828776
+    "lon": 139.8828776,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1502": {
     "name": "Ashikaga",
@@ -2965,7 +3705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3401914,
-    "lon": 139.4497731
+    "lon": 139.4497731,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1503": {
     "name": "Tochigi",
@@ -2973,7 +3715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.6782167,
-    "lon": 139.8096549
+    "lon": 139.8096549,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1504": {
     "name": "Sano",
@@ -2981,7 +3725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3144119,
-    "lon": 139.578429
+    "lon": 139.578429,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1505": {
     "name": "Kanuma",
@@ -2989,7 +3735,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5682281,
-    "lon": 139.7457781
+    "lon": 139.7457781,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1506": {
     "name": "Nikko",
@@ -2997,15 +3745,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.846433,
-    "lon": 139.5582717
+    "lon": 139.5582717,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1507": {
     "name": "Imaichi",
     "ja_name": "今市",
     "deleted": true,
-    "deleted_date": "Mar.19,2006",
+    "deleted_date": "2006-03-19",
     "lat": 36.720468,
-    "lon": 139.6872715
+    "lon": 139.6872715,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1508": {
     "name": "Oyama",
@@ -3013,7 +3765,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.315537,
-    "lon": 139.8006952
+    "lon": 139.8006952,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1509": {
     "name": "Mooka",
@@ -3021,7 +3775,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.4390901,
-    "lon": 140.0128896
+    "lon": 140.0128896,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1510": {
     "name": "Otawara",
@@ -3029,7 +3785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.87103,
-    "lon": 140.0154048
+    "lon": 140.0154048,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1511": {
     "name": "Yaita",
@@ -3037,15 +3795,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.8066705,
-    "lon": 139.9236292
+    "lon": 139.9236292,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1512": {
     "name": "Kuroiso",
     "ja_name": "黒磯",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 36.9701908,
-    "lon": 140.0601121
+    "lon": 140.0601121,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1513": {
     "name": "Nasushiobara",
@@ -3053,7 +3815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.9621788,
-    "lon": 140.0467207
+    "lon": 140.0467207,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1514": {
     "name": "Sakura",
@@ -3061,7 +3825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7234619,
-    "lon": 140.2240158
+    "lon": 140.2240158,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1515": {
     "name": "Nasukarasuyama",
@@ -3069,7 +3835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.657187,
-    "lon": 140.1518102
+    "lon": 140.1518102,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1516": {
     "name": "Shimotsuke",
@@ -3077,7 +3845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3943469,
-    "lon": 139.8515863
+    "lon": 139.8515863,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1601": {
     "name": "Maebashi",
@@ -3085,7 +3855,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3893418,
-    "lon": 139.0632826
+    "lon": 139.0632826,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1602": {
     "name": "Takasaki",
@@ -3093,7 +3865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3220984,
-    "lon": 139.0032758
+    "lon": 139.0032758,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1603": {
     "name": "Kiryu",
@@ -3101,7 +3875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.4055296,
-    "lon": 139.3310209
+    "lon": 139.3310209,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1604": {
     "name": "Isesaki",
@@ -3109,7 +3885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3111734,
-    "lon": 139.1968083
+    "lon": 139.1968083,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1605": {
     "name": "Ota",
@@ -3117,7 +3895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.561206,
-    "lon": 139.715843
+    "lon": 139.715843,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1606": {
     "name": "Numata",
@@ -3125,7 +3905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.6440697,
-    "lon": 139.0428829
+    "lon": 139.0428829,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1607": {
     "name": "Tatebayashi",
@@ -3133,7 +3915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2454338,
-    "lon": 139.5421576
+    "lon": 139.5421576,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1608": {
     "name": "Shibukawa",
@@ -3141,7 +3925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.4894606,
-    "lon": 139.0001287
+    "lon": 139.0001287,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1609": {
     "name": "Fujioka",
@@ -3149,7 +3935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.258633,
-    "lon": 139.0745021
+    "lon": 139.0745021,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1610": {
     "name": "Tomioka",
@@ -3157,7 +3945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2598266,
-    "lon": 138.8899792
+    "lon": 138.8899792,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1611": {
     "name": "Annaka",
@@ -3165,7 +3955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.3263653,
-    "lon": 138.8878314
+    "lon": 138.8878314,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1612": {
     "name": "Midori",
@@ -3173,7 +3965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8713637,
-    "lon": 139.6839185
+    "lon": 139.6839185,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1701": {
     "name": "Kofu",
@@ -3181,7 +3975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6652481,
-    "lon": 138.5710441
+    "lon": 138.5710441,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1702": {
     "name": "Fujiyoshida",
@@ -3189,15 +3985,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4835487,
-    "lon": 138.7958212
+    "lon": 138.7958212,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1703": {
     "name": "Enzan",
     "ja_name": "塩山",
     "deleted": true,
-    "deleted_date": "Oct.31,2005",
+    "deleted_date": "2005-10-31",
     "lat": 35.7054703,
-    "lon": 138.7341835
+    "lon": 138.7341835,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1704": {
     "name": "Tsuru",
@@ -3205,7 +4005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5516184,
-    "lon": 138.9054872
+    "lon": 138.9054872,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1705": {
     "name": "Yamanashi",
@@ -3213,7 +4015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6399328,
-    "lon": 138.6380495
+    "lon": 138.6380495,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1706": {
     "name": "Otsuki",
@@ -3221,7 +4025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6128834,
-    "lon": 138.9429092
+    "lon": 138.9429092,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1707": {
     "name": "Nirasaki",
@@ -3229,7 +4035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.717518,
-    "lon": 138.409373
+    "lon": 138.409373,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1708": {
     "name": "Minami-Alps",
@@ -3237,7 +4045,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6083617,
-    "lon": 138.4649893
+    "lon": 138.4649893,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1709": {
     "name": "Hokuto",
@@ -3245,7 +4055,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 41.8240228,
-    "lon": 140.6529686
+    "lon": 140.6529686,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1710": {
     "name": "Kai",
@@ -3253,7 +4065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.668167,
-    "lon": 138.515327
+    "lon": 138.515327,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1711": {
     "name": "Fuefuki",
@@ -3261,7 +4075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.60117,
-    "lon": 138.68119
+    "lon": 138.68119,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1712": {
     "name": "Uenohara",
@@ -3269,7 +4085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.632505,
-    "lon": 139.08775
+    "lon": 139.08775,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1713": {
     "name": "Koshu",
@@ -3277,7 +4095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.726318,
-    "lon": 138.793924
+    "lon": 138.793924,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1714": {
     "name": "Chuo",
@@ -3285,7 +4105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.666255,
-    "lon": 139.775565
+    "lon": 139.775565,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1801": {
     "name": "Shizuoka",
@@ -3293,7 +4115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9332488,
-    "lon": 138.0955398
+    "lon": 138.0955398,
+    "designated_city": true,
+    "designated_city_date": "2005-04-01"
   },
   "1802": {
     "name": "Hamamatsu",
@@ -3301,7 +4125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7109786,
-    "lon": 137.7259431
+    "lon": 137.7259431,
+    "designated_city": true,
+    "designated_city_date": "2007-04-01"
   },
   "1803": {
     "name": "Numazu",
@@ -3309,15 +4135,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.094699,
-    "lon": 138.866742
+    "lon": 138.866742,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1804": {
     "name": "Shimizu",
     "ja_name": "清水",
     "deleted": true,
-    "deleted_date": "Mar.31,2003",
+    "deleted_date": "2003-03-31",
     "lat": 35.10764,
-    "lon": 138.898974
+    "lon": 138.898974,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1805": {
     "name": "Atami",
@@ -3325,7 +4155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.08992,
-    "lon": 139.059891
+    "lon": 139.059891,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1806": {
     "name": "Mishima",
@@ -3333,7 +4165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.147361,
-    "lon": 138.948903
+    "lon": 138.948903,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1807": {
     "name": "Fujinomiya",
@@ -3341,7 +4175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2221369,
-    "lon": 138.6214683
+    "lon": 138.6214683,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1808": {
     "name": "Ito",
@@ -3349,7 +4185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.926734,
-    "lon": 139.087685
+    "lon": 139.087685,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1809": {
     "name": "Shimada",
@@ -3357,15 +4195,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.879912,
-    "lon": 138.146599
+    "lon": 138.146599,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1810": {
     "name": "Yoshiwara",
     "ja_name": "吉原",
     "deleted": true,
-    "deleted_date": "Oct.31,1966",
+    "deleted_date": "1966-10-31",
     "lat": 35.1439052,
-    "lon": 138.7023368
+    "lon": 138.7023368,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1811": {
     "name": "Iwata",
@@ -3373,7 +4215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.706481,
-    "lon": 137.851285
+    "lon": 137.851285,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1812": {
     "name": "Yaizu",
@@ -3381,7 +4225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.86877,
-    "lon": 138.31952
+    "lon": 138.31952,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1813": {
     "name": "Fuji",
@@ -3389,7 +4235,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.362799,
-    "lon": 138.730781
+    "lon": 138.730781,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1814": {
     "name": "Kakegawa",
@@ -3397,7 +4245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.793469,
-    "lon": 138.018733
+    "lon": 138.018733,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1815": {
     "name": "Fujieda",
@@ -3405,7 +4255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8493225,
-    "lon": 138.2522508
+    "lon": 138.2522508,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1816": {
     "name": "Gotemba",
@@ -3413,7 +4265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.301048,
-    "lon": 138.877573
+    "lon": 138.877573,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1817": {
     "name": "Fukuroi",
@@ -3421,23 +4275,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7500522,
-    "lon": 137.9258871
+    "lon": 137.9258871,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1818": {
     "name": "Tenryu",
     "ja_name": "天竜",
     "deleted": true,
-    "deleted_date": "Jun.30,2005",
+    "deleted_date": "2005-06-30",
     "lat": 35.2761975,
-    "lon": 137.8543424
+    "lon": 137.8543424,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1819": {
     "name": "Hamakita",
     "ja_name": "浜北",
     "deleted": true,
-    "deleted_date": "Jun.30,2005",
+    "deleted_date": "2005-06-30",
     "lat": 36.7324457,
-    "lon": 136.6957647
+    "lon": 136.6957647,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1820": {
     "name": "Shimoda",
@@ -3445,7 +4305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.679545,
-    "lon": 138.945379
+    "lon": 138.945379,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1821": {
     "name": "Susono",
@@ -3453,7 +4315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.21843,
-    "lon": 138.881738
+    "lon": 138.881738,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1822": {
     "name": "Kosai",
@@ -3461,7 +4325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.710542,
-    "lon": 137.531599
+    "lon": 137.531599,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1823": {
     "name": "Izu",
@@ -3469,7 +4335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9764551,
-    "lon": 138.9467078
+    "lon": 138.9467078,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1824": {
     "name": "Omaezaki",
@@ -3477,7 +4345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.647956,
-    "lon": 138.146936
+    "lon": 138.146936,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1825": {
     "name": "Kikugawa",
@@ -3485,7 +4355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7562641,
-    "lon": 138.0873547
+    "lon": 138.0873547,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1826": {
     "name": "Izunokuni",
@@ -3493,7 +4365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.035531,
-    "lon": 138.961915
+    "lon": 138.961915,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1827": {
     "name": "Makinohara",
@@ -3501,7 +4375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.718766,
-    "lon": 138.18517
+    "lon": 138.18517,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1901": {
     "name": "Gifu",
@@ -3509,7 +4385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7867449,
-    "lon": 137.0460777
+    "lon": 137.0460777,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1902": {
     "name": "Ogaki",
@@ -3517,7 +4395,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3671141,
-    "lon": 136.6179746
+    "lon": 136.6179746,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1903": {
     "name": "Takayama",
@@ -3525,7 +4405,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.1396246,
-    "lon": 137.2510322
+    "lon": 137.2510322,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1904": {
     "name": "Tajimi",
@@ -3533,7 +4415,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3329961,
-    "lon": 137.1319459
+    "lon": 137.1319459,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1905": {
     "name": "Seki",
@@ -3541,7 +4425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4958031,
-    "lon": 136.9181482
+    "lon": 136.9181482,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1906": {
     "name": "Nakatsugawa",
@@ -3549,7 +4435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4876463,
-    "lon": 137.5005402
+    "lon": 137.5005402,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1907": {
     "name": "Mino",
@@ -3557,7 +4445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5442619,
-    "lon": 136.9075182
+    "lon": 136.9075182,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1908": {
     "name": "Mizunami",
@@ -3565,7 +4455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3619929,
-    "lon": 137.2541668
+    "lon": 137.2541668,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1909": {
     "name": "Hashima",
@@ -3573,7 +4465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3195107,
-    "lon": 136.7027348
+    "lon": 136.7027348,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1910": {
     "name": "Ena",
@@ -3581,7 +4475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4492674,
-    "lon": 137.412703
+    "lon": 137.412703,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1911": {
     "name": "Minokamo",
@@ -3589,7 +4485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4406551,
-    "lon": 137.0155052
+    "lon": 137.0155052,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1912": {
     "name": "Toki",
@@ -3597,7 +4495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3524854,
-    "lon": 137.1834191
+    "lon": 137.1834191,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1913": {
     "name": "Kakamigahara",
@@ -3605,7 +4505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3995831,
-    "lon": 136.8485648
+    "lon": 136.8485648,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1914": {
     "name": "Kani",
@@ -3613,7 +4515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4261093,
-    "lon": 137.0613166
+    "lon": 137.0613166,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1915": {
     "name": "Yamagata",
@@ -3621,7 +4525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 38.4746705,
-    "lon": 140.083237
+    "lon": 140.083237,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1916": {
     "name": "Mizuho",
@@ -3629,7 +4535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7487675,
-    "lon": 139.7015731
+    "lon": 139.7015731,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1917": {
     "name": "Hida",
@@ -3637,7 +4545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2383204,
-    "lon": 137.1859372
+    "lon": 137.1859372,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1918": {
     "name": "Motosu",
@@ -3645,7 +4555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4830261,
-    "lon": 136.6780554
+    "lon": 136.6780554,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1919": {
     "name": "Gujo",
@@ -3653,7 +4565,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.748417,
-    "lon": 136.9643095
+    "lon": 136.9643095,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1920": {
     "name": "Gero",
@@ -3661,7 +4575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.8064271,
-    "lon": 137.2433187
+    "lon": 137.2433187,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "1921": {
     "name": "Kaizu",
@@ -3669,7 +4585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2205087,
-    "lon": 136.637211
+    "lon": 136.637211,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2001": {
     "name": "Nagoya",
@@ -3677,7 +4595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1851045,
-    "lon": 136.8998438
+    "lon": 136.8998438,
+    "designated_city": true,
+    "designated_city_date": "1956-09-01"
   },
   "2002": {
     "name": "Toyohashi",
@@ -3685,7 +4605,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.769123,
-    "lon": 137.391461
+    "lon": 137.391461,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2003": {
     "name": "Okazaki",
@@ -3693,7 +4615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.950974,
-    "lon": 137.260842
+    "lon": 137.260842,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2004": {
     "name": "Ichinomiya",
@@ -3701,7 +4625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.304878,
-    "lon": 136.806915
+    "lon": 136.806915,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2005": {
     "name": "Seto",
@@ -3709,7 +4635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.240984,
-    "lon": 137.116187
+    "lon": 137.116187,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2006": {
     "name": "Handa",
@@ -3717,7 +4645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8938136,
-    "lon": 136.9369523
+    "lon": 136.9369523,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2007": {
     "name": "Kasugai",
@@ -3725,7 +4655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.273804,
-    "lon": 137.007459
+    "lon": 137.007459,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2008": {
     "name": "Toyokawa",
@@ -3733,7 +4665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.827644,
-    "lon": 137.378586
+    "lon": 137.378586,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2009": {
     "name": "Tsushima",
@@ -3741,7 +4675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3952765,
-    "lon": 129.315449
+    "lon": 129.315449,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2010": {
     "name": "Hekinan",
@@ -3749,7 +4685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.86505,
-    "lon": 136.984523
+    "lon": 136.984523,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2011": {
     "name": "Kariya",
@@ -3757,7 +4695,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.974678,
-    "lon": 137.002791
+    "lon": 137.002791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2012": {
     "name": "Toyota",
@@ -3765,7 +4705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.09611,
-    "lon": 137.15631
+    "lon": 137.15631,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2013": {
     "name": "Anjo",
@@ -3773,7 +4715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.947764,
-    "lon": 137.075563
+    "lon": 137.075563,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2014": {
     "name": "Nishio",
@@ -3781,7 +4725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.822498,
-    "lon": 137.069626
+    "lon": 137.069626,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2015": {
     "name": "Gamagori",
@@ -3789,7 +4735,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.833929,
-    "lon": 137.225163
+    "lon": 137.225163,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2016": {
     "name": "Inuyama",
@@ -3797,7 +4745,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3609734,
-    "lon": 136.9845491
+    "lon": 136.9845491,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2017": {
     "name": "Tokoname",
@@ -3805,15 +4755,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.895858,
-    "lon": 136.838323
+    "lon": 136.838323,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2018": {
     "name": "Moriyama",
     "ja_name": "守山",
     "deleted": true,
-    "deleted_date": "Feb.9,1963",
+    "deleted_date": "1963-02-09",
     "lat": 35.0513649,
-    "lon": 135.9958308
+    "lon": 135.9958308,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2019": {
     "name": "Konan",
@@ -3821,15 +4775,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.344508,
-    "lon": 136.866742
+    "lon": 136.866742,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2020": {
     "name": "Bisai",
     "ja_name": "尾西",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.3176054,
-    "lon": 136.7781385
+    "lon": 136.7781385,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2021": {
     "name": "Komaki",
@@ -3837,7 +4795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3066073,
-    "lon": 136.934098
+    "lon": 136.934098,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2022": {
     "name": "Inazawa",
@@ -3845,7 +4805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.240484,
-    "lon": 136.758964
+    "lon": 136.758964,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2023": {
     "name": "Shinshiro",
@@ -3853,7 +4815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.946784,
-    "lon": 137.533234
+    "lon": 137.533234,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2024": {
     "name": "Tokai",
@@ -3861,7 +4825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.46075,
-    "lon": 140.58052
+    "lon": 140.58052,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2025": {
     "name": "Obu",
@@ -3869,7 +4835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0165825,
-    "lon": 136.954545
+    "lon": 136.954545,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2026": {
     "name": "Chita",
@@ -3877,7 +4845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.96956,
-    "lon": 136.864
+    "lon": 136.864,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2027": {
     "name": "Takahama",
@@ -3885,7 +4855,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.920796,
-    "lon": 136.988604
+    "lon": 136.988604,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2028": {
     "name": "Chiryu",
@@ -3893,7 +4865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0014831,
-    "lon": 137.0516484
+    "lon": 137.0516484,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2029": {
     "name": "Owariasahi",
@@ -3901,7 +4875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.208148,
-    "lon": 137.03722
+    "lon": 137.03722,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2030": {
     "name": "Iwakura",
@@ -3909,7 +4885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.274632,
-    "lon": 136.870713
+    "lon": 136.870713,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2031": {
     "name": "Toyoake",
@@ -3917,7 +4895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.05936,
-    "lon": 137.013714
+    "lon": 137.013714,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2032": {
     "name": "Nissin",
@@ -3925,7 +4905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6559905,
-    "lon": 139.7400983
+    "lon": 139.7400983,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2033": {
     "name": "Tahara",
@@ -3933,7 +4915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.639112,
-    "lon": 137.183207
+    "lon": 137.183207,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2034": {
     "name": "Aisai",
@@ -3941,7 +4925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.142205,
-    "lon": 136.727208
+    "lon": 136.727208,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2035": {
     "name": "Kiyosu",
@@ -3949,7 +4935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.21595,
-    "lon": 136.845107
+    "lon": 136.845107,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2036": {
     "name": "Kitanagoya",
@@ -3957,7 +4945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.244369,
-    "lon": 136.879032
+    "lon": 136.879032,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2037": {
     "name": "Yatomi",
@@ -3965,7 +4955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.098209,
-    "lon": 136.747831
+    "lon": 136.747831,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2038": {
     "name": "Miyoshi",
@@ -3973,7 +4965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.81024,
-    "lon": 132.851691
+    "lon": 132.851691,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2039": {
     "name": "Ama",
@@ -3981,7 +4975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.08498,
-    "lon": 133.10022
+    "lon": 133.10022,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2040": {
     "name": "Nagakute",
@@ -3989,7 +4985,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.174318,
-    "lon": 137.070047
+    "lon": 137.070047,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2101": {
     "name": "Tsu",
@@ -3997,7 +4995,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7341973,
-    "lon": 136.5153283
+    "lon": 136.5153283,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2102": {
     "name": "Yokkaichi",
@@ -4005,7 +5005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9648428,
-    "lon": 136.624845
+    "lon": 136.624845,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2103": {
     "name": "Ise",
@@ -4013,7 +5015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4996115,
-    "lon": 136.7271774
+    "lon": 136.7271774,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2104": {
     "name": "Matsusaka",
@@ -4021,7 +5025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5868422,
-    "lon": 136.5412491
+    "lon": 136.5412491,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2105": {
     "name": "Kuwana",
@@ -4029,15 +5035,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0666099,
-    "lon": 136.6843004
+    "lon": 136.6843004,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2106": {
     "name": "Ueno",
     "ja_name": "上野",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 35.7117224,
-    "lon": 139.776143
+    "lon": 139.776143,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2107": {
     "name": "Suzuka",
@@ -4045,7 +5055,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8817102,
-    "lon": 136.5836516
+    "lon": 136.5836516,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2108": {
     "name": "Nabari",
@@ -4053,7 +5065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6279243,
-    "lon": 136.1086582
+    "lon": 136.1086582,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2109": {
     "name": "Owase",
@@ -4061,7 +5075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0707815,
-    "lon": 136.1911394
+    "lon": 136.1911394,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2110": {
     "name": "Kameyama",
@@ -4069,7 +5085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8619883,
-    "lon": 136.446694
+    "lon": 136.446694,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2111": {
     "name": "Toba",
@@ -4077,7 +5095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4714464,
-    "lon": 136.8293576
+    "lon": 136.8293576,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2112": {
     "name": "Kumano",
@@ -4085,23 +5105,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8885409,
-    "lon": 136.100411
+    "lon": 136.100411,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2113": {
     "name": "Hisai",
     "ja_name": "久居",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 34.6758168,
-    "lon": 136.4779166
+    "lon": 136.4779166,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2114": {
     "name": "Ujiyamada",
     "ja_name": "宇治山田",
     "deleted": true,
-    "deleted_date": "Dec.31,1954",
+    "deleted_date": "1954-12-31",
     "lat": 34.48825,
-    "lon": 136.7139235
+    "lon": 136.7139235,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2115": {
     "name": "Inabe",
@@ -4109,7 +5135,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1573562,
-    "lon": 136.5043894
+    "lon": 136.5043894,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2116": {
     "name": "Shima",
@@ -4117,7 +5145,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3411841,
-    "lon": 136.8196451
+    "lon": 136.8196451,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2117": {
     "name": "Iga",
@@ -4125,7 +5155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7497761,
-    "lon": 136.1423355
+    "lon": 136.1423355,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2201": {
     "name": "Kyoto",
@@ -4133,7 +5165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.021041,
-    "lon": 135.7556075
+    "lon": 135.7556075,
+    "designated_city": true,
+    "designated_city_date": "1956-09-01"
   },
   "2202": {
     "name": "Fukuchiyama",
@@ -4141,7 +5175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2966996,
-    "lon": 135.126643
+    "lon": 135.126643,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2203": {
     "name": "Maizuru",
@@ -4149,7 +5185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.46859,
-    "lon": 135.33964
+    "lon": 135.33964,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2204": {
     "name": "Ayabe",
@@ -4157,7 +5195,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.359169,
-    "lon": 135.353791
+    "lon": 135.353791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2205": {
     "name": "Uji",
@@ -4165,7 +5205,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8933744,
-    "lon": 135.8059219
+    "lon": 135.8059219,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2206": {
     "name": "Miyazu",
@@ -4173,7 +5215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5815605,
-    "lon": 135.199274
+    "lon": 135.199274,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2207": {
     "name": "Kameoka",
@@ -4181,7 +5225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0134403,
-    "lon": 135.5733728
+    "lon": 135.5733728,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2208": {
     "name": "Joyo",
@@ -4189,7 +5235,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8457965,
-    "lon": 135.798831
+    "lon": 135.798831,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2209": {
     "name": "Nagaokakyo",
@@ -4197,7 +5245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.924418,
-    "lon": 135.680271
+    "lon": 135.680271,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2210": {
     "name": "Muko",
@@ -4205,7 +5255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9492795,
-    "lon": 135.700666
+    "lon": 135.700666,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2211": {
     "name": "Yawata",
@@ -4213,7 +5265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.860714,
-    "lon": 135.7164
+    "lon": 135.7164,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2212": {
     "name": "Kyotanabe",
@@ -4221,7 +5275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8029175,
-    "lon": 135.760651
+    "lon": 135.760651,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2213": {
     "name": "Kyotango",
@@ -4229,7 +5285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6455135,
-    "lon": 135.0434555
+    "lon": 135.0434555,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2214": {
     "name": "Nantan",
@@ -4237,7 +5295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2027706,
-    "lon": 135.51952
+    "lon": 135.51952,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2215": {
     "name": "Kizugawa",
@@ -4245,7 +5305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.75455,
-    "lon": 135.848026
+    "lon": 135.848026,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2301": {
     "name": "Otsu",
@@ -4253,7 +5315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0047096,
-    "lon": 135.8686739
+    "lon": 135.8686739,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2302": {
     "name": "Hikone",
@@ -4261,7 +5325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.254276,
-    "lon": 136.215376
+    "lon": 136.215376,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2303": {
     "name": "Nagahama",
@@ -4269,7 +5335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4857724,
-    "lon": 136.294057
+    "lon": 136.294057,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2304": {
     "name": "Omihachiman",
@@ -4277,15 +5345,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1527915,
-    "lon": 136.0687365
+    "lon": 136.0687365,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2305": {
     "name": "Yokaichi",
     "ja_name": "八日市",
     "deleted": true,
-    "deleted_date": "Feb.10,2005",
+    "deleted_date": "2005-02-10",
     "lat": 35.1138501,
-    "lon": 136.2036693
+    "lon": 136.2036693,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2306": {
     "name": "Kusatsu",
@@ -4293,7 +5365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0179088,
-    "lon": 135.96046
+    "lon": 135.96046,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2307": {
     "name": "Moriyama",
@@ -4301,7 +5375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0513649,
-    "lon": 135.9958308
+    "lon": 135.9958308,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2308": {
     "name": "Ritto",
@@ -4309,7 +5385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0257669,
-    "lon": 135.9836707
+    "lon": 135.9836707,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2309": {
     "name": "Koka",
@@ -4317,7 +5395,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9625992,
-    "lon": 136.1655415
+    "lon": 136.1655415,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2310": {
     "name": "Yasu",
@@ -4325,7 +5405,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0932388,
-    "lon": 136.0159278
+    "lon": 136.0159278,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2311": {
     "name": "Konan",
@@ -4333,7 +5415,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.344508,
-    "lon": 136.866742
+    "lon": 136.866742,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2312": {
     "name": "Takashima",
@@ -4341,7 +5425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3519223,
-    "lon": 136.0423359
+    "lon": 136.0423359,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2313": {
     "name": "Higashioumi",
@@ -4349,7 +5435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.10936,
-    "lon": 136.28598
+    "lon": 136.28598,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2314": {
     "name": "Maibara",
@@ -4357,7 +5445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3149074,
-    "lon": 136.2901179
+    "lon": 136.2901179,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2401": {
     "name": "Nara",
@@ -4365,7 +5455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2963089,
-    "lon": 135.8816819
+    "lon": 135.8816819,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2402": {
     "name": "Yamatotakada",
@@ -4373,7 +5465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5150901,
-    "lon": 135.7364961
+    "lon": 135.7364961,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2403": {
     "name": "Yamatokoriyama",
@@ -4381,7 +5475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6496181,
-    "lon": 135.7829497
+    "lon": 135.7829497,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2404": {
     "name": "Tenri",
@@ -4389,7 +5485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5965738,
-    "lon": 135.8373696
+    "lon": 135.8373696,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2405": {
     "name": "Kashihara",
@@ -4397,7 +5495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5094067,
-    "lon": 135.792955
+    "lon": 135.792955,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2406": {
     "name": "Sakurai",
@@ -4405,7 +5505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5186316,
-    "lon": 135.8434724
+    "lon": 135.8434724,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2407": {
     "name": "Gojo",
@@ -4413,7 +5515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.351939,
-    "lon": 135.693596
+    "lon": 135.693596,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2408": {
     "name": "Gose",
@@ -4421,7 +5525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4651956,
-    "lon": 135.7338458
+    "lon": 135.7338458,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2409": {
     "name": "Ikoma",
@@ -4429,7 +5535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6915267,
-    "lon": 135.6961681
+    "lon": 135.6961681,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2410": {
     "name": "Kashiba",
@@ -4437,7 +5545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5415175,
-    "lon": 135.6988328
+    "lon": 135.6988328,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2411": {
     "name": "Katsuragi",
@@ -4445,7 +5555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4888006,
-    "lon": 135.7266816
+    "lon": 135.7266816,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2412": {
     "name": "Uda",
@@ -4453,7 +5565,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.52121,
-    "lon": 135.99972
+    "lon": 135.99972,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2501": {
     "name": "Osaka",
@@ -4461,7 +5575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7021912,
-    "lon": 135.4955866
+    "lon": 135.4955866,
+    "designated_city": true,
+    "designated_city_date": "1956-09-01"
   },
   "2502": {
     "name": "Sakai",
@@ -4469,7 +5585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5289178,
-    "lon": 135.5015548
+    "lon": 135.5015548,
+    "designated_city": true,
+    "designated_city_date": "2006-04-01"
   },
   "2503": {
     "name": "Kishiwada",
@@ -4477,7 +5595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4644,
-    "lon": 135.385237
+    "lon": 135.385237,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2504": {
     "name": "Toyonaka",
@@ -4485,15 +5605,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7862025,
-    "lon": 135.4737093
+    "lon": 135.4737093,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2505": {
     "name": "Fuse",
     "ja_name": "布施",
     "deleted": true,
-    "deleted_date": "",
+    "deleted_date": "1967-01-31",
     "lat": 34.6640039,
-    "lon": 135.563573
+    "lon": 135.563573,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2506": {
     "name": "Ikeda",
@@ -4501,7 +5625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.819371,
-    "lon": 135.433332
+    "lon": 135.433332,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2507": {
     "name": "Suita",
@@ -4509,7 +5635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.764884,
-    "lon": 135.51735
+    "lon": 135.51735,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2508": {
     "name": "Izumiotsu",
@@ -4517,7 +5645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.506612,
-    "lon": 135.408793
+    "lon": 135.408793,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2509": {
     "name": "Takatsuki",
@@ -4525,7 +5655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8812905,
-    "lon": 135.6012398
+    "lon": 135.6012398,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2510": {
     "name": "Kaizuka",
@@ -4533,7 +5665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6256085,
-    "lon": 140.1396283
+    "lon": 140.1396283,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2511": {
     "name": "Moriguchi",
@@ -4541,7 +5675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.746898,
-    "lon": 135.566663
+    "lon": 135.566663,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2512": {
     "name": "Hirakata",
@@ -4549,7 +5685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.818215,
-    "lon": 135.659225
+    "lon": 135.659225,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2513": {
     "name": "Ibaraki",
@@ -4557,7 +5695,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2869536,
-    "lon": 140.4703384
+    "lon": 140.4703384,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2514": {
     "name": "Yao",
@@ -4565,7 +5705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.626275,
-    "lon": 135.605845
+    "lon": 135.605845,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2515": {
     "name": "Izumisano",
@@ -4573,7 +5715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.394629,
-    "lon": 135.322725
+    "lon": 135.322725,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2516": {
     "name": "Tondabayashi",
@@ -4581,7 +5725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.478781,
-    "lon": 135.595519
+    "lon": 135.595519,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2517": {
     "name": "Neyagawa",
@@ -4589,7 +5735,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.76751,
-    "lon": 135.633907
+    "lon": 135.633907,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2518": {
     "name": "Kawachinagano",
@@ -4597,23 +5745,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4575979,
-    "lon": 135.5643131
+    "lon": 135.5643131,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2519": {
     "name": "Hiraoka",
     "ja_name": "枚岡",
     "deleted": true,
-    "deleted_date": "Jan.31,1967",
+    "deleted_date": "1967-01-31",
     "lat": 35.273846,
-    "lon": 137.8538052
+    "lon": 137.8538052,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2520": {
     "name": "Kawachi",
     "ja_name": "河内",
     "deleted": true,
-    "deleted_date": "Jan.31,1967",
+    "deleted_date": "1967-01-31",
     "lat": 35.8845477,
-    "lon": 140.2446262
+    "lon": 140.2446262,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2521": {
     "name": "Matsubara",
@@ -4621,7 +5775,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.580779,
-    "lon": 135.546552
+    "lon": 135.546552,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2522": {
     "name": "Daito",
@@ -4629,7 +5785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.710679,
-    "lon": 135.635478
+    "lon": 135.635478,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2523": {
     "name": "Izumi",
@@ -4637,7 +5795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.43108,
-    "lon": 135.474789
+    "lon": 135.474789,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2524": {
     "name": "Mino",
@@ -4645,7 +5805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5442619,
-    "lon": 136.9075182
+    "lon": 136.9075182,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2525": {
     "name": "Kashiwara",
@@ -4653,7 +5815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.59077,
-    "lon": 135.635035
+    "lon": 135.635035,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2526": {
     "name": "Habikino",
@@ -4661,7 +5825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.54158,
-    "lon": 135.599097
+    "lon": 135.599097,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2527": {
     "name": "Kadoma",
@@ -4669,7 +5835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.728801,
-    "lon": 135.59691
+    "lon": 135.59691,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2528": {
     "name": "Settsu",
@@ -4677,7 +5845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.782761,
-    "lon": 135.553584
+    "lon": 135.553584,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2529": {
     "name": "Fujiidera",
@@ -4685,7 +5855,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5715838,
-    "lon": 135.594395
+    "lon": 135.594395,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2530": {
     "name": "Takaishi",
@@ -4693,7 +5865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.532059,
-    "lon": 135.424388
+    "lon": 135.424388,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2531": {
     "name": "Higashiosaka",
@@ -4701,7 +5875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.678147,
-    "lon": 135.597728
+    "lon": 135.597728,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2532": {
     "name": "Sennan",
@@ -4709,7 +5885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3657277,
-    "lon": 135.2739742
+    "lon": 135.2739742,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2533": {
     "name": "Shijonawate",
@@ -4717,7 +5895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.730447,
-    "lon": 135.674005
+    "lon": 135.674005,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2534": {
     "name": "Katano",
@@ -4725,7 +5905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.792144,
-    "lon": 135.678333
+    "lon": 135.678333,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2535": {
     "name": "Osakasayama",
@@ -4733,7 +5915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.503879,
-    "lon": 135.549966
+    "lon": 135.549966,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2536": {
     "name": "Hannan",
@@ -4741,7 +5925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3595067,
-    "lon": 135.2398397
+    "lon": 135.2398397,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2601": {
     "name": "Wakayama",
@@ -4749,7 +5935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8070292,
-    "lon": 135.5930743
+    "lon": 135.5930743,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2602": {
     "name": "Shingu",
@@ -4757,7 +5945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7241003,
-    "lon": 135.9930029
+    "lon": 135.9930029,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2603": {
     "name": "Kainan",
@@ -4765,7 +5955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.1548656,
-    "lon": 135.2092791
+    "lon": 135.2092791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2604": {
     "name": "Tanabe",
@@ -4773,7 +5965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7278991,
-    "lon": 135.3777917
+    "lon": 135.3777917,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2605": {
     "name": "Gobo",
@@ -4781,7 +5975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8913819,
-    "lon": 135.152572
+    "lon": 135.152572,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2606": {
     "name": "Hashimoto",
@@ -4789,7 +5985,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3258291,
-    "lon": 135.6190034
+    "lon": 135.6190034,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2607": {
     "name": "Arida",
@@ -4797,7 +5995,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0832764,
-    "lon": 135.1278229
+    "lon": 135.1278229,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2608": {
     "name": "Kinokawa",
@@ -4805,7 +6005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2697102,
-    "lon": 135.3636692
+    "lon": 135.3636692,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2609": {
     "name": "Iwade",
@@ -4813,7 +6015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2558554,
-    "lon": 135.3112418
+    "lon": 135.3112418,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2701": {
     "name": "Kobe",
@@ -4821,7 +6025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6932379,
-    "lon": 135.1943764
+    "lon": 135.1943764,
+    "designated_city": true,
+    "designated_city_date": "1956-09-01"
   },
   "2702": {
     "name": "Himeji",
@@ -4829,7 +6035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8153529,
-    "lon": 134.6854793
+    "lon": 134.6854793,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2703": {
     "name": "Amagasaki",
@@ -4837,7 +6045,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7288995,
-    "lon": 135.412989
+    "lon": 135.412989,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2704": {
     "name": "Akashi",
@@ -4845,7 +6055,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6832635,
-    "lon": 134.9476925
+    "lon": 134.9476925,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2705": {
     "name": "Nishinomiya",
@@ -4853,7 +6065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7386033,
-    "lon": 135.3394138
+    "lon": 135.3394138,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2706": {
     "name": "Sumoto",
@@ -4861,7 +6075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3389909,
-    "lon": 134.859985
+    "lon": 134.859985,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2707": {
     "name": "Ashiya",
@@ -4869,7 +6085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7324313,
-    "lon": 135.3069326
+    "lon": 135.3069326,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2708": {
     "name": "Itami",
@@ -4877,7 +6095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.786159,
-    "lon": 135.407994
+    "lon": 135.407994,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2709": {
     "name": "Aioi",
@@ -4885,7 +6105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8097456,
-    "lon": 134.4719626
+    "lon": 134.4719626,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2710": {
     "name": "Toyooka",
@@ -4893,7 +6115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5446737,
-    "lon": 134.8201126
+    "lon": 134.8201126,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2711": {
     "name": "Kakogawa",
@@ -4901,15 +6125,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.786771,
-    "lon": 134.8498955
+    "lon": 134.8498955,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2712": {
     "name": "Tatsuno",
     "ja_name": "龍野",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 34.8743067,
-    "lon": 134.512583
+    "lon": 134.512583,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2713": {
     "name": "Ako",
@@ -4917,7 +6145,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.78986,
-    "lon": 134.37209
+    "lon": 134.37209,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2714": {
     "name": "Nishiwaki",
@@ -4925,7 +6155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0125755,
-    "lon": 134.996262
+    "lon": 134.996262,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2715": {
     "name": "Takarazuka",
@@ -4933,7 +6165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8036525,
-    "lon": 135.3673535
+    "lon": 135.3673535,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2716": {
     "name": "Miki",
@@ -4941,7 +6175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8533422,
-    "lon": 135.0765718
+    "lon": 135.0765718,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2717": {
     "name": "Takasago",
@@ -4949,7 +6185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7739854,
-    "lon": 134.7880412
+    "lon": 134.7880412,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2718": {
     "name": "Kawanishi",
@@ -4957,7 +6195,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8699135,
-    "lon": 135.4147005
+    "lon": 135.4147005,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2719": {
     "name": "Ono",
@@ -4965,7 +6205,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.861365,
-    "lon": 134.9547785
+    "lon": 134.9547785,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2720": {
     "name": "Sanda",
@@ -4973,7 +6215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8889881,
-    "lon": 135.2284629
+    "lon": 135.2284629,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2721": {
     "name": "Kasai",
@@ -4981,15 +6225,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.92507,
-    "lon": 134.85322
+    "lon": 134.85322,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2722": {
     "name": "Sasayama",
     "ja_name": "篠山",
     "deleted": true,
-    "deleted_date": "Apr.30,2019",
+    "deleted_date": "2019-04-30",
     "lat": 33.0558032,
-    "lon": 132.6590785
+    "lon": 132.6590785,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2723": {
     "name": "Yabu",
@@ -4997,7 +6245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4044647,
-    "lon": 134.7674637
+    "lon": 134.7674637,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2724": {
     "name": "Tanba",
@@ -5005,7 +6255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.17494,
-    "lon": 135.04373
+    "lon": 135.04373,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2725": {
     "name": "Minamiawaji",
@@ -5013,7 +6265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2556695,
-    "lon": 134.762265
+    "lon": 134.762265,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2726": {
     "name": "Asago",
@@ -5021,7 +6275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3398402,
-    "lon": 134.8527042
+    "lon": 134.8527042,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2727": {
     "name": "Awaji",
@@ -5029,7 +6285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5014505,
-    "lon": 134.9071385
+    "lon": 134.9071385,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2728": {
     "name": "Shiso",
@@ -5037,7 +6295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0043515,
-    "lon": 134.5495517
+    "lon": 134.5495517,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2729": {
     "name": "Kato",
@@ -5045,7 +6305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.930544,
-    "lon": 135.007803
+    "lon": 135.007803,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2730": {
     "name": "Tatsuno",
@@ -5053,7 +6315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8743067,
-    "lon": 134.512583
+    "lon": 134.512583,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2731": {
     "name": "Tanbasasayama",
@@ -5061,7 +6325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.075757,
-    "lon": 135.2193373
+    "lon": 135.2193373,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2801": {
     "name": "Toyama",
@@ -5069,7 +6335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.6468015,
-    "lon": 137.2183531
+    "lon": 137.2183531,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2802": {
     "name": "Takaoka",
@@ -5077,15 +6345,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.7362147,
-    "lon": 137.0187306
+    "lon": 137.0187306,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2803": {
     "name": "Shinminato",
     "ja_name": "新湊",
     "deleted": true,
-    "deleted_date": "Oct.31,2005",
+    "deleted_date": "2005-10-31",
     "lat": 36.7825348,
-    "lon": 137.0794368
+    "lon": 137.0794368,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2804": {
     "name": "Uozu",
@@ -5093,7 +6365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 43.086459,
-    "lon": 141.4056708
+    "lon": 141.4056708,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2805": {
     "name": "Himi",
@@ -5101,7 +6375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.8645966,
-    "lon": 136.9704027
+    "lon": 136.9704027,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2806": {
     "name": "Namerikawa",
@@ -5109,7 +6385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.7643429,
-    "lon": 137.3413791
+    "lon": 137.3413791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2807": {
     "name": "Kurobe",
@@ -5117,7 +6395,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.8712828,
-    "lon": 137.4478857
+    "lon": 137.4478857,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2808": {
     "name": "Tonami",
@@ -5125,7 +6405,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.6364136,
-    "lon": 136.9468199
+    "lon": 136.9468199,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2809": {
     "name": "Oyabe",
@@ -5133,7 +6415,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.6755895,
-    "lon": 136.8688637
+    "lon": 136.8688637,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2810": {
     "name": "Nanto",
@@ -5141,7 +6425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.45356,
-    "lon": 136.91942
+    "lon": 136.91942,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2811": {
     "name": "Imizu",
@@ -5149,7 +6435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.7304657,
-    "lon": 137.0753818
+    "lon": 137.0753818,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2901": {
     "name": "Fukui",
@@ -5157,7 +6445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9263502,
-    "lon": 136.6068127
+    "lon": 136.6068127,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2902": {
     "name": "Tsuruga",
@@ -5165,15 +6455,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6445135,
-    "lon": 136.0734634
+    "lon": 136.0734634,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2903": {
     "name": "Takefu",
     "ja_name": "武生",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 35.9031163,
-    "lon": 136.1710672
+    "lon": 136.1710672,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2904": {
     "name": "Obama",
@@ -5181,7 +6475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4938281,
-    "lon": 135.7446614
+    "lon": 135.7446614,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2905": {
     "name": "Ono",
@@ -5189,7 +6485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.861365,
-    "lon": 134.9547785
+    "lon": 134.9547785,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2906": {
     "name": "Katsuyama",
@@ -5197,7 +6495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.060766,
-    "lon": 136.5007964
+    "lon": 136.5007964,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2907": {
     "name": "Sabae",
@@ -5205,7 +6505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9565096,
-    "lon": 136.1843593
+    "lon": 136.1843593,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2908": {
     "name": "Awara",
@@ -5213,7 +6515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.2113447,
-    "lon": 136.2290431
+    "lon": 136.2290431,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2909": {
     "name": "Echizen",
@@ -5221,7 +6525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9034571,
-    "lon": 136.1689317
+    "lon": 136.1689317,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "2910": {
     "name": "Sakai",
@@ -5229,7 +6535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5289178,
-    "lon": 135.5015548
+    "lon": 135.5015548,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3001": {
     "name": "Kanazawa",
@@ -5237,7 +6545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5780499,
-    "lon": 136.6480247
+    "lon": 136.6480247,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3002": {
     "name": "Nanao",
@@ -5245,7 +6555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.0521078,
-    "lon": 136.946461
+    "lon": 136.946461,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3003": {
     "name": "Komatsu",
@@ -5253,7 +6565,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.4032931,
-    "lon": 136.4495465
+    "lon": 136.4495465,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3004": {
     "name": "Wajima",
@@ -5261,7 +6575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.3905644,
-    "lon": 136.8994281
+    "lon": 136.8994281,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3005": {
     "name": "Suzu",
@@ -5269,7 +6585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 37.438147,
-    "lon": 137.2484135
+    "lon": 137.2484135,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3006": {
     "name": "Kaga",
@@ -5277,7 +6595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.25406,
-    "lon": 136.37874
+    "lon": 136.37874,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3007": {
     "name": "Hakui",
@@ -5285,15 +6605,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.8948225,
-    "lon": 136.7782938
+    "lon": 136.7782938,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3008": {
     "name": "Matsuto",
     "ja_name": "松任",
     "deleted": true,
-    "deleted_date": "Jan.31,2005",
+    "deleted_date": "2005-01-31",
     "lat": 36.51667,
-    "lon": 136.56667
+    "lon": 136.56667,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3009": {
     "name": "Kahoku",
@@ -5301,7 +6625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.7498188,
-    "lon": 136.7195952
+    "lon": 136.7195952,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3010": {
     "name": "Hakusan",
@@ -5309,7 +6635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.7215048,
-    "lon": 139.7521578
+    "lon": 139.7521578,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3011": {
     "name": "Nomi",
@@ -5317,7 +6645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.43655,
-    "lon": 136.54449
+    "lon": 136.54449,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3012": {
     "name": "Nonoichi",
@@ -5325,7 +6655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.5197206,
-    "lon": 136.6098107
+    "lon": 136.6098107,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3101": {
     "name": "Okayama",
@@ -5333,7 +6665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8581334,
-    "lon": 133.7759256
+    "lon": 133.7759256,
+    "designated_city": true,
+    "designated_city_date": "2009-04-01"
   },
   "3102": {
     "name": "Kurashiki",
@@ -5341,7 +6675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5850791,
-    "lon": 133.7719957
+    "lon": 133.7719957,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3103": {
     "name": "Tsuyama",
@@ -5349,7 +6685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0691284,
-    "lon": 134.0043355
+    "lon": 134.0043355,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3104": {
     "name": "Tamano",
@@ -5357,23 +6695,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.491942,
-    "lon": 133.9460028
+    "lon": 133.9460028,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3105": {
     "name": "Kojima",
     "ja_name": "児島",
     "deleted": true,
-    "deleted_date": "Jan.31,1967",
+    "deleted_date": "1967-01-31",
     "lat": 34.4627408,
-    "lon": 133.8076652
+    "lon": 133.8076652,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3106": {
     "name": "Tamashima",
     "ja_name": "玉島",
     "deleted": true,
-    "deleted_date": "Jan.31,1967",
+    "deleted_date": "1967-01-31",
     "lat": 34.5527958,
-    "lon": 133.6849722
+    "lon": 133.6849722,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3107": {
     "name": "Kasaoka",
@@ -5381,15 +6725,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5071461,
-    "lon": 133.5074654
+    "lon": 133.5074654,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3108": {
     "name": "saidaiji",
     "ja_name": "西大寺",
     "deleted": true,
-    "deleted_date": "Feb.16,1969",
+    "deleted_date": "1969-02-16",
     "lat": 34.6619241,
-    "lon": 134.0373128
+    "lon": 134.0373128,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3109": {
     "name": "Ibara",
@@ -5397,7 +6745,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5977243,
-    "lon": 133.4638119
+    "lon": 133.4638119,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3110": {
     "name": "Soja",
@@ -5405,7 +6755,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6728162,
-    "lon": 133.7466763
+    "lon": 133.7466763,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3111": {
     "name": "Takahashi",
@@ -5413,7 +6765,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7908975,
-    "lon": 133.6169111
+    "lon": 133.6169111,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3112": {
     "name": "Niimi",
@@ -5421,7 +6775,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.9775653,
-    "lon": 133.4704309
+    "lon": 133.4704309,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3113": {
     "name": "Bizen",
@@ -5429,7 +6785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.744987,
-    "lon": 134.1882633
+    "lon": 134.1882633,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3114": {
     "name": "Setouchi",
@@ -5437,7 +6795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6647608,
-    "lon": 134.0926948
+    "lon": 134.0926948,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3115": {
     "name": "Akaiwa",
@@ -5445,7 +6805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.7553412,
-    "lon": 134.0188207
+    "lon": 134.0188207,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3116": {
     "name": "Maniwa",
@@ -5453,7 +6815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.075681,
-    "lon": 133.7532375
+    "lon": 133.7532375,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3117": {
     "name": "Mimasaka",
@@ -5461,7 +6825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0085854,
-    "lon": 134.1485964
+    "lon": 134.1485964,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3118": {
     "name": "Asakuchi",
@@ -5469,7 +6835,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5279193,
-    "lon": 133.5849605
+    "lon": 133.5849605,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3201": {
     "name": "Matsue",
@@ -5477,7 +6845,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.468115,
-    "lon": 133.048768
+    "lon": 133.048768,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3202": {
     "name": "Hamada",
@@ -5485,7 +6855,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8991982,
-    "lon": 132.0799984
+    "lon": 132.0799984,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3203": {
     "name": "Izumo",
@@ -5493,7 +6865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3668891,
-    "lon": 132.7548827
+    "lon": 132.7548827,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3204": {
     "name": "Masuda",
@@ -5501,7 +6875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.6748584,
-    "lon": 131.8428933
+    "lon": 131.8428933,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3205": {
     "name": "Oda",
@@ -5509,7 +6885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1920988,
-    "lon": 132.4994679
+    "lon": 132.4994679,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3206": {
     "name": "Yasugi",
@@ -5517,7 +6895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.431337,
-    "lon": 133.250942
+    "lon": 133.250942,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3207": {
     "name": "Gotsu",
@@ -5525,15 +6905,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0111168,
-    "lon": 132.2213266
+    "lon": 132.2213266,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3208": {
     "name": "Hirata",
     "ja_name": "平田",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 37.2219658,
-    "lon": 140.5756791
+    "lon": 140.5756791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3209": {
     "name": "Unnan",
@@ -5541,7 +6925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.2880963,
-    "lon": 132.9001494
+    "lon": 132.9001494,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3301": {
     "name": "Yamaguchi",
@@ -5549,7 +6935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2379614,
-    "lon": 131.5873845
+    "lon": 131.5873845,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3302": {
     "name": "Shimonoseki",
@@ -5557,7 +6945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9577116,
-    "lon": 130.9415455
+    "lon": 130.9415455,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3303": {
     "name": "Ube",
@@ -5565,7 +6955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9518498,
-    "lon": 131.2472243
+    "lon": 131.2472243,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3304": {
     "name": "Hagi",
@@ -5573,15 +6965,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4074815,
-    "lon": 131.399194
+    "lon": 131.399194,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3305": {
     "name": "Tokuyama",
     "ja_name": "徳山",
     "deleted": true,
-    "deleted_date": "Apr.20,2003",
+    "deleted_date": "2003-04-20",
     "lat": 34.0510183,
-    "lon": 131.8020941
+    "lon": 131.8020941,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3306": {
     "name": "Hofu",
@@ -5589,7 +6985,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0517226,
-    "lon": 131.5629141
+    "lon": 131.5629141,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3307": {
     "name": "Kudamatsu",
@@ -5597,7 +6995,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0149872,
-    "lon": 131.8704567
+    "lon": 131.8704567,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3308": {
     "name": "Iwakuni",
@@ -5605,15 +7005,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.1664995,
-    "lon": 132.2191163
+    "lon": 132.2191163,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3309": {
     "name": "Onoda",
     "ja_name": "小野田",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 34.0079811,
-    "lon": 131.1854093
+    "lon": 131.1854093,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3310": {
     "name": "Hikari",
@@ -5621,7 +7025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9615807,
-    "lon": 131.9425203
+    "lon": 131.9425203,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3311": {
     "name": "Nagato",
@@ -5629,7 +7035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3708941,
-    "lon": 131.1821587
+    "lon": 131.1821587,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3312": {
     "name": "Yanai",
@@ -5637,7 +7045,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9640825,
-    "lon": 132.101193
+    "lon": 132.101193,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3313": {
     "name": "Mine",
@@ -5645,15 +7055,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.1666165,
-    "lon": 131.2054466
+    "lon": 131.2054466,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3314": {
     "name": "Shinnan'yo",
     "ja_name": "新南陽",
     "deleted": true,
-    "deleted_date": "Apr.20,2003",
+    "deleted_date": "2003-04-20",
     "lat": 34.0696603,
-    "lon": 131.7700182
+    "lon": 131.7700182,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3315": {
     "name": "Shunan",
@@ -5661,7 +7075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0550595,
-    "lon": 131.8064092
+    "lon": 131.8064092,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3316": {
     "name": "San'yoonoda",
@@ -5669,7 +7085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0439,
-    "lon": 131.16032
+    "lon": 131.16032,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3401": {
     "name": "Tottori",
@@ -5677,7 +7095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.3555075,
-    "lon": 133.8678525
+    "lon": 133.8678525,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3402": {
     "name": "Kurayoshi",
@@ -5685,7 +7105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.430166,
-    "lon": 133.825525
+    "lon": 133.825525,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3403": {
     "name": "Yonago",
@@ -5693,7 +7115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.4276408,
-    "lon": 133.331459
+    "lon": 133.331459,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3404": {
     "name": "Sakaiminato",
@@ -5701,7 +7125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.5391751,
-    "lon": 133.2318575
+    "lon": 133.2318575,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3501": {
     "name": "Hiroshima",
@@ -5709,7 +7135,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3917241,
-    "lon": 132.4517589
+    "lon": 132.4517589,
+    "designated_city": true,
+    "designated_city_date": "1980-04-01"
   },
   "3502": {
     "name": "Kure",
@@ -5717,7 +7145,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2484488,
-    "lon": 132.5652498
+    "lon": 132.5652498,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3503": {
     "name": "Takehara",
@@ -5725,7 +7155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3418377,
-    "lon": 132.9070476
+    "lon": 132.9070476,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3504": {
     "name": "Mihara",
@@ -5733,7 +7165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3974407,
-    "lon": 133.0785046
+    "lon": 133.0785046,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3505": {
     "name": "Onomichi",
@@ -5741,23 +7175,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4088519,
-    "lon": 133.2051549
+    "lon": 133.2051549,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3506": {
     "name": "Innoshima",
     "ja_name": "因島",
     "deleted": true,
-    "deleted_date": "",
+    "deleted_date": "2006-01-09",
     "lat": 34.3388148,
-    "lon": 133.1610464
+    "lon": 133.1610464,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3507": {
     "name": "Matsunaga",
     "ja_name": "松永",
     "deleted": true,
-    "deleted_date": "Apr.30,1966",
+    "deleted_date": "1966-04-30",
     "lat": 34.4507804,
-    "lon": 133.2586195
+    "lon": 133.2586195,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3508": {
     "name": "Fukuyama",
@@ -5765,7 +7205,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.4857039,
-    "lon": 133.3623097
+    "lon": 133.3623097,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3509": {
     "name": "Fuchu",
@@ -5773,7 +7215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.5683141,
-    "lon": 133.2366327
+    "lon": 133.2366327,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3510": {
     "name": "Miyoshi",
@@ -5781,7 +7225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.81024,
-    "lon": 132.851691
+    "lon": 132.851691,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3511": {
     "name": "Syoubara",
@@ -5789,7 +7235,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.8272451,
-    "lon": 132.9753076
+    "lon": 132.9753076,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3512": {
     "name": "Otake",
@@ -5797,7 +7245,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2378742,
-    "lon": 132.2223092
+    "lon": 132.2223092,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3513": {
     "name": "Higashihiroshima",
@@ -5805,7 +7255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.42683,
-    "lon": 132.741552
+    "lon": 132.741552,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3514": {
     "name": "Hatsukaichi",
@@ -5813,7 +7265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3485048,
-    "lon": 132.331833
+    "lon": 132.331833,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3515": {
     "name": "Akitakata",
@@ -5821,7 +7275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.70296,
-    "lon": 132.6775
+    "lon": 132.6775,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3516": {
     "name": "Etajima",
@@ -5829,7 +7285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.1749619,
-    "lon": 132.4622276
+    "lon": 132.4622276,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3601": {
     "name": "Takamatsu",
@@ -5837,7 +7295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3425592,
-    "lon": 134.0465338
+    "lon": 134.0465338,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3602": {
     "name": "Marugame",
@@ -5845,7 +7305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2888128,
-    "lon": 133.7982421
+    "lon": 133.7982421,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3603": {
     "name": "Sakaide",
@@ -5853,7 +7315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3082086,
-    "lon": 133.8698532
+    "lon": 133.8698532,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3604": {
     "name": "Zentsuji",
@@ -5861,7 +7325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2194913,
-    "lon": 133.7613603
+    "lon": 133.7613603,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3605": {
     "name": "Kan'onji",
@@ -5869,7 +7335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.1284693,
-    "lon": 133.6628679
+    "lon": 133.6628679,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3606": {
     "name": "Sanuki",
@@ -5877,7 +7345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2931892,
-    "lon": 134.1890881
+    "lon": 134.1890881,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3607": {
     "name": "Higashikagawa",
@@ -5885,7 +7355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.2223617,
-    "lon": 134.3192814
+    "lon": 134.3192814,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3608": {
     "name": "Mitoyo",
@@ -5893,7 +7365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.1986856,
-    "lon": 133.7179334
+    "lon": 133.7179334,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3701": {
     "name": "Tokushima",
@@ -5901,7 +7375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9196418,
-    "lon": 134.2509634
+    "lon": 134.2509634,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3702": {
     "name": "Naruto",
@@ -5909,7 +7385,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6084534,
-    "lon": 140.4108142
+    "lon": 140.4108142,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3703": {
     "name": "Komatsushima",
@@ -5917,7 +7395,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0044235,
-    "lon": 134.5906577
+    "lon": 134.5906577,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3704": {
     "name": "Anan",
@@ -5925,7 +7405,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.31854,
-    "lon": 137.76495
+    "lon": 137.76495,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3705": {
     "name": "Yoshinogawa",
@@ -5933,7 +7415,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0663158,
-    "lon": 134.3585119
+    "lon": 134.3585119,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3706": {
     "name": "Awa",
@@ -5941,7 +7425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.1254245,
-    "lon": 139.8358817
+    "lon": 139.8358817,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3707": {
     "name": "Mima",
@@ -5949,7 +7435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0537915,
-    "lon": 134.1700644
+    "lon": 134.1700644,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3708": {
     "name": "Miyoshi",
@@ -5957,7 +7445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.81024,
-    "lon": 132.851691
+    "lon": 132.851691,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3801": {
     "name": "Matsuyama",
@@ -5965,7 +7455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8395188,
-    "lon": 132.7653521
+    "lon": 132.7653521,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3802": {
     "name": "Imabari",
@@ -5973,7 +7465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.0658182,
-    "lon": 132.9976758
+    "lon": 132.9976758,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3803": {
     "name": "Uwajima",
@@ -5981,7 +7475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2232315,
-    "lon": 132.5606514
+    "lon": 132.5606514,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3804": {
     "name": "Yawatahama",
@@ -5989,7 +7485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.4627983,
-    "lon": 132.4235208
+    "lon": 132.4235208,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3805": {
     "name": "Niihama",
@@ -5997,7 +7495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9603497,
-    "lon": 133.2835899
+    "lon": 133.2835899,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3806": {
     "name": "Saijo",
@@ -6005,7 +7505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.9194466,
-    "lon": 133.1813268
+    "lon": 133.1813268,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3807": {
     "name": "Ozu",
@@ -6013,23 +7515,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.506488,
-    "lon": 132.5446842
+    "lon": 132.5446842,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3808": {
     "name": "Iyomishima",
     "ja_name": "伊予三島",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 33.9,
-    "lon": 133.5
+    "lon": 133.5,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3809": {
     "name": "Kawanoe",
     "ja_name": "川之江",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 34.0143555,
-    "lon": 133.5760642
+    "lon": 133.5760642,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3810": {
     "name": "Iyo",
@@ -6037,23 +7545,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7578962,
-    "lon": 132.7039458
+    "lon": 132.7039458,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3811": {
     "name": "Hojo",
     "ja_name": "北条",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 34.994923,
-    "lon": 139.8665482
+    "lon": 139.8665482,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3812": {
     "name": "Toyo",
     "ja_name": "東予",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 33.5230707,
-    "lon": 134.2429417
+    "lon": 134.2429417,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3813": {
     "name": "Shikokuchuo",
@@ -6061,7 +7575,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.980744,
-    "lon": 133.5499338
+    "lon": 133.5499338,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3814": {
     "name": "Seiyo",
@@ -6069,7 +7585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3625533,
-    "lon": 132.5109394
+    "lon": 132.5109394,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3815": {
     "name": "Toon",
@@ -6077,7 +7595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7908821,
-    "lon": 132.8718965
+    "lon": 132.8718965,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3901": {
     "name": "Kochi",
@@ -6085,7 +7605,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.57984,
-    "lon": 133.50752
+    "lon": 133.50752,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3902": {
     "name": "Muroto",
@@ -6093,7 +7615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2898523,
-    "lon": 134.1522806
+    "lon": 134.1522806,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3903": {
     "name": "Aki",
@@ -6101,7 +7625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5019095,
-    "lon": 133.9072127
+    "lon": 133.9072127,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3904": {
     "name": "Tosa",
@@ -6109,7 +7635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.4960168,
-    "lon": 133.425544
+    "lon": 133.425544,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3905": {
     "name": "Susaki",
@@ -6117,15 +7645,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.400826,
-    "lon": 133.2829594
+    "lon": 133.2829594,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3906": {
     "name": "Nakamura",
     "ja_name": "中村",
     "deleted": true,
-    "deleted_date": "Apr.9,2005",
+    "deleted_date": "2005-04-09",
     "lat": 32.9843748,
-    "lon": 132.9440278
+    "lon": 132.9440278,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3907": {
     "name": "Sukumo",
@@ -6133,7 +7665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9390595,
-    "lon": 132.7262671
+    "lon": 132.7262671,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3908": {
     "name": "Tosashimizu",
@@ -6141,7 +7675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.7816213,
-    "lon": 132.9548557
+    "lon": 132.9548557,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3909": {
     "name": "Nankoku",
@@ -6149,7 +7685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5755463,
-    "lon": 133.6413009
+    "lon": 133.6413009,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3910": {
     "name": "Shimanto",
@@ -6157,7 +7695,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9912232,
-    "lon": 132.9336984
+    "lon": 132.9336984,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3911": {
     "name": "Konan",
@@ -6165,7 +7705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.344508,
-    "lon": 136.866742
+    "lon": 136.866742,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "3912": {
     "name": "Kami",
@@ -6173,7 +7715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.6321694,
-    "lon": 134.6293314
+    "lon": 134.6293314,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4001": {
     "name": "Fukuoka",
@@ -6181,47 +7725,59 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.6251241,
-    "lon": 130.6180016
+    "lon": 130.6180016,
+    "designated_city": true,
+    "designated_city_date": "1972-04-01"
   },
   "4002": {
     "name": "Kokura",
     "ja_name": "小倉",
     "deleted": true,
-    "deleted_date": "Feb.9,1963",
+    "deleted_date": "1963-02-09",
     "lat": 33.8867625,
-    "lon": 130.8821624
+    "lon": 130.8821624,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4003": {
     "name": "Moji",
     "ja_name": "門司",
     "deleted": true,
-    "deleted_date": "Feb.9,1963",
+    "deleted_date": "1963-02-09",
     "lat": 33.9043043,
-    "lon": 130.9328578
+    "lon": 130.9328578,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4004": {
     "name": "Yahata",
     "ja_name": "八幡",
     "deleted": true,
-    "deleted_date": "Feb.9,1963",
+    "deleted_date": "1963-02-09",
     "lat": 33.8692953,
-    "lon": 130.7954174
+    "lon": 130.7954174,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4005": {
     "name": "Tobata",
     "ja_name": "戸畑",
     "deleted": true,
-    "deleted_date": "Feb.9,1963",
+    "deleted_date": "1963-02-09",
     "lat": 33.8972177,
-    "lon": 130.8206112
+    "lon": 130.8206112,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4006": {
     "name": "Wakamatsu",
     "ja_name": "若松",
     "deleted": true,
-    "deleted_date": "Feb.9,1963",
+    "deleted_date": "1963-02-09",
     "lat": 33.9009962,
-    "lon": 130.8060685
+    "lon": 130.8060685,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4007": {
     "name": "Kurume",
@@ -6229,7 +7785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3196545,
-    "lon": 130.5080625
+    "lon": 130.5080625,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4008": {
     "name": "Omuta",
@@ -6237,7 +7795,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.047013,
-    "lon": 130.464155
+    "lon": 130.464155,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4009": {
     "name": "Noogata",
@@ -6245,7 +7805,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.743936,
-    "lon": 130.7297462
+    "lon": 130.7297462,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4010": {
     "name": "Iizuka",
@@ -6253,7 +7815,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.646594,
-    "lon": 130.6911579
+    "lon": 130.6911579,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4011": {
     "name": "Tagawa",
@@ -6261,7 +7825,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.6387807,
-    "lon": 130.8063352
+    "lon": 130.8063352,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4012": {
     "name": "Yanagawa",
@@ -6269,23 +7835,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1630969,
-    "lon": 130.4058091
+    "lon": 130.4058091,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4013": {
     "name": "Amagi",
     "ja_name": "甘木",
     "deleted": true,
-    "deleted_date": "Mar.19,2006",
+    "deleted_date": "2006-03-19",
     "lat": 27.818004,
-    "lon": 128.90815
+    "lon": 128.90815,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4014": {
     "name": "Yamada",
     "ja_name": "山田",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 34.8056396,
-    "lon": 135.5155581
+    "lon": 135.5155581,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4015": {
     "name": "Yame",
@@ -6293,7 +7865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2116721,
-    "lon": 130.5579706
+    "lon": 130.5579706,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4016": {
     "name": "Chikugo",
@@ -6301,7 +7875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2123783,
-    "lon": 130.5017727
+    "lon": 130.5017727,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4017": {
     "name": "Okawa",
@@ -6309,7 +7885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2061857,
-    "lon": 130.3835746
+    "lon": 130.3835746,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4018": {
     "name": "Yukuhashi",
@@ -6317,7 +7895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7292049,
-    "lon": 130.9831626
+    "lon": 130.9831626,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4019": {
     "name": "Buzen",
@@ -6325,7 +7905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.6114994,
-    "lon": 131.1304409
+    "lon": 131.1304409,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4020": {
     "name": "Nakama",
@@ -6333,7 +7915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8164202,
-    "lon": 130.7090761
+    "lon": 130.7090761,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4021": {
     "name": "Kitakyushu",
@@ -6341,7 +7925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8829996,
-    "lon": 130.8749015
+    "lon": 130.8749015,
+    "designated_city": true,
+    "designated_city_date": "1963-04-01"
   },
   "4022": {
     "name": "Ogoori",
@@ -6349,7 +7935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3963946,
-    "lon": 130.5554371
+    "lon": 130.5554371,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4023": {
     "name": "Kasuga",
@@ -6357,7 +7945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5326446,
-    "lon": 130.4713013
+    "lon": 130.4713013,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4024": {
     "name": "Chikushino",
@@ -6365,7 +7955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.4906026,
-    "lon": 130.520329
+    "lon": 130.520329,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4025": {
     "name": "Onojo",
@@ -6373,7 +7965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.547399,
-    "lon": 130.488786
+    "lon": 130.488786,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4026": {
     "name": "Munakata",
@@ -6381,7 +7975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.8055642,
-    "lon": 130.5406875
+    "lon": 130.5406875,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4027": {
     "name": "Dazaifu",
@@ -6389,15 +7985,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5129189,
-    "lon": 130.5242217
+    "lon": 130.5242217,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4028": {
     "name": "Maebaru",
     "ja_name": "前原",
     "deleted": true,
-    "deleted_date": "Dec.31,2009",
+    "deleted_date": "2009-12-31",
     "lat": 32.99109,
-    "lon": 130.605873
+    "lon": 130.605873,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4029": {
     "name": "Koga",
@@ -6405,7 +8005,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 36.178025,
-    "lon": 139.7553638
+    "lon": 139.7553638,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4030": {
     "name": "Fukutsu",
@@ -6413,7 +8015,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7668264,
-    "lon": 130.4913329
+    "lon": 130.4913329,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4031": {
     "name": "Ukiha",
@@ -6421,7 +8025,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3473997,
-    "lon": 130.7552293
+    "lon": 130.7552293,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4032": {
     "name": "Miyawaka",
@@ -6429,7 +8035,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7235894,
-    "lon": 130.6667511
+    "lon": 130.6667511,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4033": {
     "name": "Kama",
@@ -6437,7 +8045,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5367,
-    "lon": 130.74015
+    "lon": 130.74015,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4034": {
     "name": "Asakura",
@@ -6445,7 +8055,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.4234248,
-    "lon": 130.6657037
+    "lon": 130.6657037,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4035": {
     "name": "Miyama",
@@ -6453,7 +8065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1523675,
-    "lon": 130.4746267
+    "lon": 130.4746267,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4036": {
     "name": "Itoshima",
@@ -6461,7 +8075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5572419,
-    "lon": 130.1955242
+    "lon": 130.1955242,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4037": {
     "name": "nakagawa",
@@ -6469,7 +8085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.4994449,
-    "lon": 130.4216086
+    "lon": 130.4216086,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4101": {
     "name": "Saga",
@@ -6477,7 +8095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2185408,
-    "lon": 130.1296585
+    "lon": 130.1296585,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4102": {
     "name": "Karatsu",
@@ -6485,7 +8105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.4503405,
-    "lon": 129.9679345
+    "lon": 129.9679345,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4103": {
     "name": "Tosu",
@@ -6493,7 +8115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3778536,
-    "lon": 130.5061966
+    "lon": 130.5061966,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4104": {
     "name": "Taku",
@@ -6501,7 +8125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2885725,
-    "lon": 130.1100243
+    "lon": 130.1100243,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4105": {
     "name": "Imari",
@@ -6509,7 +8135,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2644557,
-    "lon": 129.8808439
+    "lon": 129.8808439,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4106": {
     "name": "Takeo",
@@ -6517,7 +8145,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.20099,
-    "lon": 129.99846
+    "lon": 129.99846,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4107": {
     "name": "Kashima",
@@ -6525,7 +8155,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.9661164,
-    "lon": 140.6450292
+    "lon": 140.6450292,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4108": {
     "name": "Ogi",
@@ -6533,7 +8165,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2738076,
-    "lon": 130.2171043
+    "lon": 130.2171043,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4109": {
     "name": "Ureshino",
@@ -6541,7 +8175,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1279109,
-    "lon": 130.0599074
+    "lon": 130.0599074,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4110": {
     "name": "Kanzaki",
@@ -6549,7 +8185,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3115907,
-    "lon": 130.3719429
+    "lon": 130.3719429,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4201": {
     "name": "Nagasaki",
@@ -6557,7 +8195,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1154683,
-    "lon": 129.7874339
+    "lon": 129.7874339,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4202": {
     "name": "Sasebo",
@@ -6565,7 +8205,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1799965,
-    "lon": 129.7152872
+    "lon": 129.7152872,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4203": {
     "name": "Shimabara",
@@ -6573,7 +8215,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.788084,
-    "lon": 130.3705411
+    "lon": 130.3705411,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4204": {
     "name": "Isahaya",
@@ -6581,7 +8225,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.843426,
-    "lon": 130.0530537
+    "lon": 130.0530537,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4205": {
     "name": "Omura",
@@ -6589,15 +8235,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9002281,
-    "lon": 129.9585055
+    "lon": 129.9585055,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4206": {
     "name": "Fukue",
     "ja_name": "福江",
     "deleted": true,
-    "deleted_date": "Jul.31,2004",
+    "deleted_date": "2004-07-31",
     "lat": 34.0471135,
-    "lon": 130.9156608
+    "lon": 130.9156608,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4207": {
     "name": "Hirado",
@@ -6605,7 +8255,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3680705,
-    "lon": 129.5539153
+    "lon": 129.5539153,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4208": {
     "name": "Matsuura",
@@ -6613,7 +8265,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.3410429,
-    "lon": 129.7088042
+    "lon": 129.7088042,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4209": {
     "name": "Tsushima",
@@ -6621,7 +8275,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.3952765,
-    "lon": 129.315449
+    "lon": 129.315449,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4210": {
     "name": "Iki",
@@ -6629,7 +8285,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.7500515,
-    "lon": 129.6913078
+    "lon": 129.6913078,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4211": {
     "name": "Goto",
@@ -6637,7 +8295,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.6951424,
-    "lon": 128.8408104
+    "lon": 128.8408104,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4212": {
     "name": "Saikai",
@@ -6645,7 +8305,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9331936,
-    "lon": 129.6430585
+    "lon": 129.6430585,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4213": {
     "name": "Unzen",
@@ -6653,7 +8315,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.83515,
-    "lon": 130.18772
+    "lon": 130.18772,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4214": {
     "name": "Minamishimabara",
@@ -6661,7 +8325,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.6597338,
-    "lon": 130.2976992
+    "lon": 130.2976992,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4301": {
     "name": "Kumamoto",
@@ -6669,7 +8335,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.6450475,
-    "lon": 130.6341345
+    "lon": 130.6341345,
+    "designated_city": true,
+    "designated_city_date": "2012-04-01"
   },
   "4302": {
     "name": "Yatsushiro",
@@ -6677,7 +8345,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.5081425,
-    "lon": 130.6020211
+    "lon": 130.6020211,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4303": {
     "name": "Hitoyoshi",
@@ -6685,7 +8355,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.2056644,
-    "lon": 130.7601392
+    "lon": 130.7601392,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4304": {
     "name": "Arao",
@@ -6693,7 +8365,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9867584,
-    "lon": 130.4334027
+    "lon": 130.4334027,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4305": {
     "name": "Minamata",
@@ -6701,7 +8375,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.2123376,
-    "lon": 130.4087616
+    "lon": 130.4087616,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4306": {
     "name": "Tamana",
@@ -6709,15 +8385,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9352591,
-    "lon": 130.5628137
+    "lon": 130.5628137,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4307": {
     "name": "Hondo",
     "ja_name": "本渡",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 32.45583,
-    "lon": 130.17078
+    "lon": 130.17078,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4308": {
     "name": "Yamaga",
@@ -6725,15 +8405,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.0177456,
-    "lon": 130.6911907
+    "lon": 130.6911907,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4309": {
     "name": "Ushibuka",
     "ja_name": "牛深",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 32.1939884,
-    "lon": 130.0274164
+    "lon": 130.0274164,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4310": {
     "name": "Kikuchi",
@@ -6741,7 +8425,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9798234,
-    "lon": 130.8131987
+    "lon": 130.8131987,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4311": {
     "name": "Uto",
@@ -6749,7 +8435,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.6879177,
-    "lon": 130.6598222
+    "lon": 130.6598222,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4312": {
     "name": "Kamiamakusa",
@@ -6757,7 +8445,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.4963015,
-    "lon": 130.3960215
+    "lon": 130.3960215,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4313": {
     "name": "Uki",
@@ -6765,7 +8455,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.647181,
-    "lon": 130.6839693
+    "lon": 130.6839693,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4314": {
     "name": "Aso",
@@ -6773,7 +8465,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9524903,
-    "lon": 131.1214674
+    "lon": 131.1214674,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4315": {
     "name": "Amakusa",
@@ -6781,7 +8475,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.4585127,
-    "lon": 130.1930487
+    "lon": 130.1930487,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4316": {
     "name": "Koshi",
@@ -6789,7 +8485,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.89351,
-    "lon": 130.76862
+    "lon": 130.76862,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4401": {
     "name": "Oita",
@@ -6797,7 +8495,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2393864,
-    "lon": 131.6096524
+    "lon": 131.6096524,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4402": {
     "name": "Beppu",
@@ -6805,7 +8505,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.2845752,
-    "lon": 131.4913063
+    "lon": 131.4913063,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4403": {
     "name": "Nakatsu",
@@ -6813,7 +8515,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5982794,
-    "lon": 131.1883225
+    "lon": 131.1883225,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4404": {
     "name": "Hita",
@@ -6821,7 +8525,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.33428,
-    "lon": 130.94266
+    "lon": 130.94266,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4405": {
     "name": "Saiki",
@@ -6829,7 +8535,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9601732,
-    "lon": 131.8996704
+    "lon": 131.8996704,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4406": {
     "name": "Usuki",
@@ -6837,7 +8545,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1261032,
-    "lon": 131.8048454
+    "lon": 131.8048454,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4407": {
     "name": "Tsukumi",
@@ -6845,7 +8555,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.0722942,
-    "lon": 131.861347
+    "lon": 131.861347,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4408": {
     "name": "Taketa",
@@ -6853,15 +8565,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9736821,
-    "lon": 131.3979534
+    "lon": 131.3979534,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4409": {
     "name": "Tsurusaki",
     "ja_name": "鶴崎",
     "deleted": true,
-    "deleted_date": "Mar.9,1963",
+    "deleted_date": "1963-03-09",
     "lat": 33.2427592,
-    "lon": 131.6869622
+    "lon": 131.6869622,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4410": {
     "name": "Bungotakada",
@@ -6869,7 +8585,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5562136,
-    "lon": 131.4469025
+    "lon": 131.4469025,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4411": {
     "name": "Kitsuki",
@@ -6877,7 +8595,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.416849,
-    "lon": 131.6217599
+    "lon": 131.6217599,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4412": {
     "name": "Usa",
@@ -6885,7 +8605,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 35.0103,
-    "lon": 139.07152
+    "lon": 139.07152,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4413": {
     "name": "Bungoono",
@@ -6893,7 +8615,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.9775643,
-    "lon": 131.5841178
+    "lon": 131.5841178,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4414": {
     "name": "Yufu",
@@ -6901,7 +8625,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.1800993,
-    "lon": 131.4269323
+    "lon": 131.4269323,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4415": {
     "name": "Kunisaki",
@@ -6909,7 +8635,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 33.5632982,
-    "lon": 131.7322544
+    "lon": 131.7322544,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4501": {
     "name": "Miyazaki",
@@ -6917,7 +8645,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.097681,
-    "lon": 131.294542
+    "lon": 131.294542,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4502": {
     "name": "Miyakonojo",
@@ -6925,7 +8655,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.7196106,
-    "lon": 131.0612029
+    "lon": 131.0612029,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4503": {
     "name": "Nobeoka",
@@ -6933,7 +8665,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.5823063,
-    "lon": 131.6649034
+    "lon": 131.6649034,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4504": {
     "name": "Nichinan",
@@ -6941,7 +8675,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.6019221,
-    "lon": 131.3788769
+    "lon": 131.3788769,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4505": {
     "name": "Kobayashi",
@@ -6949,7 +8685,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.9966841,
-    "lon": 130.9731456
+    "lon": 130.9731456,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4506": {
     "name": "Hyuga",
@@ -6957,7 +8695,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.4225483,
-    "lon": 131.6244443
+    "lon": 131.6244443,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4507": {
     "name": "Kushima",
@@ -6965,7 +8705,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.4649768,
-    "lon": 131.2282568
+    "lon": 131.2282568,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4508": {
     "name": "Saito",
@@ -6973,7 +8715,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.1078882,
-    "lon": 131.4008856
+    "lon": 131.4008856,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4509": {
     "name": "Ebino",
@@ -6981,7 +8725,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.0422993,
-    "lon": 130.8159272
+    "lon": 130.8159272,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4601": {
     "name": "Kagoshima",
@@ -6989,15 +8735,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.521587,
-    "lon": 130.5474077
+    "lon": 130.5474077,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4602": {
     "name": "Sendai",
     "ja_name": "川内",
     "deleted": true,
-    "deleted_date": "Oct.11,2004",
+    "deleted_date": "2004-10-11",
     "lat": 38.2677554,
-    "lon": 140.8691498
+    "lon": 140.8691498,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4603": {
     "name": "Kanoya",
@@ -7005,7 +8755,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.3780472,
-    "lon": 130.8525167
+    "lon": 130.8525167,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4604": {
     "name": "Makurazaki",
@@ -7013,15 +8765,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.2728756,
-    "lon": 130.2970739
+    "lon": 130.2970739,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4605": {
     "name": "Kushikino",
     "ja_name": "串木野",
     "deleted": true,
-    "deleted_date": "Oct.10,2005",
+    "deleted_date": "2005-10-10",
     "lat": 31.7212541,
-    "lon": 130.2744046
+    "lon": 130.2744046,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4606": {
     "name": "Akune",
@@ -7029,7 +8785,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.0143139,
-    "lon": 130.1927415
+    "lon": 130.1927415,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4607": {
     "name": "Izumi",
@@ -7037,23 +8795,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 34.43108,
-    "lon": 135.474789
+    "lon": 135.474789,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4608": {
     "name": "Naze",
     "ja_name": "名瀬",
     "deleted": true,
-    "deleted_date": "Mar.19,2006",
+    "deleted_date": "2006-03-19",
     "lat": 26.21094,
-    "lon": 127.68359
+    "lon": 127.68359,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4609": {
     "name": "Okuchi",
     "ja_name": "大口",
     "deleted": true,
-    "deleted_date": "Oct.31,2008",
+    "deleted_date": "2008-10-31",
     "lat": 39.9477028,
-    "lon": 141.823169
+    "lon": 141.823169,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4610": {
     "name": "Ibusuki",
@@ -7061,31 +8825,39 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.2527953,
-    "lon": 130.6333097
+    "lon": 130.6333097,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4611": {
     "name": "Kaseda",
     "ja_name": "加世田",
     "deleted": true,
-    "deleted_date": "Nov.6,2005",
+    "deleted_date": "2005-11-06",
     "lat": 31.41647,
-    "lon": 130.3131
+    "lon": 130.3131,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4612": {
     "name": "Kokubu",
     "ja_name": "国分",
     "deleted": true,
-    "deleted_date": "Nov.6,2005",
+    "deleted_date": "2005-11-06",
     "lat": 31.7436681,
-    "lon": 130.7634464
+    "lon": 130.7634464,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4613": {
     "name": "Taniyama",
     "ja_name": "谷山",
     "deleted": true,
-    "deleted_date": "Apr.28,1967",
+    "deleted_date": "1967-04-28",
     "lat": 31.5267756,
-    "lon": 130.5182922
+    "lon": 130.5182922,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4614": {
     "name": "Nishinoomote",
@@ -7093,7 +8865,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 30.7325356,
-    "lon": 130.9970786
+    "lon": 130.9970786,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4615": {
     "name": "Tarumizu",
@@ -7101,7 +8875,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.4926939,
-    "lon": 130.7012264
+    "lon": 130.7012264,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4616": {
     "name": "Satsumasendai",
@@ -7109,7 +8885,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.813421,
-    "lon": 130.3039789
+    "lon": 130.3039789,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4617": {
     "name": "Hioki",
@@ -7117,7 +8895,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.6336972,
-    "lon": 130.4024361
+    "lon": 130.4024361,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4618": {
     "name": "Soo",
@@ -7125,7 +8905,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.6535068,
-    "lon": 131.0194108
+    "lon": 131.0194108,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4619": {
     "name": "Kirishima",
@@ -7133,7 +8915,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.7410148,
-    "lon": 130.7632406
+    "lon": 130.7632406,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4620": {
     "name": "Ichikikushikino",
@@ -7141,7 +8925,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.7146024,
-    "lon": 130.2721599
+    "lon": 130.2721599,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4621": {
     "name": "Minamisatsuma",
@@ -7149,7 +8935,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.4165805,
-    "lon": 130.3236567
+    "lon": 130.3236567,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4622": {
     "name": "Shibushi",
@@ -7157,7 +8945,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.4953083,
-    "lon": 131.0456478
+    "lon": 131.0456478,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4623": {
     "name": "Amami",
@@ -7165,7 +8955,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 28.3776614,
-    "lon": 129.4938985
+    "lon": 129.4938985,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4624": {
     "name": "Minamikyushu",
@@ -7173,7 +8965,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.3782842,
-    "lon": 130.4416754
+    "lon": 130.4416754,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4625": {
     "name": "Isa",
@@ -7181,7 +8975,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 32.0569877,
-    "lon": 130.6130906
+    "lon": 130.6130906,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4626": {
     "name": "Aira",
@@ -7189,7 +8985,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 31.78172,
-    "lon": 130.59637
+    "lon": 130.59637,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4701": {
     "name": "Naha",
@@ -7197,23 +8995,29 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.2122345,
-    "lon": 127.6791452
+    "lon": 127.6791452,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4702": {
     "name": "Ishikawa",
     "ja_name": "石川",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 36.9890574,
-    "lon": 136.8162839
+    "lon": 136.8162839,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4703": {
     "name": "Hirara",
     "ja_name": "平良",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 24.8032045,
-    "lon": 125.3029776
+    "lon": 125.3029776,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4704": {
     "name": "Ishigaki",
@@ -7221,15 +9025,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 24.3439358,
-    "lon": 124.1861835
+    "lon": 124.1861835,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4705": {
     "name": "Koza",
     "ja_name": "コザ",
     "deleted": true,
-    "deleted_date": "",
+    "deleted_date": "1974-03-31",
     "lat": 33.5193114,
-    "lon": 135.820911
+    "lon": 135.820911,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4706": {
     "name": "Ginowan",
@@ -7237,15 +9045,19 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.2814968,
-    "lon": 127.7784916
+    "lon": 127.7784916,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4707": {
     "name": "Gushikawa",
     "ja_name": "具志川",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 26.3589102,
-    "lon": 127.8675878
+    "lon": 127.8675878,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4708": {
     "name": "Nago",
@@ -7253,7 +9065,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.5919599,
-    "lon": 127.9774759
+    "lon": 127.9774759,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4709": {
     "name": "Urasoe",
@@ -7261,7 +9075,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.249754,
-    "lon": 127.716591
+    "lon": 127.716591,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4710": {
     "name": "Itoman",
@@ -7269,7 +9085,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.106017,
-    "lon": 127.686066
+    "lon": 127.686066,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4711": {
     "name": "Okinawa",
@@ -7277,7 +9095,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.5707754,
-    "lon": 128.0255901
+    "lon": 128.0255901,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4712": {
     "name": "Tomigusuku",
@@ -7285,7 +9105,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.1772381,
-    "lon": 127.6863791
+    "lon": 127.6863791,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4713": {
     "name": "Uruma",
@@ -7293,7 +9115,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.384705,
-    "lon": 127.851324
+    "lon": 127.851324,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4714": {
     "name": "Miyakojima",
@@ -7301,7 +9125,9 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 24.8054647,
-    "lon": 125.2811296
+    "lon": 125.2811296,
+    "designated_city": false,
+    "designated_city_date": ""
   },
   "4715": {
     "name": "Nanjo",
@@ -7309,6 +9135,8 @@
     "deleted": false,
     "deleted_date": "",
     "lat": 26.1625434,
-    "lon": 127.771152
+    "lon": 127.771152,
+    "designated_city": false,
+    "designated_city_date": ""
   }
 }

--- a/assets/json/japan_award/jcg_list.json
+++ b/assets/json/japan_award/jcg_list.json
@@ -27,7 +27,7 @@
     "name": "Atsuta",
     "ja_name": "厚田",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 43.40013889,
     "lon": 141.4341944
   },
@@ -91,7 +91,7 @@
     "name": "Utasutsu",
     "ja_name": "歌棄",
     "deleted": true,
-    "deleted_date": "Jan.14,1955",
+    "deleted_date": "1955-01-14",
     "lat": 42.725041667,
     "lon": 140.341027778
   },
@@ -131,7 +131,7 @@
     "name": "Oshoro",
     "ja_name": "忍路",
     "deleted": true,
-    "deleted_date": "Mar.31,1958",
+    "deleted_date": "1958-03-31",
     "lat": 43.209305556,
     "lon": 140.921888889
   },
@@ -227,7 +227,7 @@
     "name": "Sapporo",
     "ja_name": "札幌",
     "deleted": true,
-    "deleted_date": "Aug.31,1996",
+    "deleted_date": "1996-08-31",
     "lat": 42.9855,
     "lon": 141.563083333
   },
@@ -251,7 +251,7 @@
     "name": "Shizunai",
     "ja_name": "静内",
     "deleted": true,
-    "deleted_date": "Mar.30,2006",
+    "deleted_date": "2006-03-30",
     "lat": 42.341277778,
     "lon": 142.368583333
   },
@@ -347,7 +347,7 @@
     "name": "Chitose",
     "ja_name": "千歳",
     "deleted": true,
-    "deleted_date": "Oct.31,1970",
+    "deleted_date": "1970-10-31",
     "lat": 42.86667,
     "lon": 141.63333
   },
@@ -427,7 +427,7 @@
     "name": "Nemuro",
     "ja_name": "根室",
     "deleted": true,
-    "deleted_date": "Jul.31,1957",
+    "deleted_date": "1957-07-31",
     "lat": 43.281055556,
     "lon": 145.420305556
   },
@@ -443,7 +443,7 @@
     "name": "Hanasaki",
     "ja_name": "花咲",
     "deleted": true,
-    "deleted_date": "Mar.31,1959",
+    "deleted_date": "1959-03-31",
     "lat": 43.343583333,
     "lon": 145.75425
   },
@@ -451,7 +451,7 @@
     "name": "Hamamasu",
     "ja_name": "浜益",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 43.600638889,
     "lon": 141.38675
   },
@@ -459,7 +459,7 @@
     "name": "Bikuni",
     "ja_name": "美国",
     "deleted": true,
-    "deleted_date": "Sep.29,1956",
+    "deleted_date": "1956-09-29",
     "lat": 43.298722222,
     "lon": 140.598
   },
@@ -483,7 +483,7 @@
     "name": "Futoro",
     "ja_name": "太櫓",
     "deleted": true,
-    "deleted_date": "Mar.31,1955",
+    "deleted_date": "1955-03-31",
     "lat": 42.358222222,
     "lon": 139.906944444
   },
@@ -515,7 +515,7 @@
     "name": "Horobetsu",
     "ja_name": "幌別",
     "deleted": true,
-    "deleted_date": "Jul.31,1970",
+    "deleted_date": "1970-07-31",
     "lat": 42.439152778,
     "lon": 141.091208333
   },
@@ -539,7 +539,7 @@
     "name": "Mitsuishi",
     "ja_name": "三石",
     "deleted": true,
-    "deleted_date": "Mar.30,2006",
+    "deleted_date": "2006-03-30",
     "lat": 42.248333333,
     "lon": 142.560305556
   },
@@ -731,7 +731,7 @@
     "name": "Esashi",
     "ja_name": "江刺",
     "deleted": true,
-    "deleted_date": "Nov.2,1958",
+    "deleted_date": "1958-11-02",
     "lat": 39.191472222,
     "lon": 141.173611111
   },
@@ -795,7 +795,7 @@
     "name": "Hienuki",
     "ja_name": "稗貫",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 39.477666667,
     "lon": 141.195555556
   },
@@ -803,7 +803,7 @@
     "name": "Higashiiwai",
     "ja_name": "東磐井",
     "deleted": true,
-    "deleted_date": "Sep.25,2011",
+    "deleted_date": "2011-09-25",
     "lat": 38.934722222,
     "lon": 141.126666666
   },
@@ -835,7 +835,7 @@
     "name": "Kawabe",
     "ja_name": "河辺",
     "deleted": true,
-    "deleted_date": "Jan.10,2005",
+    "deleted_date": "2005-01-10",
     "lat": 39.65277778,
     "lon": 140.21527778
   },
@@ -859,7 +859,7 @@
     "name": "Hiraka",
     "ja_name": "平鹿",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 39.31138889,
     "lon": 140.55333333
   },
@@ -883,7 +883,7 @@
     "name": "Yuri",
     "ja_name": "由利",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 39.385,
     "lon": 140.048
   },
@@ -915,7 +915,7 @@
     "name": "Nishitagawa",
     "ja_name": "西田川",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 38.620888889,
     "lon": 139.586972222
   },
@@ -955,7 +955,7 @@
     "name": "Minamiokitama",
     "ja_name": "南置賜",
     "deleted": true,
-    "deleted_date": "Mar.31,1958",
+    "deleted_date": "1958-03-31",
     "lat": 37.919111111,
     "lon": 139.881194444
   },
@@ -963,7 +963,7 @@
     "name": "Minamimurayama",
     "ja_name": "南村山",
     "deleted": true,
-    "deleted_date": "Mar.20,1957",
+    "deleted_date": "1957-03-20",
     "lat": 38.185638889,
     "lon": 140.224722222
   },
@@ -1011,7 +1011,7 @@
     "name": "Kurihara",
     "ja_name": "栗原",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 38.74166667,
     "lon": 141.01725
   },
@@ -1027,7 +1027,7 @@
     "name": "Shida",
     "ja_name": "志田",
     "deleted": true,
-    "deleted_date": "Mar.30,2006",
+    "deleted_date": "2006-03-30",
     "lat": 38.504259259,
     "lon": 141.03187037
   },
@@ -1043,7 +1043,7 @@
     "name": "Tamatsukuri",
     "ja_name": "玉造",
     "deleted": true,
-    "deleted_date": "Mar.30,2006",
+    "deleted_date": "2006-03-30",
     "lat": 38.698416667,
     "lon": 140.797708333
   },
@@ -1059,7 +1059,7 @@
     "name": "Tome",
     "ja_name": "登米",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 38.679704861,
     "lon": 141.224291667
   },
@@ -1067,7 +1067,7 @@
     "name": "Natori",
     "ja_name": "名取",
     "deleted": true,
-    "deleted_date": "Feb.29,1988",
+    "deleted_date": "1988-02-29",
     "lat": 38.258388889,
     "lon": 140.671361111
   },
@@ -1091,7 +1091,7 @@
     "name": "Monou",
     "ja_name": "桃生",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 38.492256944,
     "lon": 141.282736111
   },
@@ -1107,7 +1107,7 @@
     "name": "Asaka",
     "ja_name": "安積",
     "deleted": true,
-    "deleted_date": "Apr.30,1965",
+    "deleted_date": "1965-04-30",
     "lat": 37.420151235,
     "lon": 140.30578395
   },
@@ -1131,7 +1131,7 @@
     "name": "Ishiki",
     "ja_name": "石城",
     "deleted": true,
-    "deleted_date": "Sep.30,1966",
+    "deleted_date": "1966-09-30",
     "lat": 37.087365079,
     "lon": 140.798412698
   },
@@ -1163,7 +1163,7 @@
     "name": "Kitaaizu",
     "ja_name": "北会津",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 37.491555556,
     "lon": 139.874083333
   },
@@ -1171,7 +1171,7 @@
     "name": "Shinobu",
     "ja_name": "信夫",
     "deleted": true,
-    "deleted_date": "Sep.30,1968",
+    "deleted_date": "1968-09-30",
     "lat": 37.758666667,
     "lon": 140.396222222
   },
@@ -1259,7 +1259,7 @@
     "name": "Kitauonuma",
     "ja_name": "北魚沼",
     "deleted": true,
-    "deleted_date": "Mar.30,2010",
+    "deleted_date": "2010-03-30",
     "lat": 37.436472,
     "lon": 138.838861
   },
@@ -1275,7 +1275,7 @@
     "name": "Koshi",
     "ja_name": "古志",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 37.32658333,
     "lon": 138.89
   },
@@ -1283,7 +1283,7 @@
     "name": "Sado",
     "ja_name": "佐渡",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 38.083333333,
     "lon": 138.333055555
   },
@@ -1307,7 +1307,7 @@
     "name": "Nakakambara",
     "ja_name": "中蒲原",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 37.693472222,
     "lon": 139.174527778
   },
@@ -1315,7 +1315,7 @@
     "name": "Nakakubiki",
     "ja_name": "中頸城",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 37.095812989,
     "lon": 138.308506578
   },
@@ -1331,7 +1331,7 @@
     "name": "Nishikubiki",
     "ja_name": "西頸城",
     "deleted": true,
-    "deleted_date": "Mar.18,2005",
+    "deleted_date": "2005-03-18",
     "lat": 37.0,
     "lon": 138.0
   },
@@ -1347,7 +1347,7 @@
     "name": "Higashikubiki",
     "ja_name": "東頸城",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 37.120712963,
     "lon": 138.49662037
   },
@@ -1419,7 +1419,7 @@
     "name": "Sarashina",
     "ja_name": "更級",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 36.50644444,
     "lon": 137.9886389
   },
@@ -1483,7 +1483,7 @@
     "name": "Minamiazumi",
     "ja_name": "南安曇",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 36.240773809,
     "lon": 137.842099205
   },
@@ -1499,7 +1499,7 @@
     "name": "Kitatama",
     "ja_name": "北多摩",
     "deleted": true,
-    "deleted_date": "Nov.2,1970",
+    "deleted_date": "1970-11-02",
     "lat": 35.754833333,
     "lon": 139.387361111
   },
@@ -1515,7 +1515,7 @@
     "name": "Minamitama",
     "ja_name": "南多摩",
     "deleted": true,
-    "deleted_date": "Oct.31,1971",
+    "deleted_date": "1971-10-31",
     "lat": 35.637444444,
     "lon": 139.475416667
   },
@@ -1587,7 +1587,7 @@
     "name": "Tsukui",
     "ja_name": "津久井",
     "deleted": true,
-    "deleted_date": "Mar.10,2007",
+    "deleted_date": "2007-03-10",
     "lat": 35.602951389,
     "lon": 139.225819444
   },
@@ -1627,7 +1627,7 @@
     "name": "Ichihara",
     "ja_name": "市原",
     "deleted": true,
-    "deleted_date": "Sep.30,1967",
+    "deleted_date": "1967-09-30",
     "lat": 35.368222222,
     "lon": 140.141402778
   },
@@ -1643,7 +1643,7 @@
     "name": "Kaijo",
     "ja_name": "海上",
     "deleted": true,
-    "deleted_date": "Jun.30,2005",
+    "deleted_date": "2005-06-30",
     "lat": 35.721,
     "lon": 140.702722222
   },
@@ -1659,7 +1659,7 @@
     "name": "Kimitsu",
     "ja_name": "君津",
     "deleted": true,
-    "deleted_date": "Mar.31,1991",
+    "deleted_date": "1991-03-31",
     "lat": 35.38333333,
     "lon": 139.91666667
   },
@@ -1675,7 +1675,7 @@
     "name": "Sosa",
     "ja_name": "匝瑳",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 35.663166667,
     "lon": 140.536805556
   },
@@ -1683,7 +1683,7 @@
     "name": "Chiba",
     "ja_name": "千葉",
     "deleted": true,
-    "deleted_date": "Dec.31,1966",
+    "deleted_date": "1966-12-31",
     "lat": 35.722416667,
     "lon": 140.099888889
   },
@@ -1699,7 +1699,7 @@
     "name": "Higashikatsushika",
     "ja_name": "東葛飾",
     "deleted": true,
-    "deleted_date": "Mar.27,2005",
+    "deleted_date": "2005-03-27",
     "lat": 35.841444444,
     "lon": 140.00775
   },
@@ -1739,7 +1739,7 @@
     "name": "Kitasaitama",
     "ja_name": "北埼玉",
     "deleted": true,
-    "deleted_date": "Mar.22,2010",
+    "deleted_date": "2010-03-22",
     "lat": 36.131388888,
     "lon": 139.601666666
   },
@@ -1787,7 +1787,7 @@
     "name": "Kashima",
     "ja_name": "鹿島",
     "deleted": true,
-    "deleted_date": "Oct.10,2005",
+    "deleted_date": "2005-10-10",
     "lat": 35.965556,
     "lon": 140.644722
   },
@@ -1819,7 +1819,7 @@
     "name": "Taga",
     "ja_name": "多賀",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 36.716667,
     "lon": 140.683333
   },
@@ -1827,7 +1827,7 @@
     "name": "Tsukuba",
     "ja_name": "筑波",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 35.976402778,
     "lon": 140.023847222
   },
@@ -1843,7 +1843,7 @@
     "name": "Namegata",
     "ja_name": "行方",
     "deleted": true,
-    "deleted_date": "Sep.1,2005",
+    "deleted_date": "2005-09-01",
     "lat": 36.1,
     "lon": 140.433333
   },
@@ -1851,7 +1851,7 @@
     "name": "Niihari",
     "ja_name": "新治",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 36.166541667,
     "lon": 140.298361111
   },
@@ -1859,7 +1859,7 @@
     "name": "Nishiibaraki",
     "ja_name": "西茨城",
     "deleted": true,
-    "deleted_date": "Mar.18,2006",
+    "deleted_date": "2006-03-18",
     "lat": 36.361667,
     "lon": 140.266667
   },
@@ -1875,7 +1875,7 @@
     "name": "Makabe",
     "ja_name": "真壁",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 36.3,
     "lon": 139.983333
   },
@@ -1891,7 +1891,7 @@
     "name": "Ashikaga",
     "ja_name": "足利",
     "deleted": true,
-    "deleted_date": "Sep.30,1962",
+    "deleted_date": "1962-09-30",
     "lat": 36.344138889,
     "lon": 139.438472222
   },
@@ -1899,7 +1899,7 @@
     "name": "Aso",
     "ja_name": "安蘇",
     "deleted": true,
-    "deleted_date": "Feb.27,2005",
+    "deleted_date": "2005-02-27",
     "lat": 36.388527778,
     "lon": 139.590513889
   },
@@ -1907,7 +1907,7 @@
     "name": "Kamitsuga",
     "ja_name": "上都賀",
     "deleted": true,
-    "deleted_date": "Sep.30,2011",
+    "deleted_date": "2011-09-30",
     "lat": 36.381388888,
     "lon": 139.730277777
   },
@@ -1963,7 +1963,7 @@
     "name": "Usui",
     "ja_name": "碓氷",
     "deleted": true,
-    "deleted_date": "Mar.17,2006",
+    "deleted_date": "2006-03-17",
     "lat": 36.314583333,
     "lon": 138.790472222
   },
@@ -1995,7 +1995,7 @@
     "name": "Gumma",
     "ja_name": "群馬",
     "deleted": true,
-    "deleted_date": "Sep.30,2006",
+    "deleted_date": "2006-09-30",
     "lat": 36.385166667,
     "lon": 138.881916667
   },
@@ -2011,7 +2011,7 @@
     "name": "Seta",
     "ja_name": "勢多",
     "deleted": true,
-    "deleted_date": "May.04,2009",
+    "deleted_date": "2009-05-04",
     "lat": 36.49306,
     "lon": 139.11526
   },
@@ -2035,7 +2035,7 @@
     "name": "Nitta",
     "ja_name": "新田",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 36.394833333,
     "lon": 139.281083333
   },
@@ -2043,7 +2043,7 @@
     "name": "Yamada",
     "ja_name": "山田",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 36.43275,
     "lon": 139.273277778
   },
@@ -2051,7 +2051,7 @@
     "name": "Kitakoma",
     "ja_name": "北巨摩",
     "deleted": true,
-    "deleted_date": "Mar.14,2006",
+    "deleted_date": "2006-03-14",
     "lat": 35.862444444,
     "lon": 138.318944444
   },
@@ -2083,7 +2083,7 @@
     "name": "Higashiyatsushiro",
     "ja_name": "東八代",
     "deleted": true,
-    "deleted_date": "Jul.31,2006",
+    "deleted_date": "2006-07-31",
     "lat": 35.553416667,
     "lon": 138.665083333
   },
@@ -2091,7 +2091,7 @@
     "name": "Higashiyamanashi",
     "ja_name": "東山梨",
     "deleted": true,
-    "deleted_date": "Oct.31,2005",
+    "deleted_date": "2005-10-31",
     "lat": 35.652166667,
     "lon": 138.751055556
   },
@@ -2115,7 +2115,7 @@
     "name": "Abe",
     "ja_name": "安倍",
     "deleted": true,
-    "deleted_date": "Dec.31,1968",
+    "deleted_date": "1968-12-31",
     "lat": 34.975,
     "lon": 138.38361111
   },
@@ -2123,7 +2123,7 @@
     "name": "Inasa",
     "ja_name": "引佐",
     "deleted": true,
-    "deleted_date": "Jun.30,2005",
+    "deleted_date": "2005-06-30",
     "lat": 34.814583333,
     "lon": 137.625675926
   },
@@ -2131,7 +2131,7 @@
     "name": "Ihara",
     "ja_name": "庵原",
     "deleted": true,
-    "deleted_date": "Oct.31,2008",
+    "deleted_date": "2008-10-31",
     "lat": 35.127930556,
     "lon": 138.590208333
   },
@@ -2139,7 +2139,7 @@
     "name": "Iwata",
     "ja_name": "磐田",
     "deleted": true,
-    "deleted_date": "Jun.30,2005",
+    "deleted_date": "2005-06-30",
     "lat": 34.857298611,
     "lon": 137.850302083
   },
@@ -2147,7 +2147,7 @@
     "name": "Ogasa",
     "ja_name": "小笠",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 34.672277778,
     "lon": 138.021680556
   },
@@ -2163,7 +2163,7 @@
     "name": "Shida",
     "ja_name": "志太",
     "deleted": true,
-    "deleted_date": "Dec.31,2008",
+    "deleted_date": "2008-12-31",
     "lat": 34.91666667,
     "lon": 138.28333333
   },
@@ -2203,7 +2203,7 @@
     "name": "Hamana",
     "ja_name": "浜名",
     "deleted": true,
-    "deleted_date": "Mar.22,2010",
+    "deleted_date": "2010-03-22",
     "lat": 34.6943,
     "lon": 137.5598
   },
@@ -2211,7 +2211,7 @@
     "name": "Fuji",
     "ja_name": "富士",
     "deleted": true,
-    "deleted_date": "Mar.22,2010",
+    "deleted_date": "2010-03-22",
     "lat": 35.25,
     "lon": 138.63333
   },
@@ -2227,7 +2227,7 @@
     "name": "Inaba",
     "ja_name": "稲葉",
     "deleted": true,
-    "deleted_date": "Mar.31,1963",
+    "deleted_date": "1963-03-31",
     "lat": 35.400479167,
     "lon": 136.867430556
   },
@@ -2243,7 +2243,7 @@
     "name": "Ena",
     "ja_name": "恵那",
     "deleted": true,
-    "deleted_date": "Feb.12,2005",
+    "deleted_date": "2005-02-12",
     "lat": 35.449571,
     "lon": 137.40936
   },
@@ -2259,7 +2259,7 @@
     "name": "Kaizu",
     "ja_name": "海津",
     "deleted": true,
-    "deleted_date": "Mar.27,2005",
+    "deleted_date": "2005-03-27",
     "lat": 35.23250926,
     "lon": 136.623740752
   },
@@ -2283,7 +2283,7 @@
     "name": "Gujo",
     "ja_name": "郡上",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 35.807027778,
     "lon": 136.954801587
   },
@@ -2291,7 +2291,7 @@
     "name": "Toki",
     "ja_name": "土岐",
     "deleted": true,
-    "deleted_date": "Jan.22,2006",
+    "deleted_date": "2006-01-22",
     "lat": 35.35,
     "lon": 137.183333333
   },
@@ -2315,7 +2315,7 @@
     "name": "Mashita",
     "ja_name": "益田",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 35.833566667,
     "lon": 137.210272222
   },
@@ -2323,7 +2323,7 @@
     "name": "Mugi",
     "ja_name": "武儀",
     "deleted": true,
-    "deleted_date": "Feb.6,2005",
+    "deleted_date": "2005-02-06",
     "lat": 35.604622222,
     "lon": 136.903205556
   },
@@ -2339,7 +2339,7 @@
     "name": "Yamagata",
     "ja_name": "山県",
     "deleted": true,
-    "deleted_date": "Mar.31,2003",
+    "deleted_date": "2003-03-31",
     "lat": 34.655337302,
     "lon": 132.354626984
   },
@@ -2355,7 +2355,7 @@
     "name": "Yoshiki",
     "ja_name": "吉城",
     "deleted": true,
-    "deleted_date": "Jan.31,2005",
+    "deleted_date": "2005-01-31",
     "lat": 36.248708331,
     "lon": 137.287902772
   },
@@ -2371,7 +2371,7 @@
     "name": "Atsumi",
     "ja_name": "渥美",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 34.623222222,
     "lon": 137.109555556
   },
@@ -2403,7 +2403,7 @@
     "name": "Nakashima",
     "ja_name": "中島",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.212888889,
     "lon": 136.739611111
   },
@@ -2419,7 +2419,7 @@
     "name": "Nishikamo",
     "ja_name": "西加茂",
     "deleted": true,
-    "deleted_date": "Jan.03,2010",
+    "deleted_date": "2010-01-03",
     "lat": 35.08333333,
     "lon": 137.06666667
   },
@@ -2443,7 +2443,7 @@
     "name": "Haguri",
     "ja_name": "葉栗",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.337111111,
     "lon": 136.778138889
   },
@@ -2451,7 +2451,7 @@
     "name": "Hazu",
     "ja_name": "幡豆",
     "deleted": true,
-    "deleted_date": "Mar.31,2011",
+    "deleted_date": "2011-03-31",
     "lat": 34.82323,
     "lon": 137.021192
   },
@@ -2459,7 +2459,7 @@
     "name": "Higashikasugai",
     "ja_name": "東春日井",
     "deleted": true,
-    "deleted_date": "Nov.30,1970",
+    "deleted_date": "1970-11-30",
     "lat": 35.216527778,
     "lon": 137.035361111
   },
@@ -2467,7 +2467,7 @@
     "name": "Higashikamo",
     "ja_name": "東加茂",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.08333333,
     "lon": 137.06666667
   },
@@ -2475,7 +2475,7 @@
     "name": "Hekikai",
     "ja_name": "碧海",
     "deleted": true,
-    "deleted_date": "Nov.30,1970",
+    "deleted_date": "1970-11-30",
     "lat": 34.964444444,
     "lon": 137.01925
   },
@@ -2483,7 +2483,7 @@
     "name": "Hoi",
     "ja_name": "宝飯",
     "deleted": true,
-    "deleted_date": "Jan.31,2010",
+    "deleted_date": "2010-01-31",
     "lat": 34.8231,
     "lon": 137.38
   },
@@ -2491,7 +2491,7 @@
     "name": "Minamishitara",
     "ja_name": "南設楽",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 34.9,
     "lon": 137.5
   },
@@ -2499,7 +2499,7 @@
     "name": "Yana",
     "ja_name": "八名",
     "deleted": true,
-    "deleted_date": "Sep.29,1956",
+    "deleted_date": "1956-09-29",
     "lat": 34.8425,
     "lon": 137.422222
   },
@@ -2507,7 +2507,7 @@
     "name": "Age",
     "ja_name": "安芸",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 34.768215278,
     "lon": 136.451381944
   },
@@ -2515,7 +2515,7 @@
     "name": "Ano",
     "ja_name": "安濃",
     "deleted": true,
-    "deleted_date": "Sep.29,1956",
+    "deleted_date": "1956-09-29",
     "lat": 34.759657407,
     "lon": 136.4205
   },
@@ -2523,7 +2523,7 @@
     "name": "Ayama",
     "ja_name": "阿山",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 34.797090278,
     "lon": 136.167034722
   },
@@ -2531,7 +2531,7 @@
     "name": "Iinan",
     "ja_name": "飯南",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 34.439125,
     "lon": 136.361666667
   },
@@ -2539,7 +2539,7 @@
     "name": "Ichishi",
     "ja_name": "一志",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 34.623854168,
     "lon": 136.394277781
   },
@@ -2555,7 +2555,7 @@
     "name": "Kawage",
     "ja_name": "河芸",
     "deleted": true,
-    "deleted_date": "Sep.29,1956",
+    "deleted_date": "1956-09-29",
     "lat": 34.796083334,
     "lon": 136.477159721
   },
@@ -2579,7 +2579,7 @@
     "name": "Shima",
     "ja_name": "志摩",
     "deleted": true,
-    "deleted_date": "Sep.30,2004",
+    "deleted_date": "2004-09-30",
     "lat": 34.328194444,
     "lon": 136.829666667
   },
@@ -2587,7 +2587,7 @@
     "name": "Suzuka",
     "ja_name": "鈴鹿",
     "deleted": true,
-    "deleted_date": "Jan.10,2005",
+    "deleted_date": "2005-01-10",
     "lat": 34.854833333,
     "lon": 136.391138889
   },
@@ -2603,7 +2603,7 @@
     "name": "Naga",
     "ja_name": "名賀",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 34.669611111,
     "lon": 136.177861111
   },
@@ -2635,7 +2635,7 @@
     "name": "Amada",
     "ja_name": "天田",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 35.3,
     "lon": 135.133333
   },
@@ -2643,7 +2643,7 @@
     "name": "Ikaruga",
     "ja_name": "何鹿",
     "deleted": true,
-    "deleted_date": "Sep.29,1956",
+    "deleted_date": "1956-09-29",
     "lat": 35.317555556,
     "lon": 135.187222222
   },
@@ -2659,7 +2659,7 @@
     "name": "Kasa",
     "ja_name": "加佐",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 35.409555556,
     "lon": 135.197666667
   },
@@ -2667,7 +2667,7 @@
     "name": "Kitakuwada",
     "ja_name": "北桑田",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 35.213652778,
     "lon": 135.591652778
   },
@@ -2683,7 +2683,7 @@
     "name": "Kumano",
     "ja_name": "熊野",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 35.603444444,
     "lon": 134.895
   },
@@ -2699,7 +2699,7 @@
     "name": "Takeno",
     "ja_name": "竹野",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 35.693305556,
     "lon": 135.073425926
   },
@@ -2715,7 +2715,7 @@
     "name": "Naka",
     "ja_name": "中",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 35.303208333,
     "lon": 139.283416667
   },
@@ -2731,7 +2731,7 @@
     "name": "Minamikuwada",
     "ja_name": "南桑田",
     "deleted": true,
-    "deleted_date": "Sep.29,1959",
+    "deleted_date": "1959-09-29",
     "lat": 35.004194444,
     "lon": 135.605416667
   },
@@ -2747,7 +2747,7 @@
     "name": "Ika",
     "ja_name": "伊香",
     "deleted": true,
-    "deleted_date": "Dec.31,2009",
+    "deleted_date": "2009-12-31",
     "lat": 35.5339,
     "lon": 136.1987
   },
@@ -2779,7 +2779,7 @@
     "name": "Kanzaki",
     "ja_name": "神崎",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 35.001287037,
     "lon": 134.754416667
   },
@@ -2787,7 +2787,7 @@
     "name": "Kurita",
     "ja_name": "栗太",
     "deleted": true,
-    "deleted_date": "Sep.30,2001",
+    "deleted_date": "2001-09-30",
     "lat": 35.01027778,
     "lon": 135.98527778
   },
@@ -2795,7 +2795,7 @@
     "name": "Koka",
     "ja_name": "甲賀",
     "deleted": true,
-    "deleted_date": "Sep.30,2004",
+    "deleted_date": "2004-09-30",
     "lat": 34.946638889,
     "lon": 136.148055556
   },
@@ -2803,7 +2803,7 @@
     "name": "Sakata",
     "ja_name": "坂田",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 35.33725,
     "lon": 136.303889
   },
@@ -2811,7 +2811,7 @@
     "name": "Shiga",
     "ja_name": "滋賀",
     "deleted": true,
-    "deleted_date": "Mar.19,2006",
+    "deleted_date": "2006-03-19",
     "lat": 35.206333333,
     "lon": 135.921166667
   },
@@ -2819,7 +2819,7 @@
     "name": "Takashima",
     "ja_name": "高島",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 35.353,
     "lon": 136.035722222
   },
@@ -2827,7 +2827,7 @@
     "name": "Higashiazai",
     "ja_name": "東浅井",
     "deleted": true,
-    "deleted_date": "Dec.31,2009",
+    "deleted_date": "2009-12-31",
     "lat": 35.3713,
     "lon": 136.3946
   },
@@ -2835,7 +2835,7 @@
     "name": "Yasu",
     "ja_name": "野洲",
     "deleted": true,
-    "deleted_date": "Sep.30,2004",
+    "deleted_date": "2004-09-30",
     "lat": 35.085347222,
     "lon": 136.019027778
   },
@@ -2859,7 +2859,7 @@
     "name": "Uchi",
     "ja_name": "宇智",
     "deleted": true,
-    "deleted_date": "Dec.31,1958",
+    "deleted_date": "1958-12-31",
     "lat": 34.335361111,
     "lon": 135.70125
   },
@@ -2883,7 +2883,7 @@
     "name": "Soekami",
     "ja_name": "添上",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 34.709472222,
     "lon": 136.044
   },
@@ -2899,7 +2899,7 @@
     "name": "Minamikatsuragi",
     "ja_name": "南葛城",
     "deleted": true,
-    "deleted_date": "Mar.30,1958",
+    "deleted_date": "1958-03-30",
     "lat": 34.444694444,
     "lon": 135.738520833
   },
@@ -2923,7 +2923,7 @@
     "name": "Kitakawachi",
     "ja_name": "北河内",
     "deleted": true,
-    "deleted_date": "Nov.2,1971",
+    "deleted_date": "1971-11-02",
     "lat": 34.787944444,
     "lon": 135.679944444
   },
@@ -2955,7 +2955,7 @@
     "name": "Nakakawachi",
     "ja_name": "中河内",
     "deleted": true,
-    "deleted_date": "Apr.2,1965",
+    "deleted_date": "1965-04-02",
     "lat": 34.579277778,
     "lon": 135.628611111
   },
@@ -3003,7 +3003,7 @@
     "name": "Naga",
     "ja_name": "那賀",
     "deleted": true,
-    "deleted_date": "Mar.31,2006",
+    "deleted_date": "2006-03-31",
     "lat": 33.857416667,
     "lon": 134.496638889
   },
@@ -3043,7 +3043,7 @@
     "name": "Asago",
     "ja_name": "朝来",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.23333,
     "lon": 134.83333
   },
@@ -3051,7 +3051,7 @@
     "name": "Arima",
     "ja_name": "有馬",
     "deleted": true,
-    "deleted_date": "May.30,1958",
+    "deleted_date": "1958-05-30",
     "lat": 34.889972222,
     "lon": 135.225444444
   },
@@ -3059,7 +3059,7 @@
     "name": "Izushi",
     "ja_name": "出石",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.465875,
     "lon": 134.912583333
   },
@@ -3075,7 +3075,7 @@
     "name": "Innami",
     "ja_name": "印南",
     "deleted": true,
-    "deleted_date": "Jan.31,1979",
+    "deleted_date": "1979-01-31",
     "lat": 34.82125,
     "lon": 134.819333
   },
@@ -3091,7 +3091,7 @@
     "name": "Kasai",
     "ja_name": "加西",
     "deleted": true,
-    "deleted_date": "Mar.31,1967",
+    "deleted_date": "1967-03-31",
     "lat": 34.923814815,
     "lon": 134.863759259
   },
@@ -3099,7 +3099,7 @@
     "name": "Kato",
     "ja_name": "加東",
     "deleted": true,
-    "deleted_date": "Mar.19,2006",
+    "deleted_date": "2006-03-19",
     "lat": 34.92062037,
     "lon": 134.994648148
   },
@@ -3123,7 +3123,7 @@
     "name": "Kinosaki",
     "ja_name": "城崎",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 35.596076389,
     "lon": 134.740798611
   },
@@ -3139,7 +3139,7 @@
     "name": "Shikama",
     "ja_name": "飾磨",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 34.824319444,
     "lon": 134.608444444
   },
@@ -3147,7 +3147,7 @@
     "name": "Shiso",
     "ja_name": "宍粟",
     "deleted": true,
-    "deleted_date": "Mar.26,2006",
+    "deleted_date": "2006-03-26",
     "lat": 34.98575,
     "lon": 134.595583333
   },
@@ -3163,7 +3163,7 @@
     "name": "Taki",
     "ja_name": "多紀",
     "deleted": true,
-    "deleted_date": "Mar.31,1999",
+    "deleted_date": "1999-03-31",
     "lat": 35.059756944,
     "lon": 135.170847222
   },
@@ -3171,7 +3171,7 @@
     "name": "Tsuna",
     "ja_name": "津名",
     "deleted": true,
-    "deleted_date": "Feb.10,2006",
+    "deleted_date": "2006-02-10",
     "lat": 34.383,
     "lon": 134.836
   },
@@ -3179,7 +3179,7 @@
     "name": "Hikami",
     "ja_name": "氷上",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 35.168148148,
     "lon": 135.064925926
   },
@@ -3195,7 +3195,7 @@
     "name": "Mino",
     "ja_name": "美嚢",
     "deleted": true,
-    "deleted_date": "Oct.23,2005",
+    "deleted_date": "2005-10-23",
     "lat": 34.88666667,
     "lon": 135.12416667
   },
@@ -3203,7 +3203,7 @@
     "name": "Mihara",
     "ja_name": "三原",
     "deleted": true,
-    "deleted_date": "Jan.10,2005",
+    "deleted_date": "2005-01-10",
     "lat": 34.300840278,
     "lon": 134.766263889
   },
@@ -3211,7 +3211,7 @@
     "name": "Muko",
     "ja_name": "武庫",
     "deleted": true,
-    "deleted_date": "Mar.31,1954",
+    "deleted_date": "1954-03-31",
     "lat": 34.7371605,
     "lon": 135.3523598
   },
@@ -3219,7 +3219,7 @@
     "name": "Yabu",
     "ja_name": "養父",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 35.404611111,
     "lon": 134.767611111
   },
@@ -3227,7 +3227,7 @@
     "name": "Imizu",
     "ja_name": "射水",
     "deleted": true,
-    "deleted_date": "Oct.31,2005",
+    "deleted_date": "2005-10-31",
     "lat": 36.727006944,
     "lon": 137.089958333
   },
@@ -3235,7 +3235,7 @@
     "name": "Kaminiikawa",
     "ja_name": "上新川",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 36.594722221,
     "lon": 137.251861094
   },
@@ -3259,7 +3259,7 @@
     "name": "Nishitonami",
     "ja_name": "西砺波",
     "deleted": true,
-    "deleted_date": "Oct.31,2005",
+    "deleted_date": "2005-10-31",
     "lat": 36.632555556,
     "lon": 136.899638889
   },
@@ -3267,7 +3267,7 @@
     "name": "Nei",
     "ja_name": "婦負",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 36.588534722,
     "lon": 137.152201389
   },
@@ -3275,7 +3275,7 @@
     "name": "Himi",
     "ja_name": "氷見",
     "deleted": true,
-    "deleted_date": "Mar.31,1954",
+    "deleted_date": "1954-03-31",
     "lat": 36.85555,
     "lon": 136.965702778
   },
@@ -3283,7 +3283,7 @@
     "name": "Higashitonami",
     "ja_name": "東砺波",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 36.509784722,
     "lon": 136.948072917
   },
@@ -3291,7 +3291,7 @@
     "name": "Asuwa",
     "ja_name": "足羽",
     "deleted": true,
-    "deleted_date": "Jan.30,2006",
+    "deleted_date": "2006-01-30",
     "lat": 35.998722222,
     "lon": 136.360611111
   },
@@ -3315,7 +3315,7 @@
     "name": "Ono",
     "ja_name": "大野",
     "deleted": true,
-    "deleted_date": "Nov.6,2005",
+    "deleted_date": "2005-11-06",
     "lat": 36.270944444,
     "lon": 136.898555556
   },
@@ -3323,7 +3323,7 @@
     "name": "Onyu",
     "ja_name": "遠敷",
     "deleted": true,
-    "deleted_date": "Mar.2,2006",
+    "deleted_date": "2006-03-02",
     "lat": 35.400027778,
     "lon": 135.682111111
   },
@@ -3331,7 +3331,7 @@
     "name": "Sakai",
     "ja_name": "坂井",
     "deleted": true,
-    "deleted_date": "Mar.19,2006",
+    "deleted_date": "2006-03-19",
     "lat": 36.166811111,
     "lon": 136.218848611
   },
@@ -3339,7 +3339,7 @@
     "name": "Tsuruga",
     "ja_name": "敦賀",
     "deleted": true,
-    "deleted_date": "Jan.14,1955",
+    "deleted_date": "1955-01-14",
     "lat": 35.645194444,
     "lon": 136.0555
   },
@@ -3387,7 +3387,7 @@
     "name": "Ishikawa",
     "ja_name": "石川",
     "deleted": true,
-    "deleted_date": "Nov.10,2011",
+    "deleted_date": "2011-11-10",
     "lat": 36.54,
     "lon": 136.61
   },
@@ -3395,7 +3395,7 @@
     "name": "Enuma",
     "ja_name": "江沼",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 36.246527778,
     "lon": 136.371972222
   },
@@ -3419,7 +3419,7 @@
     "name": "Suzu",
     "ja_name": "珠洲",
     "deleted": true,
-    "deleted_date": "Feb.28,2005",
+    "deleted_date": "2005-02-28",
     "lat": 37.35325,
     "lon": 137.244527778
   },
@@ -3443,7 +3443,7 @@
     "name": "Fugeshi",
     "ja_name": "鳳至",
     "deleted": true,
-    "deleted_date": "Feb.28,2005",
+    "deleted_date": "2005-02-28",
     "lat": 37.259152778,
     "lon": 136.840152778
   },
@@ -3467,7 +3467,7 @@
     "name": "Akaiwa",
     "ja_name": "赤磐",
     "deleted": true,
-    "deleted_date": "Jan.21,2007",
+    "deleted_date": "2007-01-21",
     "lat": 34.733888889,
     "lon": 134.039027778
   },
@@ -3483,7 +3483,7 @@
     "name": "Atetsu",
     "ja_name": "阿哲",
     "deleted": true,
-    "deleted_date": "Mar.30,2005",
+    "deleted_date": "2005-03-30",
     "lat": 34.985243056,
     "lon": 133.436451389
   },
@@ -3491,7 +3491,7 @@
     "name": "Oku",
     "ja_name": "邑久",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 34.661824074,
     "lon": 134.11412963
   },
@@ -3515,7 +3515,7 @@
     "name": "Kawakami",
     "ja_name": "川上",
     "deleted": true,
-    "deleted_date": "Sep.30,2004",
+    "deleted_date": "2004-09-30",
     "lat": 43.394291667,
     "lon": 144.529958333
   },
@@ -3523,7 +3523,7 @@
     "name": "Kibi",
     "ja_name": "吉備",
     "deleted": true,
-    "deleted_date": "Jul.31,2005",
+    "deleted_date": "2005-07-31",
     "lat": 34.62902778,
     "lon": 133.6922222
   },
@@ -3539,7 +3539,7 @@
     "name": "Kojima",
     "ja_name": "児島",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 34.544,
     "lon": 133.864944444
   },
@@ -3547,7 +3547,7 @@
     "name": "Shitsuki",
     "ja_name": "後月",
     "deleted": true,
-    "deleted_date": "Feb.28,2005",
+    "deleted_date": "2005-02-28",
     "lat": 34.6325,
     "lon": 133.432416667
   },
@@ -3555,7 +3555,7 @@
     "name": "Jodo",
     "ja_name": "上道",
     "deleted": true,
-    "deleted_date": "Apr.30,1971",
+    "deleted_date": "1971-04-30",
     "lat": 34.699555556,
     "lon": 134.054444444
   },
@@ -3563,7 +3563,7 @@
     "name": "Jobo",
     "ja_name": "上房",
     "deleted": true,
-    "deleted_date": "Mar.30,2005",
+    "deleted_date": "2005-03-30",
     "lat": 34.961611111,
     "lon": 133.632916667
   },
@@ -3595,7 +3595,7 @@
     "name": "Mitsu",
     "ja_name": "御津",
     "deleted": true,
-    "deleted_date": "Jan.21,2007",
+    "deleted_date": "2007-01-21",
     "lat": 34.869318889,
     "lon": 133.903786111
   },
@@ -3619,7 +3619,7 @@
     "name": "Ano",
     "ja_name": "安濃",
     "deleted": true,
-    "deleted_date": "Mar.31,1954",
+    "deleted_date": "1954-03-31",
     "lat": 35.201638889,
     "lon": 132.533280864
   },
@@ -3627,7 +3627,7 @@
     "name": "Ama",
     "ja_name": "海士",
     "deleted": true,
-    "deleted_date": "Mar.31,1969",
+    "deleted_date": "1969-03-31",
     "lat": 36.096527778,
     "lon": 133.096805556
   },
@@ -3651,7 +3651,7 @@
     "name": "Ohara",
     "ja_name": "大原",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 35.319509259,
     "lon": 132.92612037
   },
@@ -3667,7 +3667,7 @@
     "name": "Ochi",
     "ja_name": "隠地",
     "deleted": true,
-    "deleted_date": "Mar.31,1969",
+    "deleted_date": "1969-03-31",
     "lat": 34.921,
     "lon": 132.513
   },
@@ -3683,7 +3683,7 @@
     "name": "Suki",
     "ja_name": "周吉",
     "deleted": true,
-    "deleted_date": "Mar.31,1969",
+    "deleted_date": "1969-03-31",
     "lat": 36.251347222,
     "lon": 133.339458333
   },
@@ -3691,7 +3691,7 @@
     "name": "Chibu",
     "ja_name": "知夫",
     "deleted": true,
-    "deleted_date": "Mar.31,1969",
+    "deleted_date": "1969-03-31",
     "lat": 36.053527778,
     "lon": 133.016944444
   },
@@ -3699,7 +3699,7 @@
     "name": "Naka",
     "ja_name": "那賀",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 33.921796296,
     "lon": 134.595861111
   },
@@ -3715,7 +3715,7 @@
     "name": "Nima",
     "ja_name": "迩摩",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 35.119263889,
     "lon": 132.381805556
   },
@@ -3723,7 +3723,7 @@
     "name": "Nogi",
     "ja_name": "能義",
     "deleted": true,
-    "deleted_date": "Sep.30,2004",
+    "deleted_date": "2004-09-30",
     "lat": 35.360708333,
     "lon": 133.225097222
   },
@@ -3731,7 +3731,7 @@
     "name": "Hikawa",
     "ja_name": "簸川",
     "deleted": true,
-    "deleted_date": "Sep.30,2011",
+    "deleted_date": "2011-09-30",
     "lat": 35.39,
     "lon": 132.83
   },
@@ -3739,7 +3739,7 @@
     "name": "Mino",
     "ja_name": "美濃",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 34.618833333,
     "lon": 132.000263889
   },
@@ -3747,7 +3747,7 @@
     "name": "Yatsuka",
     "ja_name": "八束",
     "deleted": true,
-    "deleted_date": "Jul.31,2011",
+    "deleted_date": "2011-07-31",
     "lat": 35.465,
     "lon": 133.051111111
   },
@@ -3755,7 +3755,7 @@
     "name": "Asa",
     "ja_name": "厚狭",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 34.050680556,
     "lon": 131.19275
   },
@@ -3779,7 +3779,7 @@
     "name": "Otsu",
     "ja_name": "大津",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 34.374564815,
     "lon": 131.13762963
   },
@@ -3803,7 +3803,7 @@
     "name": "Saba",
     "ja_name": "佐波",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 34.189353,
     "lon": 131.655486
   },
@@ -3811,7 +3811,7 @@
     "name": "Tsuno",
     "ja_name": "都濃",
     "deleted": true,
-    "deleted_date": "Apr.20,2003",
+    "deleted_date": "2003-04-20",
     "lat": 34.232027778,
     "lon": 131.817222222
   },
@@ -3819,7 +3819,7 @@
     "name": "Toyoura",
     "ja_name": "豊浦",
     "deleted": true,
-    "deleted_date": "Feb.12,2005",
+    "deleted_date": "2005-02-12",
     "lat": 34.191066862,
     "lon": 130.99552825
   },
@@ -3827,7 +3827,7 @@
     "name": "Mine",
     "ja_name": "美祢",
     "deleted": true,
-    "deleted_date": "Mar.20,2008",
+    "deleted_date": "2008-03-20",
     "lat": 34.219402778,
     "lon": 131.317944444
   },
@@ -3835,7 +3835,7 @@
     "name": "Yoshiki",
     "ja_name": "吉敷",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 34.043138889,
     "lon": 131.396314815
   },
@@ -3851,7 +3851,7 @@
     "name": "Ketaka",
     "ja_name": "気高",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 35.487638888,
     "lon": 134.131472222
   },
@@ -3899,7 +3899,7 @@
     "name": "Asa",
     "ja_name": "安佐",
     "deleted": true,
-    "deleted_date": "Mar.19,1973",
+    "deleted_date": "1973-03-19",
     "lat": 34.470342593,
     "lon": 132.494981481
   },
@@ -3907,7 +3907,7 @@
     "name": "Ashina",
     "ja_name": "芦品",
     "deleted": true,
-    "deleted_date": "Feb.2,2003",
+    "deleted_date": "2003-02-02",
     "lat": 34.557125,
     "lon": 133.273180556
   },
@@ -3915,7 +3915,7 @@
     "name": "Kamo",
     "ja_name": "賀茂",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 34.741116667,
     "lon": 138.888266667
   },
@@ -3923,7 +3923,7 @@
     "name": "Konu",
     "ja_name": "甲奴",
     "deleted": true,
-    "deleted_date": "Mar.30,2005",
+    "deleted_date": "2005-03-30",
     "lat": 34.728351852,
     "lon": 133.088861111
   },
@@ -3931,7 +3931,7 @@
     "name": "Saeki",
     "ja_name": "佐伯",
     "deleted": true,
-    "deleted_date": "Nov.2,2005",
+    "deleted_date": "2005-11-02",
     "lat": 34.295828889,
     "lon": 132.306508889
   },
@@ -3955,7 +3955,7 @@
     "name": "Takata",
     "ja_name": "高田",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 34.681537037,
     "lon": 132.68949537
   },
@@ -3971,7 +3971,7 @@
     "name": "Numakuma",
     "ja_name": "沼隈",
     "deleted": true,
-    "deleted_date": "Jan.31,2005",
+    "deleted_date": "2005-01-31",
     "lat": 34.5211,
     "lon": 133.3364
   },
@@ -3979,7 +3979,7 @@
     "name": "Hiba",
     "ja_name": "比婆",
     "deleted": true,
-    "deleted_date": "Mar.30,2005",
+    "deleted_date": "2005-03-30",
     "lat": 34.953816667,
     "lon": 133.037205556
   },
@@ -3987,7 +3987,7 @@
     "name": "Fukayasu",
     "ja_name": "深安",
     "deleted": true,
-    "deleted_date": "Feb.28,2006",
+    "deleted_date": "2006-02-28",
     "lat": 34.546333333,
     "lon": 133.374
   },
@@ -3995,7 +3995,7 @@
     "name": "Futami",
     "ja_name": "双三",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 34.795527778,
     "lon": 132.857356481
   },
@@ -4003,7 +4003,7 @@
     "name": "Mitsugi",
     "ja_name": "御調",
     "deleted": true,
-    "deleted_date": "Mar.27,2005",
+    "deleted_date": "2005-03-27",
     "lat": 34.453305556,
     "lon": 133.171972222
   },
@@ -4027,7 +4027,7 @@
     "name": "Okawa",
     "ja_name": "大川",
     "deleted": true,
-    "deleted_date": "Mar.31,2003",
+    "deleted_date": "2003-03-31",
     "lat": 34.197,
     "lon": 134.239
   },
@@ -4067,7 +4067,7 @@
     "name": "Mitoyo",
     "ja_name": "三豊",
     "deleted": true,
-    "deleted_date": "Dec.31,2005",
+    "deleted_date": "2005-12-31",
     "lat": 34.169583729,
     "lon": 133.705701196
   },
@@ -4075,7 +4075,7 @@
     "name": "Awa",
     "ja_name": "阿波",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 34.090194444,
     "lon": 134.284944444
   },
@@ -4091,7 +4091,7 @@
     "name": "Oe",
     "ja_name": "麻植",
     "deleted": true,
-    "deleted_date": "Sep.30,2004",
+    "deleted_date": "2004-09-30",
     "lat": 34.052324074,
     "lon": 134.31262963
   },
@@ -4163,7 +4163,7 @@
     "name": "Uma",
     "ja_name": "宇摩",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 33.914518517,
     "lon": 133.478416667
   },
@@ -4179,7 +4179,7 @@
     "name": "Onsen",
     "ja_name": "温泉",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 33.975277778,
     "lon": 132.629694444
   },
@@ -4211,7 +4211,7 @@
     "name": "Shuso",
     "ja_name": "周桑",
     "deleted": true,
-    "deleted_date": "Oct.31,2004",
+    "deleted_date": "2004-10-31",
     "lat": 33.901666667,
     "lon": 133.087694444
   },
@@ -4219,7 +4219,7 @@
     "name": "Nii",
     "ja_name": "新居",
     "deleted": true,
-    "deleted_date": "Mar.31,1959",
+    "deleted_date": "1959-03-31",
     "lat": 33.922416667,
     "lon": 133.305805556
   },
@@ -4235,7 +4235,7 @@
     "name": "Higashiuwa",
     "ja_name": "東宇和",
     "deleted": true,
-    "deleted_date": "Mar.31,2004",
+    "deleted_date": "2004-03-31",
     "lat": 33.359826389,
     "lon": 132.5843125
   },
@@ -4267,7 +4267,7 @@
     "name": "Kami",
     "ja_name": "香美",
     "deleted": true,
-    "deleted_date": "Feb.28,2006",
+    "deleted_date": "2006-02-28",
     "lat": 33.588836806,
     "lon": 133.745545139
   },
@@ -4315,7 +4315,7 @@
     "name": "Itoshima",
     "ja_name": "糸島",
     "deleted": true,
-    "deleted_date": "Dec.31,2009",
+    "deleted_date": "2009-12-31",
     "lat": 33.555,
     "lon": 130.18611111
   },
@@ -4323,7 +4323,7 @@
     "name": "Ukiha",
     "ja_name": "浮羽",
     "deleted": true,
-    "deleted_date": "Mar.19,2005",
+    "deleted_date": "2005-03-19",
     "lat": 33.3435,
     "lon": 130.711131
   },
@@ -4363,7 +4363,7 @@
     "name": "Sawara",
     "ja_name": "早良",
     "deleted": true,
-    "deleted_date": "Feb.28,1975",
+    "deleted_date": "1975-02-28",
     "lat": 33.518805556,
     "lon": 130.336
   },
@@ -4379,7 +4379,7 @@
     "name": "Chikushi",
     "ja_name": "筑紫",
     "deleted": true,
-    "deleted_date": "Sep.30,2018",
+    "deleted_date": "2018-09-30",
     "lat": 33.46626,
     "lon": 130.42202
   },
@@ -4403,7 +4403,7 @@
     "name": "Miike",
     "ja_name": "三池",
     "deleted": true,
-    "deleted_date": "Jan.28,2007",
+    "deleted_date": "2007-01-28",
     "lat": 33.105833333,
     "lon": 130.493611111
   },
@@ -4427,7 +4427,7 @@
     "name": "Munakata",
     "ja_name": "宗像",
     "deleted": true,
-    "deleted_date": "Mar.27,2005",
+    "deleted_date": "2005-03-27",
     "lat": 33.766806,
     "lon": 130.491083
   },
@@ -4435,7 +4435,7 @@
     "name": "Yamato",
     "ja_name": "山門",
     "deleted": true,
-    "deleted_date": "Jan.28,2007",
+    "deleted_date": "2007-01-28",
     "lat": 33.142222222,
     "lon": 130.461388888
   },
@@ -4451,7 +4451,7 @@
     "name": "Ogi",
     "ja_name": "小城",
     "deleted": true,
-    "deleted_date": "Feb.28,2005",
+    "deleted_date": "2005-02-28",
     "lat": 33.260666667,
     "lon": 130.206618056
   },
@@ -4475,7 +4475,7 @@
     "name": "Saga",
     "ja_name": "佐賀",
     "deleted": true,
-    "deleted_date": "ept.30,2007",
+    "deleted_date": "2007-09-30",
     "lat": 33.211259259,
     "lon": 130.28275
   },
@@ -4515,7 +4515,7 @@
     "name": "Iki",
     "ja_name": "壱岐",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 33.787159722,
     "lon": 129.725208333
   },
@@ -4523,7 +4523,7 @@
     "name": "Kamiagata",
     "ja_name": "上県",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 34.586666667,
     "lon": 129.391666667
   },
@@ -4531,7 +4531,7 @@
     "name": "Kitatakaki",
     "ja_name": "北高来",
     "deleted": true,
-    "deleted_date": "Feb.28,2005",
+    "deleted_date": "2005-02-28",
     "lat": 32.862395833,
     "lon": 130.120805556
   },
@@ -4547,7 +4547,7 @@
     "name": "Shimoagata",
     "ja_name": "下県",
     "deleted": true,
-    "deleted_date": "Feb.29,2004",
+    "deleted_date": "2004-02-29",
     "lat": 34.288898148,
     "lon": 129.305833333
   },
@@ -4571,7 +4571,7 @@
     "name": "Minamitakaki",
     "ja_name": "南高来",
     "deleted": true,
-    "deleted_date": "Mar.30,2006",
+    "deleted_date": "2006-03-30",
     "lat": 32.657822917,
     "lon": 130.268836806
   },
@@ -4611,7 +4611,7 @@
     "name": "Uto",
     "ja_name": "宇土",
     "deleted": true,
-    "deleted_date": "Jan.14,2005",
+    "deleted_date": "2005-01-14",
     "lat": 32.629708333,
     "lon": 130.569444444
   },
@@ -4627,7 +4627,7 @@
     "name": "Kamoto",
     "ja_name": "鹿本",
     "deleted": true,
-    "deleted_date": "Mar.22,2010",
+    "deleted_date": "2010-03-22",
     "lat": 32.8,
     "lon": 130.7
   },
@@ -4667,7 +4667,7 @@
     "name": "Hotaku",
     "ja_name": "飽託",
     "deleted": true,
-    "deleted_date": "Jan.31,1991",
+    "deleted_date": "1991-01-31",
     "lat": 32.797111111,
     "lon": 130.645145833
   },
@@ -4683,7 +4683,7 @@
     "name": "Usa",
     "ja_name": "宇佐",
     "deleted": true,
-    "deleted_date": "Mar.30,2005",
+    "deleted_date": "2005-03-30",
     "lat": 33.42975,
     "lon": 131.335416667
   },
@@ -4691,7 +4691,7 @@
     "name": "Oita",
     "ja_name": "大分",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 33.214175926,
     "lon": 131.431916667
   },
@@ -4699,7 +4699,7 @@
     "name": "Ono",
     "ja_name": "大野",
     "deleted": true,
-    "deleted_date": "Mar.30,2005",
+    "deleted_date": "2005-03-30",
     "lat": 36.270944444,
     "lon": 136.898555556
   },
@@ -4707,7 +4707,7 @@
     "name": "Kitaamabe",
     "ja_name": "北海部",
     "deleted": true,
-    "deleted_date": "Dec.31,2004",
+    "deleted_date": "2004-12-31",
     "lat": 33.247027778,
     "lon": 131.8765
   },
@@ -4723,7 +4723,7 @@
     "name": "Shimoge",
     "ja_name": "下毛",
     "deleted": true,
-    "deleted_date": "Feb.28,2005",
+    "deleted_date": "2005-02-28",
     "lat": 33.477,
     "lon": 131.1315
   },
@@ -4731,7 +4731,7 @@
     "name": "Naoiri",
     "ja_name": "直入",
     "deleted": true,
-    "deleted_date": "Mar.31,2005",
+    "deleted_date": "2005-03-31",
     "lat": 33.005685185,
     "lon": 131.325638889
   },
@@ -4739,7 +4739,7 @@
     "name": "Nishikunisaki",
     "ja_name": "西国東",
     "deleted": true,
-    "deleted_date": "Sep.30,2005",
+    "deleted_date": "2005-09-30",
     "lat": 33.495527778,
     "lon": 131.557166667
   },
@@ -4763,7 +4763,7 @@
     "name": "Hita",
     "ja_name": "日田",
     "deleted": true,
-    "deleted_date": "Mar.21,2005",
+    "deleted_date": "2005-03-21",
     "lat": 33.190695556,
     "lon": 130.963916667
   },
@@ -4771,7 +4771,7 @@
     "name": "Minamiamabe",
     "ja_name": "南海部",
     "deleted": true,
-    "deleted_date": "Mar.2,2005",
+    "deleted_date": "2005-03-02",
     "lat": 32.923888889,
     "lon": 131.85678125
   },
@@ -4827,7 +4827,7 @@
     "name": "Minaminaka",
     "ja_name": "南那珂",
     "deleted": true,
-    "deleted_date": "Mar.29,2009",
+    "deleted_date": "2009-03-29",
     "lat": 31.6015,
     "lon": 131.379
   },
@@ -4835,7 +4835,7 @@
     "name": "Miyazaki",
     "ja_name": "宮崎",
     "deleted": true,
-    "deleted_date": "Mar.22,2010",
+    "deleted_date": "2010-03-22",
     "lat": 31.907777777,
     "lon": 131.420277777
   },
@@ -4851,7 +4851,7 @@
     "name": "Isa",
     "ja_name": "伊佐",
     "deleted": true,
-    "deleted_date": "Oct.31,2008",
+    "deleted_date": "2008-10-31",
     "lat": 32.057222222,
     "lon": 130.613055555
   },
@@ -4867,7 +4867,7 @@
     "name": "Ibusuki",
     "ja_name": "揖宿",
     "deleted": true,
-    "deleted_date": "Nov.30,2007",
+    "deleted_date": "2007-11-30",
     "lat": 31.2525,
     "lon": 130.6338
   },
@@ -4891,7 +4891,7 @@
     "name": "Kawanabe",
     "ja_name": "川辺",
     "deleted": true,
-    "deleted_date": "Nov.30,2007",
+    "deleted_date": "2007-11-30",
     "lat": 31.322778,
     "lon": 130.296667
   },
@@ -4931,7 +4931,7 @@
     "name": "Hioki",
     "ja_name": "日置",
     "deleted": true,
-    "deleted_date": "Nov.6,2005",
+    "deleted_date": "2005-11-06",
     "lat": 31.633722,
     "lon": 130.366667
   },

--- a/assets/json/japan_award/ku_list.json
+++ b/assets/json/japan_award/ku_list.json
@@ -3,1098 +3,1472 @@
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.055277777,
+    "lon": 141.341111111
   },
   "010102": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.090833333,
+    "lon": 141.340833333
   },
   "010103": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.076111111,
+    "lon": 141.363611111
   },
   "010104": {
     "name": "Shiroishi",
     "ja_name": "白石",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.047777777,
+    "lon": 141.405
   },
   "010105": {
     "name": "Toyohira",
     "ja_name": "豊平",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.013333333,
+    "lon": 141.391111111
   },
   "010106": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 42.99,
+    "lon": 141.353333333
   },
   "010107": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.074444444,
+    "lon": 141.300833333
   },
   "010108": {
     "name": "Atsubetsu",
     "ja_name": "厚別",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.036111111,
+    "lon": 141.474722222
   },
   "010109": {
     "name": "Teine",
     "ja_name": "手稲",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 43.121944444,
+    "lon": 141.245555555
   },
   "010110": {
     "name": "Kiyota",
     "ja_name": "清田",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 42.999444444,
+    "lon": 141.443888888
   },
   "060101": {
     "name": "Aoba",
     "ja_name": "青葉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 38.269166666,
+    "lon": 140.870555555
   },
   "060102": {
     "name": "Miyagino",
     "ja_name": "宮城野",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 38.266388888,
+    "lon": 140.910277777
   },
   "060103": {
     "name": "Wakabayashi",
     "ja_name": "若林",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 38.244166666,
+    "lon": 140.900833333
   },
   "060104": {
     "name": "Taihaku",
     "ja_name": "太白",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 38.224444444,
+    "lon": 140.877222222
   },
   "060105": {
     "name": "Izumi",
     "ja_name": "泉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 38.326388888,
+    "lon": 140.881388888
   },
   "080101": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.91638889,
+    "lon": 139.21861111
   },
   "080102": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.936944444,
+    "lon": 139.073055555
   },
   "080103": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.916111111,
+    "lon": 139.036388888
   },
   "080104": {
     "name": "Konan",
     "ja_name": "江南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.867777777,
+    "lon": 139.094166666
   },
   "080105": {
     "name": "Akiha",
     "ja_name": "秋葉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.788611111,
+    "lon": 139.114444444
   },
   "080106": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.765833333,
+    "lon": 139.019166666
   },
   "080107": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.873888888,
+    "lon": 138.971666666
   },
   "080108": {
     "name": "Nishikan",
     "ja_name": "西蒲",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 37.760555555,
+    "lon": 138.889166666
   },
   "110101": {
     "name": "Tsurumi",
     "ja_name": "鶴見",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.508333333,
+    "lon": 139.6825
   },
   "110102": {
     "name": "Kanagawa",
     "ja_name": "神奈川",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.476944444,
+    "lon": 139.629444444
   },
   "110103": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.453611111,
+    "lon": 139.616944444
   },
   "110104": {
     "name": "Naka",
     "ja_name": "中",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.444444444,
+    "lon": 139.643333333
   },
   "110105": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.431388888,
+    "lon": 139.608888888
   },
   "110106": {
     "name": "Hodogaya",
     "ja_name": "保土ケ谷",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.46,
+    "lon": 139.596111111
   },
   "110107": {
     "name": "Isogo",
     "ja_name": "磯子",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.402222222,
+    "lon": 139.618888888
   },
   "110108": {
     "name": "Kanazawa",
     "ja_name": "金沢",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.3375,
+    "lon": 139.624444444
   },
   "110109": {
     "name": "Kohoku",
     "ja_name": "港北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.518888888,
+    "lon": 139.633055555
   },
   "110110": {
     "name": "Totsuka",
     "ja_name": "戸塚",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.396388888,
+    "lon": 139.5325
   },
   "110111": {
     "name": "Konan",
     "ja_name": "港南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.400555555,
+    "lon": 139.591388888
   },
   "110112": {
     "name": "Asahi",
     "ja_name": "旭",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.474722222,
+    "lon": 139.544722222
   },
   "110113": {
     "name": "Midori",
     "ja_name": "緑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.5125,
+    "lon": 139.538055555
   },
   "110114": {
     "name": "Seya",
     "ja_name": "瀬谷",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.466388888,
+    "lon": 139.499166666
   },
   "110115": {
     "name": "Sakae",
     "ja_name": "栄",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.364444444,
+    "lon": 139.554166666
   },
   "110116": {
     "name": "Izumi",
     "ja_name": "泉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.417777777,
+    "lon": 139.488611111
   },
   "110117": {
     "name": "Aoba",
     "ja_name": "青葉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.552777777,
+    "lon": 139.537222222
   },
   "110118": {
     "name": "Tsuzuki",
     "ja_name": "都筑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.544722222,
+    "lon": 139.570555555
   },
   "110301": {
     "name": "Kawasaki",
     "ja_name": "川崎",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.529444444,
+    "lon": 139.703333333
   },
   "110302": {
     "name": "Saiwai",
     "ja_name": "幸",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.544444444,
+    "lon": 139.6875
   },
   "110303": {
     "name": "Nakahara",
     "ja_name": "中原",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.576111111,
+    "lon": 139.655833333
   },
   "110304": {
     "name": "Takatsu",
     "ja_name": "高津",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.599444444,
+    "lon": 139.608055555
   },
   "110305": {
     "name": "Tama",
     "ja_name": "多摩",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.619722222,
+    "lon": 139.561944444
   },
   "110306": {
     "name": "Miyamae",
     "ja_name": "宮前",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.589166666,
+    "lon": 139.578611111
   },
   "110307": {
     "name": "Asao",
     "ja_name": "麻生",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.603888888,
+    "lon": 139.505833333
   },
   "111001": {
     "name": "Midori",
     "ja_name": "緑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.59583333,
+    "lon": 139.34472222
   },
   "111002": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.57138889,
+    "lon": 139.37333333
   },
   "111003": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.51666667,
+    "lon": 139.41666667
   },
   "120101": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.620555555,
+    "lon": 140.135833333
   },
   "120102": {
     "name": "Hanamigawa",
     "ja_name": "花見川",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.66277778,
+    "lon": 140.06916667
   },
   "120103": {
     "name": "Inage",
     "ja_name": "稲毛",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.636388888,
+    "lon": 140.107222222
   },
   "120104": {
     "name": "Wakaba",
     "ja_name": "若葉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.6294,
+    "lon": 140.163
   },
   "120105": {
     "name": "Midori",
     "ja_name": "緑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.56055556,
+    "lon": 140.17611111
   },
   "120106": {
     "name": "Mihama",
     "ja_name": "美浜",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.640277777,
+    "lon": 140.063055555
   },
   "134401": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.916666666,
+    "lon": 139.566666666
   },
   "134402": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.93,
+    "lon": 139.620555555
   },
   "134403": {
     "name": "Omiya",
     "ja_name": "大宮",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.906111111,
+    "lon": 139.628611111
   },
   "134404": {
     "name": "Minuma",
     "ja_name": "見沼",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.935277777,
+    "lon": 139.654444444
   },
   "134405": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.88378,
+    "lon": 139.626156
   },
   "134406": {
     "name": "Sakura",
     "ja_name": "桜",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.856944444,
+    "lon": 139.609444444
   },
   "134407": {
     "name": "Urawa",
     "ja_name": "浦和",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.862008333,
+    "lon": 139.645538888
   },
   "134408": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.833333333,
+    "lon": 139.633333333
   },
   "134409": {
     "name": "Midori",
     "ja_name": "緑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.871388888,
+    "lon": 139.684444444
   },
   "134410": {
     "name": "Iwatsuki",
     "ja_name": "岩槻",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.95,
+    "lon": 139.7
   },
   "180101": {
     "name": "Aoi",
     "ja_name": "葵",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.975,
+    "lon": 138.383611111
   },
   "180102": {
     "name": "Suruga",
     "ja_name": "駿河",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.960555555,
+    "lon": 138.404166666
   },
   "180103": {
     "name": "Shimizu",
     "ja_name": "清水",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.015833333,
+    "lon": 138.489722222
   },
   "180201": {
     "name": "Naka",
     "ja_name": "中",
     "deleted": true,
-    "deleted_date": "2023年12月31日以前"
+    "deleted_date": "2023-12-31",
+    "lat": 34.710805555,
+    "lon": 137.726083333
   },
   "180202": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": true,
-    "deleted_date": "2023年12月31日以前"
+    "deleted_date": "2023-12-31",
+    "lat": 34.741388888,
+    "lon": 137.791666666
   },
   "180203": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": true,
-    "deleted_date": "2023年12月31日以前"
+    "deleted_date": "2023-12-31",
+    "lat": 34.692713888,
+    "lon": 137.645333333
   },
   "180204": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": true,
-    "deleted_date": "2023年12月31日以前"
+    "deleted_date": "2023-12-31",
+    "lat": 34.667222222,
+    "lon": 137.752222222
   },
   "180205": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": true,
-    "deleted_date": "2023年12月31日以前"
+    "deleted_date": "2023-12-31",
+    "lat": 34.817777777,
+    "lon": 137.739722222
   },
   "180206": {
     "name": "Hamakita",
     "ja_name": "浜北",
     "deleted": true,
-    "deleted_date": "2023年12月31日以前"
+    "deleted_date": "2023-12-31",
+    "lat": 34.8,
+    "lon": 137.783333333
   },
   "180207": {
     "name": "Tenryu",
     "ja_name": "天竜",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.095555555,
+    "lon": 137.796944444
   },
   "180208": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.7108169,
+    "lon": 137.7262391
   },
   "180209": {
     "name": "Hamana",
     "ja_name": "浜名",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.7916503,
+    "lon": 137.7832575
   },
   "200101": {
     "name": "Chikusa",
     "ja_name": "千種",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.166444444,
+    "lon": 136.946444444
   },
   "200102": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.179444444,
+    "lon": 136.926111111
   },
   "200103": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.194166666,
+    "lon": 136.911666666
   },
   "200104": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.185555555,
+    "lon": 136.885833333
   },
   "200105": {
     "name": "Nakamura",
     "ja_name": "中村",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.168611111,
+    "lon": 136.873055555
   },
   "200106": {
     "name": "Naka",
     "ja_name": "中",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.168611111,
+    "lon": 136.910277777
   },
   "200107": {
     "name": "Showa",
     "ja_name": "昭和",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.150277777,
+    "lon": 136.934166666
   },
   "200108": {
     "name": "Mizuho",
     "ja_name": "瑞穂",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.131666666,
+    "lon": 136.935
   },
   "200109": {
     "name": "Atsuta",
     "ja_name": "熱田",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.128055555,
+    "lon": 136.911111111
   },
   "200110": {
     "name": "Nakagawa",
     "ja_name": "中川",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.141666666,
+    "lon": 136.855
   },
   "200111": {
     "name": "Minato",
     "ja_name": "港",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.107777777,
+    "lon": 136.885555555
   },
   "200112": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.095,
+    "lon": 136.931111111
   },
   "200113": {
     "name": "Moriyama",
     "ja_name": "守山",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.203305555,
+    "lon": 136.976194444
   },
   "200114": {
     "name": "Midori",
     "ja_name": "緑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.070833333,
+    "lon": 136.952222222
   },
   "200115": {
     "name": "Meito",
     "ja_name": "名東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.175833333,
+    "lon": 137.010277777
   },
   "200116": {
     "name": "Tenpaku",
     "ja_name": "天白",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.122222222,
+    "lon": 136.975833333
   },
   "220101": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.041111111,
+    "lon": 135.754166666
   },
   "220102": {
     "name": "Kamigyo",
     "ja_name": "上京",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.029722222,
+    "lon": 135.756666666
   },
   "220103": {
     "name": "Sakyo",
     "ja_name": "左京",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.048333333,
+    "lon": 135.778333333
   },
   "220104": {
     "name": "Nakagyo",
     "ja_name": "中京",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.01,
+    "lon": 135.751388888
   },
   "220105": {
     "name": "Higashiyama",
     "ja_name": "東山",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.996944444,
+    "lon": 135.776388888
   },
   "220106": {
     "name": "Shimogyo",
     "ja_name": "下京",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.9875,
+    "lon": 135.755555555
   },
   "220107": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.976666666,
+    "lon": 135.746666666
   },
   "220108": {
     "name": "Ukyo",
     "ja_name": "右京",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 35.010172,
+    "lon": 135.716034
   },
   "220109": {
     "name": "Fushimi",
     "ja_name": "伏見",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.935555555,
+    "lon": 135.761388888
   },
   "220110": {
     "name": "Yamashina",
     "ja_name": "山科",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.9725,
+    "lon": 135.813611111
   },
   "220111": {
     "name": "Nishikyo",
     "ja_name": "西京",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.985041,
+    "lon": 135.693278
   },
   "250101": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.705555555,
+    "lon": 135.51
   },
   "250102": {
     "name": "Miyakojima",
     "ja_name": "都島",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.701277777,
+    "lon": 135.528088888
   },
   "250103": {
     "name": "Fukushima",
     "ja_name": "福島",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.692355555,
+    "lon": 135.472230555
   },
   "250104": {
     "name": "Konohana",
     "ja_name": "此花",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.683055555,
+    "lon": 135.452222222
   },
   "250105": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": true,
-    "deleted_date": "1989(平成元)年2月12日以前"
+    "deleted_date": "1989-02-12",
+    "lat": 34.681225,
+    "lon": 135.509687
   },
   "250106": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.676388888,
+    "lon": 135.486111111
   },
   "250107": {
     "name": "Minato",
     "ja_name": "港",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.663888888,
+    "lon": 135.460833333
   },
   "250108": {
     "name": "Taisho",
     "ja_name": "大正",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.650402777,
+    "lon": 135.4727
   },
   "250109": {
     "name": "Tennoji",
     "ja_name": "天王寺",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.657777777,
+    "lon": 135.519444444
   },
   "250110": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": true,
-    "deleted_date": "1989(平成元)年2月12日以前"
+    "deleted_date": "1989-02-12",
+    "lat": 34.667131,
+    "lon": 135.500305
   },
   "250111": {
     "name": "Naniwa",
     "ja_name": "浪速",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.659444444,
+    "lon": 135.499630555
   },
   "250112": {
     "name": "Oyodo",
     "ja_name": "大淀",
     "deleted": true,
-    "deleted_date": "1989(平成元)年2月12日以前"
+    "deleted_date": "1989-02-12",
+    "lat": 34.71393561,
+    "lon": 135.50637
   },
   "250113": {
     "name": "Nishiyodogawa",
     "ja_name": "西淀川",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.716944444,
+    "lon": 135.456388888
   },
   "250114": {
     "name": "Higashiyodogawa",
     "ja_name": "東淀川",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.741111111,
+    "lon": 135.529444444
   },
   "250115": {
     "name": "Higashinari",
     "ja_name": "東成",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.67,
+    "lon": 135.541111111
   },
   "250116": {
     "name": "Ikuno",
     "ja_name": "生野",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.652777777,
+    "lon": 135.539444444
   },
   "250117": {
     "name": "Asahi",
     "ja_name": "旭",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.721388888,
+    "lon": 135.544166666
   },
   "250118": {
     "name": "Joto",
     "ja_name": "城東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.701944444,
+    "lon": 135.546111111
   },
   "250119": {
     "name": "Abeno",
     "ja_name": "阿倍野",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.638972222,
+    "lon": 135.518491666
   },
   "250120": {
     "name": "Sumiyoshi",
     "ja_name": "住吉",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.603675,
+    "lon": 135.500627777
+  },
+  "250121": {
+    "name": "Higashisumiyoshi",
+    "ja_name": "東住吉",
+    "deleted": false,
+    "deleted_date": "",
+    "lat": 34.622119444,
+    "lon": 135.526613888
   },
   "250122": {
     "name": "Nishinari",
     "ja_name": "西成",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.635,
+    "lon": 135.494444444
   },
   "250123": {
     "name": "Yodogawa",
     "ja_name": "淀川",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.721111111,
+    "lon": 135.486666666
   },
   "250124": {
     "name": "Tsurumi",
     "ja_name": "鶴見",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.704166666,
+    "lon": 135.574166666
   },
   "250125": {
     "name": "Suminoe",
     "ja_name": "住之江",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.609444444,
+    "lon": 135.482777777
   },
   "250126": {
     "name": "Hirano",
     "ja_name": "平野",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.621111111,
+    "lon": 135.546111111
   },
   "250127": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.681111111,
+    "lon": 135.509722222
   },
   "250201": {
     "name": "Sakai",
     "ja_name": "堺",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.573333333,
+    "lon": 135.483055555
   },
   "250202": {
     "name": "Naka",
     "ja_name": "中",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.528338888,
+    "lon": 135.498633333
   },
   "250203": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.538191666,
+    "lon": 135.536591666
   },
   "250204": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.534997222,
+    "lon": 135.463975
   },
   "250205": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.486472,
+    "lon": 135.4905
   },
   "250206": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.565463888,
+    "lon": 135.517172222
   },
   "250207": {
     "name": "Mihara",
     "ja_name": "美原",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.538547222,
+    "lon": 135.559830555
   },
   "270101": {
     "name": "Higashinada",
     "ja_name": "東灘",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.720277777,
+    "lon": 135.265555555
   },
   "270102": {
     "name": "Nada",
     "ja_name": "灘",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.7125,
+    "lon": 135.239722222
   },
   "270103": {
     "name": "Hyogo",
     "ja_name": "兵庫",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.675833333,
+    "lon": 135.166666666
   },
   "270104": {
     "name": "Nagata",
     "ja_name": "長田",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.665694444,
+    "lon": 135.150888888
   },
   "270105": {
     "name": "Suma",
     "ja_name": "須磨",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.658638888,
+    "lon": 135.133694444
   },
   "270106": {
     "name": "Tarumi",
     "ja_name": "垂水",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.630527777,
+    "lon": 135.056722222
   },
   "270107": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.724166666,
+    "lon": 135.146166666
   },
   "270108": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.690555555,
+    "lon": 135.195833333
   },
   "270109": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.683166666,
+    "lon": 134.981583333
   },
   "270110": {
     "name": "Fukiai",
     "ja_name": "葺合",
     "deleted": true,
-    "deleted_date": "1980(昭和55)年11月30日以前"
+    "deleted_date": "1980-11-30",
+    "lat": 34.6988187,
+    "lon": 135.1944876
   },
   "270111": {
     "name": "Ikuta",
     "ja_name": "生田",
     "deleted": true,
-    "deleted_date": "1980(昭和55)年11月30日以前"
+    "deleted_date": "1980-11-30",
+    "lat": 34.6908507,
+    "lon": 135.1813705
   },
   "310101": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.655,
+    "lon": 133.919444444
   },
   "310102": {
     "name": "Naka",
     "ja_name": "中",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.67083333,
+    "lon": 133.94305556
   },
   "310103": {
     "name": "Hinagashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.65833333,
+    "lon": 134.03638889
   },
   "310104": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.59968,
+    "lon": 133.91958
   },
   "350101": {
     "name": "Naka",
     "ja_name": "中",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "350102": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.39531,
+    "lon": 132.48247
   },
   "350103": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "350104": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "350105": {
     "name": "Asaminami",
     "ja_name": "安佐南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "350106": {
     "name": "Asakita",
     "ja_name": "安佐北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "350107": {
     "name": "Aki",
     "ja_name": "安芸",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "350108": {
     "name": "Saeki",
     "ja_name": "佐伯",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 34.385277777,
+    "lon": 132.455277777
   },
   "400101": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.616388888,
+    "lon": 130.4225
   },
   "400102": {
     "name": "Hakata",
     "ja_name": "博多",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.591388888,
+    "lon": 130.414722222
   },
   "400103": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.58375,
+    "lon": 130.38625
   },
   "400104": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.561666666,
+    "lon": 130.426666666
   },
   "400105": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.582777777,
+    "lon": 130.323055555
   },
   "400106": {
     "name": "Jonan",
     "ja_name": "城南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.575833333,
+    "lon": 130.37
   },
   "400107": {
     "name": "Sawara",
     "ja_name": "早良",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.581944444,
+    "lon": 130.348333333
   },
   "402101": {
     "name": "Moji",
     "ja_name": "門司",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.941111111,
+    "lon": 130.959722222
   },
   "402102": {
     "name": "Wakamatsu",
     "ja_name": "若松",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.905555555,
+    "lon": 130.811111111
   },
   "402103": {
     "name": "Tobata",
     "ja_name": "戸畑",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.894722222,
+    "lon": 130.829444444
   },
   "402104": {
     "name": "Kokurakita",
     "ja_name": "小倉北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.880833333,
+    "lon": 130.873611111
   },
   "402105": {
     "name": "Kokuraminami",
     "ja_name": "小倉南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.846388888,
+    "lon": 130.884722222
   },
   "402106": {
     "name": "Yahatahigashi",
     "ja_name": "八幡東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.863611111,
+    "lon": 130.811944444
   },
   "402107": {
     "name": "Yahatanishi",
     "ja_name": "八幡西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 33.861388888,
+    "lon": 130.760277777
   },
   "402108": {
     "name": "Yahata",
     "ja_name": "八幡",
     "deleted": true,
-    "deleted_date": "1974(昭和49)年3月31日以前"
+    "deleted_date": "1974-03-31",
+    "lat": 33.863527777,
+    "lon": 130.811888888
   },
   "402109": {
     "name": "Kokura",
     "ja_name": "小倉",
     "deleted": true,
-    "deleted_date": "1974(昭和49)年3月31日以前"
+    "deleted_date": "1974-03-31",
+    "lat": 33.883416666,
+    "lon": 130.875194444
   },
   "430101": {
     "name": "Chuo",
     "ja_name": "中央",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 32.803333,
+    "lon": 130.708056
   },
   "430102": {
     "name": "Higashi",
     "ja_name": "東",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 32.78055556,
+    "lon": 130.76805556
   },
   "430103": {
     "name": "Nishi",
     "ja_name": "西",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 32.77638889,
+    "lon": 130.6475
   },
   "430104": {
     "name": "Minami",
     "ja_name": "南",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 32.71527778,
+    "lon": 130.6788889
   },
   "430105": {
     "name": "Kita",
     "ja_name": "北",
     "deleted": false,
-    "deleted_date": ""
+    "deleted_date": "",
+    "lat": 32.90361111,
+    "lon": 130.69444444
   }
 }

--- a/assets/json/japan_award/pref_list.json
+++ b/assets/json/japan_award/pref_list.json
@@ -1,0 +1,190 @@
+{
+  "01": {
+    "name": "Hokkaido",
+    "ja_name": "北海道"
+  },
+  "02": {
+    "name": "Aomori",
+    "ja_name": "青森"
+  },
+  "03": {
+    "name": "Iwate",
+    "ja_name": "岩手"
+  },
+  "04": {
+    "name": "Akita",
+    "ja_name": "秋田"
+  },
+  "05": {
+    "name": "Yamagata",
+    "ja_name": "山形"
+  },
+  "06": {
+    "name": "Miyagi",
+    "ja_name": "宮城"
+  },
+  "07": {
+    "name": "Fukushima",
+    "ja_name": "福島"
+  },
+  "08": {
+    "name": "Niigata",
+    "ja_name": "新潟"
+  },
+  "09": {
+    "name": "Nagano",
+    "ja_name": "長野"
+  },
+  "10": {
+    "name": "Tokyo",
+    "ja_name": "東京"
+  },
+  "11": {
+    "name": "Kanagawa",
+    "ja_name": "神奈川"
+  },
+  "12": {
+    "name": "Chiba",
+    "ja_name": "千葉"
+  },
+  "13": {
+    "name": "Saitama",
+    "ja_name": "埼玉"
+  },
+  "14": {
+    "name": "Ibaraki",
+    "ja_name": "茨城"
+  },
+  "15": {
+    "name": "Tochigi",
+    "ja_name": "栃木"
+  },
+  "16": {
+    "name": "Gunma",
+    "ja_name": "群馬"
+  },
+  "17": {
+    "name": "Yamanashi",
+    "ja_name": "山梨"
+  },
+  "18": {
+    "name": "Shizuoka",
+    "ja_name": "静岡"
+  },
+  "19": {
+    "name": "Gifu",
+    "ja_name": "岐阜"
+  },
+  "20": {
+    "name": "Aichi",
+    "ja_name": "愛知"
+  },
+  "21": {
+    "name": "Mie",
+    "ja_name": "三重"
+  },
+  "22": {
+    "name": "Kyoto",
+    "ja_name": "京都"
+  },
+  "23": {
+    "name": "Shiga",
+    "ja_name": "滋賀"
+  },
+  "24": {
+    "name": "Nara",
+    "ja_name": "奈良"
+  },
+  "25": {
+    "name": "Osaka",
+    "ja_name": "大阪"
+  },
+  "26": {
+    "name": "Wakayama",
+    "ja_name": "和歌山"
+  },
+  "27": {
+    "name": "Hyogo",
+    "ja_name": "兵庫"
+  },
+  "28": {
+    "name": "Toyama",
+    "ja_name": "富山"
+  },
+  "29": {
+    "name": "Fukui",
+    "ja_name": "福井"
+  },
+  "30": {
+    "name": "Ishikawa",
+    "ja_name": "石川"
+  },
+  "31": {
+    "name": "Okayama",
+    "ja_name": "岡山"
+  },
+  "32": {
+    "name": "Shimane",
+    "ja_name": "島根"
+  },
+  "33": {
+    "name": "Yamaguchi",
+    "ja_name": "山口"
+  },
+  "34": {
+    "name": "Tottori",
+    "ja_name": "鳥取"
+  },
+  "35": {
+    "name": "Hiroshima",
+    "ja_name": "広島"
+  },
+  "36": {
+    "name": "Kagawa",
+    "ja_name": "香川"
+  },
+  "37": {
+    "name": "Tokushima",
+    "ja_name": "徳島"
+  },
+  "38": {
+    "name": "Ehime",
+    "ja_name": "愛媛"
+  },
+  "39": {
+    "name": "Kochi",
+    "ja_name": "高知"
+  },
+  "40": {
+    "name": "Fukuoka",
+    "ja_name": "福岡"
+  },
+  "41": {
+    "name": "Saga",
+    "ja_name": "佐賀"
+  },
+  "42": {
+    "name": "Nagasaki",
+    "ja_name": "長崎"
+  },
+  "43": {
+    "name": "Kumamoto",
+    "ja_name": "熊本"
+  },
+  "44": {
+    "name": "Oita",
+    "ja_name": "大分"
+  },
+  "45": {
+    "name": "Miyazaki",
+    "ja_name": "宮崎"
+  },
+  "46": {
+    "name": "Kagoshima",
+    "ja_name": "鹿児島"
+  },
+  "47": {
+    "name": "Okinawa",
+    "ja_name": "沖縄"
+  }
+}


### PR DESCRIPTION
Hi, everyone~

This PR introduces a new UI for the JCC award, providing a more intuitive way to visualize the status and progress of QSOs across more than 800 cities.

In the new UI, each city is represented by a slot. Different style of slot means confirmed / worked / not worked. Clicking on confirmed / worked city could open the QSO list. Hovering on slot could show the full city number and name. All cities are grouped by prefecture.

Comparing to traditional city × band table, the new UI does not contain band info. Because JCC award does not consider band in score, this could be acceptable. In addition, band, mode and other endorsements could be checked with the filter above. The upcoming AJA award will still use city × band table, which is also useful for JCC. 

Also, this new UI is inspired by rdaward.ru.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ed9177bc-30e2-4846-9709-3da5e1d43c1f" />
