### PR TITLE
Fix unitialized var for Notes

### DIFF
--- a/application/models/Note.php
+++ b/application/models/Note.php
@@ -19,6 +19,7 @@ class Note extends CI_Model {
 	// Return note ID for given category and title (callsign for Contacts), else false
 	public function get_note_id_by_category($user_id, $category, $title) {
 		$check_title = $title;
+		$check_title_slashed = $title;
 		if ($category === 'Contacts') {
 			$this->load->library('callbook'); // Used for callsign parsing
 			$check_title = strtoupper($this->callbook->get_plaincall($title));


### PR DESCRIPTION
In Note.php, $check_title_slashed was used in the SQL query parameter array but only defined inside the if ($category === 'Contacts'). 

When get_note_id_by_category() is called with any non-Contacts category (e.g. 'General', 'Antennas', 'Satellites'), the variable never gets  initialized, causing `ERROR - xxxx --> Severity: Warning --> Undefined variable $check_title_slashed /var/www/html/application/models/Note.php 28`