### PR TITLE
Introduce UploadGuard for Qsl-Images and use it

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -418,7 +418,16 @@ class eqsl extends CI_Controller {
 				}
 
 				$filename = uniqid() . '.jpg';
-				$image_path = $this->paths->getUserdataPath('eqsl_card', 'p') . '/' . $filename;
+				$eqsl_path = $this->paths->getUserdataPath('eqsl_card', 'p');
+
+				// Make sure storing the downloaded card won't fill up the disk
+				$this->load->library('upload_guard');
+				if (!$this->upload_guard->has_free_space($eqsl_path, strlen($content))) {
+					show_error(__('Not enough free disk space to store the eQSL card'), 507);
+					return;
+				}
+
+				$image_path = $eqsl_path . '/' . $filename;
 				$save_result = file_put_contents($image_path, $content);
 
 				if ($save_result !== false) {
@@ -570,7 +579,13 @@ class eqsl extends CI_Controller {
 			}
 			$filename = uniqid() . '.jpg';
 			if ($this->Eqsl_images->get_image($id) == "No Image") {
-				if (file_put_contents($this->paths->getUserdataPath('eqsl_card', 'p') . '/' . $filename, $content) !== false) {
+				$eqsl_path = $this->paths->getUserdataPath('eqsl_card', 'p');
+				$this->load->library('upload_guard');
+				if (!$this->upload_guard->has_free_space($eqsl_path, strlen($content))) {
+					$error = __('Not enough free disk space to store the eQSL card');
+					return $error;
+				}
+				if (file_put_contents($eqsl_path . '/' . $filename, $content) !== false) {
 					$this->Eqsl_images->save_image($id, $filename);
 				}
 			}

--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -78,11 +78,23 @@ class Qsl extends CI_Controller {
 
     function uploadQslCardFront($qsoid) {
         $this->load->model('Qsl_model');
+        $this->load->model('logbook_model');
+        $this->load->library('upload_guard');
+
+        if (!$this->logbook_model->check_qso_is_accessible($qsoid)) {
+            return array('error' => __("You're not allowed to do that!"));
+        }
+
         $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
         $array = explode(".", $_FILES['qslcardfront']['name']);
         $ext = end($array);
-        $config['file_name'] = $qsoid . '_' . time() . '.' . $ext;
+        $config['file_name'] = $qsoid . '_' . time() . '_' . bin2hex(random_bytes(8)) . '.' . $ext;
+
+        // Refuse the upload if it would leave the storage volume too full
+        if (!$this->upload_guard->has_free_space($config['upload_path'], $_FILES['qslcardfront']['size'])) {
+            return array('error' => __("Not enough free disk space to store the QSL card."));
+        }
 
         $this->load->library('upload', $config);
 
@@ -95,6 +107,11 @@ class Qsl extends CI_Controller {
         else {
             //Upload of QSL card was successful
             $data = $this->upload->data();
+
+            if (!$this->upload_guard->is_real_image($data['full_path'])) {
+                unlink($data['full_path']);
+                return array('error' => __("The uploaded file is not a valid image."));
+            }
 
             // Now we need to insert info into database about file
             $filename = $data['file_name'];
@@ -109,11 +126,22 @@ class Qsl extends CI_Controller {
 
     function uploadQslCardBack($qsoid) {
         $this->load->model('Qsl_model');
+        $this->load->model('logbook_model');
+        $this->load->library('upload_guard');
+
+        if (!$this->logbook_model->check_qso_is_accessible($qsoid)) {
+            return array('error' => __("You're not allowed to do that!"));
+        }
+
         $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
         $array = explode(".", $_FILES['qslcardback']['name']);
         $ext = end($array);
-        $config['file_name'] = $qsoid . '_' . time() . '.' . $ext;
+        $config['file_name'] = $qsoid . '_' . time() . '_' . bin2hex(random_bytes(8)) . '.' . $ext;
+
+        if (!$this->upload_guard->has_free_space($config['upload_path'], $_FILES['qslcardback']['size'])) {
+            return array('error' => __("Not enough free disk space to store the QSL card."));
+        }
 
         $this->load->library('upload', $config);
 
@@ -126,6 +154,11 @@ class Qsl extends CI_Controller {
         else {
             //Upload of QSL card was successful
             $data = $this->upload->data();
+
+            if (!$this->upload_guard->is_real_image($data['full_path'])) {
+                unlink($data['full_path']);
+                return array('error' => __("The uploaded file is not a valid image."));
+            }
 
             // Now we need to insert info into database about file
             $filename = $data['file_name'];

--- a/application/libraries/EqslBulkDownloader.php
+++ b/application/libraries/EqslBulkDownloader.php
@@ -24,6 +24,7 @@ class EqslBulkDownloader {
 	public function __construct() {
 		$this->ci =& get_instance();
 		$this->ci->load->library('electronicqsl');
+		$this->ci->load->library('upload_guard');
 		$this->ci->load->model('user_model');
 		$this->ci->load->model('logbook_model');
 
@@ -299,7 +300,10 @@ class EqslBulkDownloader {
 					$filename = uniqid() . '.jpg';
 					$imagePath = $this->imagePath . '/' . $filename;
 
-					if (file_put_contents($imagePath, $content) !== false) {
+					if (!$this->ci->upload_guard->has_free_space($this->imagePath, strlen($content))) {
+						log_message('error', 'Not enough free disk space to store eQSL image for QSO ' . $qsoId);
+						$status[$qsoId]['error'] = 'Not enough free disk space';
+					} else if (file_put_contents($imagePath, $content) !== false) {
 						$this->ci->Eqsl_images->save_image($qsoId, $filename);
 						$status[$qsoId]['success'] = true;
 						log_message('debug', 'Successfully downloaded image for QSO ' . $qsoId);
@@ -410,6 +414,11 @@ class EqslBulkDownloader {
 		// Save image
 		$filename = uniqid() . '.jpg';
 		$imagePath = $this->imagePath . '/' . $filename;
+
+		if (!$this->ci->upload_guard->has_free_space($this->imagePath, strlen($content))) {
+			log_message('error', 'Not enough free disk space to store eQSL image: ' . $imagePath);
+			return false;
+		}
 
 		if (file_put_contents($imagePath, $content) !== false) {
 			$this->ci->Eqsl_images->save_image($qsoId, $filename);

--- a/application/libraries/Upload_guard.php
+++ b/application/libraries/Upload_guard.php
@@ -1,0 +1,45 @@
+<?php defined('BASEPATH') or exit('No direct script access allowed');
+
+/**
+ * Upload_guard
+ *
+ * Small, reusable upload-acceptance checks shared by the various file-upload
+ * paths (QSL cards, eQSL, ...). Kept free of controller/model state so it can be
+ * loaded and called from anywhere via $this->load->library('upload_guard').
+ */
+class Upload_guard {
+
+    /** Minimum free space (bytes) that must remain after a write: 4 GB. */
+    const DEFAULT_BUFFER = 4294967296; // 4 * 1024 * 1024 * 1024
+
+    /**
+     * Returns true only if $path is on a volume that, after writing
+     * $incoming_bytes, would still have at least $buffer bytes free.
+     *
+     * @param string $path           Target directory the file will be written to
+     * @param int    $incoming_bytes  Size of the file about to be written
+     * @param int    $buffer          Free-space buffer to preserve (default 4 GB)
+     */
+    public function has_free_space($path, $incoming_bytes, $buffer = self::DEFAULT_BUFFER) {
+        $free = @disk_free_space($path);
+        if ($free === false) {
+            return false; // can't determine free space -> fail safe
+        }
+        return ($free - (int) $incoming_bytes) >= $buffer;
+    }
+
+    /**
+     * Returns true if $fullpath is a real raster image (magic-byte check), not
+     * just a file carrying an image extension. Restricted to the formats the QSL
+     * card feature accepts.
+     *
+     * @param string $fullpath Absolute path to the uploaded file on disk
+     */
+    public function is_real_image($fullpath) {
+        $info = @getimagesize($fullpath);
+        if ($info === false) {
+            return false;
+        }
+        return in_array($info[2], array(IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_GIF), true);
+    }
+}

--- a/application/libraries/Upload_guard.php
+++ b/application/libraries/Upload_guard.php
@@ -9,8 +9,8 @@
  */
 class Upload_guard {
 
-    /** Minimum free space (bytes) that must remain after a write: 4 GB. */
-    const DEFAULT_BUFFER = 4294967296; // 4 * 1024 * 1024 * 1024
+    /** Minimum free space (bytes) that must remain after a write: 1 GB. */
+    const DEFAULT_BUFFER = 1073741824; // 1 * 1024 * 1024 * 1024
 
     /**
      * Returns true only if $path is on a volume that, after writing

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2675,9 +2675,7 @@ function viewEqsl(picture, callsign) {
                     }
 
                 } else if (data.status.front.status != '') {
-                    $("#qslupload").append('<div class="alert alert-danger">'+"<?= __("Front QSL Card:"); ?>  " +
-                    data.status.front.error +
-                        '</div>');
+                    showToast("<?= __("Front QSL Card"); ?>", data.status.front.error, 'bg-danger text-white', 5000);
                 }
                 if (data.status.back.status == 'Success') {
                     var qsoid = $("#qsoid").text();
@@ -2713,10 +2711,11 @@ function viewEqsl(picture, callsign) {
                         $("#qslcardback").val(null);
                     }
                 } else if (data.status.back.status != '') {
-                    $("#qslupload").append('<div class="alert alert-danger">\n'+"<?= __("Back QSL Card:"); ?>  " +
-                    data.status.back.error +
-                        '</div>');
+                    showToast("<?= __("Back QSL Card"); ?>", data.status.back.error, 'bg-danger text-white', 5000);
                 }
+            },
+            error: function () {
+                showToast("<?= __("Upload failed"); ?>", "<?= __("The QSL card upload could not be completed."); ?>", 'bg-danger text-white', 5000);
             }
         });
     }


### PR DESCRIPTION
This one tries to harden User-Uploads.

Features:
- [x] Check if uploaded QSL-Image is really an image
- [x] Reject upload if diskspace doesn't allow it (at least 1 GB should stay free / tight, but there are lot of instances running on Cheap hosters)
- [x] Show possible Failures to user (as toast)
- [x] Use Uploadguard as well in other logics 