### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-06-12 06:46+0000\n"
-"PO-Revision-Date: 2026-06-11 09:58+0000\n"
+"PO-Revision-Date: 2026-06-13 09:16+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
@@ -10606,7 +10606,7 @@ msgstr "Wie es funktioniert"
 #: application/views/cron/index.php:21
 #, php-format
 msgid "For more information or help, take a look in the %sWiki%s."
-msgstr ""
+msgstr "Für weitere Informationen oder Hilfe, schau im %sWiki%s nach."
 
 #: application/views/cron/index.php:28
 msgid ""

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-06-11 10:04+0000\n"
-"PO-Revision-Date: 2026-06-09 07:01+0000\n"
+"PO-Revision-Date: 2026-06-11 15:54+0000\n"
 "Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -10464,7 +10464,7 @@ msgstr "仕組み"
 #: application/views/cron/index.php:21
 #, php-format
 msgid "For more information or help, take a look in the %sWiki%s."
-msgstr ""
+msgstr "詳細情報やヘルプについては、以下をご覧ください。 %sWiki%s 。"
 
 #: application/views/cron/index.php:28
 msgid ""
@@ -10682,15 +10682,15 @@ msgstr "総交信数"
 
 #: application/views/dashboard/index.php:244
 msgid "QSOs this year"
-msgstr ""
+msgstr "今年のQSO数"
 
 #: application/views/dashboard/index.php:254
 msgid "QSOs this month"
-msgstr ""
+msgstr "今月の交信数"
 
 #: application/views/dashboard/index.php:264
 msgid "QSOs today"
-msgstr ""
+msgstr "今日の交信"
 
 #: application/views/dashboard/index.php:274
 msgid "Current Streak"

--- a/application/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/application/locale/sv_SE/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-06-11 10:04+0000\n"
-"PO-Revision-Date: 2026-06-09 07:01+0000\n"
+"PO-Revision-Date: 2026-06-11 15:54+0000\n"
 "Last-Translator: \"Jorgen Dahl, NU1T\" <sm6srw@arrl.net>\n"
 "Language-Team: Swedish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/sv/>\n"
@@ -10488,7 +10488,7 @@ msgstr "Hur det fungerar"
 #: application/views/cron/index.php:21
 #, php-format
 msgid "For more information or help, take a look in the %sWiki%s."
-msgstr ""
+msgstr "För mer information eller hjälp, ta en titt i %sWiki%s."
 
 #: application/views/cron/index.php:28
 msgid ""
@@ -10703,15 +10703,15 @@ msgstr "QSOs Totalt"
 
 #: application/views/dashboard/index.php:244
 msgid "QSOs this year"
-msgstr ""
+msgstr "QSOs i år"
 
 #: application/views/dashboard/index.php:254
 msgid "QSOs this month"
-msgstr ""
+msgstr "QSOn den här månaden"
 
 #: application/views/dashboard/index.php:264
 msgid "QSOs today"
-msgstr ""
+msgstr "QSOs idag"
 
 #: application/views/dashboard/index.php:274
 msgid "Current Streak"

--- a/application/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/application/locale/zh_CN/LC_MESSAGES/messages.po
@@ -32,10 +32,10 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-06-12 06:46+0000\n"
-"PO-Revision-Date: 2026-06-08 07:58+0000\n"
-"Last-Translator: \"Xu, Zefan (BI1GHZ)\" <ceba_robot@outlook.com>\n"
-"Language-Team: Chinese (Simplified Han script) <https://translate.wavelog."
-"org/projects/wavelog/main-translation/zh_Hans/>\n"
+"PO-Revision-Date: 2026-06-13 09:16+0000\n"
+"Last-Translator: \"Shen RuiQin(BH4FJN)\" <jerry19980425@gmail.com>\n"
+"Language-Team: Chinese (Simplified Han script) <https://"
+"translate.wavelog.org/projects/wavelog/main-translation/zh_Hans/>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -10249,7 +10249,7 @@ msgstr "实现原理"
 #: application/views/cron/index.php:21
 #, php-format
 msgid "For more information or help, take a look in the %sWiki%s."
-msgstr ""
+msgstr "如需更多信息或帮助，请前往%sWiki%s。"
 
 #: application/views/cron/index.php:28
 msgid ""
@@ -10444,15 +10444,15 @@ msgstr "总计 QSO"
 
 #: application/views/dashboard/index.php:244
 msgid "QSOs this year"
-msgstr ""
+msgstr "今年的QSO"
 
 #: application/views/dashboard/index.php:254
 msgid "QSOs this month"
-msgstr ""
+msgstr "当月QSO"
 
 #: application/views/dashboard/index.php:264
 msgid "QSOs today"
-msgstr ""
+msgstr "今日QSO"
 
 #: application/views/dashboard/index.php:274
 msgid "Current Streak"
@@ -10485,16 +10485,16 @@ msgstr[0] "已显示最多 %d 个先前通联"
 #: application/views/dashboard/index.php:403
 #: application/views/user/edit.php:734
 msgid "Active Expeditions"
-msgstr ""
+msgstr "活跃的远征"
 
 #: application/views/dashboard/index.php:411
 msgid "Dates"
-msgstr ""
+msgstr "日期"
 
 #: application/views/dashboard/index.php:449
 #: application/views/user/edit.php:741
 msgid "Active Contests"
-msgstr ""
+msgstr "活跃的竞赛"
 
 #: application/views/dashboard/index.php:465
 #: application/views/view_log/qso.php:621


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)