### PR TITLE
Cache CAT-Data on 1st connect

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -221,6 +221,16 @@ $(document).ready(function() {
 
         // Handle radio status updates
         if (data.type === 'radio_status' && data.radio && ($(".radios option:selected").val() == 'ws')) {
+            // Calculate age from timestamp, defaulting to 0 (fresh) if timestamp is missing
+            if (data.timestamp) {
+                data.updated_minutes_ago = Math.floor((Date.now() - data.timestamp) / 60000);
+            } else {
+                data.updated_minutes_ago = 0; // Assume fresh if no timestamp
+            }
+
+            // Cache data so it's available when CAT tracking is enabled later
+            window.lastCATData = data;
+
             // On bandmap page, check CAT Control state
             if (typeof window.isCatTrackingEnabled !== 'undefined') {
                 if (!window.isCatTrackingEnabled) {
@@ -232,13 +242,6 @@ $(document).ready(function() {
                 }
             }
 
-            // Calculate age from timestamp, defaulting to 0 (fresh) if timestamp is missing
-            if (data.timestamp) {
-                data.updated_minutes_ago = Math.floor((Date.now() - data.timestamp) / 60000);
-            } else {
-                data.updated_minutes_ago = 0; // Assume fresh if no timestamp
-            }
-            // Cache the radio data
             updateCATui(data);
         }
     }

--- a/assets/js/sections/bandmap_list.js
+++ b/assets/js/sections/bandmap_list.js
@@ -3876,9 +3876,12 @@ $(function() {
 				updateFromCAT();
 			}
 
-			// Show gradient if we have frequency data
-			if (window.lastCATData && window.lastCATData.frequency) {
-				updateFrequencyGradientColors();
+			// For websocket radios, replay cached data if fresh enough
+			if (selectedRadio === 'ws' && window.lastCATData && typeof window.updateCATui === 'function') {
+				var replayMinutes = typeof cat_timeout_minutes !== 'undefined' ? cat_timeout_minutes : 5;
+				if (window.lastCATData.updated_minutes_ago <= replayMinutes) {
+					window.updateCATui(window.lastCATData);
+				}
 			}
 
 			updateCatButtonVisual(true);


### PR DESCRIPTION
Problem:
When using WavelogGate (or any other websocket-CAT-provider):
- Navigating to `/qso` or `/bandmap/list` leads into connection to the Websocket (if chosen)
- Websocket sends welcome-message and 1st radio-info upon that connect
- Wavelog itself ignores the 1st radio-info, even when activating "CAT/WS" and Bandmap/QSO . 
- So User always has to turn VFO once, to force sync at bandmap or qso

This PR fixes that behaviour.
- The 1st info from websocket (if available) is cached and used (if not outdated)
- So User doesn't have to turn VFO if there's already fresh radiodata

Testinghints:
- Launch WavelogGate (or any other websocket-CAT-Tool) and make sure Gate has actual frequency/mode
- Navigate to `bandmap/list`, turn on CAT via websocket (or polling for testing the whole thing)
- Last QRG should be visible within WL