### PR TITLE
Switch Operator

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -950,7 +950,7 @@ class Contesting extends CI_Controller {
 		header('Content-Type: application/json');
 
 		try {
-			if (!$this->config->item('special_callsign')) {
+			if (!$this->config->item('special_callsign') || $this->config->item('disable_impersonate')) {
 				http_response_code(403);
 				echo json_encode(['success' => false, 'error' => __("Operator switching is disabled.")]);
 				return;
@@ -1016,11 +1016,18 @@ class Contesting extends CI_Controller {
 
 			// Establish the impersonation session for the new operator (same primitives
 			// as User::impersonate()). user_id stays the club.
+			// Create a fresh impersonation hash so the operator can still use "Switch back"
+			// to return to their own account. Format must match stop_impersonate()'s
+			// validation (User.php): source_uid/target_uid/timestamp — source is this
+			// operator, target is the club (which stays as user_id).
+			if (!$this->load->is_loaded('encryption')) {
+				$this->load->library('encryption');
+			}
 			$custom = [
 				'p_level'       => $p_level,
 				'src_call'      => $op->user_callsign,
 				'src_user_type' => $op->user_type,
-				'src_hash'      => '', // wipe any inherited hash from the previous operator
+				'src_hash'      => $this->encryption->encrypt($op->user_id . '/' . $club_id . '/' . time()),
 			];
 			$this->session->set_userdata('source_uid', $op->user_id);
 			$this->user_model->update_session($club_id, null, true, $custom);

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -503,11 +503,20 @@ class Contesting extends CI_Controller {
 		// Generate storage key for localStorage. This needs to be collision-free between different Wavelog Instances and different users
 		$data['storage_key'] = md5($this->config->item('base_url') . $contest_session_id . $this->session->userdata('user_id'));
 
-		$data['operator'] = $this->user_model->get_by_id($decoded_token['user_id'])->row()->user_callsign;
+		$data['operator'] = strtoupper(trim($this->session->userdata('operator_callsign') ?: $this->session->userdata('user_callsign')));
 		$data['page_title'] = !empty($data['session_info']['custom_name'])
 			? $data['session_info']['custom_name']
 			: $data['session_info']['contest_name'];
 		$data['is_club_station'] = (bool) ($this->session->userdata('clubstation') ?? false);
+		$data['switch_operator_mode'] = null;
+		if ($data['is_club_station']) {
+			if (empty($this->session->userdata('source_uid'))) {
+				$data['switch_operator_mode'] = 'callsign';
+			} elseif (!$this->config->item('disable_impersonate')) {
+				$data['switch_operator_mode'] = 'login';
+			}
+		}
+		$data['club_callsign'] = $this->session->userdata('user_callsign');
 
 		// Load available radios for CAT control
 		$this->load->model('cat');
@@ -923,6 +932,108 @@ class Contesting extends CI_Controller {
 			}
 
 			echo json_encode(['success' => true, 'qso_id' => $qso_id]);
+		} catch (Exception $e) {
+			http_response_code(400);
+			echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+		}
+	}
+
+	/**
+	 * Switch the operating user mid-session in a club station.
+	 */
+	public function switch_operator() {
+		if ($this->input->method() !== 'post') {
+			$this->_teapot();
+			return;
+		}
+
+		header('Content-Type: application/json');
+
+		try {
+			if (!$this->config->item('special_callsign')) {
+				http_response_code(403);
+				echo json_encode(['success' => false, 'error' => __("Operator switching is disabled.")]);
+				return;
+			}
+
+			$payload = json_decode($this->input->raw_input_stream, true);
+			if (!$payload) {
+				throw new Exception('Invalid JSON payload');
+			}
+
+			$contest_session_id = (int)($payload['contest_session_id'] ?? 0);
+			$user_name          = trim((string)($payload['user_name'] ?? ''));
+			$user_password      = (string)($payload['user_password'] ?? '');
+
+			if (!$contest_session_id || $user_name === '' || $user_password === '') {
+				throw new Exception('Missing required fields');
+			}
+
+			// Only valid inside a club station.
+			if ((int)$this->session->userdata('clubstation') !== 1) {
+				http_response_code(403);
+				echo json_encode(['success' => false, 'error' => __("Operator switching is only available in club stations.")]);
+				return;
+			}
+
+			$club_id = (int)$this->session->userdata('user_id');
+
+			// The club must own this contest session.
+			$this->load->model('contesting_model');
+			if (!$this->contesting_model->check_user_contest($contest_session_id)) {
+				http_response_code(403);
+				echo json_encode(['success' => false, 'error' => __("Access denied")]);
+				return;
+			}
+
+			// Re-authenticate the new operator. Reuses bcrypt verification and the
+			// login_attempts lockout. Returns 1 on success; 0/2/3 are all failures here.
+			if ($this->user_model->authenticate($user_name, $user_password) !== 1) {
+				http_response_code(401);
+				echo json_encode(['success' => false, 'error' => __("Incorrect username or password!")]);
+				return;
+			}
+			$op = $this->user_model->get($user_name)->row();
+
+			// A club account must never act as an operator. authenticate() lets club
+			// accounts through when club_direct is enabled, so reject them explicitly.
+			if ((int)$op->clubstation !== 0) {
+				http_response_code(403);
+				echo json_encode(['success' => false, 'error' => __("A club account cannot be used as an operator.")]);
+				return;
+			}
+
+			// The operator must be an authorised member (p_level >= 3) of THIS club.
+			// get_permission_noui() is the redirect-free getter (club_authorize() would
+			// redirect on failure, which breaks a JSON endpoint).
+			$this->load->model('club_model');
+			$p_level = (int)$this->club_model->get_permission_noui($club_id, $op->user_id);
+			if ($p_level < 3) {
+				http_response_code(403);
+				echo json_encode(['success' => false, 'error' => __("You're not allowed to do that!")]);
+				return;
+			}
+
+			// Establish the impersonation session for the new operator (same primitives
+			// as User::impersonate()). user_id stays the club.
+			$custom = [
+				'p_level'       => $p_level,
+				'src_call'      => $op->user_callsign,
+				'src_user_type' => $op->user_type,
+				'src_hash'      => '', // wipe any inherited hash from the previous operator
+			];
+			$this->session->set_userdata('source_uid', $op->user_id);
+			$this->user_model->update_session($club_id, null, true, $custom);
+			// update_session keeps an existing operator_callsign, so override it explicitly.
+			$this->session->set_userdata('operator_callsign', strtoupper(trim($op->user_callsign)));
+
+			// Fresh token now carries the new operator as token user_id (reads source_uid).
+			$token = $this->paths->create_contesting_logging_token($contest_session_id);
+
+			echo json_encode([
+				'success'  => true,
+				'redirect' => site_url('contesting/logging_engine') . '/' . $token,
+			]);
 		} catch (Exception $e) {
 			http_response_code(400);
 			echo json_encode(['success' => false, 'error' => $e->getMessage()]);

--- a/application/controllers/Operator.php
+++ b/application/controllers/Operator.php
@@ -24,8 +24,29 @@ class Operator extends CI_Controller {
 
 	public function saveOperator() {
 
-		$operator = ['operator_callsign' => $this->security->xss_clean(strtoupper($this->input->post('operator_callsign')))];
+		$callsign = strtoupper(trim($this->input->post('operator_callsign', TRUE)));
+
+		if (!$this->isValidCallsign($callsign)) {
+			$this->output->set_status_header(400);
+			$this->output->set_content_type('application/json')->set_output(json_encode(['error' => __('Invalid callsign')]));
+			return;
+		}
+
+		$operator = ['operator_callsign' => $callsign];
 
 		$this->session->set_userdata($operator);
+	}
+
+	# Minimal sanity check that the input looks like an amateur radio callsign.
+	# Mirrors the client-side check: >=3 chars, only A-Z/0-9 (no "/" suffix or
+	# wildcards), at least one letter and one digit.
+	private function isValidCallsign($callsign) {
+		if ($callsign === '' || strlen($callsign) < 3) return false;
+		if (!preg_match('/^[A-Z0-9]+$/', $callsign)) return false;	// letters and digits only
+		if (!preg_match('/[A-Z]/', $callsign)) return false;		// at least one letter
+		if (!preg_match('/[0-9]/', $callsign)) return false;		// at least one digit
+		// A bare 3-char string ending in a digit is a prefix, not a call (e.g. "ZL3")
+		if (strlen($callsign) === 3 && !preg_match('/[A-Z]$/', $callsign)) return false;
+		return true;
 	}
 }

--- a/application/views/contesting/logger/index.php
+++ b/application/views/contesting/logger/index.php
@@ -160,6 +160,7 @@
             <form id="switchOperatorForm" autocomplete="off" data-mode="<?= $switch_operator_mode; ?>" data-club-callsign="<?= htmlspecialchars(strtoupper((string)($club_callsign ?? '')), ENT_QUOTES); ?>">
                 <div class="modal-body">
                     <div id="switchOperatorError" class="alert alert-danger d-none" role="alert"></div>
+                    <p class="mb-3"><?= __("Current Operator:"); ?> <strong><?= htmlspecialchars(strtoupper((string)($operator ?? '')), ENT_QUOTES); ?></strong></p>
                     <?php if ($switch_operator_mode === 'login'): ?>
                     <p class="text-muted"><?= __("Log in with another operator's account to continue this contest session under their callsign."); ?></p>
                     <div class="mb-3">

--- a/application/views/contesting/logger/index.php
+++ b/application/views/contesting/logger/index.php
@@ -60,6 +60,9 @@
     let lang_settings_changed = decodeHtml("<?= __("Contest settings have been changed. Please refresh the page to apply the new settings.") ?>");
     let lang_reload_now = decodeHtml("<?= __("Reload now") ?>");
     let lang_close = decodeHtml("<?= __("Close") ?>");
+    let lang_switch_operator = decodeHtml("<?= __("Switch Operator") ?>");
+    let lang_switch_op_pending = decodeHtml("<?= __("There are still unsynced QSOs. Please wait until they are saved before switching operator.") ?>");
+    let lang_switch_op_failed = decodeHtml("<?= __("Operator switch failed. Please try again.") ?>");
 </script>
 
 <div>
@@ -91,6 +94,11 @@
         </div>
         <div class="mb-4">
             <h6 class="text-muted mb-3"><i class="fas fa-trophy"></i> <?= __("Contest"); ?></h6>
+            <?php if (!empty($switch_operator_mode)): ?>
+            <button class="btn btn-secondary w-100 mb-2" id="btnSwitchOperator" data-bs-target="#switchOperatorModal">
+                <i class="fas fa-user-friends"></i> <?= __("Switch Operator"); ?>
+            </button>
+            <?php endif; ?>
             <button class="btn btn-danger w-100" id="btnEndContest">
                 <i class="fas fa-times-circle"></i> <?= __("End Session"); ?>
             </button>
@@ -138,3 +146,46 @@
     <?php endif; ?>
 </div>
 </div>
+
+<?php if (!empty($switch_operator_mode)): ?>
+<!-- Switch Operator modal. Both modes share one shell; only the body fields differ:
+     - 'login'    (impersonation): re-authenticate another club operator's account.
+     - 'callsign' (club_direct):   set the free-text operator callsign. -->
+<div class="modal fade bg-black bg-opacity-50" id="switchOperatorModal" tabindex="-1" aria-labelledby="switchOperatorLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered modal-md">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="switchOperatorLabel"><i class="fas fa-user-friends me-2"></i><?= __("Switch Operator"); ?></h5>
+            </div>
+            <form id="switchOperatorForm" autocomplete="off" data-mode="<?= $switch_operator_mode; ?>" data-club-callsign="<?= htmlspecialchars(strtoupper((string)($club_callsign ?? '')), ENT_QUOTES); ?>">
+                <div class="modal-body">
+                    <div id="switchOperatorError" class="alert alert-danger d-none" role="alert"></div>
+                    <?php if ($switch_operator_mode === 'login'): ?>
+                    <p class="text-muted"><?= __("Log in with another operator's account to continue this contest session under their callsign."); ?></p>
+                    <div class="mb-3">
+                        <label for="switchOperatorUser" class="form-label"><?= __("Username"); ?></label>
+                        <input type="text" class="form-control" id="switchOperatorUser" name="user_name" autocomplete="off" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="switchOperatorPass" class="form-label"><?= __("Password"); ?></label>
+                        <input type="password" class="form-control" id="switchOperatorPass" name="user_password" autocomplete="new-password" required>
+                    </div>
+                    <?php else: ?>
+                    <p class="text-muted"><?= __("Please provide your personal call sign. This makes sure that QSOs are logged and exported with correct operator information."); ?></p>
+                    <div class="mb-3">
+                        <label for="switchOperatorCall" class="form-label"><?= __("Your personal Callsign:"); ?></label>
+                        <input type="text" class="form-control uppercase" id="switchOperatorCall" name="operator_callsign" autocomplete="off" required>
+                    </div>
+                    <?php endif; ?>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?= __("Cancel"); ?></button>
+                    <button type="submit" class="btn btn-success" id="switchOperatorSubmit">
+                        <i class="fas fa-sign-in-alt me-2"></i><?= __("Switch Operator"); ?>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+<?php endif; ?>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -234,7 +234,7 @@ if($this->session->userdata('user_id') != null) {
 <!-- Version Dialog END -->
 
 <!-- SPECIAL CALLSIGN OPERATOR FEATURE -->
-<?php if ($this->config->item('special_callsign') && $this->uri->segment(1) == "dashboard" && $this->session->userdata('clubstation') == 1) { ?>
+<?php if ($this->config->item('special_callsign') && $this->session->userdata('clubstation') == 1) { ?>
 <script type="text/javascript" src="<?php echo $this->paths->cache_buster('/assets/js/sections/operator.js'); ?>"></script>
 <script>
 	<?php
@@ -247,8 +247,7 @@ if($this->session->userdata('user_id') != null) {
     let sc_account_call = '<?php echo $account_call; ?>'
 
 	<?php
-    # if the operator call and the account call is the same we show the dialog (except for admins!)
-    if ($op_call == $account_call && $user_type != '99') { ?>
+    if ($this->uri->segment(1) == "dashboard" && $op_call == $account_call && $user_type != '99') { ?>
 
         // load the dialog with javascript
         displayOperatorDialog();

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -133,6 +133,7 @@
     var lang_qso_location_is_fetched_from_provided_gridsquare = "<?= __("Location is fetched from provided gridsquare"); ?>";
     var lang_qso_location_is_fetched_from_dxcc_coordinates = "<?= __("Location is fetched from DXCC coordinates (no gridsquare provided)"); ?>";
     var lang_qso_dxcc_none_location = "<?= __("Location could not be determined as gridsquare is empty and DXCC is -NONE-"); ?>";
+    var lang_operator_modal_save_error = "<?= __("Error saving operator callsign. Please try again."); ?>";
 
     // CAT Offline Status Messages
     var lang_cat_working_offline = "<?= __("Working without CAT connection"); ?>";

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -570,6 +570,9 @@
 										</button>
 									</li>
 								<?php } ?>
+								<?php if ($this->config->item('special_callsign') && $this->session->userdata('clubstation') == 1 && empty($this->session->userdata('source_uid'))) { ?>
+									<li><a class="dropdown-item" href="javascript:displayOperatorDialog();" title="<?= __("Switch Operator"); ?>"><i class="fas fa-user-friends"></i> <?= __("Switch Operator"); ?></a></li>
+								<?php } ?>
 								<li><a class="dropdown-item" href="<?php echo site_url('user/logout'); ?>" title="Logout"><i class="fas fa-sign-out-alt"></i> <?= __("Logout"); ?></a></li>
 							</ul>
 						</li>

--- a/application/views/operator/index.php
+++ b/application/views/operator/index.php
@@ -19,6 +19,7 @@ $dismissible = ($op_call !== $account_call);
                             <input type="text" class="form-control w-auto uppercase" id="operator_callsign" name="operator_callsign">
                             <div class="invalid-feedback">
                                 <?= __("You have to provide your personal callsign."); ?>
+                                <?= __("No pre-/suffix allowed."); ?>
                             </div>
                         </div>
                     </div>

--- a/application/views/operator/index.php
+++ b/application/views/operator/index.php
@@ -1,4 +1,9 @@
-<div class="modal fade bg-black bg-opacity-50" id="operatorModal" tabindex="-1" aria-labelledby="operatorLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+<?php
+$op_call = $this->session->userdata('operator_callsign');
+$account_call = $this->session->userdata('user_callsign');
+$dismissible = ($op_call !== $account_call);
+?>
+<div class="modal fade bg-black bg-opacity-50" id="operatorModal" tabindex="-1" aria-labelledby="operatorLabel" aria-hidden="true"<?php if (!$dismissible): ?> data-bs-backdrop="static" data-bs-keyboard="false"<?php endif; ?>>
     <div class="modal-dialog modal-dialog-centered modal-md">
         <div class="modal-content">
             <div class="modal-header">
@@ -20,6 +25,9 @@
                 </div>
             </div>
             <div class="modal-footer">
+                <?php if ($dismissible): ?>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?= __("Cancel"); ?></button>
+                <?php endif; ?>
                 <button class="btn btn-primary" onclick="saveOperator()"><?= __("Save"); ?></button>
             </div>
         </div>

--- a/assets/css/contesting/contesting.css
+++ b/assets/css/contesting/contesting.css
@@ -169,6 +169,52 @@
   background: var(--bs-danger);
 }
 
+/* Operator chip in the window header. Styled to match the header chrome (muted,
+   subtle border) instead of a stock Bootstrap button so it reads as part of the
+   header. Click opens the control panel. */
+.window-operator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  color: #9a9a9a;
+  background: transparent;
+  border: 1px solid var(--cl-contest-border, rgba(255, 255, 255, 0.12));
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+
+.window-operator:hover {
+  color: var(--bs-body-color);
+  background: var(--cl-contest-btn-hover-bg, #3a3a3a);
+  border-color: var(--cl-contest-btn-hover-bg, #3a3a3a);
+}
+
+.window-operator i {
+  font-size: 0.9em;
+  color: var(--bs-primary);
+}
+
+.window-operator-call {
+  letter-spacing: 0.5px;
+}
+
+/* Brief attention pulse on the Switch Operator button when invoked from the operator badge */
+@keyframes switchOperatorPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(var(--bs-warning-rgb), 0.7); }
+  50% { box-shadow: 0 0 0 6px rgba(var(--bs-warning-rgb), 0); }
+}
+
+.switch-operator-highlight {
+  animation: switchOperatorPulse 0.7s ease-out 2;
+  border-color: var(--bs-warning) !important;
+}
+
 .window-body {
   flex: 1;
   padding: 16px;

--- a/assets/js/sections/contesting/contest_engine/app.js
+++ b/assets/js/sections/contesting/contest_engine/app.js
@@ -195,6 +195,120 @@ function initControlPanel(windowManager) {
         });
     }
 
+    // Switch Operator (club stations only). One modal/form (#switchOperatorForm)
+    // serves both modes; data-mode selects the flow ('login' = re-authenticate a
+    // personal account; 'callsign' = club_direct free-text callsign).
+    // We never switch while QSOs are still pending (would mis-attribute them to the
+    // new operator). Instead of flushing/waiting, we simply block the switch and let
+    // the user retry once the sync engine has drained them.
+
+    const hasPendingQsos = () => {
+        const app = window.contestApp;
+        if (!app || !app.ds) return false;
+        return Array.from(app.ds.getPattern('qso.*').values()).some(q => q.state === 'pending');
+    };
+
+    // Gate the Switch Operator button: if anything is unsynced, block the modal and
+    // nudge the sync engine. data-bs-toggle was removed from the button so we open
+    // the target modal manually after the pending check passes.
+    const switchOperatorBtn = document.getElementById('btnSwitchOperator');
+    if (switchOperatorBtn) {
+        switchOperatorBtn.addEventListener('click', function () {
+            if (hasPendingQsos()) {
+                window.contestApp?.syncEngine?.triggerNow();
+                window.contestApp?.wm?.showToast(lang_warning, lang_switch_op_pending, 'bg-warning text-dark', 5000);
+                return;
+            }
+            const modalEl = document.querySelector(this.dataset.bsTarget);
+            if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).show();
+        });
+    }
+
+    const switchOperatorForm = document.getElementById('switchOperatorForm');
+    if (switchOperatorForm) {
+        const mode = switchOperatorForm.dataset.mode; // 'login' | 'callsign'
+        const errorBox = document.getElementById('switchOperatorError');
+        const submitBtn = document.getElementById('switchOperatorSubmit');
+
+        const showError = (msg) => {
+            if (!errorBox) return;
+            errorBox.textContent = msg;
+            errorBox.classList.remove('d-none');
+        };
+
+        switchOperatorForm.addEventListener('submit', async function (e) {
+            e.preventDefault();
+            errorBox?.classList.add('d-none');
+
+            try {
+                if (mode === 'callsign') {
+                    // club_direct: operator is a free-text callsign (no account). Set it via
+                    // the existing operator/saveOperator endpoint and reload the engine.
+                    const input = document.getElementById('switchOperatorCall');
+                    const clubCall = (switchOperatorForm.dataset.clubCallsign || '').toUpperCase();
+                    const call = (input?.value || '').trim().toUpperCase();
+                    // Reject empty or the club's own callsign (operator must be a personal call).
+                    if (call === '' || call === clubCall) {
+                        input?.classList.add('is-invalid');
+                        showError(lang_switch_op_failed);
+                        return;
+                    }
+                    submitBtn.disabled = true;
+                    const resp = await fetch(base_url + 'index.php/operator/saveOperator', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: new URLSearchParams({ operator_callsign: call })
+                    });
+                    if (resp.ok) {
+                        window.location.reload(); // re-bootstraps the engine with the new operator
+                        return;
+                    }
+                    showError(lang_switch_op_failed);
+                } else {
+                    // login: re-authenticate another operator's account, then redirect into
+                    // the same session under the new identity.
+                    submitBtn.disabled = true;
+                    const resp = await fetch(base_url + 'index.php/contesting/switch_operator', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            contest_session_id: window.ContestLoggerConfig?.sessionInfo?.contest_session_id,
+                            user_name: document.getElementById('switchOperatorUser')?.value.trim(),
+                            user_password: document.getElementById('switchOperatorPass')?.value ?? ''
+                        })
+                    });
+                    const data = await resp.json().catch(() => ({}));
+                    if (resp.ok && data.success && data.redirect) {
+                        window.location.href = data.redirect;
+                        return;
+                    }
+                    showError(data.error || lang_switch_op_failed);
+                }
+            } catch (err) {
+                console.error('Switch operator failed', err);
+                showError(lang_switch_op_failed);
+            }
+            // Reset on failure (success navigates away).
+            const passField = document.getElementById('switchOperatorPass');
+            if (passField) passField.value = '';
+            submitBtn.disabled = false;
+        });
+    }
+
+    // Operator badge in the QSO form (club stations): opens the control panel (via the
+    // button's own data-bs-toggle) and briefly highlights the Switch Operator button.
+    // Delegated on document because the badge is rendered later, during qso-form init.
+    document.addEventListener('click', (e) => {
+        if (!e.target.closest('#qso-operator-display')) return;
+        const switchBtn = document.getElementById('btnSwitchOperator');
+        if (!switchBtn) return;
+        switchBtn.scrollIntoView({ block: 'nearest' });
+        switchBtn.classList.remove('switch-operator-highlight');
+        void switchBtn.offsetWidth; // reflow so the animation restarts on repeated clicks
+        switchBtn.classList.add('switch-operator-highlight');
+        setTimeout(() => switchBtn.classList.remove('switch-operator-highlight'), 2200);
+    });
+
     // Component visibility management
     function updateComponentList() {
         const listEl = document.getElementById('componentVisibilityList');

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -52,6 +52,7 @@ class QsoFormComponent {
 		this.lastSeenId = 0;
 		this.currentOperator = (window.ContestLoggerConfig?.operator ?? '').toUpperCase();
 
+		this.renderOperatorBadge();
 		this.registerSyncHandler();
 		this.setupEventListeners();
 		this.setupEditListeners();
@@ -59,6 +60,29 @@ class QsoFormComponent {
 		this.loadExistingQSOs();
 		this.applyRstDefaults();
 		this._setupBandmapListener();
+	}
+
+	// Show the current operator as a badge in this window's header (club stations only).
+	// Built in JS from ContestLoggerConfig because the window manager generates the
+	// header from scratch — server-rendered header markup wouldn't survive. Clicking it
+	// opens the control panel; app.js highlights the Switch Operator button (delegated).
+	renderOperatorBadge() {
+		if (!window.ContestLoggerConfig?.isClubStation) return;
+		const controls = this.container.querySelector('.window-controls');
+		if (!controls || controls.querySelector('#qso-operator-display')) return;
+
+		const btn = document.createElement('button');
+		btn.type = 'button';
+		btn.id = 'qso-operator-display';
+		btn.className = 'window-operator';
+		btn.setAttribute('data-bs-toggle', 'offcanvas');
+		btn.setAttribute('data-bs-target', '#controlPanel');
+		btn.title = lang_switch_operator;
+		btn.innerHTML = 'Op: <span id="qso-operator-call" class="window-operator-call"></span>';
+		btn.querySelector('#qso-operator-call').textContent = this.currentOperator;
+
+		// Keep the close button rightmost.
+		controls.insertBefore(btn, controls.querySelector('.close'));
 	}
 
 	_setupBandmapListener() {

--- a/assets/js/sections/operator.js
+++ b/assets/js/sections/operator.js
@@ -51,7 +51,7 @@ function saveOperator() {
 				window.location.reload();
 			},
 			error: function () {
-				showToast("error", __("Error saving operator callsign. Please try again."));
+				showToast("error", lang_operator_modal_save_error, 'bg-danger text-white', 5000);
 			}
 		});
 	} else {

--- a/assets/js/sections/operator.js
+++ b/assets/js/sections/operator.js
@@ -43,10 +43,16 @@ function saveOperator() {
 			data: {
 				operator_callsign: operatorCallsign,
 			},
+			// Reload only after the session write succeeded — reloading earlier races
+			// the POST and can render the previous operator.
+			success: function () {
+				closeOperatorDialog();
+				window.location.reload();
+			},
+			error: function () {
+				showToast("error", __("Error saving operator callsign. Please try again."));
+			}
 		});
-		closeOperatorDialog();
-		// console.log("saveOperator executed");
-		// console.log("operator:" + operatorCallsign);
 	} else {
 		operatorInput.addClass("is-invalid");
 	}

--- a/assets/js/sections/operator.js
+++ b/assets/js/sections/operator.js
@@ -32,11 +32,22 @@ function closeOperatorDialog() {
 	}
 }
 
+// Kept in sync with the server-side check in Operator::isValidCallsign().
+function isValidOperatorCallsign(callsign) {
+	if (!callsign || callsign.length < 3) return false;
+	if (!/^[A-Z0-9]+$/.test(callsign)) return false;	// letters and digits only
+	if (!/[A-Z]/.test(callsign)) return false;		// at least one letter
+	if (!/[0-9]/.test(callsign)) return false;		// at least one digit
+	// A bare 3-char string ending in a digit is a prefix, not a call (e.g. "ZL3")
+	if (callsign.length === 3 && !/[A-Z]$/.test(callsign)) return false;
+	return true;
+}
+
 function saveOperator() {
 	var operatorInput = $("#operator_callsign");
-	var operatorCallsign = operatorInput.val();
+	var operatorCallsign = operatorInput.val().trim().toUpperCase();
 
-	if (operatorCallsign != "" && operatorCallsign != sc_account_call) {
+	if (operatorCallsign != sc_account_call && isValidOperatorCallsign(operatorCallsign)) {
 		$.ajax({
 			url: base_url + "index.php/operator/saveOperator",
 			method: "POST",

--- a/assets/js/sections/operator.js
+++ b/assets/js/sections/operator.js
@@ -12,6 +12,7 @@ function displayOperatorDialog() {
 		type: "GET",
 		dataType: "html",
 		success: function (data) {
+			$("#operatorModal").remove();
 			$("body").append(data);
 
 			var operatorModal = new bootstrap.Modal($("#operatorModal"));


### PR DESCRIPTION
This requested from various operators during testing of the new contesting logger. This PR introduces a "switch operator" feature for the new contest logger.

How it works:
If a contesting session is open in a clubstation you can see a little badge with the operator callsign
<img width="457" height="236" alt="grafik" src="https://github.com/user-attachments/assets/e8372497-bfd2-4157-8a2f-47a3f7164112" />

If clicked it opens the control panel and shows the "Switch Operator" button
<img width="441" height="242" alt="grafik" src="https://github.com/user-attachments/assets/9e430a70-72aa-427b-bd4c-23ed98140bc4" />

This opens a modal which allows either login as new user and directly jump into the same contesting session with the new user

OR if `club_direct` is enabled and it was a direct login simply rewrite the php session data to the new operator. 
<img width="864" height="626" alt="grafik" src="https://github.com/user-attachments/assets/1ab516b4-2ce0-4d13-ab6b-43e6c66328f4" />

---

this allows contest teams to fastswitch operator during a contesting session without going aall the way back (close session, logout, login, contestmanager, start session) which is really cumbersome. 