### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/sl/LC_MESSAGES/messages.po
+++ b/application/locale/sl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-05-06 06:07+0000\n"
-"PO-Revision-Date: 2026-05-07 21:47+0000\n"
+"PO-Revision-Date: 2026-05-08 14:17+0000\n"
 "Last-Translator: Anton Tomanič <s57xz.toni@gmail.com>\n"
 "Language-Team: Slovenian <https://translate.wavelog.org/projects/wavelog/"
 "main-translation/sl/>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
 "n%100==4 ? 2 : 3;\n"
-"X-Generator: Weblate 5.16.2\n"
+"X-Generator: Weblate 5.17.1\n"
 
 #: application/controllers/Accumulated.php:12
 #: application/controllers/Activators.php:13
@@ -8759,72 +8759,79 @@ msgstr ""
 
 #: application/views/bands/bandedges.php:29
 msgid "Frequency from (Hz)"
-msgstr ""
+msgstr "Frekvenca od (Hz)"
 
 #: application/views/bands/bandedges.php:30
 msgid "Frequency to (Hz)"
-msgstr ""
+msgstr "Frekvenca do (Hz)"
 
 #: application/views/bands/bandedges.php:65
+#, fuzzy
 msgid "Add a bandedge"
-msgstr ""
+msgstr "Dodaj rob banda"
 
 #: application/views/bands/create.php:26 application/views/bands/edit.php:9
 msgid "Name of Band (E.g. 20m)"
-msgstr ""
+msgstr "Ime banda (Npr. 20m)"
 
 #: application/views/bands/create.php:29 application/views/bands/edit.php:12
 #: application/views/bands/index.php:65
 msgid "Bandgroup"
-msgstr ""
+msgstr "Skupina bandov"
 
 #: application/views/bands/create.php:31 application/views/bands/edit.php:14
 msgid "Name of bandgroup (E.g. hf, vhf, uhf, shf)"
-msgstr ""
+msgstr "Ime skupine bandov (Npr. hf, vhf, uhf, shf)"
 
 #: application/views/bands/create.php:34 application/views/bands/edit.php:17
 #: application/views/bands/index.php:66
 msgid "SSB QRG"
-msgstr ""
+msgstr "SSB QRG"
 
 #: application/views/bands/create.php:36 application/views/bands/edit.php:19
 msgid "Frequency for SSB QRG in band (must be in Hz)"
-msgstr ""
+msgstr "Frekvenca za SSB QRG na bandu (mora biti v Hz)"
 
 #: application/views/bands/create.php:39 application/views/bands/edit.php:22
 #: application/views/bands/index.php:67
+#, fuzzy
 msgid "DATA QRG"
-msgstr ""
+msgstr "DATA QRG"
 
 #: application/views/bands/create.php:41 application/views/bands/edit.php:24
 msgid "Frequency for DATA QRG in band (must be in Hz)"
-msgstr ""
+msgstr "Frekvenca za SSB QRG na bandu (mora biti v Hz)"
 
 #: application/views/bands/create.php:44 application/views/bands/edit.php:27
 #: application/views/bands/index.php:68
+#, fuzzy
 msgid "CW QRG"
-msgstr ""
+msgstr "CW QRG"
 
 #: application/views/bands/create.php:46 application/views/bands/edit.php:29
 msgid "Frequency for CW QRG in band (must be in Hz)"
-msgstr ""
+msgstr "Frekvenca za CW QRG na bandu (mora biti v Hz)"
 
 #: application/views/bands/edit.php:2
 msgid ""
 "Changes made here are instance-wide and will affect EVERY User. You see "
 "this, because you're an instance-admin"
 msgstr ""
+"Spremembe, narejene tukaj, veljajo za celotno instanco in bodo vplivale na "
+"VSAKEGA uporabnika. To vidite, ker ste skrbnik instance"
 
 #: application/views/bands/edit.php:2
 #: application/views/logbookadvanced/index.php:53
 msgid "WARNING"
-msgstr ""
+msgstr "OPOZORILO"
 
 #: application/views/bands/index.php:38
 msgid ""
 "Using the band list you can control which bands are shown when creating a "
 "new QSO."
 msgstr ""
+"S seznamom pasov lahko nadzorujete, kateri pasovi se prikažejo pri "
+"ustvarjanju novega QSO-ja."
 
 #: application/views/bands/index.php:39
 msgid ""


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)