### PR TITLE
LBA: Batchedit for SIG / SIG_INFO + Display

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -611,6 +611,7 @@ class Logbookadvanced extends CI_Controller {
 		$json_string['sota']['show'] = $this->def_boolean($this->input->post('sota'));
 		$json_string['dok']['show'] = $this->def_boolean($this->input->post('dok'));
 		$json_string['sig']['show'] = $this->def_boolean($this->input->post('sig'));
+		$json_string['sig_info']['show'] = $this->def_boolean($this->input->post('sig_info'));
 		$json_string['wwff']['show'] = $this->def_boolean($this->input->post('wwff'));
 		$json_string['continent']['show'] = $this->def_boolean($this->input->post('continent'));
 		$json_string['qrz']['show'] = $this->def_boolean($this->input->post('qrz'));

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -1104,6 +1104,8 @@ class Logbookadvanced_model extends CI_Model {
 			case "pota": $column = 'COL_POTA_REF'; break;
 			case "sota": $column = 'COL_SOTA_REF'; break;
 			case "wwff": $column = 'COL_WWFF_REF'; break;
+			case "sig": $column = 'COL_SIG'; break;
+			case "sig_info": $column = 'COL_SIG_INFO'; break;
 			case "gridsquare": $column = 'COL_GRIDSQUARE'; break;
 			case "qslvia": $column = 'COL_QSL_VIA'; break;
 			case "satellite": $column = 'COL_SAT_NAME'; break;
@@ -1137,7 +1139,7 @@ class Logbookadvanced_model extends CI_Model {
 
 		$this->db->trans_start();
 
-		if ($column == 'COL_DARC_DOK') {
+		if ($column == 'COL_DARC_DOK' || $column == 'COL_SIG' || $column == 'COL_SIG_INFO') {
 			$value=strtoupper($value);
 		}
 		if ($column == 'station_id') {

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -1105,7 +1105,6 @@ class Logbookadvanced_model extends CI_Model {
 			case "sota": $column = 'COL_SOTA_REF'; break;
 			case "wwff": $column = 'COL_WWFF_REF'; break;
 			case "sig": $column = 'COL_SIG'; break;
-			case "sig_info": $column = 'COL_SIG_INFO'; break;
 			case "gridsquare": $column = 'COL_GRIDSQUARE'; break;
 			case "qslvia": $column = 'COL_QSL_VIA'; break;
 			case "satellite": $column = 'COL_SAT_NAME'; break;
@@ -1139,8 +1138,12 @@ class Logbookadvanced_model extends CI_Model {
 
 		$this->db->trans_start();
 
-		if ($column == 'COL_DARC_DOK' || $column == 'COL_SIG' || $column == 'COL_SIG_INFO') {
+		if ($column == 'COL_DARC_DOK') {
 			$value=strtoupper($value);
+		}
+		if ($column == 'COL_SIG') {
+			$value=strtoupper($value);
+			$value3=strtoupper($value3);
 		}
 		if ($column == 'station_id') {
 
@@ -1439,6 +1442,26 @@ class Logbookadvanced_model extends CI_Model {
 		} else if ($column == 'COL_DISTANCE' && $value == '') {
 			$this->update_distances($ids);
 			$skipqrzupdate = true;
+		} else if ($column == 'COL_SIG') {
+			$args = array();
+			if ($value != '' || $value2 == "true" || $value3 != '' || $value4 == "true") {
+				$sql = "UPDATE ".$this->config->item('table_name')." JOIN station_profile ON ".$this->config->item('table_name').".station_id = station_profile.station_id SET ";
+				if ($value != '' || $value2 == "true") {
+					$sql .= $this->config->item('table_name').".COL_SIG = ?";
+					$args[] = ($value2 == "true" ? '' : $value);
+				}
+				if ($value3 != '' || $value4 == "true") {
+					if ($value != '' || $value2 == "true") {
+						$sql .= ", ";
+					}
+					$sql .= $this->config->item('table_name').".COL_SIG_INFO = ?";
+					$args[] = ($value4 == "true" ? '' : $value3);
+				}
+				$sql .= " WHERE " . $this->config->item('table_name').".col_primary_key in ? and station_profile.user_id = ?";
+				$args[] = json_decode($ids, true);
+				$args[] = $this->session->userdata('user_id');
+				$query = $this->db->query($sql, $args);
+			}
 		} else {
 
 			if ($value == "null") {

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -251,8 +251,8 @@
 
 		<label style="display:none" id="editSigLabel" class="mx-2 w-auto" for="editSig"><?= __("SIG"); ?></label>
 		<input style="display:none" class="form-control form-control-sm w-auto" id="editSig" type="text" name="editSig" placeholder="" aria-label="editSig">
-		<input style="display:none" id="clearSig" class="mx-2 w-auto" for="editSig" type="checkbox" name="clearSig"></input><?= __("clear"); ?>
+		<input style="display:none" id="clearSig" class="mx-2 w-auto" for="editSig" type="checkbox" name="clearSig"><?= __("clear"); ?>
 		<label style="display:none" id="editSigInfoLabel" class="mx-2 w-auto" for="editSigInfo"><?= __("SIG_INFO"); ?></label>
 		<input style="display:none" class="form-control form-control-sm w-auto" id="editSigInfo" type="text" name="editSigInfo" placeholder="" aria-label="editSigInfo">
-		<input style="display:none" id="clearSigInfo" class="mx-2 w-auto" for="editSigInfo" type="checkbox" name="clearSigInfo"></input><?= __("clear"); ?>
+		<input style="display:none" id="clearSigInfo" class="mx-2 w-auto" for="editSigInfo" type="checkbox" name="clearSigInfo"><?= __("clear"); ?>
 	</form>

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -256,4 +256,3 @@
 		<input style="display:none" class="form-control form-control-sm w-auto" id="editSigInfo" type="text" name="editSigInfo" placeholder="" aria-label="editSigInfo">
 		<input style="display:none" id="clearSigInfo" class="mx-2 w-auto" for="editSigInfo" type="checkbox" name="clearSigInfo"></input><?= __("clear"); ?>
 	</form>
-	</form>

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -32,8 +32,7 @@
 				<option value="region"><?= __("Region"); ?></option>
 				<option value="sota"><?= __("SOTA"); ?></option>
 				<option value="state"><?= __("State"); ?></option>
-				<option value="sig"><?= __("SIG"); ?></option>
-				<option value="sig_info"><?= __("SIG Info"); ?></option>
+				<option value="sig"><?= __("SIG / SIG_INFO"); ?></option>
 				<option value="wwff"><?= __("WWFF"); ?></option>
 			</optgroup>
 
@@ -249,4 +248,12 @@
 		<input style="display:none" class="form-control form-control-sm w-auto" id="editDistanceInput" type="text" name="editDistanceInput" placeholder="" aria-label="editDistanceInput">
 		<input style="display:none" class="form-control form-control-sm w-auto uppercase" id="editDokInput" type="text" name="editDokInput" placeholder="" aria-label="editDokInput">
 		<input style="display:none" class="form-control form-control-sm w-auto uppercase" id="editGridsquareInput" type="text" name="editGridsquareInput" placeholder="" aria-label="editGridsquareInput">
+
+		<label style="display:none" id="editSigLabel" class="mx-2 w-auto" for="editSig"><?= __("SIG"); ?></label>
+		<input style="display:none" class="form-control form-control-sm w-auto" id="editSig" type="text" name="editSig" placeholder="" aria-label="editSig">
+		<input style="display:none" id="clearSig" class="mx-2 w-auto" for="editSig" type="checkbox" name="clearSig"></input><?= __("clear"); ?>
+		<label style="display:none" id="editSigInfoLabel" class="mx-2 w-auto" for="editSigInfo"><?= __("SIG_INFO"); ?></label>
+		<input style="display:none" class="form-control form-control-sm w-auto" id="editSigInfo" type="text" name="editSigInfo" placeholder="" aria-label="editSigInfo">
+		<input style="display:none" id="clearSigInfo" class="mx-2 w-auto" for="editSigInfo" type="checkbox" name="clearSigInfo"></input><?= __("clear"); ?>
+	</form>
 	</form>

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -32,6 +32,8 @@
 				<option value="region"><?= __("Region"); ?></option>
 				<option value="sota"><?= __("SOTA"); ?></option>
 				<option value="state"><?= __("State"); ?></option>
+				<option value="sig"><?= __("SIG"); ?></option>
+				<option value="sig_info"><?= __("SIG Info"); ?></option>
 				<option value="wwff"><?= __("WWFF"); ?></option>
 			</optgroup>
 

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -126,6 +126,7 @@
             \"dok\":{\"show\":\"true\"},
             \"wwff\":{\"show\":\"true\"},
             \"sig\":{\"show\":\"true\"},
+            \"sig_info\":{\"show\":\"false\"},
             \"continent\":{\"show\":\"true\"},
             \"qrz\":{\"show\":\"true\"},
             \"profilename\":{\"show\":\"true\"},
@@ -198,6 +199,10 @@
     }
     if (!isset($current_opts->sig)) {
         echo "\nvar o_template = { sig: {show: 'true'}};";
+        echo "\nuser_options={...user_options, ...o_template};";
+    }
+    if (!isset($current_opts->sig_info)) {
+        echo "\nvar o_template = { sig_info: {show: 'false'}};";
         echo "\nuser_options={...user_options, ...o_template};";
     }
     if (!isset($current_opts->continent)) {
@@ -1022,6 +1027,9 @@ $options = json_decode($options);
                     } ?>
                     <?php if (($options->sig->show ?? "true") == "true") {
                         echo '<th>SIG</th>';
+                    } ?>
+                    <?php if (($options->sig_info->show ?? "false") == "true") {
+                        echo '<th>' . __("SIG Info") . '</th>';
                     } ?>
                     <?php if (($options->region->show ?? "true") == "true") {
                         echo '<th>' . __("Region") . '</th>';

--- a/application/views/logbookadvanced/useroptions.php
+++ b/application/views/logbookadvanced/useroptions.php
@@ -252,6 +252,12 @@
 				</div>
 				<div class="col-md-6 col-lg-4">
 					<div class="form-check">
+						<input class="form-check-input" name="sig_info" type="checkbox" id="sig_info" <?php if (($options->sig_info->show ?? "false") == "true") { echo 'checked'; } ?>>
+						<label class="form-check-label" for="sig_info"><?= __("SIG Info"); ?></label>
+					</div>
+				</div>
+				<div class="col-md-6 col-lg-4">
+					<div class="form-check">
 						<input class="form-check-input" name="region" type="checkbox" id="region" <?php if (($options->region->show ?? "true") == "true") { echo 'checked'; } ?>>
 						<label class="form-check-label" for="region"><?= __("Region"); ?></label>
 					</div>

--- a/application/views/logbookadvanced/useroptions.php
+++ b/application/views/logbookadvanced/useroptions.php
@@ -250,12 +250,13 @@
 						<label class="form-check-label" for="sig"><?= __("SIG"); ?></label>
 					</div>
 				</div>
+				<?php /* intentional commented out, because we already have a combined field. If needed in future: Remove comment :)
 				<div class="col-md-6 col-lg-4">
 					<div class="form-check">
 						<input class="form-check-input" name="sig_info" type="checkbox" id="sig_info" <?php if (($options->sig_info->show ?? "false") == "true") { echo 'checked'; } ?>>
 						<label class="form-check-label" for="sig_info"><?= __("SIG Info"); ?></label>
 					</div>
-				</div>
+				</div> */ ?>
 				<div class="col-md-6 col-lg-4">
 					<div class="form-check">
 						<input class="form-check-input" name="region" type="checkbox" id="region" <?php if (($options->region->show ?? "true") == "true") { echo 'checked'; } ?>>

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -160,6 +160,9 @@ function updateRow(qso) {
 	if ((user_options.sig) && ((user_options.sig.show ?? 'true') == "true")){
 		cells.eq(c++).html(qso.sig);
 	}
+	if ((user_options.sig_info) && ((user_options.sig_info.show ?? 'false') == "true")){
+		cells.eq(c++).html(qso.sig_info);
+	}
 	if ((user_options.region) && ((user_options.region.show ?? 'true') == "true")){
 		cells.eq(c++).html(qso.region);
 	}
@@ -402,6 +405,9 @@ function loadQSOTable(rows) {
 		}
 		if ((user_options.sig.show ?? 'true') == "true"){
 			data.push(qso.sig);
+		}
+		if ((user_options.sig_info.show ?? 'false') == "true"){
+			data.push(qso.sig_info);
 		}
 		if ((user_options.region.show ?? 'true') == "true"){
 			data.push(qso.region);
@@ -2068,6 +2074,7 @@ function saveOptions() {
 				dok: $('input[name="dok"]').is(':checked') ? true : false,
 				wwff: $('input[name="wwff"]').is(':checked') ? true : false,
 				sig: $('input[name="sig"]').is(':checked') ? true : false,
+				sig_info: $('input[name="sig_info"]').is(':checked') ? true : false,
 				region: $('input[name="region"]').is(':checked') ? true : false,
 				continent: $('input[name="continent"]').is(':checked') ? true : false,
 				distance: $('input[name="distance"]').is(':checked') ? true : false,

--- a/assets/js/sections/logbookadvanced_edit.js
+++ b/assets/js/sections/logbookadvanced_edit.js
@@ -208,7 +208,7 @@ function saveBatchEditQsos(id_list) {
 	if (column == 'region') {
 		value = $("#editRegion").val();
 	}
-	if (column == 'sota' || column == 'pota' || column == 'wwff' || column == 'gridsquare' || column == 'comment' || column == 'operator' || column == 'qslvia' || column == 'qslmsg' || column == 'stationpower' || column == 'stxstring' || column == 'rsts' || column == 'rstr') {
+	if (column == 'sota' || column == 'pota' || column == 'wwff' || column == 'sig' || column == 'sig_info' || column == 'gridsquare' || column == 'comment' || column == 'operator' || column == 'qslvia' || column == 'qslmsg' || column == 'stationpower' || column == 'stxstring' || column == 'rsts' || column == 'rstr') {
 		value = $("#editTextInput").val();
 	}
 	if (column == 'distance') {
@@ -332,7 +332,7 @@ function changeEditType(type) {
 		$('#editEqsl').show();
 	} else if (type == "continent") {
 		$('#editContinent').show();
-	} else if (type == "sota" || type == "wwff" || type == "operator" || type == "pota" || type == "comment" || type == "qslvia" || type == "contest" || type == "qslmsg" || type == "stationpower" || type == 'stxstring' || type == 'rsts' || type == 'rstr') {
+	} else if (type == "sota" || type == "wwff" || type == "sig" || type == "sig_info" || type == "operator" || type == "pota" || type == "comment" || type == "qslvia" || type == "contest" || type == "qslmsg" || type == "stationpower" || type == 'stxstring' || type == 'rsts' || type == 'rstr') {
 		$('#editTextInput').show();
 	} else if (type == "region") {
 		$('#editRegion').show();

--- a/assets/js/sections/logbookadvanced_edit.js
+++ b/assets/js/sections/logbookadvanced_edit.js
@@ -109,6 +109,24 @@ function prepareEditDialog() {
 		var statedxcc = $('#editDxccState').val();
 		changeState(statedxcc);
 	});
+
+	$('#clearSig').change(function(){
+		if ($("#clearSig").prop("checked")) {
+			$('#editSig').prop("disabled", true);
+			$('#editSig').val("");
+		} else {
+			$('#editSig').prop("disabled", false);
+		}
+	});
+
+	$('#clearSigInfo').change(function(){
+		if ($("#clearSigInfo").prop("checked")) {
+			$('#editSigInfo').prop("disabled", true);
+			$('#editSigInfo').val("");
+		} else {
+			$('#editSigInfo').prop("disabled", false);
+		}
+	});
 }
 
 function propagationCopy() {
@@ -208,7 +226,7 @@ function saveBatchEditQsos(id_list) {
 	if (column == 'region') {
 		value = $("#editRegion").val();
 	}
-	if (column == 'sota' || column == 'pota' || column == 'wwff' || column == 'sig' || column == 'sig_info' || column == 'gridsquare' || column == 'comment' || column == 'operator' || column == 'qslvia' || column == 'qslmsg' || column == 'stationpower' || column == 'stxstring' || column == 'rsts' || column == 'rstr') {
+	if (column == 'sota' || column == 'pota' || column == 'wwff' || column == 'gridsquare' || column == 'comment' || column == 'operator' || column == 'qslvia' || column == 'qslmsg' || column == 'stationpower' || column == 'stxstring' || column == 'rsts' || column == 'rstr') {
 		value = $("#editTextInput").val();
 	}
 	if (column == 'distance') {
@@ -222,6 +240,12 @@ function saveBatchEditQsos(id_list) {
 	}
 	if (column == 'qslsentmethod' || column == 'qslreceivedmethod') {
 		value = $("#editQslMethod").val();
+	}
+	if (column == 'sig') {
+		value = $("#editSig").val();
+		value2 = $("#clearSig").prop('checked');
+		value3 = $("#editSigInfo").val();
+		value4 = $("#clearSigInfo").prop('checked');
 	}
 
 	$.ajax({
@@ -285,6 +309,12 @@ function changeEditType(type) {
 	$('#editFrequencyRx').hide();
 	$('#editFrequencyTxLabel').hide();
 	$('#editFrequencyRxLabel').hide();
+	$('#editSig').hide();
+	$('#clearSig').hide();
+	$('#editSigLabel').hide();
+	$('#editSigInfo').hide();
+	$('#clearSigInfo').hide();
+	$('#editSigInfoLabel').hide();
 	if (type == "dxcc") {
 		$('#editDxcc').show();
 	} else if (type == "iota") {
@@ -332,7 +362,7 @@ function changeEditType(type) {
 		$('#editEqsl').show();
 	} else if (type == "continent") {
 		$('#editContinent').show();
-	} else if (type == "sota" || type == "wwff" || type == "sig" || type == "sig_info" || type == "operator" || type == "pota" || type == "comment" || type == "qslvia" || type == "contest" || type == "qslmsg" || type == "stationpower" || type == 'stxstring' || type == 'rsts' || type == 'rstr') {
+	} else if (type == "sota" || type == "wwff" || type == "operator" || type == "pota" || type == "comment" || type == "qslvia" || type == "contest" || type == "qslmsg" || type == "stationpower" || type == 'stxstring' || type == 'rsts' || type == 'rstr') {
 		$('#editTextInput').show();
 	} else if (type == "region") {
 		$('#editRegion').show();
@@ -354,6 +384,13 @@ function changeEditType(type) {
 		$('#editFrequencyRx').show();
 		$('#editFrequencyTxLabel').show();
 		$('#editFrequencyRxLabel').show();
+	} else if (type == "sig") {
+		$('#editSig').show();
+		$('#clearSig').show();
+		$('#editSigLabel').show();
+		$('#editSigInfo').show();
+		$('#clearSigInfo').show();
+		$('#editSigInfoLabel').show();
 	}
 }
 

--- a/src/QSLManager/QSO.php
+++ b/src/QSLManager/QSO.php
@@ -1311,6 +1311,7 @@ class QSO
 			'dok' => $this->getFormattedDok(),
 			'wwff' => $this->getFormattedWwff(),
 			'sig' => $this->getFormattedSig(),
+			'sig_info' => $this->dxSigInfo,
 			'continent' => $this->getContinentLink(),
 			'profilename' => $this->profilename,
 			'stationpower' => empty($this->stationpower) ? null : $this->stationpower.' W',


### PR DESCRIPTION
This one adds:
- Showing SIG_INFO in LBA as extra (optional) column
- Batchedit of SIG and SIG_INFO

**open**:
Leave SIG-Display as combined field in LBA or remove SIG_INFO, since both cols are shown now? @AndreasK79 

<img width="1023" height="928" alt="image" src="https://github.com/user-attachments/assets/110b3176-966f-495f-94b4-2d0f8a3dd4fb" />
