### PR TITLE
[QSL Queue] Add qsl information, fix delete bug

### DIFF
--- a/application/controllers/Qslprint.php
+++ b/application/controllers/Qslprint.php
@@ -168,38 +168,38 @@ class QSLPrint extends CI_Controller {
 	}
 
 	public function delete_from_qsl_queue() {
-		$id = $this->input->post('id');
+		$id = $this->input->post('id', true);
 		$this->load->model('qslprint_model');
 
-		$this->qslprint_model->delete_from_qsl_queue($this->security->xss_clean($id));
+		$this->qslprint_model->delete_from_qsl_queue($id);
 	}
 
 	public function get_qsos_for_print_ajax() {
-		$station_id = $this->input->post('station_id');
+		$station_id = $this->input->post('station_id', true);
 		$this->load->model('qslprint_model');
 
-		$data['qsos'] = $this->qslprint_model->get_qsos_for_print_ajax($this->security->xss_clean($station_id));
+		$data['qsos'] = $this->qslprint_model->get_qsos_for_print_ajax($station_id);
 		$data['station_id'] = $station_id;
 		$this->load->view('qslprint/qslprint', $data);
 	}
 
 	public function open_qso_list() {
-		$callsign = $this->input->post('callsign');
+		$callsign = $this->input->post('callsign', true);
 		$this->load->model('qslprint_model');
 
-		$data['qsos'] = $this->qslprint_model->open_qso_list($this->security->xss_clean($callsign));
+		$data['qsos'] = $this->qslprint_model->open_qso_list($callsign);
 		$this->load->view('qslprint/qsolist', $data);
 	}
 
 	public function add_qso_to_print_queue() {
-		$id = $this->input->post('id');
+		$id = $this->input->post('id', true);
 		$this->load->model('qslprint_model');
 
-		$this->qslprint_model->add_qso_to_print_queue($this->security->xss_clean($id));
+		$this->qslprint_model->add_qso_to_print_queue($id);
 	}
 
 	public function show_oqrs() {
-		$id = $this->security->xss_clean($this->input->post('id'));
+		$id = $this->input->post('id', true);
 
 		$this->load->model('qslprint_model');
 
@@ -207,17 +207,4 @@ class QSLPrint extends CI_Controller {
 		$this->load->view('oqrs/showoqrs', $data);
 	}
 
-	public function get_previous_qsl() {
-		$id = $this->security->xss_clean($this->input->post('id'));
-
-		$this->load->model('qslprint_model');
-
-		$number_qsls = $this->qslprint_model->get_previous_qsls($id);
-		header('Content-Type: application/json');
-		echo json_encode($number_qsls);
-	}
-
 }
-
-/* End of file Qslprint.php */
-/* Location: ./application/controllers/Qslprint.php */

--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -68,20 +68,25 @@ class Qslprint_model extends CI_Model {
 	 * It will be provided when calling the function when the dropdown is changed and the javascript fires
 	 */
 	function get_qsos_for_print($station_id = 'All') {
-		$binding=[];
-		$binding[]=$this->session->userdata('user_id');
-		$sql="SELECT count(distinct oldlog.col_primary_key) as previous_qsl, log.COL_QSL_SENT, log.COL_PRIMARY_KEY, log.COL_DXCC, log.COL_CALL, log.COL_SAT_NAME, log.COL_SAT_MODE, log.COL_BAND_RX, log.COL_FREQ as frequency, log.COL_FREQ_RX as frequency_rx, log.COL_TIME_ON, log.COL_MODE, log.COL_RST_SENT, log.COL_RST_RCVD, log.COL_QSL_VIA, log.COL_QSL_SENT_VIA, log.COL_SUBMODE, log.COL_BAND, sp.station_id, sp.station_callsign, sp.station_profile_name, o.qsoid
+		$binding = [];
+		$binding[] = $this->session->userdata('user_id');
+		$sql = "SELECT count(distinct oldlog.col_primary_key) as previous_qsl,
+			count(distinct sentlog.col_primary_key) as qsl_sent_to_call,
+			count(distinct rcvdlog.col_primary_key) as qsl_rcvd_from_call,
+			log.COL_QSL_SENT, log.COL_PRIMARY_KEY, log.COL_DXCC, log.COL_CALL, log.COL_SAT_NAME, log.COL_SAT_MODE, log.COL_BAND_RX, log.COL_FREQ as frequency, log.COL_FREQ_RX as frequency_rx, log.COL_TIME_ON, log.COL_MODE, log.COL_RST_SENT, log.COL_RST_RCVD, log.COL_QSL_VIA, log.COL_QSL_SENT_VIA, log.COL_SUBMODE, log.COL_BAND, sp.station_id, sp.station_callsign, sp.station_profile_name, o.qsoid
 			FROM ".$this->config->item('table_name')." log
 			INNER JOIN station_profile sp ON sp.`station_id` = log.`station_id`
 			LEFT OUTER JOIN oqrs o ON o.`qsoid` = log.`COL_PRIMARY_KEY`
-			LEFT OUTER JOIN ".$this->config->item('table_name')." oldlog on (oldlog.COL_QSL_SENT = 'Y' and oldlog.station_id=sp.station_id and oldlog.COL_BAND=log.col_band and oldlog.COL_CALL=log.col_call and oldlog.COL_MODE=log.col_mode and oldlog.COL_SAT_NAME=log.col_sat_name and oldlog.COL_PRIMARY_KEY!=log.col_primary_key)
+			LEFT OUTER JOIN ".$this->config->item('table_name')." oldlog on (oldlog.COL_QSL_SENT = 'Y' and oldlog.station_id=sp.station_id and oldlog.COL_BAND=log.col_band and oldlog.COL_CALL=log.col_call and oldlog.COL_MODE=log.col_mode and oldlog.COL_SAT_NAME=log.col_sat_name and oldlog.COL_PRIMARY_KEY != log.col_primary_key)
+			LEFT OUTER JOIN ".$this->config->item('table_name')." sentlog on (sentlog.COL_QSL_SENT = 'Y' and sentlog.station_id=sp.station_id and sentlog.COL_CALL=log.col_call)
+			LEFT OUTER JOIN ".$this->config->item('table_name')." rcvdlog on (rcvdlog.COL_QSL_RCVD = 'Y' and rcvdlog.station_id=sp.station_id and rcvdlog.COL_CALL=log.col_call)
 			WHERE sp.`user_id` = ?";
 		if ($station_id != 'All') {
-			$sql.=' AND log.`station_id` = ?';
-			$binding[]=$station_id;
+			$sql .= ' AND log.`station_id` = ?';
+			$binding[] = $station_id;
 		}
-		$sql.=" AND log.`COL_QSL_SENT` IN('R', 'Q')
-			GROUP BY log.col_primary_key
+		$sql .= " AND log.`COL_QSL_SENT` IN('R', 'Q')
+			GROUP BY log.col_primary_key, log.COL_QSL_SENT, log.COL_PRIMARY_KEY, log.COL_DXCC, log.COL_CALL, log.COL_SAT_NAME, log.COL_SAT_MODE, log.COL_BAND_RX, log.COL_FREQ, log.COL_FREQ_RX, log.COL_TIME_ON, log.COL_MODE, log.COL_RST_SENT, log.COL_RST_RCVD, log.COL_QSL_VIA, log.COL_QSL_SENT_VIA, log.COL_SUBMODE, log.COL_BAND, sp.station_id, sp.station_callsign, sp.station_profile_name, o.qsoid
 			ORDER BY log.`COL_DXCC` ASC, log.`COL_CALL` ASC, log.`COL_SAT_NAME` ASC, log.`COL_SAT_MODE` ASC, log.`COL_BAND_RX` ASC, log.`COL_TIME_ON` ASC, log.`COL_MODE` ASC LIMIT 1000";
 
 		$query = $this->db->query($sql, $binding);
@@ -133,20 +138,30 @@ class Qslprint_model extends CI_Model {
 	}
 
 	function open_qso_list($callsign) {
-		$this->db->join('station_profile', 'station_profile.station_id = '.$this->config->item('table_name').'.station_id');
-		// always filter user. this ensures that no inaccesible QSOs will be returned
-		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
-		$this->db->where('(COL_CALL like "%/'.$callsign.'/%" OR COL_CALL like "%/'.$callsign.'" OR COL_CALL like "'.$callsign.'/%" OR COL_CALL = "'.$callsign.'")');
-		$this->db->where('coalesce(COL_QSL_SENT, "") not in ("R", "Q")');
-		$this->db->order_by("COL_DXCC", "ASC");
-		$this->db->order_by("COL_CALL", "ASC");
-		$this->db->order_by("COL_SAT_NAME", "ASC");
-		$this->db->order_by("COL_SAT_MODE", "ASC");
-		$this->db->order_by("COL_BAND_RX", "ASC");
-		$this->db->order_by("COL_TIME_ON", "ASC");
-		$this->db->order_by("COL_MODE", "ASC");
-		$query = $this->db->get($this->config->item('table_name'));
+		$binding = [];
 
+		$sql = "SELECT log.COL_QSL_SENT, log.COL_QSLRDATE, log.COL_QSL_RCVD, log.COL_QSL_RCVD_VIA, log.COL_QSLSDATE, log.COL_QSL_VIA, log.COL_QSL_SENT_VIA,
+			log.COL_LOTW_QSL_SENT, log.COL_LOTW_QSLSDATE, log.COL_LOTW_QSL_RCVD, log.COL_LOTW_QSLRDATE,
+			log.COL_PRIMARY_KEY, log.COL_DXCC, log.COL_CALL, log.COL_SAT_NAME, log.COL_SAT_MODE, log.COL_BAND_RX, log.COL_FREQ,
+			log.COL_FREQ_RX, log.COL_TIME_ON, log.COL_MODE, log.COL_RST_SENT, log.COL_RST_RCVD,
+			log.COL_SUBMODE, log.COL_BAND, sp.station_id, sp.station_callsign, sp.station_profile_name,
+			(SELECT COUNT(*) FROM ".$this->config->item('table_name')." sentlog WHERE sentlog.COL_QSL_SENT = 'Y' AND sentlog.station_id = log.station_id AND sentlog.COL_CALL = log.COL_CALL) as qsl_sent_to_call,
+			(SELECT COUNT(*) FROM ".$this->config->item('table_name')." rcvdlog WHERE rcvdlog.COL_QSL_RCVD = 'Y' AND rcvdlog.station_id = log.station_id AND rcvdlog.COL_CALL = log.COL_CALL) as qsl_rcvd_from_call,
+			(SELECT COUNT(*) FROM ".$this->config->item('table_name')." prevlog WHERE prevlog.COL_QSL_SENT = 'Y' AND prevlog.station_id = log.station_id AND prevlog.COL_BAND = log.COL_BAND AND prevlog.COL_CALL = log.COL_CALL AND prevlog.COL_MODE = log.COL_MODE AND COALESCE(prevlog.COL_SAT_NAME, '') = COALESCE(log.COL_SAT_NAME, '') AND prevlog.COL_PRIMARY_KEY != log.COL_PRIMARY_KEY) as previous_qsl
+			FROM ".$this->config->item('table_name')." log
+			JOIN station_profile sp ON sp.`station_id` = log.`station_id`
+			WHERE sp.`user_id` = ?
+			AND (log.COL_CALL like ? OR log.COL_CALL like ? OR log.COL_CALL like ? OR log.COL_CALL = ?)
+			AND coalesce(log.COL_QSL_SENT, '') not in ('R', 'Q')
+			ORDER BY log.`COL_DXCC` ASC, log.`COL_CALL` ASC, log.`COL_SAT_NAME` ASC, log.`COL_SAT_MODE` ASC, log.`COL_BAND_RX` ASC, log.`COL_TIME_ON` ASC, log.`COL_MODE` ASC LIMIT 1000";
+
+		$binding[] = $this->session->userdata('user_id');
+		$binding[] = "%/".$callsign."/%";
+		$binding[] = "%/".$callsign;
+		$binding[] = $callsign."/%";
+		$binding[] = $callsign;
+
+		$query = $this->db->query($sql, $binding);
 		return $query;
 	}
 

--- a/application/models/Qslprint_model.php
+++ b/application/models/Qslprint_model.php
@@ -165,26 +165,6 @@ class Qslprint_model extends CI_Model {
 		return $query;
 	}
 
-	function get_previous_qsls($qso_id) {
-		if (empty($qso_id)) {
-			return 0;
-		}
-
-		$table_name = $this->config->item('table_name');
-		$sql = "SELECT COUNT(COL_PRIMARY_KEY) AS previous_qsl
-				FROM $table_name
-				WHERE COL_QSL_SENT = 'Y'
-				AND station_id = (SELECT station_id FROM $table_name WHERE COL_PRIMARY_KEY = ?)
-				AND (COL_CALL, COL_MODE, COL_BAND, COALESCE(COL_SAT_NAME, '')) =
-					(SELECT COL_CALL, COL_MODE, COL_BAND, COALESCE(COL_SAT_NAME, '')
-					 FROM $table_name
-					 WHERE COL_PRIMARY_KEY = ?)
-				GROUP BY COL_CALL, COL_MODE, COL_BAND, COL_SAT_NAME";
-
-		// we only return the count of previous QSLs as an integer
-		return (int) ($this->db->query($sql, [$qso_id, $qso_id])->row()->previous_qsl ?? 0);
-	}
-
 	function show_oqrs($id) {
 		$this->db->select('requesttime as "Request time", requestcallsign as "Requester", email as "Email", note as "Note"');
 		$this->db->join('station_profile', 'station_profile.station_id = oqrs.station_id');

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -16,9 +16,10 @@
 	    <?= __("Export Requested QSLs for Printing"); ?>
 	  </div>
 		<div class="card-body">
-			<form class="form" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
-				<label for="station_profile" class="me-2"><?= __("Station Location"); ?>:</label>	
-				<select name="station_profile" class="station_id form-select mb-3 me-sm-3" style="width: 20%;">
+			<div class="row">
+			<form class="form col-md-6 col-lg-4 col-xl-4 col-xxl-2" action="<?php echo site_url('adif/import'); ?>" method="post" enctype="multipart/form-data">
+				<label for="station_profile" class="me-2"><?= __("Station Location"); ?>:</label>
+				<select name="station_profile" class="station_id form-select">
 					<option value="All"><?= __("All"); ?></option>
 					<?php foreach ($station_profile->result() as $station) { ?>
 						<option <?php if ($station->station_id == $station_id) { echo "selected "; } ?>value="<?php echo $station->station_id; ?>"><?= __("Callsign"); ?>: <?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>
@@ -27,13 +28,14 @@
 			</form>
 
 			<!-- Switch Band or Frequency display -->
-			<div>
+			<div class="col-md-6 col-lg-4 col-xl-4 col-xxl-2">
 				<label for="frequency_or_band" class="me-2"><?= __("Show Band or Frequency:"); ?></label>
-  				<select id="frequency_or_band" class="form-select mb-3 me-sm-3" style="width: 20%;">
+				<select id="frequency_or_band" class="form-select">
 					<option value="band" selected><?= __("Band"); ?></option>
 					<option value="frequency"><?= __("Frequency"); ?></option>
 					<option value="both"><?= __("Band & Frequency"); ?></option>
 				</select>
+			</div>
 			</div>
 
 	    <p class="card-text"><?= __("Here you can export requested QSLs as CSV or ADIF files for printing and, optionally, mark them as sent."); ?></p>
@@ -43,9 +45,9 @@
 		</p>
 
 		<div class="resulttable">
-		<?php 
+		<?php
 			$data2['qsos'] = $qsos;
-			$this->load->view('qslprint/qslprint', $data2); 
+			$this->load->view('qslprint/qslprint', $data2);
 		?>
 			</div>
 		</div>

--- a/application/views/qslprint/qslprint.php
+++ b/application/views/qslprint/qslprint.php
@@ -13,32 +13,7 @@ if (empty($station_id)) {
 	$station_id = 'all';
 }
 
-if ($qsos->result() != NULL) {
-        echo '<div style="padding-top: 10px; margin-top: 0px;" class="container logbook mb-4">';
-	echo '<table style="width:100%" class="table table-sm table-bordered table-hover table-striped table-condensed qslprint" id="qslprint_table">
-<thead>
-<tr>
-<th style=\'text-align: center\'><div class="form-check" style="margin-top: -1.5em"><input class="form-check-input" type="checkbox" id="checkBoxAll" /></div></th>
-<th style=\'text-align: center\'>'.__("Callsign").'</th>
-<th style=\'text-align: center\'>' . __("Date") . '</th>
-<th style=\'text-align: center\'>'. __("Time") .'</th>
-<th style=\'text-align: center\'>' . __("Mode") . '</th>
-<th class=\'col-band\' style=\'text-align: center\'>' . __("Band") . '</th>
-<th class=\'col-freq\' style=\'text-align: center;display:none;\'>' . __("Frequency") . '</th>
-<th style=\'text-align: center\'>' . __("RST (S)") . '</th>
-<th style=\'text-align: center\'>' . __("RST (R)") . '</th>
-<th style=\'text-align: center\'>' . __("QSL") . ' ' . __("Via") . '</th>
-<th style=\'text-align: center\'>' . __("Station") . '</th>
-<th style=\'text-align: center\'>' . __("Profile name") . '</th>
-<th style=\'text-align: center\'>' . __("Send Method") . '</th>
-<th style=\'text-align: center\'>' . __("Previous QSL") . '</th>
-<th style=\'text-align: center\'>' . __("Mark as sent") . '</th>
-<th style=\'text-align: center\'>' . __("Remove") . '</th>
-<th style=\'text-align: center\'>' . __("QSO List") . '</th>
-</tr>
-</thead><tbody>';
-
-	// Get Date format
+// Get Date format
 	if($this->session->userdata('user_date_format')) {
 		// If Logged in and session exists
 		$custom_date_format = $this->session->userdata('user_date_format');
@@ -47,7 +22,33 @@ if ($qsos->result() != NULL) {
 		$custom_date_format = $this->config->item('qso_date_format');
 	}
 
-	foreach ($qsos->result() as $qsl) {
+if ($qsos->result() != NULL) { ?>
+		<table style="width:100%" class="table table-sm table-bordered table-hover table-striped table-condensed qslprint" id="qslprint_table">
+			<thead>
+				<tr>
+					<th style="text-align: center"><div class="form-check" style="margin-top: -1.5em"><input class="form-check-input" type="checkbox" id="checkBoxAll" /></div></th>
+					<th style='text-align: center'><?= __("Callsign") ?></th>
+					<th style='text-align: center'><?= __("Date") ?></th>
+					<th style='text-align: center'><?= __("Time") ?></th>
+					<th style='text-align: center'><?= __("Mode") ?></th>
+					<th class='col-band' style='text-align: center'><?= __("Band") ?></th>
+					<th class='col-freq' style='text-align: center;display:none;'><?= __("Frequency") ?></th>
+					<th style='text-align: center'><?= __("RST (S)") ?></th>
+					<th style='text-align: center'><?= __("RST (R)") ?></th>
+					<th style='text-align: center'><?= __("QSL") ?> <?= __("Via") ?></th>
+					<th style='text-align: center'><?= __("Station") ?></th>
+					<th style='text-align: center'><?= __("Profile name") ?></th>
+					<th style='text-align: center'><?= __("Send Method") ?></th>
+					<th style='text-align: center; white-space: nowrap;'><?= __("Previous QSL") ?></th>
+					<th style='text-align: center'><?= __("Mark as sent") ?></th>
+					<th style='text-align: center'><?= __("Remove") ?></th>
+					<th style='text-align: center'><?= __("QSO List") ?></th>
+				</tr>
+			</thead><tbody>
+
+
+
+	<?php foreach ($qsos->result() as $qsl) {
 		echo '<tr id="qslprint_'.$qsl->COL_PRIMARY_KEY.'">';
 		echo '<td style=\'text-align: center\'><div class="form-check"><input class="form-check-input" type="checkbox" /></div></td>';
                 ?><td style='text-align: center'><span class="qso_call"><a id="edit_qso" href="javascript:displayQso(<?php echo $qsl->COL_PRIMARY_KEY; ?>);"><?php echo str_replace("0","&Oslash;",strtoupper($qsl->COL_CALL)); ?></a><a target="_blank" href="https://www.qrz.com/db/<?php echo strtoupper($qsl->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/qrz.png" alt="Lookup <?php echo strtoupper($qsl->COL_CALL); ?> on QRZ.com"></a> <a target="_blank" href="https://www.hamqth.com/<?php echo strtoupper($qsl->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/hamqth.png" alt="Lookup <?php echo strtoupper($qsl->COL_CALL); ?> on HamQTH"></a> <a target="_blank" href="https://www.eqsl.cc/Member.cfm?<?php echo strtoupper($qsl->COL_CALL); ?>"><img width="16" height="16" src="<?php echo base_url(); ?>images/icons/eqsl.png" alt="Lookup <?php echo strtoupper($qsl->COL_CALL); ?> on eQSL.cc"></a></td><?php
@@ -62,23 +63,27 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\'><span class="badge text-bg-light">' . $qsl->station_callsign . '</span></td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->station_profile_name . '</span></td>';
 		echo '<td class=\'send-method\' style=\'text-align: center\'>'; echo_qsl_sent_via($qsl->COL_QSL_SENT_VIA); echo '</td>';
-		echo '<td style=\'text-align: center\'>'; if ($qsl->previous_qsl > 0 ) { echo '<span class="badge bg-warning">' . $qsl->previous_qsl . '</span>'; } else { echo '<span class="badge bg-success">0</span>'; } echo '</td>';
+		echo '<td style=\'text-align: center; white-space: nowrap;\'>';
+		echo '<span class="badge ' . ($qsl->previous_qsl > 0 ? 'bg-warning' : 'bg-success') . '" data-bs-toggle="tooltip" data-bs-title="' . __("Previous QSL sent (same band/mode)") . '">' . $qsl->previous_qsl . '</span> / ';
+		echo '<span class="badge bg-info" data-bs-toggle="tooltip" data-bs-title="' . __("QSL sent to callsign (total)") . '">' . $qsl->qsl_sent_to_call . '</span> / ';
+		echo '<span class="badge bg-info" data-bs-toggle="tooltip" data-bs-title="' . __("QSL received from callsign (total)") . '">' . $qsl->qsl_rcvd_from_call . '</span>';
+		echo '</td>';
 		echo '<td style=\'text-align: center\'><button onclick="mark_qsl_sent(\''.$qsl->COL_PRIMARY_KEY.'\', \''. $qsl->COL_QSL_SENT_VIA. '\')" class="btn btn-sm btn-success"><i class="fa fa-check"></i></button></td>';
 		echo '<td style=\'text-align: center\'><button onclick="deleteFromQslQueue(\''.$qsl->COL_PRIMARY_KEY.'\')" class="btn btn-sm btn-danger"><i class="fas fa-trash-alt"></i></button></td>';
 		echo '<td style=\'text-align: center\'><button onclick="openQsoList(\''.$qsl->COL_CALL.'\')" class="btn btn-sm btn-success"><i class="fas fa-search"></i></button></td>';
 		echo '</tr>';
 	}
-	echo '</tbody></table></div>';
+	echo '</tbody></table>';
 	?>
 
-	
+
 	<!-- all the buttons to manipulate QSOs -->
 	<p>
 		<div>
 			<label for="markqslmethod" class="me-2"><?= __("Mark QSOs for a certain QSL Method:"); ?></label>
 			<div class="d-flex align-items-center mb-3">
 				<select id="markqslmethod" class="form-select me-2" style="width: 20%;">
-				<option value="ALL" selected><?= __("All"); ?></option>	
+				<option value="ALL" selected><?= __("All"); ?></option>
 				<option value="B"><?= echo_qsl_sent_via("B") ?></option>
 				<option value="D"><?= echo_qsl_sent_via("D") ?></option>
 				<option value="E"><?= echo_qsl_sent_via("E") ?></option>
@@ -88,15 +93,15 @@ if ($qsos->result() != NULL) {
 			</div>
 		</div>
 	</p>
-	
+
 	<label class="me-2"><?= __("Update QSOs"); ?>:</label>
 	<p>
-		
+
 		<button onclick="markSelectedQsos();" title="<?= __("Mark selected QSOs as sent"); ?>" class="btn btn-success markallprinted"><?= __("Mark selected QSOs as sent"); ?></button>
 		<button onclick="removeSelectedQsos();" title="<?= __("Remove selected QSOs from the queue"); ?>" class="btn btn-danger removeall"><?= __("Remove selected QSOs from the queue"); ?></button>
 		<button onclick="exportSelectedQsos();" title="<?= __("Export selected QSOs to ADIF-file"); ?>" class="btn btn-primary exportselected"><?= __("Export selected QSOs to ADIF-file"); ?></button>
 	</p>
-	
+
 
 	<p>
 		<a href="<?php echo site_url('qslprint/exportcsv/' . $station_id); ?>" title="<?= __("Export CSV-file"); ?>" class="btn btn-primary"><?= __("Export requested QSLs to CSV-file"); ?></a>

--- a/application/views/qslprint/qsolist.php
+++ b/application/views/qslprint/qsolist.php
@@ -15,6 +15,7 @@ if ($qsos->result() != NULL) {
 	<th style=\'text-align: center\'>' . __("Profile name") . '</th>
 	<th style=\'text-align: center\'>' . __("QSL") . ' ' . __("Via") . '</th>
 	<th style=\'text-align: center\'>' . __("Send Method") . '</th>
+	<th style=\'text-align: center; white-space: nowrap;\'>' . __("Previous QSL") . '</th>
 	<th style=\'text-align: center\'>' . __("QSL") . '</th>';
 	if ($this->session->userdata('user_eqsl_name') != "") {
 		echo '<th style=\'text-align: center\'>' . __("eQSL") . '</th>';
@@ -65,6 +66,11 @@ if ($qsos->result() != NULL) {
 		echo '<td style=\'text-align: center\'>' . $qsl->station_profile_name . '</span></td>';
 		echo '<td style=\'text-align: center\'>' . $qsl->COL_QSL_VIA . '</td>';
 		echo '<td style=\'text-align: center\'>'; echo_qsl_sent_via($qsl->COL_QSL_SENT_VIA); echo '</td>';
+		echo '<td style=\'text-align: center; white-space: nowrap;\'>';
+		echo '<span class="badge ' . ($qsl->previous_qsl > 0 ? 'bg-warning' : 'bg-success') . '" data-bs-toggle="tooltip" data-bs-title="' . __("Previous QSL sent (same band/mode)") . '">' . $qsl->previous_qsl . '</span> / ';
+		echo '<span class="badge bg-info" data-bs-toggle="tooltip" data-bs-title="' . __("QSL sent to callsign (total)") . '">' . $qsl->qsl_sent_to_call . '</span> / ';
+		echo '<span class="badge bg-info" data-bs-toggle="tooltip" data-bs-title="' . __("QSL received from callsign (total)") . '">' . $qsl->qsl_rcvd_from_call . '</span>';
+		echo '</td>';
 		echo '<td style=\'text-align: center\' class="qsl">';
 		echo '<span ';
 		if ($qsl->COL_QSL_SENT != "N") {

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -50,21 +50,7 @@ function openQsoList(callsign) {
 }
 
 function addQsoToPrintQueue(id) {
-    $.ajax({
-		url: base_url + 'index.php/qslprint/get_previous_qsl',
-        type: 'post',
-        data: { 'id': id },
-        success: function(result) {
-            let prev_qsl = result;
-            let prev_qsl_html;
-
-            if (prev_qsl > 0) {
-                prev_qsl_html = '<span class="badge bg-warning">' + prev_qsl + '</span>';
-            } else {
-                prev_qsl_html = '<span class="badge bg-success">0</span>';
-            }
-
-            $.ajax({
+	$.ajax({
         url: base_url + 'index.php/qslprint/add_qso_to_print_queue',
         type: 'post',
 		data: {'id': id},
@@ -94,14 +80,12 @@ function addQsoToPrintQueue(id) {
                     line += '</a>';
                     line += '</span>';
                     line += '</td>';
-
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(1)").text()+'</td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(2)").text()+'</td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(3)").text()+'</td>';
 					if (freq_or_band === 'band') {
 						line += '<td class=\'col-band\' style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(4)").text()+'</td>';
 						line += '<td class=\'col-freq\' style=\'text-align: center; display:none;\'>'+$("#qsolist_"+id).find("td:eq(5)").text()+'</td>';
-
 					} else if (freq_or_band === 'frequency') {
 						line += '<td class=\'col-band\' style=\'text-align: center; display:none;\'>'+$("#qsolist_"+id).find("td:eq(4)").text()+'</td>';
 						line += '<td class=\'col-freq\' style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(5)").text()+'</td>';
@@ -115,6 +99,7 @@ function addQsoToPrintQueue(id) {
 					line += '<td style=\'text-align: center\'><span class="badge text-bg-light">'+$("#qsolist_"+id).find("td:eq(8)").text()+'</span></td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(9)").text()+'</td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(11)").text()+'</td>';
+					let prev_qsl_html = $("#qsolist_"+id).find("td:eq(12)").html();
 					line += '<td style=\'text-align: center; white-space: nowrap;\'>'+prev_qsl_html+'</td>';
 					line += '<td style=\'text-align: center\'><button onclick="mark_qsl_sent('+id+', \'B\')" class="btn btn-sm btn-success"><i class="fa fa-check"></i></button></td>';
 					line += '<td style=\'text-align: center\'><button onclick="deleteFromQslQueue('+id+')" class="btn btn-sm btn-danger"><i class="fas fa-trash-alt"></i></button></td></td>';
@@ -127,11 +112,6 @@ function addQsoToPrintQueue(id) {
 					console.error('Error adding QSO to print queue.');
 				}
             });
-        },
-        error: function() {
-            console.error('Error fetching previous QSL.');
-		}
-});
 }
 
 $(".station_id").change(function(){

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -51,6 +51,20 @@ function openQsoList(callsign) {
 
 function addQsoToPrintQueue(id) {
     $.ajax({
+		url: base_url + 'index.php/qslprint/get_previous_qsl',
+        type: 'post',
+        data: { 'id': id },
+        success: function(result) {
+            let prev_qsl = result;
+            let prev_qsl_html;
+
+            if (prev_qsl > 0) {
+                prev_qsl_html = '<span class="badge bg-warning">' + prev_qsl + '</span>';
+            } else {
+                prev_qsl_html = '<span class="badge bg-success">0</span>';
+            }
+
+            $.ajax({
         url: base_url + 'index.php/qslprint/add_qso_to_print_queue',
         type: 'post',
 		data: {'id': id},
@@ -101,7 +115,6 @@ function addQsoToPrintQueue(id) {
 					line += '<td style=\'text-align: center\'><span class="badge text-bg-light">'+$("#qsolist_"+id).find("td:eq(8)").text()+'</span></td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(9)").text()+'</td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(11)").text()+'</td>';
-					let prev_qsl_html = $("#qsolist_"+id).find("td:eq(12)").html();
 					line += '<td style=\'text-align: center; white-space: nowrap;\'>'+prev_qsl_html+'</td>';
 					line += '<td style=\'text-align: center\'><button onclick="mark_qsl_sent('+id+', \'B\')" class="btn btn-sm btn-success"><i class="fa fa-check"></i></button></td>';
 					line += '<td style=\'text-align: center\'><button onclick="deleteFromQslQueue('+id+')" class="btn btn-sm btn-danger"><i class="fas fa-trash-alt"></i></button></td></td>';
@@ -111,8 +124,13 @@ function addQsoToPrintQueue(id) {
                     $("#qsolist_"+id).remove();
                 },
                 error: function() {
-                    console.error('Error adding QSO to print queue.');
-                }
+					console.error('Error adding QSO to print queue.');
+				}
+            });
+        },
+        error: function() {
+            console.error('Error fetching previous QSL.');
+		}
 });
 }
 
@@ -129,18 +147,12 @@ $(".station_id").change(function(){
 	});
 });
 
-let qslPrintTable = $('#qslprint_table').DataTable({
+$('#qslprint_table').DataTable({
 	"stateSave": true,
-	paging: false,
 	ordering: true,
 	paging: 'pagination',
-	// scrollY: '50vh',
-	scrollCollapse: true,
 	"language": {
 		url: getDataTablesLanguageUrl(),
-	},
-	"initComplete": function() {
-		this.api().columns.adjust();
 	}
 });
 
@@ -429,11 +441,4 @@ function switchbandandfrequencydisplay(mode){
 document.getElementById('frequency_or_band').addEventListener('change', function (event) {
 	//switch display options
 	switchbandandfrequencydisplay(event.target.value);
-});
-
-// Adjust columns on window resize
-$(window).on('resize', function() {
-	if (qslPrintTable) {
-		qslPrintTable.columns.adjust();
-	}
 });

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -9,14 +9,16 @@ function deleteFromQslQueue(id) {
 		draggable: true,
 		btnOKClass: 'btn-danger',
 		callback: function(result) {
-			$.ajax({
-				url: base_url + 'index.php/qslprint/delete_from_qsl_queue',
-				type: 'post',
-				data: {'id': id	},
-				success: function(html) {
-					$("#qslprint_"+id).remove();
-				}
-			});
+			if(result) {
+				$.ajax({
+					url: base_url + 'index.php/qslprint/delete_from_qsl_queue',
+					type: 'post',
+					data: {'id': id	},
+					success: function(html) {
+						$("#qslprint_"+id).remove();
+					}
+				});
+			}
 		}
 	});
 }
@@ -49,24 +51,10 @@ function openQsoList(callsign) {
 
 function addQsoToPrintQueue(id) {
     $.ajax({
-        url: base_url + 'index.php/qslprint/get_previous_qsl',
+        url: base_url + 'index.php/qslprint/add_qso_to_print_queue',
         type: 'post',
-        data: { 'id': id },
-        success: function(result) {
-            let prev_qsl = result;
-            let prev_qsl_html;
-
-            if (prev_qsl > 0) {
-                prev_qsl_html = '<span class="badge bg-warning">' + prev_qsl + '</span>';
-            } else {
-                prev_qsl_html = '<span class="badge bg-success">0</span>';
-            }
-
-            $.ajax({
-                url: base_url + 'index.php/qslprint/add_qso_to_print_queue',
-                type: 'post',
-				data: {'id': id},
-                success: function(html) {
+		data: {'id': id},
+        success: function(html) {
 					if (qsoDialogInstance) {
                         qsoDialogInstance.close();
                     }
@@ -113,7 +101,8 @@ function addQsoToPrintQueue(id) {
 					line += '<td style=\'text-align: center\'><span class="badge text-bg-light">'+$("#qsolist_"+id).find("td:eq(8)").text()+'</span></td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(9)").text()+'</td>';
 					line += '<td style=\'text-align: center\'>'+$("#qsolist_"+id).find("td:eq(11)").text()+'</td>';
-					line += '<td style="text-align: center">'+prev_qsl_html+'</td>';
+					let prev_qsl_html = $("#qsolist_"+id).find("td:eq(12)").html();
+					line += '<td style=\'text-align: center; white-space: nowrap;\'>'+prev_qsl_html+'</td>';
 					line += '<td style=\'text-align: center\'><button onclick="mark_qsl_sent('+id+', \'B\')" class="btn btn-sm btn-success"><i class="fa fa-check"></i></button></td>';
 					line += '<td style=\'text-align: center\'><button onclick="deleteFromQslQueue('+id+')" class="btn btn-sm btn-danger"><i class="fas fa-trash-alt"></i></button></td></td>';
 					line += '<td style=\'text-align: center\'><button onclick="openQsoList(\''+$("#qsolist_"+id).find("td:eq(0)").text()+'\')" class="btn btn-sm btn-success"><i class="fas fa-search"></i></button></td>';
@@ -124,12 +113,7 @@ function addQsoToPrintQueue(id) {
                 error: function() {
                     console.error('Error adding QSO to print queue.');
                 }
-            });
-        },
-        error: function() {
-            console.error('Error fetching previous QSL.');
-        }
-    });
+});
 }
 
 $(".station_id").change(function(){
@@ -145,11 +129,18 @@ $(".station_id").change(function(){
 	});
 });
 
-$('#qslprint_table').DataTable({
+let qslPrintTable = $('#qslprint_table').DataTable({
 	"stateSave": true,
 	paging: false,
+	ordering: true,
+	paging: 'pagination',
+	// scrollY: '50vh',
+	scrollCollapse: true,
 	"language": {
 		url: getDataTablesLanguageUrl(),
+	},
+	"initComplete": function() {
+		this.api().columns.adjust();
 	}
 });
 
@@ -438,4 +429,11 @@ function switchbandandfrequencydisplay(mode){
 document.getElementById('frequency_or_band').addEventListener('change', function (event) {
 	//switch display options
 	switchbandandfrequencydisplay(event.target.value);
+});
+
+// Adjust columns on window resize
+$(window).on('resize', function() {
+	if (qslPrintTable) {
+		qslPrintTable.columns.adjust();
+	}
 });


### PR DESCRIPTION
This pr does the following:

- If you cancel in the dialog for removing QSO from table, it would be removed regardless. Cancel now works
- Added pagination to table
- Changed so that dropdowns are on same line on page
- Fixed an issue with a full group by in the main query when entering page

Requested in #2422:
- Added information about previous QSL sent, regardless of band/mode
- Added information about previous QSL received, regardless of band/mode
Example (mouseover that says what is what):
<img width="140" height="114" alt="image" src="https://github.com/user-attachments/assets/b57d42ac-e42c-49d5-9b4f-788619f39ebf" />

