### PR TITLE
Fix error when no sat found

### DIFF
--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -180,7 +180,7 @@ class Satellite extends CI_Controller {
 		$this->load->model('stations');
 
 		$pageData['satellites'] = $this->satellite_model->get_all_satellites_with_tle();
-		$data['selsat']=strtoupper($sat ?? $this->satellite_model->get_last_worked_sat());
+		$data['selsat'] = strtoupper($sat ?? $this->satellite_model->get_last_worked_sat() ?? '');
 
 		$footerData = [];
 		$footerData['scripts'] = [


### PR DESCRIPTION
Fix this error when loading Flightpath page:

A PHP Error was encountered
Severity: Deprecated

Message: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated

Filename: controllers/Satellite.php

Line Number: 183