### PR TITLE
Decode HTML entities in propagation modes correctly

### DIFF
--- a/application/views/accumulate/index.php
+++ b/application/views/accumulate/index.php
@@ -84,7 +84,7 @@
                         <option value="NoSAT"<?php if (($propmode ?? '') == 'NoSAT') { echo 'selected="selected"'; } ?>><?= __("All but SAT"); ?></option>
                         <option value="None"<?php if (($propmode ?? '') == 'None') { echo ' selected="selected"'; } ?>><?= __("None/Empty"); ?></option>
                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                           echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                           echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
                         } ?>
                     </select>
                 </div>

--- a/application/views/accumulate/index.php
+++ b/application/views/accumulate/index.php
@@ -84,7 +84,7 @@
                         <option value="NoSAT"<?php if (($propmode ?? '') == 'NoSAT') { echo 'selected="selected"'; } ?>><?= __("All but SAT"); ?></option>
                         <option value="None"<?php if (($propmode ?? '') == 'None') { echo ' selected="selected"'; } ?>><?= __("None/Empty"); ?></option>
                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                           echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                           echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                         } ?>
                     </select>
                 </div>

--- a/application/views/callstats/index.php
+++ b/application/views/callstats/index.php
@@ -69,7 +69,7 @@
 					<option value="None" <?php if ($propagationselect == 'None') echo ' selected'; ?>><?= __("None/Empty"); ?></option>
 					<option value="NoSAT" <?php if ($propagationselect == 'NoSAT') echo ' selected'; ?>><?= __("All except SAT") ?></option>
 					<?php foreach ($adif_propmodes as $mode => $desc) {
-						echo "<option value=\"$mode\" ".((($propagationselect ?? '') == "$mode") ? "selected=\"selected\"" : "").">"._pgettext("Propagation Mode", $desc)."</option>\n";
+						echo "<option value=\"$mode\" ".((($propagationselect ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
 					} ?>
 				</select>
 			</div>

--- a/application/views/callstats/index.php
+++ b/application/views/callstats/index.php
@@ -69,7 +69,7 @@
 					<option value="None" <?php if ($propagationselect == 'None') echo ' selected'; ?>><?= __("None/Empty"); ?></option>
 					<option value="NoSAT" <?php if ($propagationselect == 'NoSAT') echo ' selected'; ?>><?= __("All except SAT") ?></option>
 					<?php foreach ($adif_propmodes as $mode => $desc) {
-						echo "<option value=\"$mode\" ".((($propagationselect ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+						echo "<option value=\"$mode\" ".((($propagationselect ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
 					} ?>
 				</select>
 			</div>

--- a/application/views/csv/index.php
+++ b/application/views/csv/index.php
@@ -94,7 +94,7 @@
 						<option value="All"><?= __("All"); ?></option>
 						<option value="NoRPT" selected="selected"><?= _pgettext("Propagation Mode","All but Repeater"); ?></option>
 						<?php foreach ($adif_propmodes as $mode => $desc) {
-							echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+							echo "<option value=\"$mode\">".htmlspecialchars_decode($desc)."</option>\n";
 						} ?>
 					</select>
 				</div>

--- a/application/views/csv/index.php
+++ b/application/views/csv/index.php
@@ -94,7 +94,7 @@
 						<option value="All"><?= __("All"); ?></option>
 						<option value="NoRPT" selected="selected"><?= _pgettext("Propagation Mode","All but Repeater"); ?></option>
 						<?php foreach ($adif_propmodes as $mode => $desc) {
-							echo "<option value=\"$mode\">"._pgettext("Propagation Mode", $desc)."</option>\n";
+							echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
 						} ?>
 					</select>
 				</div>

--- a/application/views/distances/index.php
+++ b/application/views/distances/index.php
@@ -57,7 +57,7 @@
                         <option value="NoSAT"><?= __("All but SAT"); ?></option>
                         <option value="None"><?= __("None/Empty"); ?></option>
                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                           echo "<option value=\"$mode\">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                           echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                         } ?>
                     </select>
                 </div>

--- a/application/views/distances/index.php
+++ b/application/views/distances/index.php
@@ -57,7 +57,7 @@
                         <option value="NoSAT"><?= __("All but SAT"); ?></option>
                         <option value="None"><?= __("None/Empty"); ?></option>
                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                           echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                           echo "<option value=\"$mode\">".htmlspecialchars_decode($desc)."</option>\n";
                         } ?>
                     </select>
                 </div>

--- a/application/views/dxatlas/index.php
+++ b/application/views/dxatlas/index.php
@@ -93,7 +93,7 @@
 					<select class="form-select" id="selectPropagation" name="prop_mode">
 						<option value="All"><?= __("All"); ?></option>
 						<?php foreach ($adif_propmodes as $mode => $desc) {
-							echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+							echo "<option value=\"$mode\">".htmlspecialchars_decode($desc)."</option>\n";
 						} ?>
 					</select>
 				</div>

--- a/application/views/dxatlas/index.php
+++ b/application/views/dxatlas/index.php
@@ -93,7 +93,7 @@
 					<select class="form-select" id="selectPropagation" name="prop_mode">
 						<option value="All"><?= __("All"); ?></option>
 						<?php foreach ($adif_propmodes as $mode => $desc) {
-							echo "<option value=\"$mode\">"._pgettext("Propagation Mode", $desc)."</option>\n";
+							echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
 						} ?>
 					</select>
 				</div>

--- a/application/views/gridmap/index.php
+++ b/application/views/gridmap/index.php
@@ -82,7 +82,7 @@
                                         <option value="None"><?= __("None/Empty"); ?></option>
                                         <option value="NoSAT"><?= __("All except SAT") ?></option>
                                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                                           echo "<option value=\"$mode\"" . (($user_default_band == $mode) ? "selected=\"selected\"" : "").">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                                           echo "<option value=\"$mode\"" . (($user_default_band == $mode) ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                                         } ?>
                                     </select>
                                 </div>

--- a/application/views/gridmap/index.php
+++ b/application/views/gridmap/index.php
@@ -82,7 +82,7 @@
                                         <option value="None"><?= __("None/Empty"); ?></option>
                                         <option value="NoSAT"><?= __("All except SAT") ?></option>
                                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                                           echo "<option value=\"$mode\"" . (($user_default_band == $mode) ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                                           echo "<option value=\"$mode\"" . (($user_default_band == $mode) ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
                                         } ?>
                                     </select>
                                 </div>

--- a/application/views/kml/index.php
+++ b/application/views/kml/index.php
@@ -78,7 +78,7 @@
                         <select class="form-select" id="selectPropagation" name="prop_mode">
                         <option value="All"><?= __("All"); ?></option>
                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                           echo "<option value=\"$mode\">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                           echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                         } ?>
                         </select>
                     </div>

--- a/application/views/kml/index.php
+++ b/application/views/kml/index.php
@@ -78,7 +78,7 @@
                         <select class="form-select" id="selectPropagation" name="prop_mode">
                         <option value="All"><?= __("All"); ?></option>
                         <?php foreach ($adif_propmodes as $mode => $desc) {
-                           echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                           echo "<option value=\"$mode\">".htmlspecialchars_decode($desc)."</option>\n";
                         } ?>
                         </select>
                     </div>

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -428,7 +428,7 @@ $options = json_decode($options);
                                             <option value=""><?= __("All"); ?></option>
                                             <option value="None"><?= _pgettext("Propagation Mode", "None/Empty"); ?></option>
                                             <?php foreach ($adif_propmodes as $mode => $desc) {
-                                               echo "<option value=\"$mode\">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                                               echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                                             } ?>
                                         </select>
                                     </div>

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -428,7 +428,7 @@ $options = json_decode($options);
                                             <option value=""><?= __("All"); ?></option>
                                             <option value="None"><?= _pgettext("Propagation Mode", "None/Empty"); ?></option>
                                             <?php foreach ($adif_propmodes as $mode => $desc) {
-                                               echo "<option value=\"$mode\">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                                               echo "<option value=\"$mode\">".htmlspecialchars_decode($desc)."</option>\n";
                                             } ?>
                                         </select>
                                     </div>

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -190,7 +190,7 @@
                                             <select class="form-select" id="prop_mode_edit" name="prop_mode">
                                                 <option value="" <?php if ($qso->COL_PROP_MODE == "") { echo "selected=\"selected\""; } ?>></option>
                                                 <?php foreach ($adif_propmodes as $mode => $desc) {
-                                                    echo "<option value=\"$mode\" ".($qso->COL_PROP_MODE == "$mode" ? "selected=\"selected\"" : "").">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                                                    echo "<option value=\"$mode\" ".($qso->COL_PROP_MODE == "$mode" ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                                                 } ?>
                                             </select>
                                             <small id="lotw_propmode_hint" class="form-text text-muted">

--- a/application/views/qso/edit_ajax.php
+++ b/application/views/qso/edit_ajax.php
@@ -190,7 +190,7 @@
                                             <select class="form-select" id="prop_mode_edit" name="prop_mode">
                                                 <option value="" <?php if ($qso->COL_PROP_MODE == "") { echo "selected=\"selected\""; } ?>></option>
                                                 <?php foreach ($adif_propmodes as $mode => $desc) {
-                                                    echo "<option value=\"$mode\" ".($qso->COL_PROP_MODE == "$mode" ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                                                    echo "<option value=\"$mode\" ".($qso->COL_PROP_MODE == "$mode" ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
                                                 } ?>
                                             </select>
                                             <small id="lotw_propmode_hint" class="form-text text-muted">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -538,7 +538,7 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
                   <select class="form-select" id="selectPropagation" name="prop_mode">
                     <option value="" <?php if(!empty($this->session->userdata('prop_mode'))) { echo "selected=\"selected\""; } ?>></option>
                     <?php foreach ($adif_propmodes as $mode => $desc) {
-                       echo "<option value=\"$mode\" ".($this->session->userdata('prop_mode') == "$mode" ? "selected=\"selected\"" : "").">"._pgettext("Propagation Mode", $desc)."</option>\n";
+                       echo "<option value=\"$mode\" ".($this->session->userdata('prop_mode') == "$mode" ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
                     } ?>
                   </select>
                 </div>

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -538,7 +538,7 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
                   <select class="form-select" id="selectPropagation" name="prop_mode">
                     <option value="" <?php if(!empty($this->session->userdata('prop_mode'))) { echo "selected=\"selected\""; } ?>></option>
                     <?php foreach ($adif_propmodes as $mode => $desc) {
-                       echo "<option value=\"$mode\" ".($this->session->userdata('prop_mode') == "$mode" ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+                       echo "<option value=\"$mode\" ".($this->session->userdata('prop_mode') == "$mode" ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
                     } ?>
                   </select>
                 </div>

--- a/application/views/timeline/index.php
+++ b/application/views/timeline/index.php
@@ -83,7 +83,7 @@
 						<option value="NoSAT"<?php if (($propmode ?? '') == 'NoSAT') { echo 'selected="selected"'; } ?>><?= __("All but SAT"); ?></option>
 						<option value="None"<?php if (($propmode ?? '') == 'None') { echo ' selected="selected"'; } ?>><?= __("None/Empty"); ?></option>
 						<?php foreach ($adif_propmodes as $mode => $desc) {
-							echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">"._pgettext("Propagation Mode", $desc)."</option>\n";
+							echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
 						} ?>
 					</select>
 				</div>

--- a/application/views/timeline/index.php
+++ b/application/views/timeline/index.php
@@ -83,7 +83,7 @@
 						<option value="NoSAT"<?php if (($propmode ?? '') == 'NoSAT') { echo 'selected="selected"'; } ?>><?= __("All but SAT"); ?></option>
 						<option value="None"<?php if (($propmode ?? '') == 'None') { echo ' selected="selected"'; } ?>><?= __("None/Empty"); ?></option>
 						<?php foreach ($adif_propmodes as $mode => $desc) {
-							echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode(_pgettext("Propagation Mode", $desc))."</option>\n";
+							echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
 						} ?>
 					</select>
 				</div>

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -51,7 +51,7 @@ function echo_table_col($row, $name, $adif_propmodes) {
 		case 'Name':echo '<td>' . ($row->COL_NAME ?? '') . '</td>'; break;
 		case 'Propagation':
 			if (isset($row->COL_PROP_MODE)) {
-				echo '<td>' . _pgettext("Propagation Mode", $adif_propmodes[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE) . '</td>';
+				echo '<td>' . htmlspecialchars_decode(_pgettext("Propagation Mode", $adif_propmodes[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE)) . '</td>';
 			} else {
 				echo '<td></td>';
 			}

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -51,7 +51,7 @@ function echo_table_col($row, $name, $adif_propmodes) {
 		case 'Name':echo '<td>' . ($row->COL_NAME ?? '') . '</td>'; break;
 		case 'Propagation':
 			if (isset($row->COL_PROP_MODE)) {
-				echo '<td>' . htmlspecialchars_decode(_pgettext("Propagation Mode", $adif_propmodes[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE)) . '</td>';
+				echo '<td>' . htmlspecialchars_decode($adif_propmodes[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE) . '</td>';
 			} else {
 				echo '<td></td>';
 			}

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -246,7 +246,7 @@
                     <?php if($row->COL_PROP_MODE != null and $row->COL_PROP_MODE != '') { ?>
                     <tr>
                         <td><?= __("Propagation"); ?></td>
-                        <td><?php echo htmlspecialchars_decode(_pgettext("Propagation Mode", $this->config->item('adif_propmodes')[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE)); ?></td>
+                        <td><?php echo htmlspecialchars_decode($this->config->item('adif_propmodes')[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE); ?></td>
                     </tr>
                     <?php } ?>
 

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -246,7 +246,7 @@
                     <?php if($row->COL_PROP_MODE != null and $row->COL_PROP_MODE != '') { ?>
                     <tr>
                         <td><?= __("Propagation"); ?></td>
-                        <td><?php echo _pgettext("Propagation Mode", $this->config->item('adif_propmodes')[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE); ?></td>
+                        <td><?php echo htmlspecialchars_decode(_pgettext("Propagation Mode", $this->config->item('adif_propmodes')[$row->COL_PROP_MODE] ?? $row->COL_PROP_MODE)); ?></td>
                     </tr>
                     <?php } ?>
 


### PR DESCRIPTION
In https://github.com/wavelog/wavelog/pull/3222/changes we moved definition of all ADIF modes into a central config file. The translations decoder outputs some HTML special chars which were not decoded (correctly):

<img width="1714" height="967" alt="Screenshot from 2026-05-09 08-30-02" src="https://github.com/user-attachments/assets/de23b258-ecc0-4359-aaf2-9c5bc91b96b9" />

This fixes it.