### PR TITLE
Support multiple station_ids at once for get_contacts_adif

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -532,8 +532,24 @@ class API extends CI_Controller {
 
 		//extract relevant data to variables
 		$key = $obj['key'];
-		$station_id = $obj['station_id'];
 		$fetchfromid = $obj['fetchfromid'];
+
+		$req_station_ids = is_array($obj['station_id']) ? $obj['station_id'] : [$obj['station_id']];
+		if (empty($req_station_ids)) {
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => '"station_id" must not be empty']);
+			return;
+		}
+		$normalized_station_ids = [];
+		foreach ($req_station_ids as $sid) {
+			if (!is_numeric($sid)) {
+				http_response_code(400);
+				echo json_encode(['status' => 'failed', 'reason' => '"station_id" values must be numeric']);
+				return;
+			}
+			$normalized_station_ids[] = (int)$sid;
+		}
+		$req_station_ids = array_values(array_unique($normalized_station_ids));
 		$limit = 20000;
 		if ( (array_key_exists('limit',$obj)) && (is_numeric($obj['limit']*1)) ) {
 			$limit = $obj['limit'];
@@ -629,11 +645,12 @@ class API extends CI_Controller {
 			array_push($station_ids, $row->station_id);
 		}
 
-		//return error if station not accessible for the API key
-		if(!in_array($station_id, $station_ids)) {
-			http_response_code(401);
-	 	   	echo json_encode(['status' => 'failed', 'reason' => "Station ID not accessible for this API key"]);
-			return;
+		foreach ($req_station_ids as $station_id) {
+			if (!in_array($station_id, $station_ids)) {
+				http_response_code(401);
+				echo json_encode(['status' => 'failed', 'reason' => "Station ID not accessible for this API key"]);
+				return;
+			}
 		}
 
 		//load adif data module
@@ -660,7 +677,7 @@ class API extends CI_Controller {
 			$current_chunk_size = min($chunk_size, $remaining_limit);
 
 			// Fetch chunk
-			$qsos = $this->adif_data->export_past_id_chunked($station_id, $fetchfromid, $current_chunk_size, null, $offset, $current_chunk_size, $qsl_filter, $band);
+			$qsos = $this->adif_data->export_past_id_chunked($req_station_ids, $fetchfromid, $current_chunk_size, null, $offset, $current_chunk_size, $qsl_filter, $band);
 
 			if ($qsos && $qsos->num_rows() > 0) {
 				// Process chunk

--- a/application/models/Adif_data.php
+++ b/application/models/Adif_data.php
@@ -253,17 +253,28 @@ class adif_data extends CI_Model {
 		}
 	}
 
-	function export_past_id_chunked($station_id, $fetchfromid, $limit, $onlyop = null, $offset = 0, $chunk_size = 5000, $qsl_filter = null, $band = null) {
+	function export_past_id_chunked($station_ids, $fetchfromid, $limit, $onlyop = null, $offset = 0, $chunk_size = 5000, $qsl_filter = null, $band = null) {
 		$tbl = $this->config->item('table_name');
+
+		//normalize to array of ints (accepts legacy scalar as well)
+		if (!is_array($station_ids)) {
+			$station_ids = [$station_ids];
+		}
+		$station_ids = array_map('intval', $station_ids);
+		if (empty($station_ids)) {
+			return $this->db->query("SELECT * FROM {$tbl} WHERE 1=0");
+		}
+
+		$placeholders = implode(', ', array_fill(0, count($station_ids), '?'));
 
 		$sql = "SELECT {$tbl}.*, station_profile.*, dxcc_entities.name AS station_country
 		        FROM {$tbl}
 		        JOIN station_profile ON station_profile.station_id = {$tbl}.station_id
 		        LEFT OUTER JOIN dxcc_entities ON station_profile.station_dxcc = dxcc_entities.adif
-		        WHERE {$tbl}.station_id = ?
+		        WHERE {$tbl}.station_id IN ({$placeholders})
 		        AND {$tbl}.COL_PRIMARY_KEY > ?";
 
-		$bindings = [$station_id, $fetchfromid];
+		$bindings = array_merge($station_ids, [$fetchfromid]);
 
 		if ($onlyop) {
 			$sql .= " AND UPPER({$tbl}.col_operator) = ?";


### PR DESCRIPTION
`get_contacts_adif` api has to be called for every single station_id.
if there are multiple station_ids (at one key/user) to be fetched, this has to be done over and over.

this patch fixes it, so station_id now takes an array as well as a single station_id (like before the patch).

Test:

new (station_id 1 and 2 at once)

`curl -X POST -d '{"key":"[WLKEY]", "station_id":[1,2], "fetchfromid":1578569, "output_format":"adif"}'  https://[WL_URL]/api/get_contacts_adif`

single (as before patch - only station_id 1):

`curl -X POST -d '{"key":"[WLKEY]", "station_id":1, "fetchfromid":1578569, "output_format":"adif"}'  https://[WL_URL]/api/get_contacts_adif`