### PR TITLE
Fix marking selected QSOs in qslprint

### DIFF
--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -244,8 +244,7 @@ function markSelectedQsos() {
 		url: base_url + 'index.php/logbookadvanced/update_qsl',
 		type: 'post',
 		data: {'id': JSON.stringify(id_list, null, 2),
-			'sent' : 'Y',
-			'method' : ''
+			'sent' : 'Y'
 		},
 		success: function(data) {
 			if (data !== []) {


### PR DESCRIPTION
"via"/"method" field should not be clear when marking selected QSOs as printed. It should be kept.

There is still small difference from "Mark all QSOs as printed": "Mark all" will set `via` to `B` if `via` is empty. But I don't thinks this is very necessary. 