### PR TITLE
Leftover: remove unused hook config

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -216,17 +216,6 @@ $config['charset'] = 'UTF-8';
 
 /*
 |--------------------------------------------------------------------------
-| Enable/Disable System Hooks
-|--------------------------------------------------------------------------
-|
-| If you would like to use the 'hooks' feature you must enable it by
-| setting this variable to TRUE (boolean).  See the user guide for details.
-|
-*/
-$config['enable_hooks'] = TRUE;
-
-/*
-|--------------------------------------------------------------------------
 | Class Extension Prefix
 |--------------------------------------------------------------------------
 |

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -215,17 +215,6 @@ $config['charset'] = 'UTF-8';
 
 /*
 |--------------------------------------------------------------------------
-| Enable/Disable System Hooks
-|--------------------------------------------------------------------------
-|
-| If you would like to use the 'hooks' feature you must enable it by
-| setting this variable to TRUE (boolean).  See the user guide for details.
-|
-*/
-$config['enable_hooks'] = TRUE;
-
-/*
-|--------------------------------------------------------------------------
 | Class Extension Prefix
 |--------------------------------------------------------------------------
 |


### PR DESCRIPTION
We can remove this config since we override to true anyway in order to make gettext work

Reference commit 2y ago: https://github.com/wavelog/wavelog/commit/8cc66870ca3ff68d00fe845db72edf64f218419c