### PR TITLE
Fix 13cm band designator

### DIFF
--- a/application/libraries/Cabrilloformat.php
+++ b/application/libraries/Cabrilloformat.php
@@ -96,7 +96,7 @@ class Cabrilloformat {
             $freq = "3.4G";
          }
          if ($freq >= 2320000 && $freq <= 2450000 ) {
-            $freq = "2.4G";
+            $freq = "2.3G";
          }
          if ($freq >= 1240000 && $freq <= 1300000 ) {
             $freq = "1.2G";


### PR DESCRIPTION
As per https://wwrof.org/cabrillo/cabrillo-qso-data/ (which seems to be the official standard for cbr) the 13cm band should be exported as "2.3G" instead of "2.4G". 