### PR TITLE
simplify radio tuning with database cat url (drop http/https hazzle)

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -399,59 +399,20 @@ $(document).ready(function() {
         // Validate and normalize mode parameter
         const validModes = ['lsb', 'usb', 'cw', 'fm', 'am', 'rtty', 'pkt', 'dig', 'pktlsb', 'pktusb', 'pktfm'];
         const catMode = mode && validModes.includes(mode.toLowerCase()) ? mode.toLowerCase() : 'usb';
+        const requestUrl = catUrl + '/' + freqHz + '/' + catMode;
 
-        // Determine which protocol to try first
-        // If URL is already HTTPS, use it. If HTTP, upgrade to HTTPS for first attempt.
-        const isHttps = catUrl.startsWith('https://');
-        const httpsUrl = isHttps ? catUrl : catUrl.replace(/^http:\/\//, 'https://');
-        const httpUrl = isHttps ? catUrl.replace(/^https:\/\//, 'http://') : catUrl;
-
-        // Build the full URLs with frequency and mode
-        const httpsRequestUrl = httpsUrl + '/' + freqHz + '/' + catMode;
-        const httpRequestUrl = httpUrl + '/' + freqHz + '/' + catMode;
-
-        // Try HTTPS first (unless original URL was already HTTPS, then just try that)
-        const tryHttps = !isHttps;
-
-        // Function to attempt tuning with a specific URL
-        const tryTuning = function(url, isFallback) {
-            return fetch(url, {
-                method: 'GET'
-            })
+        fetch(requestUrl, { method: 'GET' })
             .then(response => {
                 if (response.ok) {
-                    // Success - HTTP 200-299, get response text
                     return response.text();
                 } else {
-                    // HTTP error status (4xx, 5xx)
                     throw new Error('HTTP ' + response.status);
                 }
             })
             .then(data => {
-                // Call success callback with response data
                 if (typeof onSuccess === 'function') {
                     onSuccess(data);
                 }
-                return data;
-            });
-        };
-
-        // Execute failover logic: try HTTPS first, then HTTP
-        const primaryUrl = tryHttps ? httpsRequestUrl : httpRequestUrl;
-        const fallbackUrl = tryHttps ? httpRequestUrl : null;
-
-        tryTuning(primaryUrl, false)
-            .catch(error => {
-                // If HTTPS was attempted and failed, try HTTP fallback
-                if (fallbackUrl !== null) {
-                    return tryTuning(fallbackUrl, true)
-                        .catch(fallbackError => {
-                            // Both HTTPS and HTTP failed
-                            throw fallbackError;
-                        });
-                }
-                // No fallback available (was already HTTPS or only one URL to try)
-                throw error;
             })
             .catch(error => {
                 // All attempts failed - show error

--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -48,6 +48,9 @@ $(document).ready(function() {
     // Cache for radio names to avoid repeated AJAX calls
     var radioNameCache = {};
 
+    // Session cache: remembers which protocol actually worked per stored catUrl (no persistence)
+    var catWorkingUrlCache = {};
+
     // Global CAT state - stores last received data from radio
     // This allows other components (like DX Waterfall) to read radio state
     // without depending on form fields
@@ -388,8 +391,8 @@ $(document).ready(function() {
     /**
      * Perform the actual radio tuning via CAT interface
      * Sends frequency and mode to radio via HTTP/HTTPS request with failover
-     * Tries HTTPS first, falls back to HTTP on failure
-     * @param {string} catUrl - CAT interface URL for the radio
+     * Uses the protocol from catUrl as primary; retries with the opposite protocol on failure
+     * @param {string} catUrl - CAT interface URL for the radio (must include http:// or https://)
      * @param {number} freqHz - Frequency in Hz
      * @param {string} mode - Radio mode (validated against supported modes)
      * @param {function} onSuccess - Callback on successful tuning
@@ -399,17 +402,29 @@ $(document).ready(function() {
         // Validate and normalize mode parameter
         const validModes = ['lsb', 'usb', 'cw', 'fm', 'am', 'rtty', 'pkt', 'dig', 'pktlsb', 'pktusb', 'pktfm'];
         const catMode = mode && validModes.includes(mode.toLowerCase()) ? mode.toLowerCase() : 'usb';
-        const requestUrl = catUrl + '/' + freqHz + '/' + catMode;
+        // Use cached working base URL if available (session-only, cleared on radio change)
+        const primaryBase = catWorkingUrlCache[catUrl] || catUrl;
+        const fallbackBase = primaryBase.startsWith('https://')
+            ? primaryBase.replace(/^https:\/\//, 'http://')
+            : primaryBase.replace(/^http:\/\//, 'https://');
+        const requestUrl = primaryBase + '/' + freqHz + '/' + catMode;
+        const fallbackUrl = fallbackBase + '/' + freqHz + '/' + catMode;
 
-        fetch(requestUrl, { method: 'GET' })
+        let successBase = primaryBase;
+
+        const tryFetch = (url) => fetch(url, { method: 'GET' })
             .then(response => {
                 if (response.ok) {
                     return response.text();
                 } else {
                     throw new Error('HTTP ' + response.status);
                 }
-            })
+            });
+
+        tryFetch(requestUrl)
+            .catch(() => { successBase = fallbackBase; return tryFetch(fallbackUrl); })
             .then(data => {
+                catWorkingUrlCache[catUrl] = successBase;  // remember working protocol for this session
                 if (typeof onSuccess === 'function') {
                     onSuccess(data);
                 }
@@ -1212,6 +1227,7 @@ $(document).ready(function() {
         // Clear both caches when radio changes
         radioCatUrlCache = {};
         radioNameCache = {};
+        catWorkingUrlCache = {};
 
         // Reset Hybrid Mode flag
         isHybridMode = false;


### PR DESCRIPTION
The external cat url logic had a bug for other targets then our default `http://127.0.0.1:54321`. 
The line
```javascript
const tryHttps = !isHttps;
```
inverted the logic as it should be. Started the URL with https the browser first tried http and failed because of mixed content. 
We shouldn't play around here. If a user runs wavelog on http and enters an http cat url which isn't localhost we don't need to try https first. This just causes noise. 
I propose to drop the http/https (or maybe https/http/https?) logic and just use the url the user provided. Localhost will still work normally.

This PR comes with https://github.com/wavelog/WaveLogGate/pull/121 to work properly 

thx to @zone11 for the hint 