### PR TITLE
Activators grid color

### DIFF
--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -18,8 +18,12 @@ class Activators extends CI_Controller
     public function index()
     {
         $data['page_title'] = __("Gridsquare Activators");
+        $validHex = function($color, $default) {
+            return preg_match('/^#[0-9a-fA-F]{6}$/', $color ?? '') ? $color : $default;
+        };
         $map_custom_colors = json_decode($this->optionslib->get_map_custom());
-        list($r, $g, $b) = sscanf($map_custom_colors->qsoconfirm->color, "#%02x%02x%02x");
+        $color_confirmed = $map_custom_colors->qsoconfirm->color;
+        list($r, $g, $b) = sscanf($validHex($color_confirmed ?? '', '#90EE90'), "#%02x%02x%02x");
         $data['grid_color'] = "rgba(".$r.", ".$g.", ".$b.", 0.6)";
 
         $this->load->model('Activators_model');

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -19,7 +19,8 @@ class Activators extends CI_Controller
     {
         $data['page_title'] = __("Gridsquare Activators");
         $map_custom_colors = json_decode($this->optionslib->get_map_custom());
-        $data['grid_color'] = $map_custom_colors->qsoconfirm->color;
+        list($r, $g, $b) = sscanf($map_custom_colors->qsoconfirm->color, "#%02x%02x%02x");
+        $data['grid_color'] = "rgba(".$r.", ".$g.", ".$b.", 0.6)";
 
         $this->load->model('Activators_model');
 

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -18,6 +18,8 @@ class Activators extends CI_Controller
     public function index()
     {
         $data['page_title'] = __("Gridsquare Activators");
+        $map_custom_colors = json_decode($this->optionslib->get_map_custom());
+        $data['grid_color'] = $map_custom_colors->qsoconfirm->color;
 
         $this->load->model('Activators_model');
 

--- a/application/controllers/Activatorsmap.php
+++ b/application/controllers/Activatorsmap.php
@@ -15,6 +15,8 @@ class Activatorsmap extends CI_Controller {
 
 	public function index() {
 		$data['page_title'] = __("Activators Map");
+		$user_colors = json_decode($this->optionslib->get_map_custom());
+		$data['grid_color'] = $user_colors->qsoconfirm->color;
 
 		$this->load->model('stations');
         $data['station_locator'] = $this->stations->find_gridsquare();

--- a/application/controllers/Activatorsmap.php
+++ b/application/controllers/Activatorsmap.php
@@ -15,8 +15,6 @@ class Activatorsmap extends CI_Controller {
 
 	public function index() {
 		$data['page_title'] = __("Activators Map");
-		$user_colors = json_decode($this->optionslib->get_map_custom());
-		$data['grid_color'] = $user_colors->qsoconfirm->color;
 
 		$this->load->model('stations');
         $data['station_locator'] = $this->stations->find_gridsquare();

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -1,10 +1,10 @@
 <?php
-   list($r, $g, $b) = sscanf($grid_color, "#%02x%02x%02x");
-   $grid_col = "rgba(".$r.", ".$g.", ".$b.", 0.6)";
+	list($r, $g, $b) = sscanf($grid_color, "#%02x%02x%02x");
+	$grid_col = "rgba(".$r.", ".$g.", ".$b.", 0.6)";
 ?>
 <script>
 	let lang_activators_map = "<?= __("Activators Map"); ?>";
-   let grid_color = "<?= $grid_col; ?>";
+	let grid_color = "<?= $grid_col; ?>";
 </script>
 <div class="container px-3 px-lg-4 mt-3 mb-3">
 	<h2><?= __("Gridsquare Activators"); ?></h2>

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -1,5 +1,10 @@
+<?php
+   list($r, $g, $b) = sscanf($grid_color, "#%02x%02x%02x");
+   $grid_col = "rgba(".$r.", ".$g.", ".$b.", 0.6)";
+?>
 <script>
 	let lang_activators_map = "<?= __("Activators Map"); ?>";
+   let grid_color = "<?= $grid_col; ?>";
 </script>
 <div class="container px-3 px-lg-4 mt-3 mb-3">
 	<h2><?= __("Gridsquare Activators"); ?></h2>

--- a/application/views/activators/index.php
+++ b/application/views/activators/index.php
@@ -1,10 +1,6 @@
-<?php
-	list($r, $g, $b) = sscanf($grid_color, "#%02x%02x%02x");
-	$grid_col = "rgba(".$r.", ".$g.", ".$b.", 0.6)";
-?>
 <script>
 	let lang_activators_map = "<?= __("Activators Map"); ?>";
-	let grid_color = "<?= $grid_col; ?>";
+	let grid_color = "<?= $grid_color; ?>";
 </script>
 <div class="container px-3 px-lg-4 mt-3 mb-3">
 	<h2><?= __("Gridsquare Activators"); ?></h2>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -874,7 +874,7 @@ document.onkeyup = function(e) {
 
 
 
-function showActivatorsMap(call, count, grids) {
+function showActivatorsMap(call, count, grids, grid_color) {
 
     let re = /,/g;
     grids = grids.replace(re, ', ');
@@ -896,7 +896,7 @@ function showActivatorsMap(call, count, grids) {
 
     var grid_four = grids.split(', ');
 
-    var maidenhead = new L.maidenheadactivators(grid_four).addTo(map);
+    var maidenhead = new L.maidenheadactivators(grid_four, grid_color).addTo(map);
 
     var osmUrl = '<?php echo $this->optionslib->get_option('option_map_tile_server');?>';
     var osmAttrib = option_map_tile_server_copyright;

--- a/assets/js/leaflet/L.Maidenhead.activators.js
+++ b/assets/js/leaflet/L.Maidenhead.activators.js
@@ -76,21 +76,21 @@ L.MaidenheadActivators = L.LayerGroup.extend({
 				var bounds = [[lat,lon],[lat+unit,lon+(unit*2)]];
 
 				if(grid_two.includes(this._getLocator(lon,lat,map))) {
-					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle grid-confirmed', color: 'rgba(144,238,144, 0.6)', weight: 1, fillOpacity: 1, fill:true, interactive: false}));
+					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle grid-confirmed', color: grid_color, weight: 1, fillOpacity: 1, fill:true, interactive: false}));
 				}
 
 				if(grid_four.includes(this._getLocator(lon,lat,map))) {
-					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle grid-confirmed', color: 'rgba(144,238,144, 0.6)', weight: 1, fillOpacity: 1, fill:true, interactive: false}));
+					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle grid-confirmed', color: grid_color, weight: 1, fillOpacity: 1, fill:true, interactive: false}));
 				}
 
 				if (zoom < 2 || zoom > 4) {
 					this.addLayer(this._getLabel(lon+unit-(unit/lcor),lat+(unit/2)+(unit/lcor*c), map));
 				}
 				if (zoom < 3 ) {
-					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle', color: this.options.color, weight: 1, fill:false, interactive: false}));
+					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle', color: grid_color, weight: 1, fill:false, interactive: false}));
 				}
 				if (zoom < 3 || zoom > 5) {
-					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle', color: this.options.color, weight: 1, fill:false, interactive: false}));
+					this.addLayer(L.rectangle(bounds, {className: 'grid-rectangle', color: grid_color, weight: 1, fill:false, interactive: false}));
 				}
 
 				if (zoom < 3 || zoom > 5) {

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -827,7 +827,7 @@ function spawnActivatorsMap(call, count, grids) {
 				nl2br: false,
 				message: html,
 				onshown: function(dialog) {
-					showActivatorsMap(call, count, grids);
+					showActivatorsMap(call, count, grids, grid_color);
 				},
 				buttons: [{
 					label: lang_admin_close,


### PR DESCRIPTION
For some reason we used a separate hard coded green color for grid actvators map. This changes the code to use the user configured color for confirmed QSOs to make these maps a little more flexible. Screenshot shows before and after:

<img width="2007" height="1283" alt="image" src="https://github.com/user-attachments/assets/13f511fb-c0ca-4522-beb6-6b3188315230" />
