### PR TITLE
Fix missing prop mode in user column 5

### DIFF
--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -265,7 +265,7 @@ class Distances_model extends CI_Model
 			COL_QRZCOM_QSO_DOWNLOAD_DATE, COL_QRZCOM_QSO_DOWNLOAD_STATUS, COL_QRZCOM_QSO_UPLOAD_DATE, COL_QRZCOM_QSO_UPLOAD_STATUS,
 			COL_QSL_RCVD, COL_QSL_RCVD_VIA, COL_QSLRDATE, COL_QSLSDATE, COL_QSL_SENT, COL_QSL_SENT_VIA, COL_QSL_VIA, COL_RST_RCVD,
 			COL_RST_SENT, COL_SAT_NAME, COL_SOTA_REF, COL_SRX, COL_SRX_STRING, COL_STATE, COL_STX, COL_STX_STRING, COL_SUBMODE, COL_TIME_ON,
-			COL_VUCC_GRIDS, COL_WWFF_REF, dxcc_entities.end, lotw_users.lastupload, dxcc_entities.name, satellite.displayname AS sat_displayname,
+			COL_VUCC_GRIDS, COL_WWFF_REF, COL_PROP_MODE, dxcc_entities.end, lotw_users.lastupload, dxcc_entities.name, satellite.displayname AS sat_displayname,
 			station_profile.station_callsign, station_profile.station_gridsquare, station_profile.station_profile_name');
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
 		$this->db->join('dxcc_entities', 'dxcc_entities.adif = '.$this->config->item('table_name').'.COL_DXCC', 'left outer');

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -334,7 +334,7 @@ class Timeline_model extends CI_Model {
 			COL_QRZCOM_QSO_DOWNLOAD_STATUS, COL_QRZCOM_QSO_UPLOAD_DATE, COL_QRZCOM_QSO_UPLOAD_STATUS, COL_QSL_RCVD,
 			COL_QSL_RCVD_VIA, COL_QSLRDATE, COL_QSLSDATE, COL_QSL_SENT, COL_QSL_SENT_VIA, COL_QSL_VIA, COL_RST_RCVD,
 			COL_RST_SENT, COL_SAT_NAME, COL_SOTA_REF, COL_SRX, COL_SRX_STRING, COL_STATE, COL_STX, COL_STX_STRING,
-			COL_SUBMODE, COL_TIME_ON, COL_VUCC_GRIDS, COL_WWFF_REF, dxcc_entities.end, lotw_users.lastupload,
+			COL_SUBMODE, COL_TIME_ON, COL_VUCC_GRIDS, COL_WWFF_REF, COL_PROP_MODE, dxcc_entities.end, lotw_users.lastupload,
 			dxcc_entities.name, satellite.displayname AS sat_displayname, station_profile.station_callsign,
 			station_profile.station_gridsquare, station_profile.station_profile_name');
 		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');


### PR DESCRIPTION
If user column 5 is set to prop mode at least timeline and distances show empty table columns:

<img width="1221" height="315" alt="image" src="https://github.com/user-attachments/assets/101d26b5-4c28-41d6-86ba-7fbcbebe7cfe" />

<img width="1330" height="328" alt="image" src="https://github.com/user-attachments/assets/dfa39de9-1624-4e0a-a383-ecd497e289bc" />
