### PR TITLE
[Advanced Logbook] Adjust query so you can dupe check across locations

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -8,7 +8,7 @@ class Logbookadvanced_model extends CI_Model {
 		$order_by = ' ORDER BY col_call';
 
 		// Build dynamic PARTITION BY
-		$partition_by = "COL_CALL, q.station_id";
+		$partition_by = "COL_CALL";
 		$conditions = [];
 
 		if (isset($searchCriteria['dupemode']) && $searchCriteria['dupemode'] === 'Y') {


### PR DESCRIPTION
The duplicate check was adjusted a little while ago, using a windowing function.
Problem was that it partitioned with station_id. That means that it only found duplicate QSOs within the station location, no matter if you selected several locations.

Thanks to @HB9HIL for finding this one.