### PR TITLE
extend dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
-Dockerfile
 .git
 .github
+.editorconfig
+.gitignore
+Dockerfile
+*.md
+**/*.sh
+tmp/
+**/*.po
+**/*.pot


### PR DESCRIPTION
Extends dockerignore with filetypes which don't need to be in the docker image. 