### PR TITLE
Take qrzapikey on station_create

### DIFF
--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -290,6 +290,7 @@ class Stationsetup_model extends CI_Model {
 				'station_pota'          => ((isset($loc['station_pota']) && $loc['station_pota'] != "") ? xss_clean($loc['station_pota']) : null),
 				'state'                 => ((isset($loc['state']) && $loc['state'] != "") ? xss_clean($loc['state']) : null),
 				'station_cnty'          => ((isset($loc['station_cnty']) && $loc['station_cnty'] != "") ? xss_clean($loc['station_cnty']) : null),
+				'qrzapikey'             => ((isset($loc['qrzapikey']) && $loc['qrzapikey'] != "") ? xss_clean($loc['qrzapikey']) : null),
 				'qrzrealtime'           => ((isset($loc['qrzrealtime']) && $loc['qrzrealtime'] != "") ? xss_clean($loc['qrzrealtime']) : 0),
 				'oqrs'                  => ((isset($loc['oqrs']) && $loc['oqrs'] != "") ? xss_clean($loc['oqrs']) : 0),
 				'oqrs_text'             => ((isset($loc['oqrs_text']) && $loc['oqrs_text'] != "") ? xss_clean($loc['oqrs_text']) : null),


### PR DESCRIPTION
The `api/create_station` api lacked of using a possible passed qrzapikey.
this one fixes it.

Note: Export doesn't reveal it (due to privacy reasons)