### PR TITLE
[QSL Queue] Add option to show all rows + change labels in header

### DIFF
--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -1,3 +1,7 @@
+<script>
+	var lang_export_qslprint_pagination_all = '<?= __("All") ?>';
+</script>
+
 <div class="container">
 
 	<br>
@@ -29,7 +33,7 @@
 
 			<!-- Switch Band or Frequency display -->
 			<div class="col-md-6 col-lg-4 col-xl-4 col-xxl-2">
-				<label for="frequency_or_band" class="me-2"><?= __("Show Band or Frequency:"); ?></label>
+				<label for="frequency_or_band" class="me-4 text-nowrap"><?= __("Show Band or Frequency:"); ?></label>
 				<select id="frequency_or_band" class="form-select">
 					<option value="band" selected><?= __("Band"); ?></option>
 					<option value="frequency"><?= __("Frequency"); ?></option>

--- a/application/views/qslprint/index.php
+++ b/application/views/qslprint/index.php
@@ -1,5 +1,5 @@
 <script>
-	var lang_export_qslprint_pagination_all = '<?= __("All") ?>';
+	var lang_export_qslprint_pagination_all = "<?= __("All") ?>";
 </script>
 
 <div class="container">

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -130,6 +130,10 @@ $(".station_id").change(function(){
 $('#qslprint_table').DataTable({
 	"stateSave": true,
 	ordering: true,
+	lengthMenu: [
+		[10, 25, 50, 100, -1],
+		[10, 25, 50, 100, lang_export_qslprint_pagination_all]
+	],
 	paging: 'pagination',
 	"language": {
 		url: getDataTablesLanguageUrl(),

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -130,6 +130,7 @@ $(".station_id").change(function(){
 $('#qslprint_table').DataTable({
 	"stateSave": true,
 	ordering: true,
+	pageLength: 25,
 	lengthMenu: [
 		[10, 25, 50, 100, -1],
 		[10, 25, 50, 100, lang_export_qslprint_pagination_all]


### PR DESCRIPTION
This PR changes 2 small things introduced by [[QSL Queue] Add qsl information, fix delete bug #3262](https://github.com/wavelog/wavelog/pull/3262) lately.

1) Add pagination option to show "all" rows.
This restores the functionality of the workflow introduced in #2306, as well as the opportunity to view and sort for larger QSL jobs then 100. Defining the pagination options this way also allows us to add additional different steps later on in addition to the default steps. I also added 25 rows as a default, which is overwritten by the stateSave feature once the user decides on his personal preference. In the current version, the view would start at a (very conservative imho) 10 entries.
2) Changes the label for the "Band or Frequency" select to not wrap

From:
<img width="503" height="211" alt="grafik" src="https://github.com/user-attachments/assets/2acda483-2b07-4003-a070-f07eed15b7ba" />
To:
<img width="450" height="191" alt="grafik" src="https://github.com/user-attachments/assets/804464e5-167c-4e04-bbeb-3bd5457ab47f" />
