### PR TITLE
Add DXCC-Lookup to 1st-login-wizard

### DIFF
--- a/application/views/user/modals/first_login_wizard.php
+++ b/application/views/user/modals/first_login_wizard.php
@@ -65,6 +65,7 @@
                                         <div class="row gx-2">
                                             <div class="col-md-6">
                                                 <select class="form-select" id="stationCQZoneInput" name="station_cqz" required>
+                                                    <option value=""></option>
                                                     <?php
                                                     for ($i = 1; $i <= 40; $i++) {
                                                         echo '<option value="' . $i . '">' . $i . '</option>';
@@ -75,6 +76,7 @@
                                             </div>
                                             <div class="col-md-6">
                                                 <select class="form-select" id="stationITUZoneInput" name="station_ituz" required>
+                                                    <option value=""></option>
                                                     <?php
                                                     for ($i = 1; $i <= 90; $i++) {
                                                         echo '<option value="' . $i . '">' . $i . '</option>';
@@ -133,9 +135,13 @@
                                 }
                                 if (result.dxcc && result.dxcc.cqz) {
                                     $("#stationCQZoneInput").val(result.dxcc.cqz);
+                                } else {
+                                    $("#stationCQZoneInput").val("");
                                 }
                                 if (result.callsign_ituz) {
                                     $("#stationITUZoneInput").val(result.callsign_ituz);
+                                } else {
+                                    $("#stationITUZoneInput").val("");
                                 }
                             }
                         }).fail(function() {

--- a/application/views/user/modals/first_login_wizard.php
+++ b/application/views/user/modals/first_login_wizard.php
@@ -105,3 +105,45 @@
         </div>
     </div>
 </div>
+
+<script>
+(function() {
+    var checkJQuery = setInterval(function() {
+        if (window.jQuery) {
+            clearInterval(checkJQuery);
+            $(document).ready(function() {
+                $("#station_callsign").on("focusout", function() {
+                    if ($(this).val().length >= 3) {
+                        var callsign = $(this).val().toUpperCase().replaceAll('Ø', '0');
+                        var urlCallsign = callsign.replace(/\//g, "-");
+
+                        var url = base_url + "index.php/logbook/json/" + urlCallsign + "/0/0";
+
+                        $.getJSON(url, function(result) {
+                            if (callsign === result.callsign) {
+                                if (result.dxcc && result.dxcc.adif) {
+                                    if ($("#station_dxcc").data('multiselect')) {
+                                        $("#station_dxcc").multiselect('deselectAll', false);
+                                        $("#station_dxcc").multiselect('select', result.dxcc.adif.toString());
+                                        $("#station_dxcc").multiselect('refresh');
+                                    } else {
+                                        $("#station_dxcc").val(result.dxcc.adif);
+                                        $("#station_dxcc").trigger('change');
+                                    }
+                                }
+                                if (result.dxcc && result.dxcc.cqz) {
+                                    $("#stationCQZoneInput").val(result.dxcc.cqz);
+                                }
+                                if (result.callsign_ituz) {
+                                    $("#stationITUZoneInput").val(result.callsign_ituz);
+                                }
+                            }
+                        }).fail(function() {
+                        });
+                    }
+                });
+            });
+        }
+    }, 100);
+})();
+</script>


### PR DESCRIPTION
Add DXCC/ITU/CQ Lookup to 1st Login-Wizard.

Testing:
1. Create new User as admin
2. Login (incognitor or previously logged out) as that new User
3. Type in Call. If DXCC/ITU/CQ is deriveable all three fields are preselected/prefilled automatically

putted it into view and NOT extra-JS to avoid overhead. it neeeded a check if JQuery is already loaded.