### PR TITLE
Fix empty SAT-Name treated as SAT-QSO

### DIFF
--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -10,7 +10,7 @@
 				$prop_mode = $result['prop_mode'];
 			// For backward compatibility, SatPC32 does not set propergation mode
 			} else if (isset($result['sat_name'])) {
-				if (trim($prop_mode) != '') {	// Some Tools send an empty string - catch it!
+				if (trim($result['sat_name']) != '') {	// Some Tools send an empty string - catch it!
 					$prop_mode = "SAT";
 				} else {
 					$prop_mode = NULL;

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -10,7 +10,11 @@
 				$prop_mode = $result['prop_mode'];
 			// For backward compatibility, SatPC32 does not set propergation mode
 			} else if (isset($result['sat_name'])) {
-				$prop_mode = "SAT";
+				if (trim($prop_mode) != '') {	// Some Tools send an empty string - catch it!
+					$prop_mode = "SAT";
+				} else {
+					$prop_mode = NULL;
+				}
 			} else {
 				$prop_mode = NULL;
 			}

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -8,7 +8,7 @@
 
 			if (isset($result['prop_mode'])) {
 				$prop_mode = $result['prop_mode'];
-			// For backward compatibility, SatPC32 does not set propergation mode
+			// For backward compatibility, SatPC32 does not set propagation mode
 			} else if (isset($result['sat_name']) && trim($result['sat_name']) != '') {
 				$prop_mode = "SAT";
 			} else {

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -9,12 +9,8 @@
 			if (isset($result['prop_mode'])) {
 				$prop_mode = $result['prop_mode'];
 			// For backward compatibility, SatPC32 does not set propergation mode
-			} else if (isset($result['sat_name'])) {
-				if (trim($result['sat_name']) != '') {	// Some Tools send an empty string - catch it!
-					$prop_mode = "SAT";
-				} else {
-					$prop_mode = NULL;
-				}
+			} else if (isset($result['sat_name']) && trim($result['sat_name']) != '') {
+				$prop_mode = "SAT";
 			} else {
 				$prop_mode = NULL;
 			}


### PR DESCRIPTION
Some Tools like the one mentioned at https://github.com/wavelog/wavelog/discussions/3177 send an empty string - catch it!