### PR TITLE
Fix clearing QSL_SENT_VIA when marking selected QSOs

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -865,14 +865,18 @@ class Logbookadvanced_model extends CI_Model {
 				SET
 				COL_QSLSDATE = CURRENT_TIMESTAMP,
 				COL_QSL_SENT = ?,
-				COL_QSL_SENT_VIA = ?,
+				COL_QSL_SENT_VIA = COALESCE(
+					NULLIF(?, ''),
+					NULLIF(COL_QSL_SENT_VIA, ''),
+					'B'
+				),
 				COL_QRZCOM_QSO_UPLOAD_STATUS = CASE
-				WHEN COL_QRZCOM_QSO_UPLOAD_STATUS IN ('Y', 'I') THEN 'M'
-				ELSE COL_QRZCOM_QSO_UPLOAD_STATUS
+					WHEN COL_QRZCOM_QSO_UPLOAD_STATUS IN ('Y', 'I') THEN 'M'
+					ELSE COL_QRZCOM_QSO_UPLOAD_STATUS
 				END
 				WHERE COL_PRIMARY_KEY IN (".implode(',', $sanitized_ids).")";
 			$binding[] = $sent;
-			$binding[] = $method;
+			$binding[] = $method ?? '';
 			$this->db->query($sql, $binding);
 
 			return array('message' => 'OK');


### PR DESCRIPTION
Previously, in page qslprint, button "Mark selected QSOs as sent" clears the `QSL_SENT_VIA` filed wrongly.

This patch fixes this issue.

To be detailed, the calling procedure is:
1. button "Mark selected QSOs as sent"
2. javascript function `markSelectedQsos()`
3. function `update_qsl()` in controller `logbookadvanced`
4. function `updateQsl()` in model `Logbookadvanced_model`

As `update_qsl()` is also used by other buttons, `updateQsl()` now will choose a non-empty value for `QSL_SENT_VIA` as below:
1. the value provided by the caller
2. the existing value in database
3. default value 'B'

This fallback to 'B' is same as "Mark requested QSLs as sent" button.