### PR TITLE
Enable clubmembers to massedit/delete their QSOs

### DIFF
--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -641,7 +641,7 @@ class Logbookadvanced extends CI_Controller {
 	}
 
 	public function editDialog() {
-		if(!clubaccess_check(9)) return;
+		if(!clubaccess_check(3)) return;
 
 		$this->load->model('bands');
 		$this->load->model('modes');
@@ -657,7 +657,7 @@ class Logbookadvanced extends CI_Controller {
 	}
 
 	public function saveBatchEditQsos() {
-		if(!clubaccess_check(9)) return;
+		if(!clubaccess_check(3)) return;
 
 		$ids = xss_clean($this->input->post('ids'));
 		$column = xss_clean($this->input->post('column'));
@@ -665,6 +665,15 @@ class Logbookadvanced extends CI_Controller {
 		$value2 = xss_clean($this->input->post('value2'));
 		$value3 = xss_clean($this->input->post('value3'));
 		$value4 = xss_clean($this->input->post('value4'));
+
+		// Club Member may only edit QSOs he made himself; officers and normal users are unaffected 
+		$ids_array = clubaccess_filter_qso_ids(json_decode($ids, true) ?? []);
+		if (empty($ids_array)) {
+			header("Content-Type: application/json");
+			print json_encode([]);
+			return;
+		}
+		$ids = json_encode($ids_array);
 
 		$this->load->model('logbookadvanced_model');
 		$this->logbookadvanced_model->saveEditedQsos($ids, $column, $value, $value2, $value3, $value4);
@@ -704,12 +713,23 @@ class Logbookadvanced extends CI_Controller {
 	}
 
 	public function batchDeleteQsos() {
-		if(!clubaccess_check(9)) return;
+		if(!clubaccess_check(3)) return;
 
 		$ids = xss_clean($this->input->post('ids'));
 
-		$this->load->model('logbookadvanced_model');
-		$this->logbookadvanced_model->deleteQsos($ids);
+		$requested_ids = json_decode($ids, true) ?? [];
+		// Club Member (3/6) may only delete QSOs he made himself; officers and normal users are unaffected 
+		$ids_array = clubaccess_filter_qso_ids($requested_ids);
+		if (!empty($ids_array)) {
+			$this->load->model('logbookadvanced_model');
+			$this->logbookadvanced_model->deleteQsos(json_encode($ids_array));
+		}
+
+		header("Content-Type: application/json");
+		print json_encode([
+			'deleted'   => array_values($ids_array),
+			'requested' => count($requested_ids),
+		]);
 	}
 
 	public function getSubdivisionsForDxcc() {

--- a/application/helpers/club_helper.php
+++ b/application/helpers/club_helper.php
@@ -56,3 +56,70 @@ if (!function_exists('clubaccess_check')) {
         }
     }
 }
+
+/**
+ * Batch counterpart to clubaccess_check().
+ *
+ * Given a list of QSO primary keys, returns only those the current user is
+ * allowed to modify. Used by the LogbookAdvanced mass-edit / batch-delete
+ * flows so a ClubMember (Level 6) can only touch QSOs he made himself
+ * (COL_OPERATOR == his operator_callsign).
+ *
+ *  - not impersonating a clubstation / special_callsign off: returns $ids as-is
+ *  - Officer (cd_p_level >= 9): returns $ids as-is
+ *  - Club Member (3) / Club Member ADIF (6): returns only IDs owned by the user
+ *
+ * The ownership query is scoped by BOTH station ownership and operator, so it
+ * is safe against arbitrary/foreign IDs 
+ */
+if (!function_exists('clubaccess_filter_qso_ids')) {
+	function clubaccess_filter_qso_ids(array $ids): array {
+
+		$CI =& get_instance();
+		if (!$CI->load->is_loaded('session')) {
+			$CI->load->library('session');
+		}
+
+		// empty in, empty out
+		if (empty($ids)) {
+			return [];
+		}
+
+		$clubmode = $CI->config->item('special_callsign') ?? false;
+		$clubstation = $CI->session->userdata('clubstation') ?? 0;
+
+		// Not impersonating a clubstation -> normal user, no restriction
+		if (!$clubmode || $clubstation != 1) {
+			return array_values($ids);
+		}
+
+		$user_level = $CI->session->userdata('cd_p_level') ?? 0;
+
+		// Officer: may touch anything
+		if ($user_level >= 9) {
+			return array_values($ids);
+		}
+
+		// Below Club Member: no write access at all
+		if ($user_level < 3) {
+			return [];
+		}
+
+		// Club Member (3) / Club Member ADIF (6): keep only own QSOs
+		$operator_callsign = $CI->session->userdata('operator_callsign');
+		$user_id = $CI->session->userdata('user_id');
+
+		$sql = "SELECT t.col_primary_key AS id"
+			. " FROM " . $CI->config->item('table_name') . " t"
+			. " JOIN station_profile s ON t.station_id = s.station_id"
+			. " WHERE t.col_primary_key IN ? AND s.user_id = ? AND t.COL_OPERATOR = ?";
+
+		$result = $CI->db->query($sql, [array_values($ids), $user_id, $operator_callsign])->result();
+
+		$allowed = [];
+		foreach ($result as $row) {
+			$allowed[] = $row->id;
+		}
+		return $allowed;
+	}
+}

--- a/application/views/logbookadvanced/edit.php
+++ b/application/views/logbookadvanced/edit.php
@@ -15,7 +15,7 @@
 				<option value="date"><?= __("Date"); ?></option>
 				<option value="distance"><?= __("Distance"); ?></option>
 				<option value="mode"><?= __("Mode"); ?></option>
-				<option value="operator"><?= __("Operator"); ?></option>
+				<?php if (clubaccess_check(9)) { ?><option value="operator"><?= __("Operator"); ?></option><?php } ?>
 				<option value="propagation"><?= __("Propagation"); ?></option>
 				<option value="rstr"><?= __("RST (R)"); ?></option>
 				<option value="rsts"><?= __("RST (S)"); ?></option>

--- a/application/views/logbookadvanced/index.php
+++ b/application/views/logbookadvanced/index.php
@@ -102,6 +102,9 @@
 	let lang_gen_advanced_logbook_qsos_detached = '<?= __("QSOs detached to contest successfully!"); ?>';
 	let lang_gen_advanced_logbook_error_detaching = '<?= __("Error detaching QSOs"); ?>';
 
+	let lang_lba_edit_skipped   = '<?= __("%d of %d selected QSOs were skipped because you can only edit your own QSOs."); ?>';
+	let lang_lba_delete_skipped = '<?= __("%d of %d selected QSOs were skipped because you can only delete your own QSOs."); ?>';
+
 	let lang_gen_advanced_logbook_select_at_least_one_row_qslcard_print = '<?= __("You need to select at least 1 row to print a QSL card!"); ?>';
 	let lang_gen_advanced_logbook_qslcard_print_option = '<?= __("QSL Card print options"); ?>';
 
@@ -889,7 +892,7 @@ $options = json_decode($options);
 				<button type="button" class="btn btn-sm btn-primary me-1 ld-ext-right flex-grow-0 mb-2" id="invalidButton" style="white-space: nowrap;">
 					<i class="fa fa-exclamation-triangle"></i> <?= __("Invalid"); ?><div class="ld ld-ring ld-spin"></div>
 				</button>
-				<?php if(clubaccess_check(9)) { ?>
+				<?php if(clubaccess_check(3)) { ?>
 				<button type="button" class="btn btn-sm btn-primary me-1 ld-ext-right flex-grow-0 mb-2" id="editButton" style="white-space: nowrap;">
 					<i class="fas fa-edit"></i> <?= __("Edit"); ?><div class="ld ld-ring ld-spin"></div>
 				</button>
@@ -910,6 +913,8 @@ $options = json_decode($options);
 					<button type="button" class="btn btn-sm btn-primary me-1 flex-grow-0 mb-2" id="dbtools" style="white-space: nowrap;" aria-label="<?= __("Database Tools"); ?>"  data-bs-toggle="tooltip" data-bs-placement="top" title="<?= __("Database Tools"); ?>">
 						<i class="fas fa-wrench"></i>
 					</button>
+				<?php } ?>
+				<?php if(clubaccess_check(3)) { ?>
 					<button type="button" class="btn btn-sm btn-danger me-1 flex-grow-0 mb-2" id="deleteQsos" style="white-space: nowrap;" aria-label="<?= __("Delete"); ?>"  data-bs-toggle="tooltip" data-bs-placement="top" title="<?= __("Delete"); ?>">
 						<i class="fas fa-trash-alt"></i>
 					</button>

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -980,13 +980,24 @@ $(document).ready(function () {
 							'ids': JSON.stringify(id_list, null, 2)
 						},
 						success: function(data) {
-							id_list.forEach(function(id) {
+							var deleted = (data && data.deleted) ? data.deleted : id_list;
+							deleted.forEach(function(id) {
 								let row = $("#qsoID-" + id);
 								table.row(row).remove();
 							});
 							$('#deleteQsos').prop("disabled", false);
 							table.draw(false);
 							$('#checkBoxAll').prop("checked", false);
+
+							var requested = (data && data.requested) ? data.requested : id_list.length;
+							var skipped = requested - deleted.length;
+							if (skipped > 0) {
+								BootstrapDialog.alert({
+									title: lang_gen_advanced_logbook_warning,
+									message: lang_lba_delete_skipped.replace('%d', skipped).replace('%d', requested),
+									type: BootstrapDialog.TYPE_WARNING,
+								});
+							}
 						}
 					})
 				}

--- a/assets/js/sections/logbookadvanced_edit.js
+++ b/assets/js/sections/logbookadvanced_edit.js
@@ -266,6 +266,16 @@ function saveBatchEditQsos(id_list) {
 					unselectQsoID(this.qsoID);
 				});
 			}
+
+			var applied = Array.isArray(data) ? data.length : 0;
+			var skipped = id_list.length - applied;
+			if (skipped > 0) {
+				BootstrapDialog.alert({
+					title: lang_gen_advanced_logbook_warning,
+					message: lang_lba_edit_skipped.replace('%d', skipped).replace('%d', id_list.length),
+					type: BootstrapDialog.TYPE_WARNING,
+				});
+			}
 		}
 	});
 }


### PR DESCRIPTION
Problem: A clubmember can edit/delete the QSOs he made. But only QSO by QSO, not in Logbook-advanced.
This one fixes it.

Changes:
- Backend of LBA checks if QSO was created by user (helper-function in clubhelper)
- Operator-Massedit is prohibited for Clubmember
- instead of returning the amount of edited/removed QSOs, the controller returns its ids. so JS/Frontend can only the QSOs where edit/rm suceeded. If user wants to edit/delete a QSO he didn't create:
<img width="500" height="199" alt="image" src="https://github.com/user-attachments/assets/7ab8bca1-8afe-4b06-b81b-355f50e799cf" />
<img width="499" height="200" alt="image" src="https://github.com/user-attachments/assets/e8c2229c-e70e-4782-9a39-9d7594c6167f" />



Testing:
- Test (Mass-) Edit/Delete for admin, normal user, clubadmin in LBA
- Test (Mass-) Edit/Delete for clubmember. Create or use a NORMAL User which is granted as clubmember to a clubstation. Switch over. Don't test it via Impersonate. Relogin as clubmember