### PR TITLE
Take station-locations qth instead of options

### DIFF
--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -181,12 +181,11 @@
 		$active_station_id = $this->stations->find_active();
 		$station_profile = $this->stations->profile($active_station_id);
 		$active_station_info = $station_profile->row();
+		$user_gridsquare = $active_station_info->station_gridsquare ?? '';
 
-		if (strpos(($active_station_info->station_gridsquare ?? ''), ',') !== false) {
-			$gridsquareArray = explode(',', $active_station_info->station_gridsquare);
-			$user_gridsquare = $gridsquareArray[0];
-		} else {
-			$user_gridsquare = ($active_station_info->station_gridsquare ?? '');
+		// Fallback to config locator if station gridsquare is empty
+		if ($user_gridsquare === '') {
+			$user_gridsquare = $this->config->item('locator') ?? 'JJ00';
 		}
 	?>
 	var user_gridsquare = '<?php echo $user_gridsquare; ?>';

--- a/application/views/bandmap/list.php
+++ b/application/views/bandmap/list.php
@@ -176,16 +176,20 @@
 	var map_tile_server_copyright = '<?php echo $this->optionslib->get_option('option_map_tile_server_copyright');?>';
 	var icon_dot_url = "<?php echo $this->paths->cache_buster('/assets/images/dot.png'); ?>";
 
-	// User gridsquare for home position marker
-	var user_gridsquare = '<?php
-		if (($this->optionslib->get_option("station_gridsquare") ?? "") != "") {
-			echo $this->optionslib->get_option("station_gridsquare");
-		} else if (null !== $this->config->item("locator")) {
-			echo $this->config->item("locator");
+	// User gridsquare for home position marker (from active station location)
+	<?php
+		$active_station_id = $this->stations->find_active();
+		$station_profile = $this->stations->profile($active_station_id);
+		$active_station_info = $station_profile->row();
+
+		if (strpos(($active_station_info->station_gridsquare ?? ''), ',') !== false) {
+			$gridsquareArray = explode(',', $active_station_info->station_gridsquare);
+			$user_gridsquare = $gridsquareArray[0];
 		} else {
-			echo "IO91WM";
+			$user_gridsquare = ($active_station_info->station_gridsquare ?? '');
 		}
-	?>';
+	?>
+	var user_gridsquare = '<?php echo $user_gridsquare; ?>';
 </script>
 
 <link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/css/bandmap_list.css'); ?>" />


### PR DESCRIPTION
The Map at DXCluster always showed the location of the instance instead of those from the user.

Reason was: Code tries to take it from user_options (WTF?) and falls back to location set in config.

This PR fixes it. Grid from station_location will be taken.