### PR TITLE
new 404 override

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -49,7 +49,7 @@
 */
 
 $route['default_controller'] = "dashboard";
-$route['404_override'] = '';
+$route['404_override'] = 'errors/show_404';
 $route['translate_uri_dashes'] = FALSE;
 
 

--- a/application/controllers/Errors.php
+++ b/application/controllers/Errors.php
@@ -1,0 +1,31 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+/*
+	Controller for custom error pages.
+
+	Wired up via $route['404_override'] in config/routes.php, so it runs as a
+	normal controller. That means the gettext hook has already run (__() is
+	available) and autoloaded libraries like optionslib are ready.
+*/
+
+class Errors extends CI_Controller {
+
+	function __construct() {
+		parent::__construct();
+	}
+
+	// 404 page - rendered for any URI that doesn't match a route.
+	public function show_404() {
+
+		$data['theme'] = $this->optionslib->get_theme();
+		$data['logo'] = $this->paths->cache_buster('/assets/logo/'.$this->optionslib->get_logo('header_logo').'.png');
+		$data['heading'] = __("Page Not Found");
+		$data['message1'] = __("QRZ? ... no reply.");
+		$data['message2'] = __("Nobody is transmitting on this frequency.");
+
+		// Keep the HTTP status correct (404_override otherwise yields 200).
+		$this->output->set_status_header(404);
+
+		$this->load->view('errors/html/error_404', $data);
+	}
+}

--- a/application/views/errors/html/error_404.php
+++ b/application/views/errors/html/error_404.php
@@ -1,34 +1,88 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<title>404 Page Not Found</title>
-<style type="text/css">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo $heading; ?></title>
 
-body {
-background-color:	#fff;
-margin:				40px;
-font-family:		Lucida Grande, Verdana, Sans-serif;
-font-size:			12px;
-color:				#000;
-}
+	<!-- Bootstrap / theme CSS -->
+	<?php if ($theme) { ?>
+		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/bootstrap.min.css">
+		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/general.css">
+		<link rel="stylesheet" href="<?php echo base_url(); ?>assets/css/<?php echo $theme; ?>/overrides.css">
+	<?php } ?>
 
-#content  {
-border:				#999 1px solid;
-background-color:	#fff;
-padding:			20px 20px 12px 20px;
-}
+	<style>
+		html,
+		body {
+			height: 100%;
+		}
 
-h1 {
-font-weight:		normal;
-font-size:			14px;
-color:				#990000;
-margin:				0 0 4px 0;
-}
-</style>
+		body {
+			display: flex;
+			align-items: center;
+			padding-top: 40px;
+			padding-bottom: 40px;
+		}
+
+		.error-container {
+			width: 100%;
+			max-width: 430px;
+			padding: 15px;
+			margin: auto;
+		}
+
+		.error-logo {
+			max-width: 200px;
+			height: auto;
+			margin-bottom: 2rem;
+		}
+
+		.error-card {
+			border: none;
+			border-radius: 8px;
+		}
+
+		.error-icon {
+			font-size: 3rem;
+			color: #dc3545;
+			margin-bottom: 1rem;
+		}
+
+		.back-link {
+			text-decoration: none;
+		}
+
+		.back-link:hover {
+			text-decoration: underline;
+		}
+	</style>
 </head>
 <body>
-	<div id="content">
-		<h1><?php echo $heading; ?></h1>
-		<?php echo $message; ?>
-	</div>
+	<main class="error-container">
+
+		<img src="<?php echo $logo; ?>" class="mx-auto d-block mainLogo error-logo" alt="">
+
+		<div class="card error-card shadow-sm">
+			<div class="card-body text-center">
+				<div class="error-icon">⚠️</div>
+
+				<h2 class="card-title h4 mb-3 text-danger">
+					404 - <?php echo $heading; ?>
+				</h2>
+
+				<p class="card-text">
+					<?php echo $message1; ?>
+				</p>
+				<p class="card-text mb-4">
+					<?php echo $message2; ?>
+				</p>
+
+				<a href="<?php echo base_url(); ?>" class="btn btn-primary back-link">
+					<?php echo __("Go Back to Dashboard"); ?>
+				</a>
+			</div>
+		</div>
+	</main>
 </body>
 </html>

--- a/application/views/errors/html/error_404.php
+++ b/application/views/errors/html/error_404.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<?php echo $language['code']; ?>">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
I tried before in #2188 to redesign the 404 page.. I thought I need to do that at the 404 catch.. but well... Next time I should read documentation better 😆 

there is actually a override in the routes to set your own controller. No issues with gettext and theme. Works perfectly

just visit `https://log.your-wavelog.org/index.php/foobar` to test

Before:
<img width="454" height="180" alt="Bildschirmfoto 2026-06-05 um 00 29 57" src="https://github.com/user-attachments/assets/ff84b252-2f2d-483b-a03b-117a96cbd44e" />

After:
<img width="1900" height="1802" alt="grafik" src="https://github.com/user-attachments/assets/495fc809-1676-4d3a-8ebd-5049f9f9abd6" />
