### PR TITLE
SAT: Add OMM Support to be future-proof

### DIFF
--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -223,11 +223,10 @@ class Satellite extends CI_Controller {
 
 		// Synthesize TLE text at render time for the legacy JS propagator (OMM-stored sats).
 		if ($satellite_data && !empty($satellite_data->tle)) {
-			$raw = trim($satellite_data->tle);
-			if ($raw !== '' && ($raw[0] === '{' || $raw[0] === '[')) {
-				require_once './src/predict/Predict/TLE.php';
+			require_once './src/predict/Predict/TLE.php';
+			if (Predict_TLE::isOmmJson($satellite_data->tle)) {
 				try {
-					$t = Predict_TLE::fromOmmJson($raw);
+					$t = Predict_TLE::fromOmmJson($satellite_data->tle);
 					$satellite_data->tle = $t->toTwolineTle();
 				} catch (\Throwable $e) {
 					log_message('error', 'OMM->TLE synthesis failed for "'.$sat.'": '.$e->getMessage());
@@ -393,7 +392,7 @@ class Satellite extends CI_Controller {
 	private function build_predict_tle($sat_tle) {
 		$raw = isset($sat_tle->tle) ? trim($sat_tle->tle) : '';
 
-		if ($raw !== '' && ($raw[0] === '{' || $raw[0] === '[')) {
+		if (Predict_TLE::isOmmJson($raw)) {
 			return Predict_TLE::fromOmmJson($raw);
 		}
 

--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -221,6 +221,20 @@ class Satellite extends CI_Controller {
 		$this->load->model('satellite_model');
 		$satellite_data = $this->satellite_model->get_sat_info($sat);
 
+		// Synthesize TLE text at render time for the legacy JS propagator (OMM-stored sats).
+		if ($satellite_data && !empty($satellite_data->tle)) {
+			$raw = trim($satellite_data->tle);
+			if ($raw !== '' && ($raw[0] === '{' || $raw[0] === '[')) {
+				require_once './src/predict/Predict/TLE.php';
+				try {
+					$t = Predict_TLE::fromOmmJson($raw);
+					$satellite_data->tle = $t->toTwolineTle();
+				} catch (\Throwable $e) {
+					log_message('error', 'OMM->TLE synthesis failed for "'.$sat.'": '.$e->getMessage());
+				}
+			}
+		}
+
 		header('Content-Type: application/json');
 		echo json_encode($satellite_data, JSON_FORCE_OBJECT);
 	}
@@ -372,6 +386,24 @@ class Satellite extends CI_Controller {
 		echo $r;
 	}
 
+	/**
+	 * Build a Predict_TLE from stored elements, handling both legacy TLE text
+	 * and CCSDS OMM JSON.
+	 */
+	private function build_predict_tle($sat_tle) {
+		$raw = isset($sat_tle->tle) ? trim($sat_tle->tle) : '';
+
+		if ($raw !== '' && ($raw[0] === '{' || $raw[0] === '[')) {
+			return Predict_TLE::fromOmmJson($raw);
+		}
+
+		$name = (isset($sat_tle->satellite) && $sat_tle->satellite)
+			? $sat_tle->satellite
+			: (isset($sat_tle->displayname) ? $sat_tle->displayname : '');
+		$temp = preg_split('/\n/', $sat_tle->tle);
+		return new Predict_TLE($name, $temp[0], $temp[1]);
+	}
+
 	public function get_tle_for_predict() {
 
 		$input_sat = (array) ($this->security->xss_clean($this->input->post('sat')) ?? []);
@@ -432,9 +464,7 @@ class Satellite extends CI_Controller {
 				continue;
 			}
 			try {
-				$temp = preg_split('/\n/', $sat_tle->tle);
-
-				$tle     = new Predict_TLE(($sat_tle->satellite ? $sat_tle->satellite : $sat_tle->displayname), $temp[0], $temp[1]); // Instantiate it
+				$tle     = $this->build_predict_tle($sat_tle);
 				$sat     = new Predict_Sat($tle); // Load up the satellite data
 
 				$now     = $this->get_daynum_from_date($date)+($mintime/24); // get the current time as Julian Date (daynum)
@@ -508,9 +538,7 @@ class Satellite extends CI_Controller {
 		$qth->lat = $homecoordinates[0];
 		$qth->lon = $homecoordinates[1];
 
-		$temp = preg_split('/\n/', $sat_tle->tle);
-
-		$tle     = new Predict_TLE($sat_tle->satellite, $temp[0], $temp[1]); // Instantiate it
+		$tle     = $this->build_predict_tle($sat_tle);
 		$sat     = new Predict_Sat($tle); // Load up the satellite data
 
 		$now     = $this->get_daynum_from_date($date)+($mintime/24); // get the current time as Julian Date (daynum)

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -74,28 +74,43 @@ class Satellite_model extends CI_Model {
 	}
 
 	function saveTle($id, $tle) {
-		$tlelines = explode("\n", trim($tle)); // Trim to remove extra spaces or newlines
-		$lineCount = count($tlelines);
+		$trimmed = trim($tle);
+		$text = null;
 
-		if ($lineCount === 3) {
-			$tleline1 = trim($tlelines[1]); // First data line
-			$tleline2 = trim($tlelines[2]); // Second data line
-		} else {
-			$tleline1 = trim($tlelines[0]);
-			$tleline2 = trim($tlelines[1]);
+		// OMM JSON: store compact; validated at consume time like legacy TLE.
+		if ($trimmed !== '' && ($trimmed[0] === '{' || $trimmed[0] === '[')) {
+			$decoded = json_decode($trimmed, true);
+			if (isset($decoded[0]) && is_array($decoded[0])) { $decoded = $decoded[0]; }
+			if (is_array($decoded)) {
+				$text = json_encode($decoded);
+			}
+		}
+
+		if ($text === null) {
+			$tlelines = explode("\n", $trimmed); // Trim to remove extra spaces or newlines
+			$lineCount = count($tlelines);
+
+			if ($lineCount === 3) {
+				$tleline1 = trim($tlelines[1]); // First data line
+				$tleline2 = trim($tlelines[2]); // Second data line
+			} else {
+				$tleline1 = trim($tlelines[0]);
+				$tleline2 = trim($tlelines[1]);
+			}
+			$text = $tleline1 . "\n" . $tleline2;
 		}
 
 		$this->db->where('satelliteid', $id);
 		if ($this->db->get('tle')->num_rows() > 0) {
 			$data = array(
-				'tle'			=> $tleline1 . "\n" . $tleline2,
+				'tle'			=> $text,
 			);
 			$this->db->where('satelliteid', $id);
 			$this->db->update('tle', $data);
 		} else {
 			$data = array(
 				'satelliteid' 	=> $id,
-				'tle'			=> $tleline1 . "\n" . $tleline2,
+				'tle'			=> $text,
 			);
 			$this->db->insert('tle', $data);
 			$insert_id = $this->db->insert_id();

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -74,31 +74,18 @@ class Satellite_model extends CI_Model {
 	}
 
 	function saveTle($id, $tle) {
-		$trimmed = trim($tle);
-		$text = null;
+		$tlelines = explode("\n", trim($tle)); // Trim to remove extra spaces or newlines
+		$lineCount = count($tlelines);
 
-		// OMM JSON: store compact; validated at consume time like legacy TLE.
-		if ($trimmed !== '' && ($trimmed[0] === '{' || $trimmed[0] === '[')) {
-			$decoded = json_decode($trimmed, true);
-			if (isset($decoded[0]) && is_array($decoded[0])) { $decoded = $decoded[0]; }
-			if (is_array($decoded)) {
-				$text = json_encode($decoded);
-			}
+		if ($lineCount === 3) {
+			$tleline1 = trim($tlelines[1]); // First data line
+			$tleline2 = trim($tlelines[2]); // Second data line
+		} else {
+			$tleline1 = trim($tlelines[0]);
+			$tleline2 = trim($tlelines[1]);
 		}
 
-		if ($text === null) {
-			$tlelines = explode("\n", $trimmed); // Trim to remove extra spaces or newlines
-			$lineCount = count($tlelines);
-
-			if ($lineCount === 3) {
-				$tleline1 = trim($tlelines[1]); // First data line
-				$tleline2 = trim($tlelines[2]); // Second data line
-			} else {
-				$tleline1 = trim($tlelines[0]);
-				$tleline2 = trim($tlelines[1]);
-			}
-			$text = $tleline1 . "\n" . $tleline2;
-		}
+		$text = $tleline1 . "\n" . $tleline2;
 
 		$this->db->where('satelliteid', $id);
 		if ($this->db->get('tle')->num_rows() > 0) {

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -379,7 +379,7 @@ class Update_model extends CI_Model {
 			$sql = "UPDATE `tle` LEFT JOIN `satellite` ON `tle`.`satelliteid` = `satellite`.`id` SET `tle` = NULL WHERE `satellite`.`name` != '' AND `satellite`.`name` IS NOT NULL;";
 			$this->db->query($sql);
 
-			$count = 0;
+			$amsat_count = 0;
 
 			if ($response === false) {
 				return 'Error: ' . curl_error($curl);
@@ -392,7 +392,6 @@ class Update_model extends CI_Model {
 				$tleline2 = '';
 				// Process each line
 				for ($i = 0; $i < count($lines); $i += 3) {
-					$count++;
 					// Check if there are at least three lines remaining
 					if (isset($lines[$i], $lines[$i + 1], $lines[$i + 2])) {
 						// Get the three lines
@@ -408,9 +407,15 @@ class Update_model extends CI_Model {
 						tle = VALUES(tle), updated = now()
 					";
 					$this->db->query($sql, array($tleline1 . "\n" . $tleline2, $satname));
+					if ($this->db->affected_rows() > 0) {
+						$amsat_count++;
+					}
 					}
 				}
 			}
+
+			// Gap-fill NULL rows from CelesTrak OMM (covers 6+ digit NORAD IDs AMSAT can't encode).
+			$omm_count = $this->update_tle_from_celestrak_omm();
 
 
 			$mtime = microtime();
@@ -418,11 +423,59 @@ class Update_model extends CI_Model {
 			$mtime = $mtime[1] + $mtime[0];
 			$endtime = $mtime;
 			$totaltime = ($endtime - $starttime);
-			return "This page was created in ".$totaltime." seconds <br />Records inserted: " . $count;
+			return "This page was created in ".$totaltime." seconds <br />AMSAT TLE: ".$amsat_count." updated, OMM: ".$omm_count." updated";
 
 		} else {
 			return "Error: Received file was empty";
 		}
+	}
+
+	/**
+	 * Gap-fill from CelesTrak OMM JSON. Only fills NULL rows so AMSAT stays primary.
+	 * @return int records applied
+	 */
+	private function update_tle_from_celestrak_omm() {
+		$url = 'https://celestrak.org/NORAD/elements/gp.php?GROUP=amateur&FORMAT=JSON';
+		$curl = curl_init($url);
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($curl, CURLOPT_USERAGENT, 'Wavelog TLE Updater');
+		curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+		$response = curl_exec($curl);
+		$err  = curl_error($curl);
+		$http = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+		curl_close($curl);
+
+		if ($response === false || $http !== 200) {
+			log_message('error', 'CelesTrak OMM fetch failed (HTTP ' . $http . '): ' . $err);
+			return 0;
+		}
+
+		$omm = json_decode($response, true);
+		if (!is_array($omm)) {
+			return 0;
+		}
+
+		$count = 0;
+		// Only fill still-NULL rows; AMSAT stays authoritative.
+		$sql = "INSERT INTO tle (satelliteid, tle)
+			SELECT s.id, ?
+			FROM satellite s
+			WHERE s.norad_id = ?
+			ON DUPLICATE KEY UPDATE
+			tle = IF(tle IS NULL, VALUES(tle), tle),
+			updated = IF(tle IS NULL, now(), updated)";
+		foreach ($omm as $obj) {
+			if (!isset($obj['NORAD_CAT_ID'])) { continue; }
+			$cat = (int) $obj['NORAD_CAT_ID'];
+			if ($cat <= 0) { continue; }
+			$this->db->query($sql, array(json_encode($obj), $cat));
+			// Counts only newly filled rows.
+			if ($this->db->affected_rows() > 0) {
+				$count++;
+			}
+		}
+		return $count;
 	}
 
 	 function lotw_sats() {

--- a/application/views/satellite/index.php
+++ b/application/views/satellite/index.php
@@ -97,9 +97,11 @@
 					echo '</td>';
 					?>
 					<?php echo '<td style="text-align: center; vertical-align: middle;">';
-					if ($sat->tle != null) {
-						echo '<button class="btn btn-sm btn-success" onclick="editTle(' . $sat->id . ');" data-bs-toggle="tooltip" title="Last TLE updated was ' . date($custom_date_format . " H:i", strtotime($sat->updated)) . '">'.__("Yes").'</i></button>';
-					} else {
+				if ($sat->tle != null) {
+					$_tle_raw = trim($sat->tle);
+					$_tle_fmt = ($_tle_raw !== '' && ($_tle_raw[0] === '{' || $_tle_raw[0] === '[')) ? __("OMM") : __("TLE");
+					echo '<button class="btn btn-sm btn-success" onclick="editTle(' . $sat->id . ');" data-bs-toggle="tooltip" title="Last TLE updated was ' . date($custom_date_format . " H:i", strtotime($sat->updated)) . '">'.$_tle_fmt.'</i></button>';
+				} else {
 						echo '<button class="btn btn-sm btn-danger" onclick="editTle(' . $sat->id . ');">'.__("No").'</button>';
 					}
 

--- a/application/views/satellite/index.php
+++ b/application/views/satellite/index.php
@@ -98,12 +98,11 @@
 					?>
 					<?php echo '<td style="text-align: center; vertical-align: middle;">';
 				if ($sat->tle != null) {
-					$_tle_raw = trim($sat->tle);
-					$_tle_fmt = ($_tle_raw !== '' && ($_tle_raw[0] === '{' || $_tle_raw[0] === '[')) ? __("OMM") : __("TLE");
+					$_tle_fmt = preg_match('/^\s*[{[]/', $sat->tle) ? __("OMM") : __("TLE");
 					echo '<button class="btn btn-sm btn-success" onclick="editTle(' . $sat->id . ');" data-bs-toggle="tooltip" title="Last TLE updated was ' . date($custom_date_format . " H:i", strtotime($sat->updated)) . '">'.$_tle_fmt.'</i></button>';
 				} else {
-						echo '<button class="btn btn-sm btn-danger" onclick="editTle(' . $sat->id . ');">'.__("No").'</button>';
-					}
+					echo '<button class="btn btn-sm btn-danger" onclick="editTle(' . $sat->id . ');">'.__("No").'</button>';
+				}
 
 					echo '</td>';
 					?>

--- a/application/views/satellite/tleinfo.php
+++ b/application/views/satellite/tleinfo.php
@@ -4,7 +4,15 @@
 <?php
 	if ($tleinfo->tle) {
 		echo sprintf(__("TLE information for %s (last updated: %s)"), ($satinfo[0]->name ? $satinfo[0]->name : $satinfo[0]->displayname), date($custom_date_format . " H:i", strtotime($tleinfo->updated)));
-		echo '<br /><br /><pre>' . $tleinfo->tle . '</pre>';
+		$_tle_raw = trim($tleinfo->tle);
+		$_tle_show = $_tle_raw;
+		if ($_tle_raw !== '' && ($_tle_raw[0] === '{' || $_tle_raw[0] === '[')) {
+			$_tle_dec = json_decode($_tle_raw);
+			if ($_tle_dec !== null) {
+				$_tle_show = json_encode($_tle_dec, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+			}
+		}
+		echo '<br /><br /><pre>' . htmlspecialchars($_tle_show) . '</pre>';
 		echo '<button class="btn btn-sm btn-danger deletetlebutton" onclick="deleteTle(' . $satinfo[0]->id . ');">'.__("Delete TLE"). '</button>';
 	} else {
 		echo sprintf(__("No TLE information found for %s"), ($satinfo[0]->name ? $satinfo[0]->name : $satinfo[0]->displayname));

--- a/assets/js/sections/satellite.js
+++ b/assets/js/sections/satellite.js
@@ -103,23 +103,6 @@ function tleChecksum(line) {
 
 function validateTLE(tle) {
     const trimmed = tle.trim();
-
-    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-        try {
-            let obj = JSON.parse(trimmed);
-            if (Array.isArray(obj)) { obj = obj[0]; }
-            const required = ['EPOCH','MEAN_MOTION','ECCENTRICITY','INCLINATION','RA_OF_ASC_NODE','ARG_OF_PERICENTER','MEAN_ANOMALY'];
-            for (const k of required) {
-                if (!(k in obj)) {
-                    return 'Invalid OMM: missing key ' + k;
-                }
-            }
-            return true;
-        } catch (e) {
-            return 'Invalid OMM JSON: ' + e.message;
-        }
-    }
-
     const lines = trimmed.split("\n");
 
     // Must have either 2 or 3 lines

--- a/assets/js/sections/satellite.js
+++ b/assets/js/sections/satellite.js
@@ -102,7 +102,25 @@ function tleChecksum(line) {
 }
 
 function validateTLE(tle) {
-    const lines = tle.trim().split("\n");
+    const trimmed = tle.trim();
+
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+            let obj = JSON.parse(trimmed);
+            if (Array.isArray(obj)) { obj = obj[0]; }
+            const required = ['EPOCH','MEAN_MOTION','ECCENTRICITY','INCLINATION','RA_OF_ASC_NODE','ARG_OF_PERICENTER','MEAN_ANOMALY'];
+            for (const k of required) {
+                if (!(k in obj)) {
+                    return 'Invalid OMM: missing key ' + k;
+                }
+            }
+            return true;
+        } catch (e) {
+            return 'Invalid OMM JSON: ' + e.message;
+        }
+    }
+
+    const lines = trimmed.split("\n");
 
     // Must have either 2 or 3 lines
     if (lines.length < 2 || lines.length > 3) {

--- a/src/predict/Predict/TLE.php
+++ b/src/predict/Predict/TLE.php
@@ -186,7 +186,7 @@ class Predict_TLE
         $tod     = $hours * 3600 + $minutes * 60 + $secs + ($micros / 1000000.0);
         $t->epoch_fod = $tod / 86400.0;
 
-        // Reconstruct YYDDD.FFFFFFFF for parity with TLE parser (propagator doesn't use it).
+        // Reconstruct YYDDD.FFFFFFFF — consumed by Predict_Sat via Julian_Date_of_Epoch($tle->epoch).
         $yy       = $dt->format('y');
         $t->epoch = (float) ($yy . sprintf('%03d', $t->epoch_day)) + $t->epoch_fod;
 
@@ -205,11 +205,21 @@ class Predict_TLE
         $t->revnum = isset($omm['REV_AT_EPOCH'])   ? (int) $omm['REV_AT_EPOCH']   : 0;
         $t->status = isset($omm['EPHEMERIS_TYPE']) ? (int) $omm['EPHEMERIS_TYPE'] : 0;
 
-        $t->xincl1  = null;
-        $t->xnodeo1 = null;
-        $t->omegao1 = null;
+        // xincl1/xnodeo1/omegao1 left unset; constructor doesn't init them either,
+        // SGPSDP writes them before any read. PHP defaults to null on access.
 
         return $t;
+    }
+
+    /**
+     * Sniff whether a stored `tle` column value is OMM JSON rather than two-line text.
+     * Single source of truth for the OMM/TLE branch across the codebase.
+     */
+    public static function isOmmJson($raw)
+    {
+        if (!is_string($raw)) { return false; }
+        $raw = ltrim($raw);
+        return $raw !== '' && ($raw[0] === '{' || $raw[0] === '[');
     }
 
     /* Calculates the checksum mod 10 of a line from a TLE set and */

--- a/src/predict/Predict/TLE.php
+++ b/src/predict/Predict/TLE.php
@@ -47,8 +47,14 @@ class Predict_TLE
     /* to their intended numerical values. No processing   */
     /* of these values is done, e.g. from deg to rads etc. */
     /* This is done in the select_ephemeris() function.    */
-    public function __construct($header, $line1, $line2)
+    public function __construct($header = null, $line1 = null, $line2 = null)
     {
+        // Empty shell for factory (fromOmmJson); keeps existing call sites working.
+        if ($line1 === null && $line2 === null) {
+            $this->header = $header ?? '';
+            return;
+        }
+
         if (!$this->Good_Elements($line1, $line2)) {
             throw new Predict_Exception('Invalid TLE contents');
         }
@@ -124,6 +130,86 @@ class Predict_TLE
 
         /* Satellite's Revolution number at epoch */
         $this->revnum = (float) substr($line2, 63, 5);
+    }
+
+    /**
+     * Build from CCSDS OMM JSON (CelesTrak gp.php?FORMAT=JSON).
+     * Accepts single object, list, or JSON string.
+     * @throws Predict_Exception on invalid JSON or missing mean elements
+     */
+    public static function fromOmmJson($omm)
+    {
+        if (is_string($omm)) {
+            $decoded = json_decode(trim($omm), true);
+            if (!is_array($decoded)) {
+                throw new Predict_Exception('Invalid OMM JSON');
+            }
+            $omm = $decoded;
+        }
+
+        if (isset($omm[0]) && is_array($omm[0])) {
+            $omm = $omm[0];
+        }
+
+        $required = array(
+            'EPOCH', 'MEAN_MOTION', 'ECCENTRICITY', 'INCLINATION',
+            'RA_OF_ASC_NODE', 'ARG_OF_PERICENTER', 'MEAN_ANOMALY',
+        );
+        foreach ($required as $key) {
+            if (!array_key_exists($key, $omm)) {
+                throw new Predict_Exception('OMM missing key: ' . $key);
+            }
+        }
+
+        $t = new Predict_TLE();
+
+        $name          = isset($omm['OBJECT_NAME']) ? $omm['OBJECT_NAME'] : '';
+        $t->header     = $name;
+        $t->sat_name   = $name;
+        $t->catnr      = isset($omm['NORAD_CAT_ID']) ? (int) $omm['NORAD_CAT_ID'] : 0;
+        $t->idesg      = isset($omm['OBJECT_ID']) ? $omm['OBJECT_ID'] : '';
+
+        // ISO-8601 UTC -> NORAD epoch fields (epoch_day is 1-based).
+        try {
+            $dt = new DateTime($omm['EPOCH'], new DateTimeZone('UTC'));
+        } catch (Exception $e) {
+            throw new Predict_Exception('Invalid OMM EPOCH: ' . $omm['EPOCH']);
+        }
+
+        $t->epoch_year = (int) $dt->format('Y');
+        $t->epoch_day  = (int) $dt->format('z') + 1;
+
+        $hours   = (int) $dt->format('H');
+        $minutes = (int) $dt->format('i');
+        $secs    = (int) $dt->format('s');
+        $micros  = (int) $dt->format('u');
+        $tod     = $hours * 3600 + $minutes * 60 + $secs + ($micros / 1000000.0);
+        $t->epoch_fod = $tod / 86400.0;
+
+        // Reconstruct YYDDD.FFFFFFFF for parity with TLE parser (propagator doesn't use it).
+        $yy       = $dt->format('y');
+        $t->epoch = (float) ($yy . sprintf('%03d', $t->epoch_day)) + $t->epoch_fod;
+
+        // Mean elements: same units as TLE parser output.
+        $t->xno    = (float) $omm['MEAN_MOTION'];
+        $t->xndt2o = isset($omm['MEAN_MOTION_DOT'])  ? (float) $omm['MEAN_MOTION_DOT']  : 0.0;
+        $t->xndd6o = isset($omm['MEAN_MOTION_DDOT']) ? (float) $omm['MEAN_MOTION_DDOT'] : 0.0;
+        $t->bstar  = isset($omm['BSTAR'])            ? (float) $omm['BSTAR']            : 0.0;
+        $t->eo     = (float) $omm['ECCENTRICITY'];
+        $t->xincl  = (float) $omm['INCLINATION'];
+        $t->xnodeo = (float) $omm['RA_OF_ASC_NODE'];
+        $t->omegao = (float) $omm['ARG_OF_PERICENTER'];
+        $t->xmo    = (float) $omm['MEAN_ANOMALY'];
+
+        $t->elset  = isset($omm['ELEMENT_SET_NO']) ? (int) $omm['ELEMENT_SET_NO'] : 0;
+        $t->revnum = isset($omm['REV_AT_EPOCH'])   ? (int) $omm['REV_AT_EPOCH']   : 0;
+        $t->status = isset($omm['EPHEMERIS_TYPE']) ? (int) $omm['EPHEMERIS_TYPE'] : 0;
+
+        $t->xincl1  = null;
+        $t->xnodeo1 = null;
+        $t->omegao1 = null;
+
+        return $t;
     }
 
     /* Calculates the checksum mod 10 of a line from a TLE set and */
@@ -228,5 +314,73 @@ class Predict_TLE
         $checksum %= 10;
 
         return $checksum;
+    }
+
+    /**
+     * Serialize to two-line TLE (inverse of parser). Render-time shim for TLE-only consumers.
+     * Catalog numbers >99999 wrap modulo (cosmetic only). Orbit stays correct because OMM
+     * supplies the mean elements plus B* (drag) that SGP4 consumes.
+     */
+    public function toTwolineTle()
+    {
+        $cat5  = sprintf('%05d', ((int) $this->catnr) % 100000);
+        $class = 'U';
+        $idesg = substr(str_pad((string) ($this->idesg ?? ''), 8, ' '), 0, 8);
+        $yy    = sprintf('%02d', ((int) $this->epoch_year) % 100);
+        $ddd   = sprintf('%03d', (int) $this->epoch_day);
+        $frac  = sprintf('%08d', (int) round((float) ($this->epoch_fod ?? 0.0) * 100000000.0));
+        $ndot  = $this->formatDotField((float) $this->xndt2o);
+        $nddot = $this->formatExpField((float) $this->xndd6o);
+        $bstar = $this->formatExpField((float) $this->bstar);
+        $eph   = (string) ((int) ($this->status ?? 0));
+        $elset = sprintf('%4d', ((int) ($this->elset ?? 0)) % 10000);
+
+        $line1 = '1 ' . $cat5 . $class . ' ' . $idesg . ' ' . $yy . $ddd . '.' . $frac
+               . ' ' . $ndot . ' ' . $nddot . ' ' . $bstar . ' ' . $eph . ' ' . $elset;
+
+        $ecc = sprintf('%07d', (int) round((float) $this->eo * 10000000.0));
+        $no  = sprintf('%11.8f', (float) $this->xno);
+        $rev = sprintf('%5d', ((int) ($this->revnum ?? 0)) % 100000);
+
+        $line2 = '2 ' . $cat5 . ' ' . sprintf('%8.4f', (float) $this->xincl) . ' '
+               . sprintf('%8.4f', (float) $this->xnodeo) . ' ' . $ecc . ' '
+               . sprintf('%8.4f', (float) $this->omegao) . ' '
+               . sprintf('%8.4f', (float) $this->xmo) . ' ' . $no . $rev;
+
+        return $this->finalizeLine($line1) . "\n" . $this->finalizeLine($line2);
+    }
+
+    /** Pad/trim to 68 chars and append mod-10 checksum. */
+    private function finalizeLine($line)
+    {
+        if (strlen($line) < 68) {
+            $line = str_pad($line, 68, ' ');
+        } elseif (strlen($line) > 68) {
+            $line = substr($line, 0, 68);
+        }
+        return $line . self::createChecksum($line);
+    }
+
+    /** TLE fixed-point derivative field: sign + . + 8 digits. */
+    private function formatDotField($value)
+    {
+        $sign   = ($value < 0) ? '-' : ' ';
+        $digits = (int) round(abs($value) * 100000000.0);
+        return $sign . '.' . sprintf('%08d', $digits % 100000000);
+    }
+
+    /** TLE mantissa-exponential field (nddot, BSTAR): sign + 5 mantissa + exp. */
+    private function formatExpField($value)
+    {
+        if ($value == 0.0) {
+            return ' 00000-0';
+        }
+        $sign = ($value < 0) ? '-' : ' ';
+        $abs  = abs($value);
+        $e    = (int) floor(log10($abs)) + 1;
+        $mant = (int) round($abs * pow(10.0, 5 - $e));
+        if ($mant >= 100000) { $mant -= 90000; $e += 1; }
+        $expSign = ($e >= 0) ? '+' : '-';
+        return $sign . sprintf('%05d', $mant) . $expSign . (string) min(abs($e), 9);
     }
 }


### PR DESCRIPTION
As everyone knows the days of classic TLE's (Two Line Elements // keps) are counted. For the interested user: See 3.1. in this [document](https://space.commerce.gov/wp-content/uploads/2026/01/TraCSS-Spec-004-v1.2_OMM.pdf)

However - the proposed the new Standard is OMM, which solves several problems.

This PR makes WL future-proof in the following way:
1. Legacy TLE - still there and primary source
2. Fill gaps with OMM from https://celestrak.org/NORAD/elements/gp.php?GROUP=amateur&FORMAT=JSON
3. Show if TLEs or OMM is taken at admin -> satellites
4. Process TLEs and OMMs in the same way at: sat-passes, sat-flightmap, qso

Testing:
1. Go to admin -> SATs -> fetch TLE's
2. Check for SATs which are only OMM, and check sat-passed, sat-flightmap, qso for them
3. Do the same (backwards-compat) with TLE sats
4. more tests: manually add TLE. (Adding OMM manually is currently not in scope)