### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/application/locale/nl_NL/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-05-06 06:07+0000\n"
-"PO-Revision-Date: 2026-05-02 12:48+0000\n"
+"PO-Revision-Date: 2026-05-09 05:04+0000\n"
 "Last-Translator: Alexander <alexander@pa8s.nl>\n"
 "Language-Team: Dutch <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/nl/>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.16.2\n"
+"X-Generator: Weblate 5.17.1\n"
 
 #: application/controllers/Accumulated.php:12
 #: application/controllers/Activators.php:13
@@ -4284,7 +4284,7 @@ msgstr "F2 Reflection"
 #: application/views/view_log/qso.php:278
 msgctxt "Propagation Mode"
 msgid "Ground Wave"
-msgstr ""
+msgstr "Grondgolf"
 
 #: application/views/accumulate/index.php:96
 #: application/views/callstats/index.php:81 application/views/csv/index.php:106
@@ -4340,7 +4340,7 @@ msgstr "IRLP"
 #: application/views/view_log/qso.php:290
 msgctxt "Propagation Mode"
 msgid "Line of Sight (includes transmission through obstacles such as walls)"
-msgstr ""
+msgstr "Zichtlijn (inclusief transmissie door obstakels zoals muren)"
 
 #: application/views/accumulate/index.php:100
 #: application/views/callstats/index.php:85 application/views/csv/index.php:110
@@ -19621,7 +19621,7 @@ msgstr "%sOpzoeken%s"
 #: application/views/user/modals/first_login_wizard.php:112
 #: application/views/user/modals/first_login_wizard.php:134
 msgid "Skip and Open Clubstation"
-msgstr ""
+msgstr "Overslaan en Clubstation openen"
 
 #: application/views/user/modals/first_login_wizard.php:141
 msgid "Save and Start Logging"

--- a/application/locale/sl/LC_MESSAGES/messages.po
+++ b/application/locale/sl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-05-09 05:04+0000\n"
-"PO-Revision-Date: 2026-05-08 14:17+0000\n"
+"PO-Revision-Date: 2026-05-09 07:46+0000\n"
 "Last-Translator: Anton Tomanič <s57xz.toni@gmail.com>\n"
 "Language-Team: Slovenian <https://translate.wavelog.org/projects/wavelog/"
 "main-translation/sl/>\n"
@@ -7770,8 +7770,7 @@ msgstr "Nalaganje priljubljenih ni uspelo"
 
 #: application/views/bandmap/list.php:44
 msgid "Modes applied. Band filter preserved (CAT connection is active)"
-msgstr ""
-"Uveljavljene vrste dela. Band filter ohranjen (povezava CAT je aktivna)."
+msgstr "Uveljavljene vrste dela. Band filter ohranjen (povezava CAT je aktivna)"
 
 #: application/views/bandmap/list.php:45
 msgid "Applied your favorite bands and modes"

--- a/application/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/application/locale/tr_TR/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-05-06 06:07+0000\n"
-"PO-Revision-Date: 2026-04-24 05:57+0000\n"
+"PO-Revision-Date: 2026-05-09 05:04+0000\n"
 "Last-Translator: \"Erkin Mercan (TA4AQG-SP9AQG)\" <ekomeko066@gmail.com>\n"
 "Language-Team: Turkish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/tr/>\n"
@@ -22,7 +22,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.16.2\n"
+"X-Generator: Weblate 5.17.1\n"
 
 #: application/controllers/Accumulated.php:12
 #: application/controllers/Activators.php:13
@@ -439,7 +439,7 @@ msgstr "ve"
 #: application/views/awards/wae/index.php:119
 #: application/views/awards/wpx/index.php:81
 msgid "Every band (w/o SAT)"
-msgstr "Her bant (Uydu hariç)"
+msgstr "Her band (Uydu hariç)"
 
 #: application/controllers/Awards.php:569
 msgid "band"
@@ -673,7 +673,7 @@ msgstr "Notlar - Yedekleme"
 #: application/views/statistics/index.php:17
 #: application/views/statistics/index.php:105
 msgid "Bands"
-msgstr "Bantlar"
+msgstr "Bandlar"
 
 #: application/controllers/Band.php:67 application/controllers/Mode.php:41
 msgid "Create Mode"
@@ -1074,7 +1074,7 @@ msgstr "QSO'lar ile"
 
 #: application/controllers/Distances.php:83
 msgid "and band"
-msgstr "ve bant"
+msgstr "ve band"
 
 #: application/controllers/Distances.php:83
 msgid "and propagation"
@@ -1961,7 +1961,7 @@ msgstr "Mesafe"
 #: application/views/view_log/qso.php:94 application/views/visitor/index.php:33
 #: application/views/visitor/mini.php:184 application/views/widgets/qsos.php:21
 msgid "Band"
-msgstr "Bant"
+msgstr "Band"
 
 #: application/controllers/Logbook.php:1470
 #: application/controllers/Radio.php:48 application/views/bandmap/list.php:168
@@ -3722,7 +3722,7 @@ msgid ""
 "QSO on %s: You tried to import a QSO without any given Band. This QSO wasn't "
 "imported. It's invalid"
 msgstr ""
-"%s üzerindeki QSO: Bant bilgisi olmadan bir QSO içe aktarmayı denediniz. Bu "
+"%s üzerindeki QSO: Band bilgisi olmadan bir QSO içe aktarmayı denediniz. Bu "
 "QSO içe aktarılmadı, geçersiz."
 
 #: application/models/Logbook_model.php:5272
@@ -6263,7 +6263,7 @@ msgstr "Çalışıldı / Onaylandı"
 #: application/views/awards/wapc/index.php:84
 #: application/views/awards/was/index.php:82
 msgid "Every band"
-msgstr "Her bant"
+msgstr "Her band"
 
 #: application/views/awards/dok/index.php:127
 #: application/views/awards/helvetia/index.php:115
@@ -6500,7 +6500,7 @@ msgid ""
 "grid from one of the 488 mainland gridsquares!), Band must be 6M."
 msgstr ""
 "Bu Ödül için dikkate alınan Alanlar: DXCC (ABD olmalı), Gridsquare (488 ana "
-"kara grid karesinden birini içermeli), Bant 6M olmalı."
+"kara grid karesinden birini içermeli), Band 6M olmalı."
 
 #: application/views/awards/gridmaster/index.php:12
 msgid "US Gridmaster Award"
@@ -6622,8 +6622,8 @@ msgid ""
 "activities on the bands by encouraging contacts across as many Swiss cantons "
 "as possible on multiple bands."
 msgstr ""
-"USKA (İsviçre Kısa Dalga Amatörleri Birliği), bantlarda faaliyetleri teşvik "
-"etmek amacıyla, mümkün olduğunca çok İsviçre kantonu ile farklı bantlarda "
+"USKA (İsviçre Kısa Dalga Amatörleri Birliği), bandlarda faaliyetleri teşvik "
+"etmek amacıyla, mümkün olduğunca çok İsviçre kantonu ile farklı bandlarda "
 "QSO’lar yapılmasını özendiren HELVETIA 26 (H26) Ödülü ve SWITZERLAND Ödülü "
 "olmak üzere iki ödül sponsorlar."
 
@@ -6633,8 +6633,8 @@ msgid ""
 "(including SHF and UHF) bands. Valid connections for these awards date back "
 "to January 1, 1980"
 msgstr ""
-"Bu ödüller iki versiyonda sunulur: biri HF bantları, diğeri VHF (SHF ve UHF "
-"dahil) bantları içindir. Bu ödüller için geçerli bağlantılar 1 Ocak 1980 "
+"Bu ödüller iki versiyonda sunulur: biri HF bandları, diğeri VHF (SHF ve UHF "
+"dahil) bandları içindir. Bu ödüller için geçerli bağlantılar 1 Ocak 1980 "
 "tarihine kadar uzanır"
 
 #: application/views/awards/helvetia/index.php:27
@@ -6672,7 +6672,7 @@ msgid ""
 msgstr ""
 "IOTA, dünya çapında binlerce radyo amatörünün ilgisini çeken heyecan verici "
 "ve yenilikçi bir aktivite programıdır. 1964 yılında kurulan bu program, "
-"amatör bantlarda aktif olan herkesin deneyimini artırmak için dünya "
+"amatör bandlarda aktif olan herkesin deneyimini artırmak için dünya "
 "genelindeki adalarda bulunan istasyonlarla radyo temaslarını teşvik eder. "
 "Bunu başarmak için adaların etrafındaki yaygın mistik çekicilikten "
 "yararlanır."
@@ -6894,8 +6894,8 @@ msgid ""
 "(RTTY/PSK/FSK), and individual bands (160M-2M). Classes: Basic (1 QSO/voiv), "
 "Bronze (3), Silver (7), Gold (12). All 16 voivodeships required."
 msgstr ""
-"Ödül kategorileri: MIXED (tüm modlar/bantlar), PHONE (SSB/AM/FM/SSTV), CW, "
-"DIGI (RTTY/PSK/FSK) ve tekil bantlar (160M–2M). Sınıflar: Basic (her "
+"Ödül kategorileri: MIXED (tüm modlar/bandlar), PHONE (SSB/AM/FM/SSTV), CW, "
+"DIGI (RTTY/PSK/FSK) ve tekil bandlar (160M–2M). Sınıflar: Basic (her "
 "vilayetten 1 QSO), Bronze (3), Silver (7), Gold (12). Tüm 16 vilayetin "
 "tamamlanması gereklidir."
 
@@ -6914,7 +6914,7 @@ msgid ""
 ">= 1999-01-01. No cross-band/cross-mode/repeater contacts."
 msgstr ""
 "Gereksinimler: COL_STATE (voyvodalık kodu), COL_DXCC=269 (Polonya), QSO "
-"tarihi ≥ 1999-01-01. Bantlar arası/modlar arası/tekrarlayıcı bağlantılara "
+"tarihi ≥ 1999-01-01. bandlar arası/modlar arası/tekrarlayıcı bağlantılara "
 "izin yok."
 
 #: application/views/awards/pl_polska/index.php:54
@@ -6993,7 +6993,7 @@ msgstr "Mod Kategorisine Göre QSO’lar"
 
 #: application/views/awards/pl_polska/index.php:183
 msgid "QSOs by Band"
-msgstr "Banta Göre QSO’lar"
+msgstr "banda Göre QSO’lar"
 
 #: application/views/awards/pl_polska/index.php:202
 #: application/views/awards/pl_polska/index.php:273
@@ -7059,7 +7059,7 @@ msgstr "Mod Kategorileri"
 
 #: application/views/awards/pl_polska/index.php:350
 msgid "Band Categories"
-msgstr "Bant Kategorileri"
+msgstr "band Kategorileri"
 
 #: application/views/awards/pl_polska/index.php:372
 #: application/views/logbookadvanced/dbtoolsdialog.php:77
@@ -7291,7 +7291,7 @@ msgstr "Resmi bilgi ve kurallar bu belgede bulunabilir: %s."
 
 #: application/views/awards/vucc/index.php:10
 msgid "Only VHF/UHF bands are relevant."
-msgstr "Sadece VHF/UHF bantları geçerlidir."
+msgstr "Sadece VHF/UHF bandları geçerlidir."
 
 #: application/views/awards/vucc/index.php:11
 msgid ""
@@ -7397,7 +7397,7 @@ msgid ""
 "contacts with amateur radio stations in European countries and on islands "
 "listed in the WAE country list on different bands."
 msgstr ""
-"Tüm DARC sertifikalarının en eski ve en tanınmış olanı, farklı bantlarda "
+"Tüm DARC sertifikalarının en eski ve en tanınmış olanı, farklı bandlarda "
 "Avrupa ülkelerindeki ve WAE ülke listesinde yer alan adalardaki amatör "
 "telsiz istasyonlarıyla yapılan haberleşmeler için verilir."
 
@@ -7718,7 +7718,7 @@ msgstr "WAS Haritasını Göster"
 
 #: application/views/awards/wpx/index.php:76
 msgid "Band / Satellite / Orbit"
-msgstr "Bant / Uydu / Yörünge"
+msgstr "Band / Uydu / Yörünge"
 
 #: application/views/awards/wpx/wpx_details.php:21
 #: application/views/calltester/comparison_result.php:61
@@ -7854,7 +7854,7 @@ msgstr "Filtreleri Temizle"
 
 #: application/views/bandmap/list.php:20
 msgid "Band filter preserved (band lock is active)"
-msgstr "Bant filtresi korunmuştur (bant kilidi aktiftir)"
+msgstr "Band filtresi korunmuştur (band kilidi aktiftir)"
 
 #: application/views/bandmap/list.php:22
 msgid "Radio set to None - CAT connection disabled"
@@ -7898,7 +7898,7 @@ msgstr "CAT takip sistemi - Devre dışı bırakmak için tıklayın"
 
 #: application/views/bandmap/list.php:33 application/views/bandmap/list.php:236
 msgid "Click to enable band lock (requires CAT connection)"
-msgstr "Bant kilidini etkinleştirmek için tıklayın (CAT bağlantısı gereklidir)"
+msgstr "Band kilidini etkinleştirmek için tıklayın (CAT bağlantısı gereklidir)"
 
 #: application/views/bandmap/list.php:34
 msgid "Band lock active - Click to disable"
@@ -7906,11 +7906,11 @@ msgstr "Band kilidi etkin - Devre dışı bırakmak için tıklayın"
 
 #: application/views/bandmap/list.php:35
 msgid "Band Lock"
-msgstr "Bant Kilidi"
+msgstr "Band Kilidi"
 
 #: application/views/bandmap/list.php:36
 msgid "Band lock enabled - band filter will track radio band"
-msgstr "Band kilidi etkinleştirildi - bant filtresi radyo bandını takip edecek"
+msgstr "Band kilidi etkinleştirildi - band filtresi radyo bandını takip edecek"
 
 #: application/views/bandmap/list.php:37
 msgid "Band filter changed to"
@@ -7926,7 +7926,7 @@ msgstr "Frekans filtresi şu değere ayarlandı:"
 
 #: application/views/bandmap/list.php:40
 msgid "Frequency outside known bands - showing all bands"
-msgstr "Bilinen bantların dışında frekans – tüm bantlar gösteriliyor"
+msgstr "Bilinen bandların dışında frekans – tüm bandlar gösteriliyor"
 
 #: application/views/bandmap/list.php:41
 msgid "Waiting for radio data..."
@@ -7942,11 +7942,11 @@ msgstr "Favoriler yüklenirken hata oluştu"
 
 #: application/views/bandmap/list.php:44
 msgid "Modes applied. Band filter preserved (CAT connection is active)"
-msgstr "Modlar uygulandı. Bant filtresi korundu (CAT bağlantısı aktif)"
+msgstr "Modlar uygulandı. Band filtresi korundu (CAT bağlantısı aktif)"
 
 #: application/views/bandmap/list.php:45
 msgid "Applied your favorite bands and modes"
-msgstr "Favori bantlarınız ve modlarınız uygulandı"
+msgstr "Favori bandlarınız ve modlarınız uygulandı"
 
 #: application/views/bandmap/list.php:48 application/views/bandmap/list.php:319
 #: application/views/bandmap/list.php:488
@@ -8178,7 +8178,7 @@ msgstr "Üzerinde çalışıldı"
 
 #: application/views/bandmap/list.php:115
 msgid "Not worked on this band"
-msgstr "Bu bantta çalışılmadı"
+msgstr "Bu bandda çalışılmadı"
 
 #: application/views/bandmap/list.php:116
 #, php-format
@@ -8242,7 +8242,7 @@ msgstr "Tam Ekranı Aç/Kapat"
 msgid ""
 "Band filtering is controlled by your radio when CAT connection is enabled"
 msgstr ""
-"Bant filtresi, CAT bağlantısı etkin olduğunda telsiziniz tarafından kontrol "
+"band filtresi, CAT bağlantısı etkin olduğunda telsiziniz tarafından kontrol "
 "edilir"
 
 #: application/views/bandmap/list.php:132
@@ -8502,59 +8502,59 @@ msgstr "Tüm filtreleri temizle, sadece Kıta filtresini bırak"
 
 #: application/views/bandmap/list.php:445
 msgid "Toggle 160m band filter"
-msgstr "160m bant filtresini aç/kapat"
+msgstr "160m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:449
 msgid "Toggle 80m band filter"
-msgstr "80m bant filtresini aç/kapat"
+msgstr "80m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:450
 msgid "Toggle 60m band filter"
-msgstr "60m bant filtresini aç/kapat"
+msgstr "60m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:451
 msgid "Toggle 40m band filter"
-msgstr "40m bant filtresini aç/kapat"
+msgstr "40m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:452
 msgid "Toggle 30m band filter"
-msgstr "30m bant filtresini aç/kapat"
+msgstr "30m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:453
 msgid "Toggle 20m band filter"
-msgstr "20m bant filtresini aç/kapat"
+msgstr "20m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:454
 msgid "Toggle 17m band filter"
-msgstr "17m bant filtresini aç/kapat"
+msgstr "17m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:455
 msgid "Toggle 15m band filter"
-msgstr "15m bant filtresini aç/kapat"
+msgstr "15m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:456
 msgid "Toggle 12m band filter"
-msgstr "12m bant filtresini aç/kapat"
+msgstr "12m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:457
 msgid "Toggle 10m band filter"
-msgstr "10m bant filtresini aç/kapat"
+msgstr "10m band filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:461
 msgid "Toggle 6m band filter"
-msgstr "6 metre bant filtresini açıp kapatın"
+msgstr "6 metre band filtresini açıp kapatın"
 
 #: application/views/bandmap/list.php:465
 msgid "Toggle VHF bands filter"
-msgstr "VHF bantları filtresini aç/kapat"
+msgstr "VHF bandları filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:466
 msgid "Toggle UHF bands filter"
-msgstr "UHF bantları filtresini aç/kapat"
+msgstr "UHF bandları filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:467
 msgid "Toggle SHF bands filter"
-msgstr "SHF bantları filtresini aç/kapat"
+msgstr "SHF bandları filtresini aç/kapat"
 
 #: application/views/bandmap/list.php:487
 msgid "Loading submodes..."
@@ -8735,18 +8735,18 @@ msgstr "Frekans, mevcut bir QSO girdisi ile çakışıyor."
 
 #: application/views/bands/bandedges.php:5
 msgid "Are you sure you want to delete this band edge?"
-msgstr "Bu bant aralığını silmek istediğinize emin misiniz?"
+msgstr "Bu band aralığını silmek istediğinize emin misiniz?"
 
 #: application/views/bands/bandedges.php:17
 msgid "Bandedges"
-msgstr "Bant Aralıkları"
+msgstr "band Aralıkları"
 
 #: application/views/bands/bandedges.php:22
 msgid ""
 "Using the bandedges list you can control the mode classification in the "
 "cluster."
 msgstr ""
-"Bant aralığı listesini kullanarak, cluster'daki mod sınıflandırmasını "
+"band aralığı listesini kullanarak, cluster'daki mod sınıflandırmasını "
 "kontrol edebilirsiniz."
 
 #: application/views/bands/bandedges.php:29
@@ -8759,20 +8759,20 @@ msgstr "Bitiş Frekansı (Hz)"
 
 #: application/views/bands/bandedges.php:65
 msgid "Add a bandedge"
-msgstr "Bir bant aralığı ekle"
+msgstr "Bir band aralığı ekle"
 
 #: application/views/bands/create.php:26 application/views/bands/edit.php:9
 msgid "Name of Band (E.g. 20m)"
-msgstr "Bant adı (Örn. 20m)"
+msgstr "band adı (Örn. 20m)"
 
 #: application/views/bands/create.php:29 application/views/bands/edit.php:12
 #: application/views/bands/index.php:65
 msgid "Bandgroup"
-msgstr "Bant grubu"
+msgstr "band grubu"
 
 #: application/views/bands/create.php:31 application/views/bands/edit.php:14
 msgid "Name of bandgroup (E.g. hf, vhf, uhf, shf)"
-msgstr "Bant grubu adı (Örn. hf, vhf, uhf, shf)"
+msgstr "band grubu adı (Örn. hf, vhf, uhf, shf)"
 
 #: application/views/bands/create.php:34 application/views/bands/edit.php:17
 #: application/views/bands/index.php:66
@@ -8781,7 +8781,7 @@ msgstr "SSB Frekansı"
 
 #: application/views/bands/create.php:36 application/views/bands/edit.php:19
 msgid "Frequency for SSB QRG in band (must be in Hz)"
-msgstr "Bant içindeki SSB frekansı (Hz cinsinden olmalıdır)"
+msgstr "band içindeki SSB frekansı (Hz cinsinden olmalıdır)"
 
 #: application/views/bands/create.php:39 application/views/bands/edit.php:22
 #: application/views/bands/index.php:67
@@ -8790,7 +8790,7 @@ msgstr "DATA Frekansı"
 
 #: application/views/bands/create.php:41 application/views/bands/edit.php:24
 msgid "Frequency for DATA QRG in band (must be in Hz)"
-msgstr "Bant içindeki DATA frekansı (Hz cinsinden olmalıdır)"
+msgstr "band içindeki DATA frekansı (Hz cinsinden olmalıdır)"
 
 #: application/views/bands/create.php:44 application/views/bands/edit.php:27
 #: application/views/bands/index.php:68
@@ -8799,7 +8799,7 @@ msgstr "CW Frekansı"
 
 #: application/views/bands/create.php:46 application/views/bands/edit.php:29
 msgid "Frequency for CW QRG in band (must be in Hz)"
-msgstr "Bant içindeki CW frekansı (Hz cinsinden olmalıdır)"
+msgstr "band içindeki CW frekansı (Hz cinsinden olmalıdır)"
 
 #: application/views/bands/edit.php:2
 msgid ""
@@ -8820,14 +8820,14 @@ msgid ""
 "Using the band list you can control which bands are shown when creating a "
 "new QSO."
 msgstr ""
-"QSO giriş ekranında hangi bantların listeleneceğini kontrol edebilirsiniz."
+"QSO giriş ekranında hangi bandların listeleneceğini kontrol edebilirsiniz."
 
 #: application/views/bands/index.php:39
 msgid ""
 "Active bands will be shown in the QSO 'Band' drop-down, while inactive bands "
 "will be hidden and cannot be selected."
 msgstr ""
-"Aktif bantlar QSO’nun ‘Bant’ açılır menüsünde gösterilecek, pasif bantlar "
+"Aktif bandlar QSO’nun ‘band’ açılır menüsünde gösterilecek, pasif bandlar "
 "ise gizlenecek ve seçilemeyecek."
 
 #: application/views/bands/index.php:56
@@ -8875,7 +8875,7 @@ msgstr "GHz"
 
 #: application/views/bands/index.php:159 application/views/bands/index.php:165
 msgid "Create a band"
-msgstr "Bant Oluştur"
+msgstr "band Oluştur"
 
 #: application/views/bands/index.php:160
 #: application/views/club/permissions.php:175
@@ -8898,11 +8898,11 @@ msgstr "Uyarı! Aşağıdaki bandı silmek istediğinizden emin misiniz: "
 
 #: application/views/bands/index.php:162
 msgid "Warning! Are you sure you want to activate all bands?"
-msgstr "Uyarı! Tüm bantları etkinleştirmek istediğinizden emin misiniz?"
+msgstr "Uyarı! Tüm bandları etkinleştirmek istediğinizden emin misiniz?"
 
 #: application/views/bands/index.php:163
 msgid "Warning! Are you sure you want to deactivate all bands?"
-msgstr "Uyarı! Tüm bantları devre dışı bırakmak istediğinizden emin misiniz?"
+msgstr "Uyarı! Tüm bandları devre dışı bırakmak istediğinizden emin misiniz?"
 
 #: application/views/bands/index.php:166
 #: application/views/contesting/add.php:77 application/views/mode/index.php:89
@@ -9016,7 +9016,7 @@ msgstr "Yardımlı Kategorisi"
 
 #: application/views/cabrillo/index.php:67
 msgid "Category Band"
-msgstr "Bant Kategorisi"
+msgstr "band Kategorisi"
 
 #: application/views/cabrillo/index.php:93
 msgid "Light/Laser"
@@ -9024,7 +9024,7 @@ msgstr "Işık/Lazer"
 
 #: application/views/cabrillo/index.php:94
 msgid "VHF-3-BAND and VHF-FM-ONLY (ARRL VHF Contests only)"
-msgstr "VHF-3-BANT ve Yalnızca VHF-FM (sadece ARRL VHF Yarışmaları)"
+msgstr "VHF-3-band ve Yalnızca VHF-FM (sadece ARRL VHF Yarışmaları)"
 
 #: application/views/cabrillo/index.php:98
 msgid "Category Mode"
@@ -9838,11 +9838,11 @@ msgstr "modlar:"
 
 #: application/views/components/dxwaterfall.php:42
 msgid "OUT OF BANDPLAN"
-msgstr "BANT PLANININ DIŞINDA"
+msgstr "band PLANININ DIŞINDA"
 
 #: application/views/components/dxwaterfall.php:43
 msgid "Out of band"
-msgstr "Bant dışı"
+msgstr "band dışı"
 
 #: application/views/components/dxwaterfall.php:44
 msgid ""
@@ -11646,7 +11646,7 @@ msgstr "Çalışılan çağrı işareti (en fazla 5 girdi gösterilir)"
 
 #: application/views/distances/index.php:19
 msgid "Band selection"
-msgstr "Bant seçimi"
+msgstr "band seçimi"
 
 #: application/views/dxatlas/index.php:3
 msgid "DX Atlas Export"
@@ -12305,11 +12305,11 @@ msgstr "%s'ye e-posta gönder"
 msgid ""
 "Callsign was already worked and confirmed in the past on this band and mode!"
 msgstr ""
-"Bu çağrı işareti bu bant ve modda geçmişte zaten çalışılmış ve onaylanmıştı!"
+"Bu çağrı işareti bu band ve modda geçmişte zaten çalışılmış ve onaylanmıştı!"
 
 #: application/views/interface_assets/footer.php:83
 msgid "Callsign was already worked in the past on this band and mode!"
-msgstr "Çağrı işareti bu bant ve modda geçmişte zaten çalışmıştı!"
+msgstr "Çağrı işareti bu band ve modda geçmişte zaten çalışmıştı!"
 
 #: application/views/interface_assets/footer.php:84
 msgid "New Callsign!"
@@ -12334,11 +12334,11 @@ msgstr "Favoriyi silmek istediğinize emin misiniz?"
 #: application/views/interface_assets/footer.php:89
 msgid ""
 "DXCC was already worked and confirmed in the past on this band and mode!"
-msgstr "Bu DXCC ile bu bant ve modda geçmişte zaten çalışıldı ve onaylandı!"
+msgstr "Bu DXCC ile bu band ve modda geçmişte zaten çalışıldı ve onaylandı!"
 
 #: application/views/interface_assets/footer.php:90
 msgid "DXCC was already worked in the past on this band and mode!"
-msgstr "Bu DXCC ile bu bant ve modda zaten daha önce çalışılmış!"
+msgstr "Bu DXCC ile bu band ve modda zaten daha önce çalışılmış!"
 
 #: application/views/interface_assets/footer.php:91
 msgid "New DXCC, not worked on this band and mode!"
@@ -12902,7 +12902,7 @@ msgstr "Hesap"
 
 #: application/views/interface_assets/header.php:450
 msgid "Band Edges"
-msgstr "Bant Aralıkları"
+msgstr "Band Aralıkları"
 
 #: application/views/interface_assets/header.php:456
 msgid "Switch to Clubstation:"
@@ -13987,7 +13987,7 @@ msgid ""
 "The dupe search checks for duplicate QSOs with the same callsign, mode, "
 "submode, station callsign, band and satellite within 1500 seconds."
 msgstr ""
-"Tekrarlanan QSO araması, aynı çağrı işareti, mod, alt mod, bant ve uydu "
+"Tekrarlanan QSO araması, aynı çağrı işareti, mod, alt mod, band ve uydu "
 "bilgilerine sahip olan ve 25 dakika içinde kaydedilmiş yinelenen QSO'ları "
 "tespit eder."
 
@@ -14001,7 +14001,7 @@ msgstr "Mod boş veya 0 olarak ayarlanmış."
 
 #: application/views/logbookadvanced/help.php:11
 msgid "Band is blank."
-msgstr "Bant boş."
+msgstr "Band boş."
 
 #: application/views/logbookadvanced/help.php:12
 msgid "Callsign is blank."
@@ -14527,7 +14527,7 @@ msgstr "Mod Ara"
 
 #: application/views/logbookadvanced/index.php:799
 msgid "Search Band"
-msgstr "Bant Ara"
+msgstr "Band Ara"
 
 #: application/views/logbookadvanced/index.php:802
 msgid "Search IOTA"
@@ -15142,7 +15142,7 @@ msgstr "ADIF Alt Mod Adı"
 
 #: application/views/mode/create.php:42 application/views/mode/edit.php:53
 msgid "Defines the QRG-segment in bandplan."
-msgstr "Bant planındaki QRG kategorisini tanımlar."
+msgstr "Band planındaki QRG kategorisini tanımlar."
 
 #: application/views/mode/create.php:49 application/views/mode/edit.php:61
 #: application/views/mode/index.php:9 application/views/mode/index.php:55
@@ -16040,11 +16040,11 @@ msgstr "Yazdırma için Talep Edilen QSL’leri Dışa Aktar"
 
 #: application/views/qslprint/index.php:31
 msgid "Show Band or Frequency:"
-msgstr "Bant veya Frekans Göster:"
+msgstr "Band veya Frekans Göster:"
 
 #: application/views/qslprint/index.php:35
 msgid "Band & Frequency"
-msgstr "Bant & Frekans"
+msgstr "Band & Frekans"
 
 #: application/views/qslprint/index.php:39
 msgid ""
@@ -16073,7 +16073,7 @@ msgid ""
 "The column %s shows how many QSLs have been sent to the same station before "
 "on the same band and mode."
 msgstr ""
-"%s sütunu, aynı bant ve modda daha önce aynı istasyona kaç QSL "
+"%s sütunu, aynı band ve modda daha önce aynı istasyona kaç QSL "
 "gönderildiğini gösterir."
 
 #: application/views/qslprint/qslprint.php:33
@@ -16540,7 +16540,7 @@ msgstr "Frekans (RX)"
 
 #: application/views/qso/index.php:428
 msgid "Band (RX)"
-msgstr "Bant (RX)"
+msgstr "Band (RX)"
 
 #: application/views/qso/index.php:608
 msgid "For example: GM/NS-001."
@@ -16712,14 +16712,14 @@ msgstr "Lütfen bekleyin..."
 
 #: application/views/reg1test/index.php:6
 msgid "Select Band"
-msgstr "Bant Seç"
+msgstr "Band Seç"
 
 #: application/views/reg1test/index.php:8
 msgid ""
 "Bands below 50Mhz are not valid for the EDI REG1TEST format and will produce "
 "invalid files."
 msgstr ""
-"50 MHz altındaki bantlar EDI REG1TEST formatı için geçerli değildir ve "
+"50 MHz altındaki bandlar EDI REG1TEST formatı için geçerli değildir ve "
 "geçersiz dosyalar oluşturacaktır."
 
 #: application/views/reg1test/index.php:18
@@ -17343,7 +17343,7 @@ msgstr "Kapat ve Örnek Verileri Yükle"
 
 #: application/views/simplefle/index.php:23
 msgid "Band is missing!"
-msgstr "Bant bilgisi eksik!"
+msgstr "Band bilgisi eksik!"
 
 #: application/views/simplefle/index.php:24
 msgid "Mode is missing!"
@@ -17374,7 +17374,7 @@ msgid ""
 "Warning! You can't log the QSO List, because some QSO don't have band and/or "
 "mode defined!"
 msgstr ""
-"Uyarı! Bazı QSO'larda bant ve/veya mod tanımlı olmadığı için QSO Listesini "
+"Uyarı! Bazı QSO'larda band ve/veya mod tanımlı olmadığı için QSO Listesini "
 "kaydedemezsiniz!"
 
 #: application/views/simplefle/index.php:33
@@ -17509,7 +17509,7 @@ msgid ""
 msgstr ""
 "Başlamak için, sol taraftaki formu zaten tarih, istasyon çağrı işareti ve "
 "operatör çağrı işareti ile doldurduğunuzdan emin olun. Ana veriler arasında "
-"bant (veya QRG MHz cinsinden, örneğin ‘7.145’), mod ve zaman bulunur."
+"band (veya QRG MHz cinsinden, örneğin ‘7.145’), mod ve zaman bulunur."
 
 #: application/views/simplefle/syntax_help.php:9
 msgid "For example, a QSO that started at 21:34 (UTC) with 4W7EST on 20m SSB."
@@ -17533,7 +17533,7 @@ msgid ""
 "information about band and mode didn't change, so this data is omitted."
 msgstr ""
 "İlk QSO 21:34’teydi, ikinci QSO ise 21:36’da gerçekleşti. Burada değişen tek "
-"bilgi 6’dır, bu yüzden yalnızca bunu yazıyoruz. Bant ve mod hakkında "
+"bilgi 6’dır, bu yüzden yalnızca bunu yazıyoruz. band ve mod hakkında "
 "herhangi bir değişiklik olmadığı için bu veriler atlanır."
 
 #: application/views/simplefle/syntax_help.php:17
@@ -19031,11 +19031,11 @@ msgstr "Varsayılan Değerler"
 
 #: application/views/user/edit.php:867
 msgid "Settings for Default Band and Confirmation"
-msgstr "Varsayılan Bant ve Onay Ayarları"
+msgstr "Varsayılan band ve Onay Ayarları"
 
 #: application/views/user/edit.php:870
 msgid "Default Band"
-msgstr "Varsayılan Bant"
+msgstr "Varsayılan band"
 
 #: application/views/user/edit.php:880
 msgid "Default QSL-Methods"

--- a/assets/json/datatables_languages/sl.json
+++ b/assets/json/datatables_languages/sl.json
@@ -28,7 +28,7 @@
         "print": "Tiskanje",
         "copyKeys": "Pritisni Ctrl or u2318 + C za kopiranje vsebine tabele v odložišče.<br /><br />Za prekinitev klikni na to sporočilo ali pritisni Escape.",
         "copySuccess": {
-            "1": "Kopirana  1 vrstica v odložišče",
+            "1": "Kopirana 1 vrstica v odložišče",
             "_": "Kopirani %d vrstic v odložišče"
         },
         "createState": "Kreiraj državo (state)",
@@ -141,10 +141,10 @@
             "8": "September",
             "9": "October"
         },
-        "seconds": "Second",
-        "previous": "Previous",
+        "seconds": "Sekunda",
+        "previous": "Prejšnji",
         "next": "Next",
-        "hours": "Hour",
+        "hours": "Ura",
         "unknown": "-",
         "weekdays": [
             "Sun",
@@ -157,29 +157,29 @@
         ]
     },
     "editor": {
-        "close": "Close",
+        "close": "Zapri",
         "create": {
-            "button": "New",
-            "submit": "Create",
-            "title": "Create new entry"
+            "button": "Nov",
+            "submit": "Ustvari",
+            "title": "Ustvari nov vnos"
         },
         "edit": {
-            "button": "Edit",
+            "button": "Uredi",
             "submit": "Update",
-            "title": "Edit entry"
+            "title": "Uredi vnos"
         },
         "multi": {
-            "restore": "Undo changes",
-            "title": "Multiple values",
-            "noMulti": "This input can be edited individually, but not part of a group.",
-            "info": "The selected items contain different values for this input. To edit and set all items for this input to the same value, click or tap here, otherwise they will retain their individual values."
+            "restore": "Razveljavi spremembe",
+            "title": "Večkratne vrednosti",
+            "noMulti": "Ta vnos je mogoče urejati posamično, ne pa kot del skupine.",
+            "info": "Izbrani elementi vsebujejo različne vrednosti za ta vnos. Če želite urediti in nastaviti vse elemente za ta vnos na isto vrednost, kliknite ali tapnite tukaj, sicer bodo ohranili svoje individualne vrednosti."
         },
         "remove": {
             "button": "Delete",
             "submit": "Delete",
             "title": "Delete",
             "confirm": {
-                "_": "Are you sure you wish to delete %d rows?",
+                "_": "Ali ste prepričani, da želite izbrisati %d vrstic?",
                 "1": "Ali ste prepričani, da želite izbrisati 1 vrstico?"
             }
         },
@@ -237,7 +237,7 @@
     },
     "info": "Prikazujem _START_ do _END_ od _TOTAL_ vnosov",
     "infoEmpty": "Prikazujem 0 do 0 od 0 vnosov",
-    "infoFiltered": "(filtered from _MAX_ total entries)",
+    "infoFiltered": "(filtrirano iz skupnega števila vnosov _MAX_)",
     "lengthMenu": "Prikaži _MENU_ vnose",
     "aria": {
         "sortAscending": ": aktivirajte za razvrščanje stolpcev naraščajoče",


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)