### PR TITLE
Add User-Agent to JWKS request in header_auth

### DIFF
--- a/application/controllers/Header_auth.php
+++ b/application/controllers/Header_auth.php
@@ -168,7 +168,11 @@ class Header_auth extends CI_Controller {
 
         if (!empty($jwksUri)) {
             try {
-                $jwksJson = file_get_contents($jwksUri);
+                $wavelog_version = $this->optionslib->get_option('version');
+                $user_agent  = array('http' => array('user_agent' => "Wavelog/$wavelog_version"));
+
+                $context  = stream_context_create($user_agent);
+                $jwksJson = file_get_contents($jwksUri, false, $context);
                 if ($jwksJson === false) {
                     log_message('error', 'SSO Authentication: Failed to fetch JWKS from ' . $jwksUri);
                     return null;


### PR DESCRIPTION
Some WAF products (CloudFront & CloudFlare) block requests that have no UA. For example the AWS Core rule set has `AWSManagedRulesCommonRuleSet` with rule `NoUserAgent_HEADER` that blocks requests without UA.

This PR adds a UA when requesting the JSON web key set from the IdP: `Wavelog/<version_number>` eg `Wavelog/2.4.1`