### PR TITLE
Add QSO upload to QRZCALL.EU

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 278;
+$config['migration_version'] = 279;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Qrzcallupload.php
+++ b/application/controllers/Qrzcallupload.php
@@ -1,0 +1,237 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/*
+	Controller to upload QSOs to a QRZCALL.EU logbook.
+
+	QRZCALL.EU exposes a QRZ-compatible logbook endpoint, so this mirrors the
+	QRZ.com upload controller (Qrz.php) — upload paths only. QRZCALL.EU has no
+	QSL download, so there is no download/mark functionality here.
+
+	Note: the class is named Qrzcallupload (not Qrzcall) so it does not clash
+	with the existing callbook library application/libraries/Qrzcall.php.
+ */
+
+class Qrzcallupload extends CI_Controller {
+
+	function __construct()
+	{
+		parent::__construct();
+
+		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+			echo __("Maintenance Mode is active. Try again later.")."\n";
+			redirect('user/login');
+		}
+	}
+
+	// Show frontend if there is one
+	public function index() {
+		$this->config->load('config');
+	}
+
+	/*
+	 * API Token Status Test — POSTs ACTION=STATUS to the QRZCALL.EU endpoint
+	 */
+	public function qrzcall_apitest() {
+		$apikey = xss_clean($this->input->post('APIKEY'));
+		$url = 'https://api.qrzcall.eu/v1/pub/logbook_api.php';
+
+		$post_data['KEY'] = $apikey;
+		$post_data['ACTION'] = 'STATUS';
+
+		$ch = curl_init( $url );
+		curl_setopt( $ch, CURLOPT_POST, true);
+		curl_setopt( $ch, CURLOPT_POSTFIELDS, $post_data);
+		curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, 1);
+		curl_setopt( $ch, CURLOPT_HEADER, 0);
+		curl_setopt( $ch, CURLOPT_CONNECTTIMEOUT, 20);
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt( $ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
+
+		$content = curl_exec($ch);
+
+		if ($content){
+			if (stristr($content,'RESULT=OK')) {
+				$result['status'] = 'OK';
+				$result['message'] = $content;
+			}
+			else {
+				$result['status'] = 'Failed';
+				$result['message'] = $content;
+			}
+		}
+		if(curl_errno($ch)){
+			$result['status'] = 'error';
+			$result['message'] = 'Curl error: '. curl_errno($ch);
+		}
+		header('Content-Type: application/json');
+		echo json_encode($result);
+	}
+
+	/*
+	 * Upload QSOs to QRZCALL.EU.
+	 * When called from the url wavelog/qrzcallupload/upload (cron), the
+	 * function loops through every station_id with a QRZCALL.EU token defined.
+	 * All QSOs not previously uploaded are then uploaded, one at a time.
+	 */
+	public function upload() {
+		$this->setOptions();
+
+		// set the last run in cron table for the qrzcall_upload cron
+		$this->load->model('cron_model');
+		$this->cron_model->set_last_run('qrzcall_upload');
+
+		$this->load->model('logbook_model');
+
+		$station_ids = $this->logbook_model->get_station_id_with_qrzcall_api();
+
+		if ($station_ids) {
+			foreach ($station_ids as $station) {
+				$qrzcall_api_key = $station->qrzcallapikey;
+				if ($station->qrzcallrealtime>=0) {
+					if($this->mass_upload_qsos($station->station_id, $qrzcall_api_key, true)) {
+						echo "QSOs have been uploaded to QRZCALL.EU for station_id ".$station->station_id;
+					} else{
+						echo "No QSOs found for upload and station_id ".$station->station_id;
+					}
+				} else {
+					echo "Station ".$station->station_id." disabled for upload to QRZCALL.EU.";
+				}
+			}
+		} else {
+			echo "No station profiles with a QRZCALL.EU API Token found.";
+			log_message('error', "No station profiles with a QRZCALL.EU API Token found.");
+		}
+	}
+
+	function setOptions() {
+		$this->config->load('config');
+		ini_set('memory_limit', '-1');
+		ini_set('display_errors', 1);
+		ini_set('display_startup_errors', 1);
+		error_reporting(E_ALL);
+	}
+
+	/*
+	 * Gets all QSOs from the given station_id that have not been uploaded to
+	 * QRZCALL.EU. An ADIF line is built for each QSO and uploaded one at a time.
+	 */
+	function mass_upload_qsos($station_id, $qrzcall_api_key, $trusted = false) {
+		$i = 0;
+		$data['qsos'] = $this->logbook_model->get_qrzcall_qsos($station_id, $trusted);
+		$errormessages=array();
+
+		if (!$this->load->is_loaded('AdifHelper')) {
+			$this->load->library('AdifHelper');
+		}
+
+		if ($data['qsos']) {
+			foreach ($data['qsos']->result() as $qso) {
+				$adif = $this->adifhelper->getAdifLine($qso);
+
+				// A QSO previously uploaded then edited is marked 'M' — re-upload with REPLACE.
+				if ($qso->COL_QRZCALL_QSO_UPLOAD_STATUS == 'M') {
+					$result = $this->logbook_model->push_qso_to_qrzcall($qrzcall_api_key, $adif, true);
+				} else {
+					$result = $this->logbook_model->push_qso_to_qrzcall($qrzcall_api_key, $adif);
+				}
+
+				if ( ($result['status'] == 'OK') || ( ($result['status'] == 'error') && (stristr($result['message'],'RESULT=FAIL') && stristr($result['message'],'duplicate'))) ) {
+					// Uploaded, or already present (duplicate) — both count as done.
+					$this->markqso($qso->COL_PRIMARY_KEY);
+					$i++;
+					$result['status'] = 'OK';
+				} elseif ( ($result['status']=='error') && (stristr($result['message'],'RESULT=AUTH')) ) {
+					// Bad/expired token — stop and disable upload for this station.
+					log_message('error', 'QRZCALL.EU upload failed (auth) for Station_ID '.$station_id.' // Message: '.$result['message']);
+					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					$result['status'] = 'Error';
+					$this->db->query('update station_profile set qrzcallrealtime = -1 where station_id = ?', $station_id);
+					break;
+				} else {
+					log_message('error', 'QRZCALL.EU upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
+					log_message('error', 'QRZCALL.EU upload failed with the following message: ' .$result['message']);
+					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					$result['status'] = 'Error';
+				}
+			}
+			if ($i == 0) {
+				$result['status']='OK';
+			}
+			$result['count'] = $i;
+			$result['errormessages'] = $errormessages;
+			return $result;
+		} else {
+			$result['status'] = 'Error';
+			$result['count'] = $i;
+			$result['errormessages'] = $errormessages;
+			return $result;
+		}
+	}
+
+	/*
+	 * Marks the QSO with the given primarykey as uploaded to QRZCALL.EU
+	 */
+	function markqso($primarykey,$state = 'Y') {
+		$this->logbook_model->mark_qrzcall_qsos_sent($primarykey, $state);
+	}
+
+	/*
+	 * Renders the QRZCALL.EU Logbook upload page
+	 */
+	public function export() {
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
+
+		$this->load->model('stations');
+
+		$data['page_title'] = __("QRZCALL.EU Logbook");
+
+		$data['station_profile'] = $this->stations->stations_with_qrzcall_api_key();
+		$this->load->model('cron_model');
+		$data['next_run_up'] = $this->cron_model->get_next_run("qrzcall_upload");
+
+		$this->load->view('interface_assets/header', $data);
+		$this->load->view('qrzcall/export');
+		$this->load->view('interface_assets/footer');
+	}
+
+	/*
+	 * AJAX handler — manual "Upload" button for a single station profile
+	 */
+	public function upload_station() {
+		$this->setOptions();
+		$this->load->model('stations');
+
+		$postData = $this->input->post();
+
+		$this->load->model('logbook_model');
+		$result = $this->logbook_model->exists_qrzcall_api_key($postData['station_id']);
+		$qrzcall_api_key = $result->qrzcallapikey;
+		$qrzcall_enabled = $result->qrzcallrealtime;
+		header('Content-type: application/json');
+		if ($qrzcall_enabled>=0) {
+			$result = $this->mass_upload_qsos($postData['station_id'], $qrzcall_api_key);
+			if ($result['status'] == 'OK') {
+				$stationinfo = $this->stations->stations_with_qrzcall_api_key();
+				$info = $stationinfo->result();
+
+				$data['status'] = 'OK';
+				$data['info'] = $info;
+				$data['infomessage'] = $result['count'] . " QSOs are now uploaded to QRZCALL.EU";
+				$data['errormessages'] = $result['errormessages'];
+				echo json_encode($data);
+			} else {
+				$data['status'] = 'Error';
+				$data['info'] = 'Error: No QSOs found to upload.';
+				$data['errormessages'] = $result['errormessages'];
+				echo json_encode($data);
+			}
+		} else {
+			$profile = $this->stations->profile($this->security->xss_clean($postData['station_id']))->row()->station_profile_name;
+			$data['status']='Error';
+			$data['info']='QRZCALL.EU upload disabled for station profile:'.' '.$profile;
+			echo json_encode($data);
+		}
+	}
+
+}

--- a/application/migrations/279_add_qrzcall_logbook_upload.php
+++ b/application/migrations/279_add_qrzcall_logbook_upload.php
@@ -1,0 +1,75 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+/*
+ * Adds QSO upload to QRZCALL.EU, mirroring the existing QRZ.com upload:
+ *  - station_profile.qrzcallapikey   — per-station QRZCALL.EU PAT (pat_xxx)
+ *  - station_profile.qrzcallrealtime — -1 disabled / 0 enabled / 1 realtime
+ *  - COL_QRZCALL_QSO_UPLOAD_DATE / _STATUS — per-QSO upload tracking
+ *  - a background upload cron (disabled by default, like qrz_upload)
+ */
+class Migration_add_qrzcall_logbook_upload extends CI_Migration {
+
+	public function up() {
+		// Per-station QRZCALL.EU upload credentials
+		if (!$this->db->field_exists('qrzcallapikey', 'station_profile')) {
+			$this->dbforge->add_column('station_profile', array(
+				'qrzcallapikey VARCHAR(64) NULL DEFAULT NULL',
+			));
+		}
+		if (!$this->db->field_exists('qrzcallrealtime', 'station_profile')) {
+			$this->dbforge->add_column('station_profile', array(
+				'qrzcallrealtime TINYINT(1) NOT NULL DEFAULT 0',
+			));
+		}
+
+		// Per-QSO QRZCALL.EU upload tracking
+		if (!$this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_STATUS', $this->config->item('table_name'))) {
+			$fields = array(
+				'COLUMN COL_QRZCALL_QSO_UPLOAD_DATE DATETIME NULL DEFAULT NULL',
+				'COLUMN COL_QRZCALL_QSO_UPLOAD_STATUS VARCHAR(10) DEFAULT NULL',
+			);
+			$this->dbforge->add_column($this->config->item('table_name'), $fields);
+		}
+
+		// Background upload cron — disabled by default, mirrors qrz_upload
+		if ($this->chk4cron('qrzcall_upload') == 0) {
+			$data = array(
+				array(
+					'id' => 'qrzcall_upload',
+					'enabled' => '0',
+					'status' => 'pending',
+					'description' => 'Upload QSOs to QRZCALL.EU',
+					'function' => 'index.php/qrzcallupload/upload',
+					'expression' => '12 */6 * * *',
+					'last_run' => null,
+					'next_run' => null
+				));
+			$this->db->insert_batch('cron', $data);
+		}
+	}
+
+	public function down() {
+		if ($this->db->field_exists('qrzcallapikey', 'station_profile')) {
+			$this->dbforge->drop_column('station_profile', 'qrzcallapikey');
+		}
+		if ($this->db->field_exists('qrzcallrealtime', 'station_profile')) {
+			$this->dbforge->drop_column('station_profile', 'qrzcallrealtime');
+		}
+		if ($this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_DATE', $this->config->item('table_name'))) {
+			$this->dbforge->drop_column($this->config->item('table_name'), 'COL_QRZCALL_QSO_UPLOAD_DATE');
+		}
+		if ($this->db->field_exists('COL_QRZCALL_QSO_UPLOAD_STATUS', $this->config->item('table_name'))) {
+			$this->dbforge->drop_column($this->config->item('table_name'), 'COL_QRZCALL_QSO_UPLOAD_STATUS');
+		}
+		if ($this->chk4cron('qrzcall_upload') > 0) {
+			$this->db->query("delete from cron where id='qrzcall_upload'");
+		}
+	}
+
+	function chk4cron($cronkey) {
+		$query = $this->db->query("select count(id) as cid from cron where id=?", $cronkey);
+		$row = $query->row();
+		return $row->cid ?? 0;
+	}
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -929,6 +929,7 @@ class Logbook_model extends CI_Model {
 					(isset($creds->ucp) && isset($creds->ucn) && $creds->clublogrealtime == 1) ||
 					(isset($creds->hrdlog_code) && isset($creds->hrdlog_username) && $creds->hrdlogrealtime == 1) ||
 					(isset($creds->qrzapikey) && $creds->qrzrealtime == 1) ||
+					(isset($creds->qrzcallapikey) && $creds->qrzcallrealtime == 1) ||
 					(isset($creds->webadifapikey) && $creds->webadifrealtime == 1)
 					)
 				);
@@ -977,6 +978,20 @@ class Logbook_model extends CI_Model {
 					$result = $this->push_qso_to_qrz($creds->qrzapikey, $adif);
 					if (($result['status'] == 'OK') || (($result['status'] == 'error') && ($result['message'] == 'STATUS=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED='))) {
 						$this->mark_qrz_qsos_sent($last_id);
+					}
+				}
+
+				// QRZCALL.EU export
+				if ($creds && isset($creds->qrzcallapikey) && $creds->qrzcallrealtime == 1) {
+					if (!$this->load->is_loaded('AdifHelper')) {
+						$this->load->library('AdifHelper');
+					}
+
+					$adif = $this->adifhelper->getAdifLine($qso[0]);
+					$result = $this->push_qso_to_qrzcall($creds->qrzcallapikey, $adif);
+					// A duplicate (QSO already in the QRZCALL.EU logbook) is treated as success.
+					if (($result['status'] == 'OK') || (($result['status'] == 'error') && (stristr($result['message'], 'RESULT=FAIL') && stristr($result['message'], 'duplicate')))) {
+						$this->mark_qrzcall_qsos_sent($last_id);
 					}
 				}
 
@@ -1064,6 +1079,24 @@ class Logbook_model extends CI_Model {
 	}
 
 	/*
+	 * Function checks if a QRZCALL.EU API token exists for the given station id
+	 */
+	function exists_qrzcall_api_key($station_id) {
+		$sql = 'select qrzcallapikey, qrzcallrealtime from station_profile
+            where station_id = ?';
+
+		$query = $this->db->query($sql, $station_id);
+
+		$result = $query->row();
+
+		if ($result) {
+			return $result;
+		} else {
+			return false;
+		}
+	}
+
+	/*
 	 * Function checks if a WebADIF API Key exists in the table with the given station id
 	*/
 	function exists_webadif_api_key($station_id) {
@@ -1089,6 +1122,7 @@ class Logbook_model extends CI_Model {
 		$sql = 'SELECT
 					prof.hrdlog_username, prof.hrdlog_code, prof.hrdlogrealtime,
 					prof.qrzapikey, prof.qrzrealtime,
+					prof.qrzcallapikey, prof.qrzcallrealtime,
 					prof.webadifapikey, prof.webadifapiurl, prof.webadifrealtime,
 					prof.clublogrealtime,
 					auth.user_clublog_name as ucn, auth.user_clublog_password as ucp
@@ -1207,6 +1241,50 @@ class Logbook_model extends CI_Model {
 	}
 
 	/*
+	 * Function uploads a QSO to QRZCALL.EU with the API token given.
+	 * QRZCALL.EU exposes a QRZ-compatible logbook endpoint, so this mirrors
+	 * push_qso_to_qrz(): one ADIF record per call, OPTION=REPLACE to update an
+	 * existing QSO. $adif contains one QSO ending with an <EOR>.
+	 */
+	function push_qso_to_qrzcall($apikey, $adif, $replaceoption = false) {
+		$url = 'https://api.qrzcall.eu/v1/pub/logbook_api.php';
+
+		$post_data['KEY'] = $apikey;
+		$post_data['ACTION'] = 'INSERT';
+		$post_data['ADIF'] = $adif;
+
+		if ($replaceoption) {
+			$post_data['OPTION'] = 'REPLACE';
+		}
+
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+		curl_setopt($ch, CURLOPT_HEADER, 0);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$this->optionslib->get_option('version'));
+		$content = curl_exec($ch);
+		if ($content) {
+			if (stristr($content, 'RESULT=OK') || stristr($content, 'RESULT=REPLACE')) {
+				$result['status'] = 'OK';
+				return $result;
+			} else {
+				$result['status'] = 'error';
+				$result['message'] = $content;
+				return $result;
+			}
+		}
+		if (curl_errno($ch)) {
+			$result['status'] = 'error';
+			$result['message'] = 'Curl error: ' . curl_errno($ch);
+			return $result;
+		}
+	}
+
+	/*
 	 * Function uploads a QSO to WebADIF consumer with the API given.
 	 * $adif contains a line with the QSO in the ADIF format.
 	 */
@@ -1280,6 +1358,23 @@ class Logbook_model extends CI_Model {
 		$data = array(
 			'COL_QRZCOM_QSO_UPLOAD_DATE' => date("Y-m-d H:i:s", strtotime("now")),
 			'COL_QRZCOM_QSO_UPLOAD_STATUS' => $state,
+		);
+
+		$this->db->where('COL_PRIMARY_KEY', $primarykey);
+
+		$this->db->update($this->config->item('table_name'), $data);
+
+		return true;
+	}
+
+	/*
+   * Function marks QSOs as uploaded to QRZCALL.EU.
+   * $primarykey is the unique id for that QSO in the logbook
+   */
+	function mark_qrzcall_qsos_sent($primarykey, $state = 'Y') {
+		$data = array(
+			'COL_QRZCALL_QSO_UPLOAD_DATE' => date("Y-m-d H:i:s", strtotime("now")),
+			'COL_QRZCALL_QSO_UPLOAD_STATUS' => $state,
 		);
 
 		$this->db->where('COL_PRIMARY_KEY', $primarykey);
@@ -1790,6 +1885,11 @@ class Logbook_model extends CI_Model {
 			$data['COL_QRZCOM_QSO_UPLOAD_STATUS'] = 'M';
 		}
 
+		$old_qrzcall=($qso->COL_QRZCALL_QSO_UPLOAD_STATUS ?? '');
+		if ( ($old_qrzcall == 'I' || $old_qrzcall == 'Y') && $this->exists_qrzcall_api_key($data['station_id']) ) {	// Re-upload an edited QSO to QRZCALL.EU (OPTION=REPLACE)
+			$data['COL_QRZCALL_QSO_UPLOAD_STATUS'] = 'M';
+		}
+
 		$this->db->where('COL_PRIMARY_KEY', $this->input->post('id'));
 		try {
 			$this->db->update($this->config->item('table_name'), $data);
@@ -2024,6 +2124,7 @@ class Logbook_model extends CI_Model {
 			$this->db->update($this->config->item('table_name'), $data);
 			if ($this->db->affected_rows()>0) {	// Only set to modified if REALLY modified
 				$this->set_qrzcom_modified($qso_id);
+			$this->set_qrzcall_modified($qso_id);
 			}
 
 		} else {
@@ -2055,6 +2156,7 @@ class Logbook_model extends CI_Model {
 
 			if ($this->db->affected_rows()>0) {	// Only set to modified if REALLY modified
 				$this->set_qrzcom_modified($qso_id);
+			$this->set_qrzcall_modified($qso_id);
 			}
 		} else {
 			return;
@@ -2082,6 +2184,7 @@ class Logbook_model extends CI_Model {
 
 			if ($this->db->affected_rows()>0) {	// Only set to modified if REALLY modified
 				$this->set_qrzcom_modified($qso_id);
+			$this->set_qrzcall_modified($qso_id);
 			}
 		} else {
 			return;
@@ -2104,6 +2207,7 @@ class Logbook_model extends CI_Model {
 
 			if ($this->db->affected_rows()>0) {	// Only set to modified if REALLY modified
 				$this->set_qrzcom_modified($qso_id);
+			$this->set_qrzcall_modified($qso_id);
 			}
 		} else {
 			return;
@@ -2318,6 +2422,30 @@ class Logbook_model extends CI_Model {
 		return $query;
 	}
 
+	/*
+     * Function returns the QSOs from the given station_id that have not yet
+     * been uploaded to QRZCALL.EU (or are marked modified / not-uploaded).
+	 */
+	function get_qrzcall_qsos($station_id, $trusted = false) {
+		$binding = [];
+		$this->load->model('stations');
+		if ((!$trusted) && (!$this->stations->check_station_is_accessible($station_id))) {
+			return;
+		}
+		$sql = 'select *, dxcc_entities.name as station_country from ' . $this->config->item('table_name') . ' thcv ' .
+			' left join station_profile on thcv.station_id = station_profile.station_id' .
+			' left outer join dxcc_entities on thcv.col_my_dxcc = dxcc_entities.adif' .
+			' where thcv.station_id = ?' .
+			' and (COL_QRZCALL_QSO_UPLOAD_STATUS is NULL
+		  or COL_QRZCALL_QSO_UPLOAD_STATUS = ""
+		  or COL_QRZCALL_QSO_UPLOAD_STATUS = "M"
+		  or COL_QRZCALL_QSO_UPLOAD_STATUS = "N")';
+		$binding[] = $station_id;
+
+		$query = $this->db->query($sql, $binding);
+		return $query;
+	}
+
 	/**
 	 * Generic function to set the QRZ.com Upload status to 'modified'
 	 *
@@ -2333,6 +2461,25 @@ class Logbook_model extends CI_Model {
 		$this->db->group_start();
 		$this->db->where('COL_QRZCOM_QSO_UPLOAD_STATUS', 'Y');
 		$this->db->or_where('COL_QRZCOM_QSO_UPLOAD_STATUS', 'I');
+		$this->db->group_end();
+		$this->db->update($this->config->item('table_name'), $data);
+	}
+
+	/**
+	 * Generic function to set the QRZCALL.EU Upload status to 'modified'
+	 *
+	 * @param int $qso_id  the QSO primary key (COL_PRIMARY_KEY)
+	 */
+
+	function set_qrzcall_modified($qso_id) {
+		$data = array(
+			'COL_QRZCALL_QSO_UPLOAD_STATUS' => 'M'
+		);
+
+		$this->db->where('COL_PRIMARY_KEY', $qso_id);
+		$this->db->group_start();
+		$this->db->where('COL_QRZCALL_QSO_UPLOAD_STATUS', 'Y');
+		$this->db->or_where('COL_QRZCALL_QSO_UPLOAD_STATUS', 'I');
 		$this->db->group_end();
 		$this->db->update($this->config->item('table_name'), $data);
 	}
@@ -2382,6 +2529,24 @@ class Logbook_model extends CI_Model {
 	function get_station_id_with_qrz_api() {
 		$sql = 'select station_id, qrzapikey, qrzrealtime from station_profile
 		  where coalesce(qrzapikey, "") <> ""';
+
+		$query = $this->db->query($sql);
+
+		$result = $query->result();
+
+		if ($result) {
+			return $result;
+		} else {
+			return null;
+		}
+	}
+
+	/*
+     * Function returns all the station_id's with a QRZCALL.EU API token
+     */
+	function get_station_id_with_qrzcall_api() {
+		$sql = 'select station_id, qrzcallapikey, qrzcallrealtime from station_profile
+		  where coalesce(qrzcallapikey, "") <> ""';
 
 		$query = $this->db->query($sql);
 

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -154,6 +154,8 @@ class Stations extends CI_Model {
 			'clublogrealtime' => xss_clean($this->input->post('clublogrealtime', true)),
 			'qrzapikey' => xss_clean($this->input->post('qrzapikey', true)),
 			'qrzrealtime' => xss_clean($this->input->post('qrzrealtime', true)),
+			'qrzcallapikey' => xss_clean($this->input->post('qrzcallapikey', true)),
+			'qrzcallrealtime' => xss_clean($this->input->post('qrzcallrealtime', true)),
 			'oqrs' => xss_clean($this->input->post('oqrs', true) ?? '0'),
 			'oqrs_email' => xss_clean($this->input->post('oqrsemail', true) ?? '0'),
 			'oqrs_text' => xss_clean($this->input->post('oqrstext', true)),
@@ -234,6 +236,8 @@ class Stations extends CI_Model {
 			'clublogrealtime' => xss_clean($this->input->post('clublogrealtime', true)),
 			'qrzapikey' => xss_clean($this->input->post('qrzapikey', true)),
 			'qrzrealtime' => xss_clean($this->input->post('qrzrealtime', true)),
+			'qrzcallapikey' => xss_clean($this->input->post('qrzcallapikey', true)),
+			'qrzcallrealtime' => xss_clean($this->input->post('qrzcallrealtime', true)),
 			'oqrs' => xss_clean($this->input->post('oqrs', true) ?? '0'),
 			'oqrs_email' => xss_clean($this->input->post('oqrsemail', true) ?? '0'),
 			'oqrs_text' => xss_clean($this->input->post('oqrstext', true)),
@@ -514,6 +518,42 @@ class Stations extends CI_Model {
 			group by station_id
 		) as totc on station_profile.station_id = totc.station_id
 		WHERE coalesce(station_profile.qrzapikey, '') <> ''
+		AND station_profile.user_id = ?";
+	    $bindings[]=$this->session->userdata('user_id');
+	    $query = $this->db->query($sql, $bindings);
+
+	    return $query;
+    }
+
+    /*
+     * Returns the user's station profiles that have a QRZCALL.EU API token
+     * set, with per-station counts of QSOs not uploaded / modified / uploaded.
+     * Mirrors stations_with_qrz_api_key().
+     */
+    function stations_with_qrzcall_api_key() {
+	    $bindings=[];
+	    $sql = "SELECT station_profile.station_id, station_profile.station_profile_name, station_profile.station_callsign, modc.modcount, notc.notcount, totc.totcount
+		    FROM station_profile
+		    LEFT OUTER JOIN (
+			    SELECT count(*) modcount, station_id
+			    FROM ". $this->config->item('table_name') .
+			    " WHERE COL_QRZCALL_QSO_UPLOAD_STATUS = 'M'
+			    group by station_id
+		) as modc on station_profile.station_id = modc.station_id
+		LEFT OUTER JOIN (
+			SELECT count(*) notcount, station_id
+			FROM " . $this->config->item('table_name') .
+			" WHERE (coalesce(COL_QRZCALL_QSO_UPLOAD_STATUS, '') = ''
+			or COL_QRZCALL_QSO_UPLOAD_STATUS = 'N')
+			group by station_id
+		) as notc on station_profile.station_id = notc.station_id
+		LEFT OUTER JOIN (
+			SELECT count(*) totcount, station_id
+			FROM " . $this->config->item('table_name') .
+			" WHERE COL_QRZCALL_QSO_UPLOAD_STATUS = 'Y'
+			group by station_id
+		) as totc on station_profile.station_id = totc.station_id
+		WHERE coalesce(station_profile.qrzcallapikey, '') <> ''
 		AND station_profile.user_id = ?";
 	    $bindings[]=$this->session->userdata('user_id');
 	    $query = $this->db->query($sql, $bindings);

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1707,6 +1707,9 @@ $(document).ready(function(){
     <?php if ($this->uri->segment(1) == "qrz") { ?>
 		<script src="<?php echo $this->paths->cache_buster('/assets/js/sections/qrzlogbook.js'); ?>"></script>
     <?php } ?>
+    <?php if ($this->uri->segment(1) == "qrzcallupload") { ?>
+		<script src="<?php echo $this->paths->cache_buster('/assets/js/sections/qrzcalllogbook.js'); ?>"></script>
+    <?php } ?>
 	<?php if ($this->uri->segment(1) == "webadif") { ?>
 		<script src="<?php echo $this->paths->cache_buster('/assets/js/sections/webadif.js'); ?>"></script>
 	<?php } ?>

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -523,6 +523,7 @@
 										<li><a class="dropdown-item" href="<?php echo site_url('eqsl/import'); ?>" title="eQSL import / export"><i class="fas fa-sync"></i> <?= __("eQSL Import / Export"); ?></a></li>
 										<li><a class="dropdown-item" href="<?php echo site_url('hrdlog/export'); ?>" title="Upload to HRDLog.net logbook"><i class="fas fa-sync"></i> <?= __("HRDLog Logbook"); ?></a></li>
 										<li><a class="dropdown-item" href="<?php echo site_url('qrz/export'); ?>" title="Upload to QRZ.com logbook"><i class="fas fa-sync"></i> <?= __("QRZ Logbook"); ?></a></li>
+										<li><a class="dropdown-item" href="<?php echo site_url('qrzcallupload/export'); ?>" title="Upload to QRZCALL.EU logbook"><i class="fas fa-sync"></i> <?= __("QRZCALL.EU Logbook"); ?></a></li>
 										<li><a class="dropdown-item" href="<?php echo site_url('webadif/export'); ?>" title="Upload to webADIF"><i class="fas fa-sync"></i> <?= __("QO-100 Dx Club Upload"); ?></a></li>
 										<li><a class="dropdown-item" href="<?php echo site_url('clublog/export'); ?>" title="Upload to Clublog"><i class="fas fa-sync"></i> <?= __("Clublog Import / Export"); ?></a></li>
 										<?php

--- a/application/views/qrzcall/export.php
+++ b/application/views/qrzcall/export.php
@@ -1,0 +1,60 @@
+
+<div class="container adif" id="qrzcall_export">
+
+    <h2><?php echo $page_title; ?></h2>
+
+    <div class="card">
+        <div class="card-header">
+			<ul class="nav nav-tabs card-header-tabs pull-right" role="tablist">
+				<li class="nav-item">
+					<a class="nav-link active" id="export-tab" data-bs-toggle="tab" href="#export" role="tab" aria-controls="export" aria-selected="true"><?= __("Upload Logbook"); ?></a>
+				</li>
+			</ul>
+        </div>
+
+        <div class="card-body">
+			<div class="tab-content">
+				<div class="tab-pane active" id="export" role="tabpanel" aria-labelledby="export-tab">
+            <?php if (($next_run_up ?? '') != '') { echo "<p>".__("The next automatic Upload to QRZCALL.EU will happen at: ").$next_run_up." UTC</p>"; } ?>
+            <p><?= __("Here you can see all QSOs which have not been previously uploaded to a QRZCALL.EU logbook."); ?></p>
+            <p><?= __("You need to set a QRZCALL.EU API token in your station profile. Only station profiles with an API token set are displayed."); ?></p>
+            <p><span class="badge text-bg-warning"><?= __("Warning"); ?></span> <?= __("This might take a while as QSO uploads are processed sequentially."); ?></p>
+
+<?php
+            if ($station_profile->result()) {
+            echo '
+
+            <table class="table table-bordered table-hover table-striped table-condensed text-center">
+                <thead>
+                <tr>
+                    <td>' . __("Profile name") . '</td>
+                    <td>' . __("Station callsign") . '</td>
+                    <td>' . __("Edited QSOs not uploaded") . '</td>
+                    <td>' . __("Total QSOs not uploaded") . '</td>
+                    <td>' . __("Total QSOs uploaded") . '</td>
+                    <td>' . __("Actions") . '</td>
+                </thead>
+                <tbody>';
+                foreach ($station_profile->result() as $station) {      // Fills the table with the data
+                echo '<tr>';
+                    echo '<td>' . $station->station_profile_name . '</td>';
+                    echo '<td>' . $station->station_callsign . '</td>';
+                    echo '<td id ="modcount'.$station->station_id.'">' . $station->modcount . '</td>';
+                    echo '<td id ="notcount'.$station->station_id.'">' . $station->notcount . '</td>';
+                    echo '<td id ="totcount'.$station->station_id.'">' . $station->totcount . '</td>';
+                    echo '<td><button id="qrzcallUpload" type="button" name="qrzcallUpload" class="btn btn-primary btn-sm ld-ext-right ld-ext-right-'.$station->station_id.'" onclick="ExportQrzcall('. $station->station_id .')"><i class="fas fa-cloud-upload-alt"></i> ' . __("Upload") . '<div class="ld ld-ring ld-spin"></div></button></td>';
+                    echo '</tr>';
+                }
+                echo '</tbody></table>';
+
+        }
+        else {
+        echo '<div class="alert alert-danger" role="alert">' . __("Nothing found!") . '</div>';
+        }
+        ?>
+
+        </div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -315,6 +315,32 @@ if ($dxcc_list->result() > 0) {
 				</div>
 			</div>
 		</div>
+
+		<!-- QRZCALL.EU -->
+		<div class="col-md">
+			<div class="card">
+				<h5 class="card-header">QRZCALL.EU <span class="badge text-bg-warning"> <?= __("Subscription Required"); ?></span></h5> <!-- "QRZCALL.EU" does not need Multilanguage Support -->
+				<div class="card-body">
+					<div class="mb-3">
+						<label for="qrzcallApiKey"><?= __("QRZCALL.EU API Token"); ?></label>
+						<div class="input-group">
+							<input type="text" class="form-control" name="qrzcallapikey" placeholder="pat_…" id="qrzcallApiKey" aria-describedby="qrzcallApiKeyHelp" value="<?php if(isset($qrzcallapikey)) { echo $qrzcallapikey; } ?>">
+							<button class="btn btn-secondary" type="button" id="qrzcall_apitest_btn"><?= __("Test API-Token"); ?></button>
+						</div>
+						<div class="alert mt-3" style="display: none;" id="qrzcall_apitest_msg"></div>
+						<small id="qrzcallApiKeyHelp" class="form-text text-muted"><?= sprintf(_pgettext("the QRZCALL.EU API Tokens page", "Find your API token on %s"), "<a href='https://qrzcall.eu/' target='_blank'>".__("the QRZCALL.EU API Tokens page")."</a>"); ?></small>
+					</div>
+					<div class="mb-3">
+						<label for="qrzcallrealtime"><?= __("QRZCALL.EU Logbook Upload"); ?></label>
+						<select class="form-select" id="qrzcallrealtime" name="qrzcallrealtime">
+							<option value="-1" <?php if (!isset($qrzcallrealtime) || ($qrzcallrealtime != 1 && $qrzcallrealtime != 0)) { echo ' selected'; } ?>><?= __("Disabled"); ?></option>
+							<option value="1" <?php if (isset($qrzcallrealtime) && $qrzcallrealtime == 1) { echo ' selected'; } ?>><?= __("Realtime"); ?></option>
+							<option value="0" <?php if (isset($qrzcallrealtime) && $qrzcallrealtime == 0) { echo ' selected'; } ?>><?= __("Enabled"); ?></option>
+						</select>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 
 	<div class="row">

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -341,6 +341,33 @@ if ($dxcc_list->result() > 0) {
 				</div>
 			</div>
 		</div>
+
+		<!-- QRZCALL.EU -->
+		<div class="col-md">
+			<div class="card">
+				<h5 class="card-header">QRZCALL.EU <span class="badge text-bg-warning"> <?= __("Subscription Required"); ?></span></h5> <!-- "QRZCALL.EU" does not need Multilanguage Support -->
+				<div class="card-body">
+					<div class="mb-3">
+						<label for="qrzcallApiKey"><?= __("QRZCALL.EU API Token"); ?></label>
+						<div class="input-group">
+							<input type="password" class="form-control" name="qrzcallapikey" placeholder="pat_…" id="qrzcallApiKey" aria-describedby="qrzcallApiKeyHelp" value="<?php if(set_value('qrzcallapikey') != "") { echo set_value('qrzcallapikey'); } else { echo $my_station_profile->qrzcallapikey; } ?>">
+							<span class="input-group-btn"><button class="btn btn-default btn-pwd-showhide" type="button"><i class="fa fa-eye-slash"></i></button></span>
+							<button class="btn btn-secondary" type="button" id="qrzcall_apitest_btn"><?= __("Test API-Token"); ?></button>
+						</div>
+						<div class="alert mt-3" style="display: none;" id="qrzcall_apitest_msg"></div>
+						<small id="qrzcallApiKeyHelp" class="form-text text-muted"><?= sprintf(_pgettext("the QRZCALL.EU API Tokens page", "Find your API token on %s"), "<a href='https://qrzcall.eu/' target='_blank'>".__("the QRZCALL.EU API Tokens page")."</a>"); ?></small>
+					</div>
+					<div class="mb-3">
+						<label for="qrzcallrealtime"><?= __("QRZCALL.EU Logbook Upload"); ?></label>
+						<select class="form-select" id="qrzcallrealtime" name="qrzcallrealtime">
+							<option value="-1" <?php if ($my_station_profile->qrzcallrealtime == -1) { echo ' selected'; } ?>><?= __("Disabled"); ?></option>
+							<option value="1" <?php if ($my_station_profile->qrzcallrealtime == 1) { echo ' selected'; } ?>><?= __("Realtime"); ?></option>
+							<option value="0" <?php if ($my_station_profile->qrzcallrealtime == 0) { echo ' selected'; } ?>><?= __("Enabled"); ?></option>
+						</select>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 
 	<div class="row">

--- a/assets/js/sections/qrzcalllogbook.js
+++ b/assets/js/sections/qrzcalllogbook.js
@@ -1,0 +1,49 @@
+function ExportQrzcall(station_id) {
+	if ($(".alert").length > 0) {
+		$(".alert").remove();
+	}
+	if ($(".errormessages").length > 0) {
+		$(".errormessages").remove();
+	}
+	$(".ld-ext-right-"+station_id).addClass('running');
+	$(".ld-ext-right-"+station_id).prop('disabled', true);
+
+	$.ajax({
+		url: base_url + 'index.php/qrzcallupload/upload_station',
+		type: 'post',
+		data: {'station_id': station_id},
+		success: function (data) {
+			$(".ld-ext-right-"+station_id).removeClass('running');
+			$(".ld-ext-right-"+station_id).prop('disabled', false);
+			if (data.status == 'OK') {
+				$.each(data.info, function(index, value){
+					$('#modcount'+value.station_id).html(value.modcount);
+					$('#notcount'+value.station_id).html(value.notcount);
+					$('#totcount'+value.station_id).html(value.totcount);
+				});
+				$(".card-body").append('<div class="alert alert-success" role="alert">' + data.infomessage + '</div>');
+			}
+			else {
+				$(".card-body").append('<div class="alert alert-danger" role="alert">' + data.info + '</div>');
+			}
+
+			if (data.hasOwnProperty("errormessages") && data.errormessages.length > 0) {
+				$("#qrzcall_export").append(
+					'<div class="errormessages">\n' +
+					'    <div class="card mt-2">\n' +
+					'        <div class="card-header bg-danger">\n' +
+					'            Error Message\n' +
+					'        </div>\n' +
+					'        <div class="card-body">\n' +
+					'            <div class="errors"></div>\n' +
+					'        </div>\n' +
+					'    </div>\n' +
+					'</div>'
+				);
+				$.each(data.errormessages, function (index, value) {
+					$(".errors").append('<li>' + value);
+				});
+			}
+		}
+	});
+}

--- a/assets/js/sections/station_locations.js
+++ b/assets/js/sections/station_locations.js
@@ -102,6 +102,40 @@ $(document).ready(function () {
 				},
 			});
 		});
+
+		$('#qrzcall_apitest_btn').click(function(){
+
+			var apikey = $('#qrzcallApiKey').val();
+			var msg_div = $('#qrzcall_apitest_msg');
+
+			msg_div.hide();
+			msg_div.removeClass('alert-success alert-danger')
+
+			$.ajax({
+				url: base_url+'index.php/qrzcallupload/qrzcall_apitest',
+				type: 'POST',
+				data: {
+					'APIKEY': apikey
+				},
+				success: function(res) {
+					if(res.status == 'OK') {
+						msg_div.addClass('alert-success');
+						msg_div.text('Your API Token works. You are good to go!');
+						msg_div.show();
+					} else {
+						msg_div.addClass('alert-danger');
+						msg_div.text('Your API Token failed. Are you sure you have a valid QRZCALL.EU Data or Extra subscription?');
+						msg_div.show();
+						$('#qrzcallrealtime').val(-1);
+					}
+				},
+				error: function(res) {
+					msg_div.addClass('alert-danger');
+					msg_div.text('ERROR: Something went wrong on serverside. We\'re sorry..');
+					msg_div.show();
+				},
+			});
+		});
 	}
 });
 


### PR DESCRIPTION
## What this adds

QSO **upload** to [QRZCALL.EU](https://qrzcall.eu/), mirroring Wavelog's
existing QRZ.com Logbook upload. Wavelog already has QRZCALL.EU as a
**callbook lookup** provider (merged in #3233); this adds the **write** side.

QRZCALL.EU exposes a QRZ-compatible logbook endpoint
(`POST https://api.qrzcall.eu/v1/pub/logbook_api.php`,
`KEY=pat_…&ACTION=INSERT|STATUS&ADIF=…&OPTION=REPLACE`), so the implementation
is a close mirror of the QRZ.com code path. Upload only — QRZCALL.EU has no
QSL download, so there is no Download/Mark tab.

### Behaviour
- New **QRZCALL.EU** card on the Station Profile (create + edit): an API
  **token** field (`qrzcallapikey`, a QRZCALL.EU Personal Access Token
  `pat_…`), a **Test API-Token** button, and a Disabled/Enabled/Realtime
  selector (`qrzcallrealtime`) — same shape as the QRZ.com card.
- **Tools → QRZCALL.EU Logbook**: per-station upload page with a manual
  Upload button (mirrors the QRZ Logbook page, Upload tab only).
- **Realtime** upload on QSO log; an edited QSO is re-uploaded with
  `OPTION=REPLACE`. A background cron (`qrzcall_upload`, disabled by default)
  mirrors the QRZ cron.
- A duplicate already in the QRZCALL.EU logbook is treated as success.

### Files
- `application/migrations/279_add_qrzcall_logbook_upload.php` — adds
  `station_profile.qrzcallapikey` / `qrzcallrealtime`,
  `COL_QRZCALL_QSO_UPLOAD_DATE` / `_STATUS`, and the `qrzcall_upload` cron row.
- `application/controllers/Qrzcallupload.php` — upload page + manual/cron
  upload + `qrzcall_apitest`. (Named `Qrzcallupload` to avoid clashing with
  the existing `libraries/Qrzcall.php` callbook class.)
- `application/views/qrzcall/export.php`, `assets/js/sections/qrzcalllogbook.js`
- `application/models/Logbook_model.php` — `push_qso_to_qrzcall`,
  `get_qrzcall_qsos`, `mark_qrzcall_qsos_sent`, `set_qrzcall_modified`,
  `exists_qrzcall_api_key`, `get_station_id_with_qrzcall_api`; realtime hook
  in `create()`, re-upload marking in `edit()` / `paperqsl_*`.
- `application/models/Stations.php`, `station_profile/{create,edit}.php`,
  `assets/js/sections/station_locations.js`,
  `interface_assets/{header,footer}.php`.

A QRZCALL.EU Personal Access Token requires a Data or Extra subscription;
the help-text link keeps the URL out of the translatable string via
`sprintf()`.

### Testing
Built on a Wavelog `dev` checkout in Docker:
- Migration reaches version 279; the four columns and the cron row are created.
- Test API-Token returns OK against the live endpoint.
- Manual upload of pending QSOs → they appear in the QRZCALL.EU logbook;
  re-upload of a duplicate is handled; an edited QSO re-uploads via
  `OPTION=REPLACE`.
- `php -l` clean on all changed/added PHP files.