### PR TITLE
Paths Refactoring

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -26,7 +26,7 @@ class eqsl extends CI_Controller {
 
 		$this->load->model('eqsl_images');
 		$this->load->library('Genfunctions');
-		$folder_name = $this->eqsl_images->get_imagePath('p');
+		$folder_name = $this->paths->getUserdataPath('eqsl_card', 'p');
 		$data['storage_used'] = $this->genfunctions->sizeFormat($this->genfunctions->folderSize($folder_name));
 
 		// Pagination
@@ -418,7 +418,7 @@ class eqsl extends CI_Controller {
 				}
 
 				$filename = uniqid() . '.jpg';
-				$image_path = $this->Eqsl_images->get_imagePath('p') . '/' . $filename;
+				$image_path = $this->paths->getUserdataPath('eqsl_card', 'p') . '/' . $filename;
 				$save_result = file_put_contents($image_path, $content);
 
 				if ($save_result !== false) {
@@ -433,7 +433,7 @@ class eqsl extends CI_Controller {
 		} else {
 			// Load server-cached image if etag isn't 0
 			if ($etag != '0') {
-				$image_file = $this->Eqsl_images->get_imagePath('p') . '/' . $this->Eqsl_images->get_image($id);
+				$image_file = $this->paths->getUserdataPath('eqsl_card', 'p') . '/' . $this->Eqsl_images->get_image($id);
 				$content = file_get_contents($image_file);
 				if ($content !== false) {
 					$this->output_image_with_width($content, $width, $etag);
@@ -570,7 +570,7 @@ class eqsl extends CI_Controller {
 			}
 			$filename = uniqid() . '.jpg';
 			if ($this->Eqsl_images->get_image($id) == "No Image") {
-				if (file_put_contents($this->Eqsl_images->get_imagePath('p') . '/' . $filename, $content) !== false) {
+				if (file_put_contents($this->paths->getUserdataPath('eqsl_card', 'p') . '/' . $filename, $content) !== false) {
 					$this->Eqsl_images->save_image($id, $filename);
 				}
 			}

--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -18,7 +18,7 @@ class Qsl extends CI_Controller {
 
         $this->load->model('qsl_model');
         $this->load->library('Genfunctions');
-        $folder_name = $this->qsl_model->get_imagePath('p');
+        $folder_name = $this->paths->getUserdataPath('qsl_card', 'p');
         $data['storage_used'] = $this->genfunctions->sizeFormat($this->genfunctions->folderSize($folder_name));
 
         // Render Page
@@ -78,7 +78,7 @@ class Qsl extends CI_Controller {
 
     function uploadQslCardFront($qsoid) {
         $this->load->model('Qsl_model');
-        $config['upload_path']          = $this->Qsl_model->get_imagePath('p');
+        $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
         $array = explode(".", $_FILES['qslcardfront']['name']);
         $ext = end($array);
@@ -109,7 +109,7 @@ class Qsl extends CI_Controller {
 
     function uploadQslCardBack($qsoid) {
         $this->load->model('Qsl_model');
-        $config['upload_path']          = $this->Qsl_model->get_imagePath('p');
+        $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
         $array = explode(".", $_FILES['qslcardback']['name']);
         $ext = end($array);

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -31,10 +31,6 @@ class Update extends CI_Controller {
 	* Load the DXCC entities
 	*/
 	private function dxcc_entities($xml_data = null) {
-		// Ensure the Paths library is loaded
-		if (!$this->load->is_loaded('Paths')) {
-			$this->load->library('Paths');
-		}
 
 		// Load XML data if not provided
 		if ($xml_data === null) {
@@ -96,10 +92,6 @@ class Update extends CI_Controller {
      * Load the dxcc prefixes
      */
 	private function dxcc_exceptions($xml_data = null) {
-		// Ensure the Paths library is loaded
-		if (!$this->load->is_loaded('Paths')) {
-			$this->load->library('Paths');
-		}
 
 		// Load XML data if not provided
 		if ($xml_data === null) {
@@ -147,10 +139,6 @@ class Update extends CI_Controller {
      * Load the dxcc prefixes
      */
 	private function dxcc_prefixes($xml_data = null) {
-		// Load the cty file
-		if (!$this->load->is_loaded('Paths')) {
-			$this->load->library('Paths');
-		}
 
 		// Load XML data if not provided
 		if ($xml_data === null) {
@@ -199,10 +187,6 @@ class Update extends CI_Controller {
 		$lockfilename='/tmp/.update_dxcc_running';
 		if (!file_exists($lockfilename)) {
 			touch($lockfilename);
-
-			if(!$this->load->is_loaded('Paths')) {
-				$this->load->library('Paths');
-			}
 
 			// set the last run in cron table for the correct cron id
 			$this->load->model('cron_model');
@@ -315,10 +299,6 @@ class Update extends CI_Controller {
 	}
 
 	private function update_status($done=""){
-
-        if(!$this->load->is_loaded('Paths')) {
-        	$this->load->library('Paths');
-		}
 
 		if ($done != "Downloading file"){
 			// Check that everything is done?

--- a/application/libraries/EqslBulkDownloader.php
+++ b/application/libraries/EqslBulkDownloader.php
@@ -24,12 +24,11 @@ class EqslBulkDownloader {
 	public function __construct() {
 		$this->ci =& get_instance();
 		$this->ci->load->library('electronicqsl');
-		$this->ci->load->model('Eqsl_images');
 		$this->ci->load->model('user_model');
 		$this->ci->load->model('logbook_model');
 
 		// Get image path
-		$this->imagePath = $this->ci->Eqsl_images->get_imagePath('p');
+		$this->imagePath = $this->ci->paths->getUserdataPath('eqsl_card', 'p');
 
 		log_message('info', 'EqslBulkDownloader initialized with concurrency=' . self::CONCURRENCY);
 	}

--- a/application/libraries/Paths.php
+++ b/application/libraries/Paths.php
@@ -3,22 +3,85 @@
 /***
  * Paths Library to return specific paths
  */
-class Paths
-{
-    // generic function for return eQsl path //
-    function getPathEqsl()
-    {
+class Paths {
+
+    /**
+     * Returns the userdata path (or legacy path if the userdata option is not set) for the given type and user_id.
+     * 
+     * @param string $type The type of path to return (e.g. 'eqsl_card', 'qsl_card')
+     * @param string $pathorurl 'u' to return the web-relative path, 'p' to return the absolute filesystem path
+     * @param int|null $user_id The user_id to return the path for. If null, will use the user_id from session data
+     */
+    function getUserdataPath($type, $pathorurl = 'u', $user_id = null) {
+        // test if new folder directory option is enabled
         $CI = &get_instance();
-        $CI->load->model('Eqsl_images');
-        return $CI->Eqsl_images->get_imagePath();
+        $userdata_dir = $CI->config->item('userdata');
+
+        // make sure these are the same as in Debug_model.php function migrate_userdata()
+        $allowed_types = [
+            'eqsl_card', 
+            'qsl_card'
+        ];
+
+        // validate path type
+        if (!in_array($pathorurl, ['u', 'p'])) {
+            log_message('error', 'Invalid pathorurl passed to getUserdataPath: ' . $pathorurl);
+            return false; // invalid pathorurl
+        }
+
+        if (!in_array($type, $allowed_types)) {
+            log_message('error', 'Invalid type passed to getUserdataPath: ' . $type);
+            return false; // invalid type
+        }
+
+        if (isset($userdata_dir)) {
+
+            if (!valid_uid($user_id)) {
+                $user_id = $CI->session->userdata('user_id');
+            }
+
+            // check if there is a user_id in the session data and it's not empty
+            if (valid_uid($user_id)) {
+
+                // create the folder
+                if (!file_exists(realpath(APPPATH . '../') . '/' . $userdata_dir . '/' . $user_id . '/' . $type)) {
+                    mkdir(realpath(APPPATH . '../') . '/' . $userdata_dir . '/' . $user_id . '/' . $type, 0755, true);
+                }
+
+                // and return it
+                if ($pathorurl == 'u') {
+                    return $userdata_dir . '/' . $user_id . '/' . $type;
+                } else {
+                    return realpath(APPPATH . '../') . '/' . $userdata_dir . '/' . $user_id . '/' . $type;
+                }
+            } else {
+                log_message('error', 'getUserdataPath(); Can not get ' . $type . ' path because no user_id in session data');
+            }
+        } else {
+            // if the config option is not set we just return the old path
+            return $this->legacyPaths($type, $pathorurl);
+        }
     }
 
-    // generic function for return Qsl path //
-    function getPathQsl()
-    {
-        $CI = &get_instance();
-        $CI->load->model('Qsl_model');
-        return $CI->Qsl_model->get_imagePath();
+    private function legacyPaths($type, $pathorurl = 'u') {
+        switch ($type) {
+            case 'eqsl_card':
+                $path = 'images/eqsl_card_images';
+                break;
+            case 'qsl_card':
+                $path = 'assets/qslcard';
+                break;
+            default:
+                log_message('error', 'Invalid type passed to legacyPaths(): ' . $type);
+                return false;
+        }
+
+        // 'u' returns the web-relative path, anything else the absolute filesystem path
+        if ($pathorurl == 'u') {
+            return $path;
+        } else {
+            return realpath(APPPATH . '../') . '/' . $path;
+        }
     }
 
     function make_update_path($path) {

--- a/application/models/Debug_model.php
+++ b/application/models/Debug_model.php
@@ -18,10 +18,10 @@ class Debug_model extends CI_Model
         $this->flag_file = '.migrated'; // we use this flag file to determine if the migration already run through
 
         $this->src_eqsl = 'images/eqsl_card_images';
-        $this->eqsl_dir = 'eqsl_card';  // make sure this is the same as in Eqsl_images.php function get_imagePath()
+        $this->eqsl_dir = 'eqsl_card';  // make sure this is the same as in Paths.php function getUserdataPath()
 
         $this->src_qsl = 'assets/qslcard';
-        $this->qsl_dir = 'qsl_card';  // make sure this is the same as in Qsl_model.php function get_imagePath()
+        $this->qsl_dir = 'qsl_card';  // make sure this is the same as in Paths.php function getUserdataPath()
     }
 
     function migrate_userdata()

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -19,7 +19,6 @@ class Eqsl_images extends CI_Model {
 	}
 
 	function del_image($qso_id, $user_id = null) {
-		$this->load->library('paths');
 		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
 		$table_name = $this->config->item('table_name');
 		$sql = "SELECT e.image_file,e.id, qso.station_id, s.user_id 

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -3,12 +3,15 @@
 class Eqsl_images extends CI_Model {
 
 	function get_image($qso_id) {
-		$this->db->where('qso_id', $qso_id);
-		$query = $this->db->get('eQSL_images');
+		$sql = "SELECT image_file 
+				FROM `eQSL_images` 
+				WHERE qso_id = ?";
+
+		$query = $this->db->query($sql, [$qso_id]);
 
 		$row = $query->row();
 
-		if(isset($row)) {
+		if (isset($row)) {
 			return $row->image_file;
 		} else {
 			return "No Image";
@@ -16,29 +19,40 @@ class Eqsl_images extends CI_Model {
 	}
 
 	function del_image($qso_id, $user_id = null) {
+		$this->load->library('paths');
 		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
-		$eqsl_img=$this->db->query('SELECT e.image_file,e.id, qso.station_id, s.user_id FROM `eQSL_images` e INNER JOIN '.$this->config->item('table_name').' qso ON (e.qso_id = qso.COL_PRIMARY_KEY) inner join station_profile s on (s.station_id=qso.station_id) where qso.COL_PRIMARY_KEY=?',$qso_id);
+		$table_name = $this->config->item('table_name');
+		$sql = "SELECT e.image_file,e.id, qso.station_id, s.user_id 
+				FROM `eQSL_images` e 
+				INNER JOIN {$table_name} qso ON (e.qso_id = qso.COL_PRIMARY_KEY) 
+				INNER JOIN station_profile s ON (s.station_id = qso.station_id) 
+				WHERE qso.COL_PRIMARY_KEY = ?";
+
+		$eqsl_img = $this->db->query($sql, [$qso_id]);
+		
+		if (!valid_uid($user_id)) {
+			$user_id = $this->session->userdata('user_id');
+		}
 		foreach ($eqsl_img->result() as $row) {
-			if (($user_id ?? '') == '') {					// Calling as User? Check if User-id matches User-id from QSO
-				$user_id = $this->session->userdata('user_id');
-				if ($row->user_id != $user_id) {
-					return "No Image";				// Image doesn't belong to user, so return
-				}
+			// Calling as User? Check if User-id matches User-id from QSO
+			if ($row->user_id != $user_id) {
+				return "No Image"; // Image doesn't belong to user, so return
 			}
-			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->image_file;
+			$image = $this->paths->getUserdataPath('eqsl_card', 'p', $row->user_id) . '/' . $row->image_file;
 			unlink($image);
-			$this->db->delete('eQSL_images', array('id' => $row->id));
+			$this->db->delete('eQSL_images', [['id' => $row->id]]);
 			return $image;
 		}
 	}
 
 	function save_image($qso_id, $image_name) {
-		$data = array(
-		        'qso_id' => $qso_id,
-		        'image_file' => $image_name,
-		);
+		$data = [
+			'qso_id' => $qso_id,
+			'image_file' => $image_name,
+		];
 
 		$this->db->insert('eQSL_images', $data);
+
 	}
 
 	function count_eqsl_qso_list() {
@@ -47,10 +61,15 @@ class Eqsl_images extends CI_Model {
 		if ($logbooks_locations_array[0] === -1) {
 			return;
 		}
-		$this->db->join($this->config->item('table_name'), 'qso_id = COL_PRIMARY_KEY', 'left outer');
-		$this->db->join('station_profile', $this->config->item('table_name').'.station_id = station_profile.station_id', 'left outer');
-		$this->db->where_in('station_profile.station_id', $logbooks_locations_array);
-		return $this->db->count_all_results('eQSL_images');
+		$table_name = $this->config->item('table_name');
+		$sql = "SELECT COUNT(*) AS cnt
+				FROM `eQSL_images` e
+				INNER JOIN {$table_name} qso ON (e.qso_id = qso.COL_PRIMARY_KEY)
+				INNER JOIN station_profile s ON (s.station_id = qso.station_id)
+				WHERE s.station_id IN ?";
+
+		$query = $this->db->query($sql, [$logbooks_locations_array]);
+		return (int) $query->row()->cnt;
 	}
 
 	function eqsl_qso_list($limit = null, $offset = null) {
@@ -59,53 +78,20 @@ class Eqsl_images extends CI_Model {
 		if ($logbooks_locations_array[0] === -1) {
 			return;
 		}
-		$this->db->select('COL_PRIMARY_KEY, qso_id, COL_CALL, COL_MODE, COL_SUBMODE, COL_TIME_ON, COL_BAND, COL_PROP_MODE, COL_SAT_NAME, COL_QSLMSG_RCVD, COL_EQSL_QSLRDATE, image_file');
-		$this->db->join($this->config->item('table_name'), 'qso_id = COL_PRIMARY_KEY', 'left outer');
-		$this->db->join('station_profile', $this->config->item('table_name').'.station_id = station_profile.station_id', 'left outer');
-		$this->db->where_in('station_profile.station_id', $logbooks_locations_array);
-		$this->db->order_by('COL_TIME_ON', 'DESC');
+		$table_name = $this->config->item('table_name');
+		$sql = "SELECT qso.COL_PRIMARY_KEY, e.qso_id, qso.COL_CALL, qso.COL_MODE, qso.COL_SUBMODE, qso.COL_TIME_ON, qso.COL_BAND, qso.COL_PROP_MODE, qso.COL_SAT_NAME, qso.COL_QSLMSG_RCVD, qso.COL_EQSL_QSLRDATE, e.image_file
+				FROM `eQSL_images` e
+				INNER JOIN {$table_name} qso ON (e.qso_id = qso.COL_PRIMARY_KEY)
+				INNER JOIN station_profile s ON (s.station_id = qso.station_id)
+				WHERE s.station_id IN ?
+				ORDER BY qso.COL_TIME_ON DESC";
+
+		$binds = [$logbooks_locations_array];
 		if ($limit !== null && $offset !== null) {
-			$this->db->limit($limit, $offset);
+			$sql .= " LIMIT ? OFFSET ?";
+			$binds[] = (int) $limit;
+			$binds[] = (int) $offset;
 		}
-		return $this->db->get('eQSL_images');
-	}
-
-	// return path of eQsl file : u=url / p=real path
-	function get_imagePath($pathorurl='u', $user_id = null) {
-
-		// test if new folder directory option is enabled
-		$userdata_dir = $this->config->item('userdata');
-
-		if (isset($userdata_dir)) {
-
-			$eqsl_dir = "eqsl_card"; // make sure this is the same as in Debug_model.php function migrate_userdata()
-
-			if (($user_id ?? '') == '') {
-				$user_id = $this->session->userdata('user_id');
-			}
-
-			// check if there is a user_id in the session data and it's not empty
-			if ($user_id != '') {
-
-				// create the folder
-				if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir)) {
-					mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir, 0755, true);
-				}
-
-				// and return it
-				if ($pathorurl=='u') {
-					return $userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
-				} else {
-					return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$eqsl_dir;
-				}
-			} else {
-				log_message('info', 'Can not get eqsl image path because no user_id in session data');
-			}
-		} else {
-			// if the config option is not set we just return the old path
-			return 'images/eqsl_card_images';
-		}
+		return $this->db->query($sql, $binds);
 	}
 }
-
-?>

--- a/application/models/Eqsl_images.php
+++ b/application/models/Eqsl_images.php
@@ -39,8 +39,10 @@ class Eqsl_images extends CI_Model {
 				return "No Image"; // Image doesn't belong to user, so return
 			}
 			$image = $this->paths->getUserdataPath('eqsl_card', 'p', $row->user_id) . '/' . $row->image_file;
-			unlink($image);
-			$this->db->delete('eQSL_images', [['id' => $row->id]]);
+			if (file_exists($image)) {
+				unlink($image);
+			}
+			$this->db->delete('eQSL_images', ['id' => $row->id]);
 			return $image;
 		}
 	}

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -60,7 +60,7 @@ class Qsl_model extends CI_Model {
 					return "No Image";				// Image doesn't belong to user, so return
 				}
 			}
-			$image=$this->get_imagePath('p',$row->user_id).'/'.$row->filename;
+			$image = $this->paths->getUserdataPath('qsl_card', 'p',$row->user_id).'/'.$row->filename;
 			unlink($image);
 			$this->db->delete('qsl_images', array('id' => $row->id));
 		}
@@ -80,7 +80,7 @@ class Qsl_model extends CI_Model {
 			return;
 		}
 		// We cannot call del_image_for_qso here, since this one only deletes ONE QSL-Card (Multiple QSL-Cards can belong to one QSO)
-		$path = $this->get_imagePath('p');
+		$path = $this->paths->getUserdataPath('qsl_card', 'p');
 		$file = $this->getFilename($clean_id)->row();
 		$filename = basename($file->filename);
 		unlink($path.'/'.$filename);
@@ -139,44 +139,6 @@ class Qsl_model extends CI_Model {
 		$this->db->insert('qsl_images', $data);
 
 		return $this->db->insert_id();
-	}
-
-	// return path of qsl file : u=url / p=real path
-	function get_imagePath($pathorurl='u', $user_id=null) {
-
-		// test if new folder directory option is enabled
-		$userdata_dir = $this->config->item('userdata');
-
-		if (isset($userdata_dir)) {
-
-			$qsl_dir = "qsl_card"; // make sure this is the same as in Debug_model.php function migrate_userdata()
-
-			if (($user_id ?? '') == '') {
-				$user_id = $this->session->userdata('user_id');
-			}
-
-			// check if there is a user_id in the session data and it's not empty
-			if ($user_id != '') {
-
-				// create the folder
-				if (!file_exists(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir)) {
-					mkdir(realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir, 0755, true);
-				}
-
-				// and return it
-				if ($pathorurl=='u') {
-					return $userdata_dir.'/'.$user_id.'/'.$qsl_dir;
-				} else {
-					return realpath(APPPATH.'../').'/'.$userdata_dir.'/'.$user_id.'/'.$qsl_dir;
-				}
-			} else {
-				log_message('info', 'Can not get qsl card image path because no user_id in session data');
-			}
-		} else {
-
-			// if the config option is not set we just return the old path
-			return 'assets/qslcard';
-		}
 	}
 
 	function getConfirmations($confirmationtype) {

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -53,15 +53,19 @@ class Qsl_model extends CI_Model {
 	function del_image_for_qso($qso_id, $user_id = null) {
 		// QSO belongs to station_profile. But since we have folders for Users (and therefore an extra indirect relation) we need to lookup user for station first...
 		$qsl_img=$this->db->query('SELECT e.filename, e.id, qso.station_id, s.user_id FROM qsl_images e INNER JOIN '.$this->config->item('table_name').' qso ON (e.qsoid = qso.COL_PRIMARY_KEY) inner join station_profile s on (s.station_id=qso.station_id) where qso.COL_PRIMARY_KEY=?',$qso_id);
+
+		if (!valid_uid($user_id)) {
+			$user_id = $this->session->userdata('user_id');
+		}
 		foreach ($qsl_img->result() as $row) {
-			if (($user_id ?? '') == '') {					// Calling as User? Check if User-id matches User-id from QSO
-				$user_id = $this->session->userdata('user_id');
-				if ($row->user_id != $user_id) {
-					return "No Image";				// Image doesn't belong to user, so return
-				}
+			// Calling as User? Check if User-id matches User-id from QSO
+			if ($row->user_id != $user_id) {
+				return "No Image"; // Image doesn't belong to user, so return
 			}
-			$image = $this->paths->getUserdataPath('qsl_card', 'p',$row->user_id).'/'.$row->filename;
-			unlink($image);
+			$image = $this->paths->getUserdataPath('qsl_card', 'p', $row->user_id).'/'.$row->filename;
+			if (file_exists($image)) {
+				unlink($image);
+			}
 			$this->db->delete('qsl_images', array('id' => $row->id));
 		}
 	}
@@ -83,7 +87,9 @@ class Qsl_model extends CI_Model {
 		$path = $this->paths->getUserdataPath('qsl_card', 'p');
 		$file = $this->getFilename($clean_id)->row();
 		$filename = basename($file->filename);
-		unlink($path.'/'.$filename);
+		if (file_exists($path.'/'.$filename)) {
+			unlink($path.'/'.$filename);
+		}
 		// Delete Mode
 		$this->db->delete('qsl_images', array('id' => $clean_id));
 	}

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -6,7 +6,6 @@ class Update_model extends CI_Model {
     function clublog_scp() {
         // set the last run in cron table for the correct cron id
         $this->load->model('cron_model');
-        $this->load->library('Paths');
 
         $this->cron_model->set_last_run($this->router->class . '_' . $this->router->method);
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2375,7 +2375,7 @@ $('#sats').change(function(){
 <script>
 function viewQsl(picture, callsign) {
 
-            var webpath_qsl = "<?php echo $this->paths->getPathQsl(); ?>";
+            var webpath_qsl = "<?php echo $this->paths->getUserdataPath('qsl_card'); ?>";
             var textAndPic = $('<div class="text-center"></div>');
                 textAndPic.append('<img class="img-fluid w-qsl" style="height:auto;width:auto;"src="'+base_url+webpath_qsl+'/'+picture+'" />');
             var title = '';
@@ -2436,7 +2436,7 @@ function deleteQsl(id) {
 </script>
 <script>
 function viewEqsl(picture, callsign) {
-            var webpath_eqsl = '<?php echo $this->paths->getPathEqsl(); ?>';
+            var webpath_eqsl = '<?php echo $this->paths->getUserdataPath('eqsl_card'); ?>';
             var baseURL= "<?php echo base_url(); ?>";
             var $textAndPic = $('<div></div>');
                 $textAndPic.append('<img class="img-fluid" style="height:auto;width:auto;"src="'+baseURL+webpath_eqsl+'/'+picture+'" />');
@@ -2630,7 +2630,7 @@ function viewEqsl(picture, callsign) {
     }
 
     function uploadQsl() {
-        var webpath_qsl = "<?php echo $this->paths->getPathQsl(); ?>";
+        var webpath_qsl = "<?php echo $this->paths->getUserdataPath('qsl_card'); ?>";
         var formdata = new FormData(document.getElementById("fileinfo"));
 
         $.ajax({

--- a/application/views/logbookadvanced/qslcarousel.php
+++ b/application/views/logbookadvanced/qslcarousel.php
@@ -56,7 +56,7 @@
 		?>
 		</tbody>
 </table>
-        <?php echo '<img class="img-fluid w-qsl" src="' . base_url() . '/'. $this->paths->getPathQsl() .'/' . $image->filename .'" alt="' . __("QSL picture #") . $i++.'">';
+        <?php echo '<img class="img-fluid w-qsl" src="' . base_url() . '/'. $this->paths->getUserdataPath('qsl_card') .'/' . $image->filename .'" alt="' . __("QSL picture #") . $i++.'">';
         echo '</div>';
     }
     ?>

--- a/application/views/qslcard/index.php
+++ b/application/views/qslcard/index.php
@@ -109,7 +109,7 @@
 					$user_id = $this->session->userdata('user_id');
 
 					// Build correct image path: userdata/[user_id]/qsl_card/[filename]
-					$image_path = base_url().$this->paths->getPathQsl() . '/' . $filename;
+					$image_path = base_url().$this->paths->getUserdataPath('qsl_card') . '/' . $filename;
 					?>
 					<div class="waterfall-item">
 						<div class="card h-100">

--- a/application/views/qslcard/qslcarousel.php
+++ b/application/views/qslcard/qslcarousel.php
@@ -22,7 +22,7 @@
             echo ' active';
         }
         echo '">';
-        echo '<img class="img-fluid w-qsl" src="' . base_url() . '/'. $this->paths->getPathQsl() .'/' . $image->filename .'" alt="' . __("QSL picture #") . $i++.'">';
+        echo '<img class="img-fluid w-qsl" src="' . base_url() . '/'. $this->paths->getUserdataPath('qsl_card') .'/' . $image->filename .'" alt="' . __("QSL picture #") . $i++.'">';
         echo '</div>';
     }
     ?>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -801,7 +801,7 @@
         <div class="tab-pane fade" id="eqslcard" role="tabpanel" aria-labelledby="table-tab">
         <?php
 	    if ($row->eqsl_image_file != null) {
-		    echo '<img class="d-block" src="' . base_url() . '/'. $this->paths->getPathEqsl() .'/' . $row->eqsl_image_file .'" alt="' . __("eQSL picture") . '">';
+		    echo '<img class="d-block" src="' . base_url() . '/'. $this->paths->getUserdataPath('eqsl_card') .'/' . $row->eqsl_image_file .'" alt="' . __("eQSL picture") . '">';
 	    }
         ?>
         </div>

--- a/system/helpers/security_helper.php
+++ b/system/helpers/security_helper.php
@@ -111,3 +111,20 @@ if ( ! function_exists('encode_php_tags'))
 		return str_replace(array('<?', '?>'), array('&lt;?', '?&gt;'), $str);
 	}
 }
+
+// ------------------------------------------------------------------------
+
+if ( ! function_exists('valid_uid'))
+{
+	/**
+	 * Validate user id
+	 * Returns TRUE if the value is a positive integer, otherwise FALSE.
+	 *
+	 * @param	mixed	$value
+	 * @return	bool
+	 */
+	function valid_uid($value)
+	{
+		return filter_var($value, FILTER_VALIDATE_INT, array('options' => array('min_range' => 1))) !== FALSE;
+	}
+}


### PR DESCRIPTION
This is a larger refactoring of the Paths Library, namely the userdata path logic

when it was implemented by @abarrau a while ago, improved by @int2001 and myself we didn't take into account that in future there might by other userdata uploaded aswell. This will propably now the case with #3303 as we want to store this data in the userdata directory, seperated by the users. 

To make this possible we need to refactor the logic and (which is a good idea anyway) reduce duplicate code. The get_Imagepath logic was duped in qsl and eqsl logic only seperated by a keyword, aka. data- `$type` and is with this PR now merged into one userdata paths logic. This new logic allows future expansion with other datatypes. 

As small bonus for the future: There is a new security helper function `valid_uid()` which securely validates a user_id and makes sure it's an integer larger 0. This prevents dealing with `?? '') != '' || foobar` and makes it much easier to securely validate a user_id (which is part of the filepath by the way)

> [!note]
> The paths lib is autoloaded so you don't need `$this->load->library('paths');`

---

### a small documentation

you want the web path for eqsl image $foobar, use
```php
<?php
// second parameter defaults to 'u' for url
$filepath = $this->paths->$this->paths->getUserdataPath('eqsl_card') . '/' . $foobar;
```
you want the serverside filepath for eqsl image $foobar, use
```php
<?php
// 'p' is path like serverside filepath
$filepath = $this->paths->$this->paths->getUserdataPath('eqsl_card', 'p') . '/' . $foobar;
```
you want the web path for qsl card image $foobar, use
```php
<?php
$filepath = $this->paths->$this->paths->getUserdataPath('qsl_card') . '/' . $foobar;
```
you need a path to store the receipe for a good german currywurst on the server, use
```php
<?php
$filepath = $this->paths->$this->paths->getUserdataPath('currywurst', 'p') . '/' . $foobar;
```
...
you get an idea