### PR TITLE
Additional implementation of 'stations_active_log_only' option

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -1089,6 +1089,13 @@ class Logbook extends CI_Controller {
 		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
+		$stationsactivelogonly_sql = '';
+		if (!empty($this->session->userdata('user_stations_active_log_only'))) {
+			$stationid_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+			$station_id_list = "'" . implode("','", $stationid_array) . "'";
+			$stationsactivelogonly_sql = " AND `station_profile`.`station_id` IN (" . $station_id_list .") ";
+		}
+
 		$binding = array();
 		$sql = "SELECT dxcc_entities.adif, lotw_users.callsign, COL_BAND, COL_CALL, COL_CLUBLOG_QSO_DOWNLOAD_DATE, COL_DCL_QSLRDATE, COL_DCL_QSLSDATE, COL_DCL_QSL_SENT, COL_DCL_QSL_RCVD,
 			COL_PROP_MODE,
@@ -1110,6 +1117,7 @@ class Logbook extends CI_Controller {
 			LEFT OUTER JOIN satellite ON qsos.col_prop_mode='SAT' and qsos.COL_SAT_NAME = COALESCE(NULLIF(satellite.name, ''), NULLIF(satellite.displayname, ''))
 			WHERE ( qsos.COL_CALL LIKE ? ESCAPE '!' OR qsos.COL_GRIDSQUARE LIKE ? ESCAPE '!' OR qsos.COL_VUCC_GRIDS LIKE ? ESCAPE '!')
 			AND station_profile.user_id = ".$this->session->userdata('user_id')."
+			" . $stationsactivelogonly_sql . "
 			ORDER BY COL_TIME_ON DESC;";
 		$binding[] = '%'.$id.'%';
 		$binding[] = '%'.$id.'%';
@@ -1129,16 +1137,23 @@ class Logbook extends CI_Controller {
 		}
 
 		$this->load->model('stations');
-		$logbooks_locations_array = $this->stations->all_of_user();
-
-		$station_ids = array();
-
-		if ($logbooks_locations_array->num_rows() > 0){
-			foreach ($logbooks_locations_array->result() as $row) {
-				array_push($station_ids, $row->station_id);
+		if (!empty($this->session->userdata('user_stations_active_log_only'))) {
+			$station_ids = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+			if ($station_ids == array(-1)) {
+				return null;
 			}
 		} else {
-			return null;
+			$logbooks_locations_array = $this->stations->all_of_user();
+
+			$station_ids = array();
+
+			if ($logbooks_locations_array->num_rows() > 0){
+				foreach ($logbooks_locations_array->result() as $row) {
+					array_push($station_ids, $row->station_id);
+				}
+			} else {
+				return null;
+			}
 		}
 
 		$location_list = "'".implode("','",$station_ids)."'";

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -47,7 +47,13 @@ class Search extends CI_Controller {
 	public function lotw_unconfirmed() {
 		$this->load->model('stations');
 
-		$data['station_profile'] = $this->stations->all_of_user();
+		if (!empty($this->session->userdata('user_stations_active_log_only'))) {
+			$data['station_profile'] = $this->logbooks_model->list_logbooks_linked($this->session->userdata('active_station_logbook'));
+			$data['stations_active_log_only'] = true;
+		} else {
+			$data['station_profile'] = $this->stations->all_of_user();
+			$data['stations_active_log_only'] = false;
+		}
 		$data['page_title'] = __("QSOs unconfirmed on LoTW, but the callsign has uploaded to LoTW after QSO date");
 
 		$this->load->view('interface_assets/header', $data);

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -13,6 +13,8 @@ class Search extends CI_Controller {
 	public function index() {
 		$data['page_title'] = __("Search");
 
+		$data['stations_active_log_only'] = !empty($this->session->userdata('user_stations_active_log_only'));
+
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('search/main');
 		$this->load->view('interface_assets/footer');
@@ -28,6 +30,8 @@ class Search extends CI_Controller {
 
 		$data['get_table_names'] = $this->Search_filter->get_table_columns();
 		$data['stored_queries'] = $this->Search_filter->get_stored_queries();
+
+		$data['stations_active_log_only'] = !empty($this->session->userdata('user_stations_active_log_only'));
 
 		//print_r($this->Search_filter->get_table_columns());
 
@@ -336,6 +340,11 @@ class Search extends CI_Controller {
 
 	function fetchQueryResult($json, $returnquery) {
 		$search_items = json_decode($json, true);
+
+		if (!empty($this->session->userdata('user_stations_active_log_only'))) {
+			$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+			$this->db->where_in($this->config->item('table_name').'.station_id', $logbooks_locations_array);
+		}
 
 		$this->db->select($this->config->item('table_name').'.*, station_profile.station_profile_name, station_profile.station_gridsquare, station_profile.station_city, station_profile.station_iota, station_profile.station_callsign, station_profile.station_sota, station_profile.station_wwff, station_profile.station_dxcc, station_profile.station_pota, station_profile.station_cq, station_profile.station_itu, station_profile.station_sig, station_profile.station_sig_info, station_profile.station_cnty, station_profile.county, station_profile.state, dxcc_entities.name as station_country');
 

--- a/application/controllers/Stationsetup.php
+++ b/application/controllers/Stationsetup.php
@@ -526,6 +526,7 @@ class Stationsetup extends CI_Controller {
 		$data['locations'] = $this->stationsetup_model->list_all_locations();
 		$data['page_title'] = __("Station location list");
 		$data['cd_p_level'] = ($this->session->userdata('cd_p_level') ?? 0);
+		$data['stations_active_log_only'] = !empty($this->session->userdata('user_stations_active_log_only'));
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('stationsetup/locationlist');
 		$this->load->view('interface_assets/footer');

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -250,7 +250,17 @@ class Stationsetup_model extends CI_Model {
 		$result = $query->result();
 		$this->load->model('user_options_model');
 
-		foreach($result as $location) {
+		// restrict station locations listing to those linked to active logbook for clubmember/clubmember adif, if user option enabled
+		$stations_linked = '';
+		if (in_array(($this->session->userdata('cd_p_level') ?? 0), [3,6]) && !empty($this->session->userdata('user_stations_active_log_only'))) {
+			$stations_linked = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+		}
+
+		foreach($result as $key => $location) {
+			if (!empty($stations_linked) && !in_array($location->station_id, $stations_linked)) {
+				unset($result[$key]);
+				continue;
+			}
 			$options_object = $this->user_options_model->get_options('eqsl_default_qslmsg', array('option_name' => 'key_station_id', 'option_key' => $location->station_id))->result();
 			if (isset($options_object[0])) {
 				$location->eqsl_default_qslmsg = $options_object[0]->option_value;

--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -250,9 +250,9 @@ class Stationsetup_model extends CI_Model {
 		$result = $query->result();
 		$this->load->model('user_options_model');
 
-		// restrict station locations listing to those linked to active logbook for clubmember/clubmember adif, if user option enabled
+		// restrict station locations listing to those linked to active logbook for users with permission lower than club officer (if clubstation), if user option enabled
 		$stations_linked = '';
-		if (in_array(($this->session->userdata('cd_p_level') ?? 0), [3,6]) && !empty($this->session->userdata('user_stations_active_log_only'))) {
+		if ((($this->session->userdata('cd_p_level') ?? 0) < 9) && !empty($this->session->userdata('user_stations_active_log_only'))) {
 			$stations_linked = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 		}
 

--- a/application/views/search/filter.php
+++ b/application/views/search/filter.php
@@ -28,7 +28,7 @@
 	    </ul>
 	  </div>
 	  <div class="card-body main">
-
+		<?php if ($stations_active_log_only) { ?><p class="card-text"><span class="badge text-bg-info"><i class="fa-solid fa-info"></i></span> <?= __("Search is limited to station locations linked to active logbook") ?></p><?php } ?>
 		<div class="card-text col-md-4" id="builder"></div>
 
 		<p class="card-text">

--- a/application/views/search/lotw_unconfirmed.php
+++ b/application/views/search/lotw_unconfirmed.php
@@ -20,20 +20,22 @@
 	    </ul>
 	  </div>
 	  <div class="card-body">
-        <?= __("The search displays QSOs which are unconfirmed on LoTW, but the callsign worked has uploaded to LoTW after your QSO date."); ?><br/><br />
+        <?= __("The search displays QSOs which are unconfirmed on LoTW, but the callsign worked has uploaded to LoTW after your QSO date."); ?>
+		<?php if ($stations_active_log_only) { ?><br /><span class="badge text-bg-info"><i class="fa-solid fa-info"></i></span> <?= __("All is limited to station locations linked to active logbook") ?><?php } ?>
+		<br/><br />
 	  	<form method="post" action="" id="search_box" name="test">
-		  <div class="mb-3 row">
-		    <label for="callsign" class="w-auto col-form-label"><?= __("Station location"); ?>:</label>
-		    <select id="station_id" name="station_profile" class="form-select form-select-sm mb-3 w-auto">
+			<div class="mb-3 row">
+				<label for="callsign" class="w-auto col-form-label"><?= __("Station location"); ?>:</label>
+				<select id="station_id" name="station_profile" class="form-select form-select-sm mb-3 w-auto">
 					<option value="All"><?= __("All"); ?></option>
-                    <?php foreach ($station_profile->result() as $station) { ?>
-                    <option value="<?php echo $station->station_id; ?>"><?= __("Callsign"); ?>: <?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>
-                    <?php } ?>
-                    </select>
-		    <div class="col-sm-2">
-		    	<button onclick="findlotwunconfirmed();" class="btn btn-sm btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?= __("Search"); ?></button>
-		    </div>
-		  </div>
+					<?php if($station_profile !== FALSE) { foreach ($station_profile->result() as $station) { ?>
+						<option value="<?php echo $station->station_id; ?>"><?= __("Callsign"); ?>: <?php echo $station->station_callsign; ?> (<?php echo $station->station_profile_name; ?>)</option>
+					<?php } } ?>
+				</select>
+				<div class="col-sm-2">
+					<button onclick="findlotwunconfirmed();" class="btn btn-sm btn-outline-success my-2 my-sm-0" type="submit"><i class="fas fa-search"></i> <?= __("Search"); ?></button>
+				</div>
+			</div>
 		</form>
 
 		<div id="partial_view"></div>

--- a/application/views/search/main.php
+++ b/application/views/search/main.php
@@ -20,6 +20,7 @@
 	    </ul>
 	  </div>
 	  <div class="card-body">
+		<?php if ($stations_active_log_only) { ?><p class="card-text"><span class="badge text-bg-info"><i class="fa-solid fa-info"></i></span> <?= __("Search is limited to station locations linked to active logbook") ?></p><?php } ?>
 	  	<form method="post" action="" id="search_box" name="test">
 		  <div class="mb-3 row">
 		    <label for="callsign" class="col-sm-2 col-form-label"><?= __("Callsign / Gridsquare"); ?></label>

--- a/application/views/stationsetup/locationlist.php
+++ b/application/views/stationsetup/locationlist.php
@@ -1,5 +1,6 @@
 <div class="container-fluid pt-3 ps-4 pe-4">
 <h2><?= $page_title ?></h2>
+<?php if (in_array($cd_p_level, [3,6]) && $stations_active_log_only) { ?><p class="card-text"><span class="badge text-bg-info"><i class="fa-solid fa-info"></i></span> <?= __("Limited to station locations linked to active logbook") ?></p><?php } ?>
 
         <div class="table-responsive mt-3">
 			<table style="width:100%" class="table-sm table table-hover table-striped table-bordered table-condensed" id="qsoList">
@@ -40,7 +41,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <?php foreach ($locations as $loc): 
+                    <?php foreach ($locations as $loc):
 				$qrzr=($loc->qrzrealtime ?? -1);
 				if ($qrzr == -1) {
 					$qrzr=__("No");


### PR DESCRIPTION
This is an extension of #3362

Adds support for the stations_active_log_only user option to QSO search functions, and station location listing (for clubmember/clubmember adif). Help text indicating limited listing is present when user option is enabled.

The clubmember/clubmember adif already have limited privileges in the stationsetup pages; this extends that behavior to hide station locations not associated with the active logbook (if option is enabled). (also found station location export button permission bug, that'll be a different PR)

Pages affected:
search
search/filter
search/lotw_unconfirmed
stationsetup/list_locations