### PR TITLE
only export COUNTRY in ADIF if DXCC is not 0

### DIFF
--- a/application/libraries/AdifHelper.php
+++ b/application/libraries/AdifHelper.php
@@ -25,7 +25,6 @@ class AdifHelper {
 			'CONT',
 			'CONTACTED_OP',
 			'CONTEST_ID',
-			'COUNTRY',
 			'CQZ',
 			'CREDIT_GRANTED',
 			'CREDIT_SUBMITTED',
@@ -152,6 +151,10 @@ class AdifHelper {
 				$date = date('Ymd', $date);
 				$line .= $this->getAdifFieldLine($field, $date);
 			}
+		}
+
+		if ($qso->COL_DXCC != 0) {
+			$line .= $this->getAdifFieldLine("COUNTRY", $qso->COL_COUNTRY);
 		}
 
 		if ($qso->COL_FREQ != 0) {


### PR DESCRIPTION
the only issue I could find in #3202 is that we export `- None - (E.g. /Mm, /Am)` as the `COUNTRY` field when DXCC is `0`. This can be considered as bug and should be fixed. 

Before:
If COL_DXCC is `0` the ADIF Line for country was: `<COUNTRY:24>- None - (E.g. /Mm, /Am)`

After:
If COL_DXCC is `0` we omit `COUNTRY`
otherwise we export normally