### PR TITLE
Fix clear-bug for Batch-Edit of SIG/SIG_INFO

### DIFF
--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -251,8 +251,8 @@
 
 		<label style="display:none" id="editSigLabel" class="mx-2 w-auto" for="editSig"><?= __("SIG"); ?></label>
 		<input style="display:none" class="form-control form-control-sm w-auto" id="editSig" type="text" name="editSig" placeholder="" aria-label="editSig">
-		<input style="display:none" id="clearSig" class="mx-2 w-auto" for="editSig" type="checkbox" name="clearSig"><?= __("clear"); ?>
+		<input style="display:none" id="clearSig" class="mx-2 w-auto" type="checkbox" name="clearSig"><label style="display:none" id="clearSigLabel" for="clearSig"><?= __("clear"); ?></label>
 		<label style="display:none" id="editSigInfoLabel" class="mx-2 w-auto" for="editSigInfo"><?= __("SIG_INFO"); ?></label>
 		<input style="display:none" class="form-control form-control-sm w-auto" id="editSigInfo" type="text" name="editSigInfo" placeholder="" aria-label="editSigInfo">
-		<input style="display:none" id="clearSigInfo" class="mx-2 w-auto" for="editSigInfo" type="checkbox" name="clearSigInfo"><?= __("clear"); ?>
+		<input style="display:none" id="clearSigInfo" class="mx-2 w-auto" type="checkbox" name="clearSigInfo"><label style="display:none" id="clearSigInfoLabel" for="clearSigInfo"><?= __("clear"); ?></label>
 	</form>

--- a/assets/js/sections/logbookadvanced_edit.js
+++ b/assets/js/sections/logbookadvanced_edit.js
@@ -311,9 +311,11 @@ function changeEditType(type) {
 	$('#editFrequencyRxLabel').hide();
 	$('#editSig').hide();
 	$('#clearSig').hide();
+	$('#clearSigLabel').hide();
 	$('#editSigLabel').hide();
 	$('#editSigInfo').hide();
 	$('#clearSigInfo').hide();
+	$('#clearSigInfoLabel').hide();
 	$('#editSigInfoLabel').hide();
 	if (type == "dxcc") {
 		$('#editDxcc').show();
@@ -387,9 +389,11 @@ function changeEditType(type) {
 	} else if (type == "sig") {
 		$('#editSig').show();
 		$('#clearSig').show();
+		$('#clearSigLabel').show();
 		$('#editSigLabel').show();
 		$('#editSigInfo').show();
 		$('#clearSigInfo').show();
+		$('#clearSigInfoLabel').show();
 		$('#editSigInfoLabel').show();
 	}
 }


### PR DESCRIPTION
Fixes two issues:
1. clear wasn't hidden, if something else than SIG/SIG_INFO wasn't chosen --> fixed
2. alignment was a bit "fuzzy"


Current dev:
<img width="482" height="226" alt="image" src="https://github.com/user-attachments/assets/e4386a72-f045-4664-973a-9ca6640ea91c" />

Current dev with SIG/SIG_INFO chosen:
<img width="902" height="227" alt="image" src="https://github.com/user-attachments/assets/59c57ecc-2f83-46e8-90dc-ae7541d3aab4" />


After patching:
<img width="895" height="230" alt="image" src="https://github.com/user-attachments/assets/dcba2227-dc6c-4082-8df0-92d1b9ab453d" />

With SIG/SIG_INFO chosen:
<img width="898" height="231" alt="image" src="https://github.com/user-attachments/assets/8b6e4451-33c9-4f89-9371-33f9d6359602" />
