### PR TITLE
Take care of possible ratelimit for get_contacts_adif

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -511,6 +511,9 @@ class API extends CI_Controller {
 			return;
 		}
 
+		$identifier = isset($obj['key']) ? $obj['key'] : null;
+		$this->check_rate_limit('get_contacts_adif', $identifier);
+
 		//do authorization
 		if(!isset($obj['key']) || $this->api_model->authorize($obj['key']) == 0) {
 		   http_response_code(401);


### PR DESCRIPTION
get_contacts_adif is a critical endpoint.
normally it doesn't have a rate-limit.

with this PR one CAN enable a rate-limit for it at config.php (like for qso, radio and other endpoints).

without the config.php-key the behaviour is the same than before this patch