### PR TITLE
add support for commented CBR files in CBR import

### DIFF
--- a/application/libraries/Cbr_parser.php
+++ b/application/libraries/Cbr_parser.php
@@ -28,6 +28,11 @@ class CBR_Parser
         //loop through each line
         foreach ($lines as $line) {
 
+            //if we encounter a line starting with "#", skip that line as comment
+            if (substr(ltrim($line), 0, 1) === '#') {
+                continue;
+            }
+
             //if we encounter "QSO" or "X-QSO" switch processing mode to QSO mode
             if (strpos($line, 'QSO:') === 0 or strpos($line, 'X-QSO:') === 0) {
                 $qso_mode = true;


### PR DESCRIPTION
Some programs create commented CBR files (like fldigi in some circumstances).
With this PR, the parser now skips these lines completely instead of treating them like a header.