### PR TITLE
Skip to Clubstation - First Login Wizard

### DIFF
--- a/application/views/user/modals/first_login_wizard.php
+++ b/application/views/user/modals/first_login_wizard.php
@@ -101,6 +101,43 @@
                     </div>
             </div>
             <div class="modal-footer">
+
+                <!-- Show more buttons if Clubstation enabled and user has rights -->
+                <?php if ($this->config->item('special_callsign') && !empty($this->session->userdata('available_clubstations'))) { ?>  
+                    <?php if (count($this->session->userdata('available_clubstations')) > 1) { ?> 
+
+                        <!-- If user has more than 1 clubstation, use dropdown -->
+                        <div class="dropdown">  
+                            <button class="btn btn-secondary dropdown-toggle" type="button" id="skipClubstationDropdown" data-bs-toggle="dropdown" aria-expanded="false">  
+                                <?= __("Skip and Open Clubstation"); ?>  
+                            </button>  
+                            <ul class="dropdown-menu" aria-labelledby="skipClubstationDropdown">  
+                                <?php foreach ($this->session->userdata('available_clubstations') as $clubstation) { ?>  
+                                    <li>  
+                                        <a class="dropdown-item" href="#"   
+                                        onclick="clubswitch_modal('<?php echo $clubstation->user_id; ?>', '<?php echo $clubstation->user_callsign; ?>'); $('#firstLoginWizardModal').modal('hide'); return false;"  
+                                        title="<?= sprintf(__("Switch to %s"), $clubstation->user_callsign); ?>">  
+                                            <?php echo $clubstation->user_callsign; ?>  
+                                        </a>  
+                                    </li>  
+                                <?php } ?>  
+                            </ul>  
+                        </div>  
+
+                    <?php } else { ?>
+                        
+                        <!-- Only show button, if only one clubstation -->
+                        <?php foreach ($this->session->userdata('available_clubstations') as $clubstation) { ?>  
+                                <a class="btn btn-secondary" href="#"   
+                                onclick="clubswitch_modal('<?php echo $clubstation->user_id; ?>', '<?php echo $clubstation->user_callsign; ?>'); $('#firstLoginWizardModal').modal('hide'); return false;"  
+                                title="<?= sprintf(__("Switch to %s"), $clubstation->user_callsign); ?>">  
+                                    <?= __("Skip and Open Clubstation"); ?> <?php echo $clubstation->user_callsign; ?>  
+                                </a>  
+                        <?php } ?>  
+
+                    <?php } ?>
+
+                <?php } ?>
                 <button type="submit" class="btn btn-success"><?= __("Save and Start Logging"); ?></button>
             </div>
             </form>

--- a/application/views/user/modals/first_login_wizard.php
+++ b/application/views/user/modals/first_login_wizard.php
@@ -103,7 +103,7 @@
             <div class="modal-footer">
 
                 <!-- Show more buttons if Clubstation enabled and user has rights -->
-                <?php if ($this->config->item('special_callsign') && !empty($this->session->userdata('available_clubstations'))) { ?>  
+                <?php if ($this->config->item('special_callsign') && is_array($this->session->userdata('available_clubstations'))) { ?>
                     <?php if (count($this->session->userdata('available_clubstations')) > 1) { ?> 
 
                         <!-- If user has more than 1 clubstation, use dropdown -->


### PR DESCRIPTION
In the wizard, allow users to skip directly to clubstations they have permissions to.

Add a button / dropdown to First Login Wizard to allow users to skip setting up a station location if they have a clubstation. If they have no clubstations, UI does not change.

Wizard will continue to show on future logins

<details>
  <summary>Show screenshots</summary>
<img width="400" alt="firstLoginWizard_skip_single" src="https://github.com/user-attachments/assets/1964c57a-9606-44e5-a013-6d2e3319f746" />
<img width="400" alt="firstLoginWizard_skip_multiple" src="https://github.com/user-attachments/assets/730207b5-9194-422b-96be-79118b7ce46f" />
</details>