### PR TITLE
Oqrs fix invalid slug

### DIFF
--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -61,8 +61,8 @@ class Oqrs extends CI_Controller {
 			$data['disable_oqrs'] = $this->config->item('disable_oqrs');
 			$data['stations'] = $this->oqrs_model->get_oqrs_stations($data['userid']);
 			$data['page_title'] = __("Log Search & OQRS");
-			$data['global_oqrs_text'] = $this->user_options_model->get_options('oqrs',array('option_name'=>'global_oqrs_text','option_key'=>'text'))->row()->option_value ?? '';
-			$data['groupedSearch'] = $this->user_options_model->get_options('oqrs',array('option_name'=>'oqrs_grouped_search','option_key'=>'boolean'), $data['userid'])->row()->option_value;
+			$data['global_oqrs_text'] = $this->user_options_model->get_options('oqrs',array('option_name'=>'global_oqrs_text','option_key'=>'text'))->row()?->option_value ?? '';
+			$data['groupedSearch'] = $this->user_options_model->get_options('oqrs',array('option_name'=>'oqrs_grouped_search','option_key'=>'boolean'), $data['userid'])->row()?->option_value ?? false;
 		}
 
 		$this->load->view('visitor/layout/header', $data);
@@ -107,7 +107,7 @@ class Oqrs extends CI_Controller {
 		$data['disable_oqrs'] = $this->config->item('disable_oqrs');
 		$data['oqrs_enabled'] = $this->oqrs_model->oqrs_enabled($slug);
 		$data['public_search_enabled'] = $this->publicsearch->public_search_enabled($slug);
-		$data['groupedSearchShowStationName'] = $this->user_options_model->get_options('oqrs',array('option_name'=>'oqrs_grouped_search_show_station_name','option_key'=>'boolean'), $userid)->row()->option_value;
+		$data['groupedSearchShowStationName'] = $this->user_options_model->get_options('oqrs',array('option_name'=>'oqrs_grouped_search_show_station_name','option_key'=>'boolean'), $userid)->row()?->option_value ?? false;
 
 		$data['result'] = $this->oqrs_model->getQueryDataGrouped($this->input->post('callsign', TRUE), $userid);
 		$data['callsign'] = $this->input->post('callsign', TRUE);
@@ -115,7 +115,7 @@ class Oqrs extends CI_Controller {
 		$data['slug'] = $this->input->post('slug', TRUE);
 		$data['oqrs_delivery_method'] = $this->user_options_model
 			->get_options('oqrs', array('option_name' => 'oqrs_delivery_method', 'option_key' => 'setting'), $userid)
-			->row()->option_value ?? 'both';
+			->row()?->option_value ?? 'both';
 
 		if($this->input->post('widget') != 'true') {
 			$this->load->view('oqrs/request_grouped', $data);
@@ -163,7 +163,7 @@ class Oqrs extends CI_Controller {
 		$owner_id = $this->oqrs_model->get_user_id_for_station($station_id);
 		$data['oqrs_delivery_method'] = $this->user_options_model
 			->get_options('oqrs', array('option_name' => 'oqrs_delivery_method', 'option_key' => 'setting'), $owner_id)
-			->row()->option_value ?? 'both';
+			->row()?->option_value ?? 'both';
 
 		$this->load->view('oqrs/request', $data);
 	}

--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -104,6 +104,10 @@ class Oqrs extends CI_Controller {
 
 		$slug = $this->input->post('slug', TRUE);
 		$userid = $this->publicsearch->get_userid_for_slug($slug);
+		if ($userid === null) {
+			echo __("Invalid station slug");
+			return;
+		}
 		$data['disable_oqrs'] = $this->config->item('disable_oqrs');
 		$data['oqrs_enabled'] = $this->oqrs_model->oqrs_enabled($slug);
 		$data['public_search_enabled'] = $this->publicsearch->public_search_enabled($slug);

--- a/application/models/Publicsearch.php
+++ b/application/models/Publicsearch.php
@@ -24,7 +24,8 @@ class Publicsearch extends CI_Model {
 	function get_userid_for_slug($slug) {
 		$sql = "SELECT user_id FROM station_logbooks WHERE public_slug = ?";
 		$query = $this->db->query($sql, array($slug));
-		return $query->result_array()[0]['user_id'];
+		$row = $query->result_array();
+		return $row ? $row[0]['user_id'] : null;
 	}
 
 	function public_search_enabled($slug) {
@@ -32,7 +33,8 @@ class Publicsearch extends CI_Model {
 			$sql = "SELECT public_search FROM station_logbooks WHERE public_slug = ?";
 			$query = $this->db->query($sql, array($slug));
 
-			if ($query->result_array()[0]['public_search'] == 1) {
+			$result = $query->result_array();
+			if (!empty($result) && $result[0]['public_search'] == 1) {
 				return true;
 			}
 		}

--- a/application/views/oqrs/index.php
+++ b/application/views/oqrs/index.php
@@ -22,7 +22,7 @@
 				} else {
 					$callsign_value = '';
 				}
-				if ($stations->result()) {
+				if ($stations && $stations->result()) {
 					if ($groupedSearch == 'on') {
 						echo __("This search will search in all station locations where OQRS is active.").'<br /><br /><form class="d-flex align-items-center" onsubmit="return false;"><label class="my-1 me-2" for="oqrssearch">' . __("Enter your callsign") . ': </label>
 						<input class="form-control me-sm-2 w-auto" id="oqrssearch" type="search" name="callsign" placeholder="' . __("Search Callsign") . '" aria-label="Search" '.$callsign_value.' required="required">


### PR DESCRIPTION
when calling an invalid slug (e.g. wavelog.url/oqrs/doesntexist) there are PHP-warnings, because of not catched null-values.

this one fixes it.
