### PR TITLE
change quotation style for translated texts in javascript

### DIFF
--- a/application/views/reg1test/index.php
+++ b/application/views/reg1test/index.php
@@ -1,11 +1,11 @@
 <script>
-	var lang_export_reg1testedi_proceed = '<?= __("Proceed") ?>';
+	var lang_export_reg1testedi_proceed = "<?= __("Proceed") ?>";
 	var lang_export_reg1testedi_select_year = "<?= __("Select Year") ?>";
-	var lang_export_reg1testedi_select_contest = '<?= __("Select Contest") ?>';
-	var lang_export_reg1testedi_select_date_range = '<?= __("Select Date Range") ?>';
-	var lang_export_reg1testedi_select_band = '<?= __("Select Band") ?>';
-	var lang_export_reg1testedi_no_contests_for_stationlocation = '<?= __("No contests were found for this station location!") ?>';
-	var lang_export_reg1testedi_bandhint = '<?= __("Bands below 50Mhz are not valid for the EDI REG1TEST format and will produce invalid files.") ?>';
+	var lang_export_reg1testedi_select_contest = "<?= __("Select Contest") ?>";
+	var lang_export_reg1testedi_select_date_range = "<?= __("Select Date Range") ?>";
+	var lang_export_reg1testedi_select_band = "<?= __("Select Band") ?>";
+	var lang_export_reg1testedi_no_contests_for_stationlocation = "<?= __("No contests were found for this station location!") ?>";
+	var lang_export_reg1testedi_bandhint = "<?= __("Bands below 50Mhz are not valid for the EDI REG1TEST format and will produce invalid files.") ?>";
 </script>
 <div class="container">
 


### PR DESCRIPTION
This PR changes the quotation style for translated text inside javascript as mentioned in #3271 

This changes the style for the texts I'm responsible for in the past (and what I used as reference for #3271). 
Maybe preparing a bigger PR to fix all the other occurances in the future.