### PR TITLE
[Advanced Logbook] Duplicate query rewrite

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -5,25 +5,24 @@ use Wavelog\Dxcc\Dxcc;
 class Logbookadvanced_model extends CI_Model {
 
 	public function dupeSearchQuery($searchCriteria, $binding) {
-		$conditions = [];
-		$group_by_append = '';
-		$order_by = '';
+		$order_by = ' ORDER BY col_call';
 
-		$order_by .= ' order by col_call';
-		$id_sql = "select GROUP_CONCAT(col_primary_key separator ',') as qsoids, COL_CALL, station_callsign, min(col_time_on) Mintime, max(col_time_on) Maxtime";
+		// Build dynamic PARTITION BY
+		$partition_by = "COL_CALL, q.station_id";
+		$conditions = [];
 
 		if (isset($searchCriteria['dupemode']) && $searchCriteria['dupemode'] === 'Y') {
-			$id_sql .= ", COL_MODE, COL_SUBMODE";
-			$group_by_append .= ", COL_MODE, COL_SUBMODE";
+			$partition_by .= ", COL_MODE, COALESCE(COL_SUBMODE, '')";
 		}
 		if (isset($searchCriteria['dupeband']) && $searchCriteria['dupeband'] === 'Y') {
-			$id_sql .= ", COL_BAND";
-			$group_by_append .= ", COL_BAND";
+			$partition_by .= ", COL_BAND";
 		}
 		if (isset($searchCriteria['dupesat']) && $searchCriteria['dupesat'] === 'Y') {
-			$id_sql .= ", COL_SAT_NAME";
-			$group_by_append .= ", COL_SAT_NAME";
-			$conditions[] = "COL_PROP_MODE = 'SAT' and COL_SAT_NAME <> '' and COL_SAT_NAME is not null";
+			$partition_by .= ", COL_SAT_NAME";
+			$conditions[] = "COL_PROP_MODE = 'SAT' AND COL_SAT_NAME <> '' AND COL_SAT_NAME IS NOT NULL";
+		}
+		if (isset($searchCriteria['dupedate']) && $searchCriteria['dupedate'] === 'Y') {
+			$order_by = ' ORDER BY col_call, col_time_on DESC';
 		}
 
 		if (isset($searchCriteria['de']) && $searchCriteria['de'] == '') {
@@ -41,31 +40,63 @@ class Logbookadvanced_model extends CI_Model {
 				$stationids = 'null';
 			}
 		}
-		$conditions[] = "qsos.station_id in (".$stationids.")";
-		$dupeWhere = " and qsos.station_id in (".$stationids.") ";
 
-		$id_sql .= " from " . $this->config->item('table_name') . " qsos
-			join station_profile on qsos.station_id = station_profile.station_id where station_profile.user_id = ?";
-		$id_sql .= $dupeWhere;
-
-		$id_sql .= "group by COL_CALL, station_callsign";
-		$id_sql .= $group_by_append;
-		$id_sql .= " having count(*) > 1";
-		if (isset($searchCriteria['dupedate']) && $searchCriteria['dupedate'] === 'Y') {
-			$id_sql .= " AND TIMESTAMPDIFF(SECOND, Mintime, Maxtime) < 1800";
-			$order_by .= ' , col_time_on desc';
+		$where_conditions = "";
+		if (!empty($conditions)) {
+			$where_conditions = "AND " . implode(" AND ", $conditions);
 		}
+
+		// Build the dupedate HAVING condition
+		$having_condition = isset($searchCriteria['dupedate']) && $searchCriteria['dupedate'] === 'Y'
+			? "AND TIMESTAMPDIFF(SECOND, prev_time_on, col_time_on) < 1800"
+			: "";
+
+		$id_sql = "
+			WITH ranked AS (
+				SELECT
+					q.col_primary_key,
+					q.COL_CALL,
+					q.col_time_on,
+					q.station_id,
+					LAG(q.col_time_on) OVER (
+						PARTITION BY $partition_by
+						ORDER BY q.col_time_on
+					) as prev_time_on,
+					LAG(q.col_primary_key) OVER (
+						PARTITION BY $partition_by
+						ORDER BY q.col_time_on
+					) as prev_primary_key
+				FROM " . $this->config->item('table_name') . " q
+				JOIN station_profile sp ON q.station_id = sp.station_id
+				WHERE sp.user_id = ?
+					AND q.station_id IN ($stationids)
+					$where_conditions
+			)
+			SELECT
+				col_primary_key,
+				prev_primary_key
+			FROM ranked
+			WHERE prev_time_on IS NOT NULL
+			$having_condition
+		";
 
 		$id_query = $this->db->query($id_sql, array($this->session->userdata('user_id')));
-		$ids2fetch = '';
+
+		$ids2fetch = [];
 		foreach ($id_query->result() as $id) {
-			$ids2fetch .= ','.$id->qsoids;
+			$ids2fetch[] = $id->col_primary_key;
+			if ($id->prev_primary_key) {
+				$ids2fetch[] = $id->prev_primary_key;
+			}
 		}
-		$ids2fetch = ltrim($ids2fetch, ',');
-		if ($ids2fetch ?? '' !== '') {
-			$conditions[] = "qsos.COL_PRIMARY_KEY in (".$ids2fetch.")";
+		$ids2fetch = array_unique($ids2fetch);
+
+		$final_conditions[] = "qsos.station_id IN ($stationids)";
+
+		if (!empty($ids2fetch)) {
+			$final_conditions[] = "qsos.COL_PRIMARY_KEY IN (" . implode(',', $ids2fetch) . ")";
 		} else {
-			$conditions[] = "1=0";
+			$final_conditions[] = "1 = 0";
 		}
 
 		if (($searchCriteria['ids'] ?? '') !== '') {
@@ -76,12 +107,12 @@ class Logbookadvanced_model extends CI_Model {
 					return $id > 0;
 				});
 				if (!empty($sanitized_ids)) {
-					$conditions[] = "qsos.COL_PRIMARY_KEY in (".implode(",",$sanitized_ids).")";
+					$final_conditions[] = "qsos.COL_PRIMARY_KEY IN (" . implode(",", $sanitized_ids) . ")";
 				}
 			}
 		}
 
-		$where = trim(implode(" AND ", $conditions));
+		$where = trim(implode(" AND ", $final_conditions));
 		if ($where != "") {
 			$where = "AND $where";
 		}
@@ -96,18 +127,18 @@ class Logbookadvanced_model extends CI_Model {
 		}
 
 		$sql = "
-		SELECT qsos.*, qsos.last_modified AS qso_last_modified, dxcc_entities.*, lotw_users.*, station_profile.*, satellite.*, dxcc_entities.name as dxccname, mydxcc.name AS station_country, exists(select 1 from qsl_images where qsoid = qsos.COL_PRIMARY_KEY) as qslcount, coalesce(contest.name, qsos.col_contest_id) as contestname
-		FROM " . $this->config->item('table_name') . " qsos
-		INNER JOIN station_profile ON qsos.station_id=station_profile.station_id
-		LEFT OUTER JOIN satellite ON qsos.col_prop_mode='SAT' and qsos.COL_SAT_NAME = COALESCE(NULLIF(satellite.name, ''), NULLIF(satellite.displayname, ''))
-		LEFT OUTER JOIN dxcc_entities ON qsos.col_dxcc = dxcc_entities.adif
-		left outer join dxcc_entities mydxcc on qsos.col_my_dxcc = mydxcc.adif
-		LEFT OUTER JOIN lotw_users ON qsos.col_call = lotw_users.callsign
-		LEFT OUTER JOIN contest ON qsos.col_contest_id = contest.adifname
-		WHERE station_profile.user_id =  ?
-		$where
-		$order_by
-		$limit
+			SELECT qsos.*, qsos.last_modified AS qso_last_modified, dxcc_entities.*, lotw_users.*, station_profile.*, satellite.*, dxcc_entities.name as dxccname, mydxcc.name AS station_country, exists(select 1 from qsl_images where qsoid = qsos.COL_PRIMARY_KEY) as qslcount, coalesce(contest.name, qsos.col_contest_id) as contestname
+			FROM " . $this->config->item('table_name') . " qsos
+			INNER JOIN station_profile ON qsos.station_id=station_profile.station_id
+			LEFT OUTER JOIN satellite ON qsos.col_prop_mode='SAT' and qsos.COL_SAT_NAME = COALESCE(NULLIF(satellite.name, ''), NULLIF(satellite.displayname, ''))
+			LEFT OUTER JOIN dxcc_entities ON qsos.col_dxcc = dxcc_entities.adif
+			left outer join dxcc_entities mydxcc on qsos.col_my_dxcc = mydxcc.adif
+			LEFT OUTER JOIN lotw_users ON qsos.col_call = lotw_users.callsign
+			LEFT OUTER JOIN contest ON qsos.col_contest_id = contest.adifname
+			WHERE station_profile.user_id =  ?
+			$where
+			$order_by
+			$limit
 		";
 		return $this->db->query($sql, $binding);
 	}


### PR DESCRIPTION
It turns out that the existing query for finding duplicates in the Advanced Logbook contains a weakness.
It will not find a duplicate, if you have a third QSO with that station outside the duplicate window of 1800s. 
That is because of the usage of min/max for col_time_on.

Since we require MySQL8+, we can use windowing functions. 