### PR TITLE
Reset propmode when coming from cluster

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -948,6 +948,12 @@ if (qso_manual == 0) {
 					$("#mode").val(ev.data.mode);
 				}
 
+				// Clear satellite/propagation fields when clicking bandmap spots (HF DX spots)
+				$("#selectPropagation").val("");
+				$("#sat_name").val("");
+				$("#sat_mode").val("");
+				stop_az_ele_ticker();    // Stop satellite position ticker if running
+
 				// Store sequence for validation in populatePendingReferences
 				$("#callsign").data('expected-refs-seq', seq);
 


### PR DESCRIPTION
When working SAT with SAT, SAT_MODE, PROP_MODE entered, Wavelog remembers those informations for the next QSO.
Which is okay and wanted.

But: When working mixed mode with coming from DXCluster, SAT & Co. are still in QSO-Form, even if cluster is HF-Only.

This patch fixes that behaviour. When coming from cluster prop, name and mode are emptied