### PR TITLE
Fix FULL_GROUP_BYs

### DIFF
--- a/application/models/Labels_model.php
+++ b/application/models/Labels_model.php
@@ -88,7 +88,7 @@ class Labels_model extends CI_Model {
 	}
 
 	function fetchPapertypes($user_id) {
-		$sql="SELECT p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified, p.orientation,COUNT(DISTINCT l.id) AS lbl_cnt FROM paper_types p  LEFT OUTER JOIN  label_types l ON (p.paper_id = l.paper_type_id and p.user_id=l.user_id) WHERE p.user_id = ? group by p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified;";
+		$sql="SELECT p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified, p.orientation,COUNT(DISTINCT l.id) AS lbl_cnt FROM paper_types p  LEFT OUTER JOIN  label_types l ON (p.paper_id = l.paper_type_id and p.user_id=l.user_id) WHERE p.user_id = ? group by p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified,p.orientation;";
         	$query = $this->db->query($sql, $this->session->userdata('user_id'));
         	return $query->result();
 	}

--- a/application/models/Labels_model.php
+++ b/application/models/Labels_model.php
@@ -88,7 +88,7 @@ class Labels_model extends CI_Model {
 	}
 
 	function fetchPapertypes($user_id) {
-		$sql="SELECT p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified, p.orientation,COUNT(DISTINCT l.id) AS lbl_cnt FROM paper_types p  LEFT OUTER JOIN  label_types l ON (p.paper_id = l.paper_type_id and p.user_id=l.user_id) WHERE p.user_id = ? group by p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified,p.orientation;";
+		$sql="SELECT p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified, p.orientation,COUNT(DISTINCT l.id) AS lbl_cnt FROM paper_types p  LEFT OUTER JOIN  label_types l ON (p.paper_id = l.paper_type_id and p.user_id=l.user_id) WHERE p.user_id = ? group by p.paper_id;";
         	$query = $this->db->query($sql, $this->session->userdata('user_id'));
         	return $query->result();
 	}

--- a/application/models/Labels_model.php
+++ b/application/models/Labels_model.php
@@ -88,7 +88,10 @@ class Labels_model extends CI_Model {
 	}
 
 	function fetchPapertypes($user_id) {
-		$sql="SELECT p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified, p.orientation,COUNT(DISTINCT l.id) AS lbl_cnt FROM paper_types p  LEFT OUTER JOIN  label_types l ON (p.paper_id = l.paper_type_id and p.user_id=l.user_id) WHERE p.user_id = ? group by p.paper_id;";
+		$sql="SELECT p.paper_id,p.user_id,p.paper_name,p.metric,p.width,p.height,p.last_modified, p.orientation,COUNT(DISTINCT l.id) AS lbl_cnt
+			FROM paper_types p
+			LEFT OUTER JOIN  label_types l ON (p.paper_id = l.paper_type_id and p.user_id=l.user_id)
+			WHERE p.user_id = ? group by p.paper_id, p.user_id, p.paper_name, p.metric, p.width, p.height, p.last_modified, p.orientation;";
         	$query = $this->db->query($sql, $this->session->userdata('user_id'));
         	return $query->result();
 	}

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -7,7 +7,7 @@ class Satellite_model extends CI_Model {
 		from satellite
 		left outer join satellitemode on satellite.id = satellitemode.satelliteid
 		left outer join tle on satellite.id = tle.satelliteid
-		group by satellite.id, tle.satelliteid";
+		group by satellite.id, tle.satelliteid, satellite.name, satellite.displayname, satellite.orbit, satellite.lotw, tle.updated, tle.tle";
 
 		return $this->db->query($sql)->result();
 	}

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -7,7 +7,7 @@ class Satellite_model extends CI_Model {
 		from satellite
 		left outer join satellitemode on satellite.id = satellitemode.satelliteid
 		left outer join tle on satellite.id = tle.satelliteid
-		group by satellite.name, satellite.displayname, satellite.orbit, satellite.id, tle.updated";
+		group by satellite.id, tle.satelliteid";
 
 		return $this->db->query($sql)->result();
 	}

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -7,7 +7,7 @@ class Satellite_model extends CI_Model {
 		from satellite
 		left outer join satellitemode on satellite.id = satellitemode.satelliteid
 		left outer join tle on satellite.id = tle.satelliteid
-		group by satellite.id, tle.satelliteid, satellite.name, satellite.displayname, satellite.orbit, satellite.lotw, tle.updated, tle.tle";
+		group by satellite.id, tle.id";
 
 		return $this->db->query($sql)->result();
 	}

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -7,7 +7,7 @@ class Satellite_model extends CI_Model {
 		from satellite
 		left outer join satellitemode on satellite.id = satellitemode.satelliteid
 		left outer join tle on satellite.id = tle.satelliteid
-		group by satellite.id, tle.id";
+		group by satellite.name, satellite.id, tle.id, satellite.displayname, satellite.orbit, satellite.id, tle.updated, satellite.lotw, tle.tle";
 
 		return $this->db->query($sql)->result();
 	}

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -222,15 +222,19 @@ class Stationsetup_model extends CI_Model {
 	}
 
 	function get_all_locations() {
-		$this->db->select('station_profile.*, dxcc_entities.name as station_country, dxcc_entities.end as dxcc_end, count('.$this->config->item('table_name').'.station_id) as qso_total, max(col_time_on) as lastqsodate, exists(select 1 from station_logbooks_relationship where station_location_id = station_profile.station_id and station_logbook_id = '.($this->session->userdata('active_station_logbook') ?? 0).') as linked');
-		$this->db->from('station_profile');
-		$this->db->join($this->config->item('table_name'),'station_profile.station_id = '.$this->config->item('table_name').'.station_id','left');
-		$this->db->join('dxcc_entities','station_profile.station_dxcc = dxcc_entities.adif','left outer');
-		$this->db->group_by('station_profile.station_id');
-		$this->db->where('station_profile.user_id', $this->session->userdata('user_id'));
-		$this->db->or_where('station_profile.user_id =', NULL);
+		$sql = "select station_profile.*, dxcc_entities.name as station_country, dxcc_entities.end as dxcc_end, count(" . $this->config->item('table_name') . ".station_id) as qso_total,
+		max(col_time_on) as lastqsodate, exists (select 1 from station_logbooks_relationship where station_location_id = station_profile.station_id and station_logbook_id = " . ($this->session->userdata('active_station_logbook') ?? 0) . ") as linked
+		from station_profile
+		left join " . $this->config->item('table_name') . " on station_profile.station_id = " . $this->config->item('table_name') . ".station_id
+		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
+		where user_id = ?
+		group by station_profile.hrdlog_code, station_profile.webadifapiurl, station_profile.webadifapikey, station_profile.user_id, station_profile.qrzapikey, station_profile.station_id,
+		dxcc_entities.end, dxcc_entities.adif, station_profile.station_profile_name, station_profile.hrdlog_username, station_profile.station_gridsquare, station_profile.station_city,
+		station_profile.station_iota, station_profile.station_sota, station_profile.station_callsign, station_profile.station_power, station_profile.station_dxcc, dxcc_entities.name,
+		dxcc_entities.prefix, station_cnty, station_cq, station_itu, station_active, eqslqthnickname, state, county, station_sig, station_sig_info, qrzrealtime, station_wwff, station_pota,
+		oqrs, oqrs_text, oqrs_email, webadifrealtime, clublogrealtime, clublogignore, hrdlogrealtime, station_profile.creation_date, station_profile.last_modified, station_uuid";
 
-		return $this->db->get();
+		return $this->db->query($sql, array($this->session->userdata('user_id')));
 	}
 
 	function list_all_locations() {
@@ -239,7 +243,7 @@ class Stationsetup_model extends CI_Model {
 		left join ".$this->config->item('table_name')." on station_profile.station_id = ".$this->config->item('table_name').".station_id
 		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
 		where user_id = ?
-		group by station_profile.station_id, dxcc_entities.adif;";
+		group by dxcc_entities.end, station_profile.station_id, station_profile_name, station_profile.hrdlog_username, station_gridsquare, station_city, station_iota, station_sota, station_callsign, station_power, station_dxcc, dxcc_entities.name, dxcc_entities.prefix, station_cnty, station_cq, station_itu, station_active, eqslqthnickname, state, county, station_sig, station_sig_info, qrzrealtime, station_wwff, station_pota, oqrs, oqrs_text, oqrs_email, webadifrealtime, clublogrealtime, clublogignore, hrdlogrealtime, station_profile.creation_date, station_profile.last_modified, station_uuid;";
 
 		$query = $this->db->query($sql, array($this->session->userdata('user_id')));
 

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -228,11 +228,7 @@ class Stationsetup_model extends CI_Model {
 		left join " . $this->config->item('table_name') . " on station_profile.station_id = " . $this->config->item('table_name') . ".station_id
 		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
 		where user_id = ?
-		group by station_profile.hrdlog_code, station_profile.webadifapiurl, station_profile.webadifapikey, station_profile.user_id, station_profile.qrzapikey, station_profile.station_id,
-		dxcc_entities.end, dxcc_entities.adif, station_profile.station_profile_name, station_profile.hrdlog_username, station_profile.station_gridsquare, station_profile.station_city,
-		station_profile.station_iota, station_profile.station_sota, station_profile.station_callsign, station_profile.station_power, station_profile.station_dxcc, dxcc_entities.name,
-		dxcc_entities.prefix, station_cnty, station_cq, station_itu, station_active, eqslqthnickname, state, county, station_sig, station_sig_info, qrzrealtime, station_wwff, station_pota,
-		oqrs, oqrs_text, oqrs_email, webadifrealtime, clublogrealtime, clublogignore, hrdlogrealtime, station_profile.creation_date, station_profile.last_modified, station_uuid";
+		group by station_profile.station_id, dxcc_entities.adif";
 
 		return $this->db->query($sql, array($this->session->userdata('user_id')));
 	}
@@ -243,7 +239,7 @@ class Stationsetup_model extends CI_Model {
 		left join ".$this->config->item('table_name')." on station_profile.station_id = ".$this->config->item('table_name').".station_id
 		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
 		where user_id = ?
-		group by dxcc_entities.end, station_profile.station_id, station_profile_name, station_profile.hrdlog_username, station_gridsquare, station_city, station_iota, station_sota, station_callsign, station_power, station_dxcc, dxcc_entities.name, dxcc_entities.prefix, station_cnty, station_cq, station_itu, station_active, eqslqthnickname, state, county, station_sig, station_sig_info, qrzrealtime, station_wwff, station_pota, oqrs, oqrs_text, oqrs_email, webadifrealtime, clublogrealtime, clublogignore, hrdlogrealtime, station_profile.creation_date, station_profile.last_modified, station_uuid;";
+		group by station_profile.station_id, dxcc_entities.adif;";
 
 		$query = $this->db->query($sql, array($this->session->userdata('user_id')));
 

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -234,12 +234,16 @@ class Stationsetup_model extends CI_Model {
 	}
 
 	function list_all_locations() {
-		$sql = "select dxcc_entities.end, station_profile.station_id, station_profile_name, count(".$this->config->item('table_name').".station_id) as qso_total, station_profile.hrdlog_username, station_gridsquare, station_city, station_iota, station_sota, station_callsign, station_power, station_dxcc, dxcc_entities.name as dxccname, dxcc_entities.prefix as dxccprefix, station_cnty, station_cq, station_itu, station_active, eqslqthnickname, state, county, station_sig, station_sig_info, qrzrealtime, station_wwff, station_pota, oqrs, oqrs_text, oqrs_email, webadifrealtime, clublogrealtime, clublogignore, hrdlogrealtime, station_profile.creation_date, station_profile.last_modified, station_uuid
+		$sql = "select dxcc_entities.end, station_profile.station_id, station_profile_name,
+		(select count(*) from " . $this->config->item('table_name') . " where station_id = station_profile.station_id) as qso_total,
+		station_profile.hrdlog_username, station_gridsquare, station_city, station_iota, station_sota, station_callsign,
+		station_power, station_dxcc, dxcc_entities.name as dxccname, dxcc_entities.prefix as dxccprefix, station_cnty,
+		station_cq, station_itu, station_active, eqslqthnickname, state, county, station_sig, station_sig_info, qrzrealtime, station_wwff,
+		station_pota, oqrs, oqrs_text, oqrs_email, webadifrealtime, clublogrealtime, clublogignore, hrdlogrealtime, station_profile.creation_date,
+		station_profile.last_modified, station_uuid
 		from station_profile
-		left join ".$this->config->item('table_name')." on station_profile.station_id = ".$this->config->item('table_name').".station_id
 		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
-		where user_id = ?
-		group by station_profile.station_id, dxcc_entities.adif;";
+		where station_profile.user_id = ?";
 
 		$query = $this->db->query($sql, array($this->session->userdata('user_id')));
 

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -239,7 +239,7 @@ class Stationsetup_model extends CI_Model {
 		left join ".$this->config->item('table_name')." on station_profile.station_id = ".$this->config->item('table_name').".station_id
 		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
 		where user_id = ?
-		group by station_profile.station_id;";
+		group by station_profile.station_id, dxcc_entities.adif;";
 
 		$query = $this->db->query($sql, array($this->session->userdata('user_id')));
 

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -222,13 +222,13 @@ class Stationsetup_model extends CI_Model {
 	}
 
 	function get_all_locations() {
-		$sql = "select station_profile.*, dxcc_entities.name as station_country, dxcc_entities.end as dxcc_end, count(" . $this->config->item('table_name') . ".station_id) as qso_total,
-		max(col_time_on) as lastqsodate, exists (select 1 from station_logbooks_relationship where station_location_id = station_profile.station_id and station_logbook_id = " . ($this->session->userdata('active_station_logbook') ?? 0) . ") as linked
+		$sql = "select station_profile.*, dxcc_entities.name as station_country, dxcc_entities.end as dxcc_end,
+		(select count(*) from " . $this->config->item('table_name') . " where station_id = station_profile.station_id) as qso_total,
+		(select max(col_time_on) as lastqsodate from " . $this->config->item('table_name') . " where station_id = station_profile.station_id) as lastqsodate,
+		exists (select 1 from station_logbooks_relationship where station_location_id = station_profile.station_id and station_logbook_id = " . ($this->session->userdata('active_station_logbook') ?? 0) . ") as linked
 		from station_profile
-		left join " . $this->config->item('table_name') . " on station_profile.station_id = " . $this->config->item('table_name') . ".station_id
 		left outer join dxcc_entities on station_profile.station_dxcc = dxcc_entities.adif
-		where user_id = ?
-		group by station_profile.station_id, dxcc_entities.adif";
+		where station_profile.user_id = ?";
 
 		return $this->db->query($sql, array($this->session->userdata('user_id')));
 	}


### PR DESCRIPTION
Some databases are picky, and only allow so called "FULL_GROUP_BYs", means every selected column has to appear also in `GROUP BY` (Normal on enterprise-DBs, seems not normal on mysql/mariadb).

This patch adresses and fixes it.
