### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-06-28 07:34+0000\n"
-"PO-Revision-Date: 2026-06-26 13:34+0000\n"
+"PO-Revision-Date: 2026-06-28 14:44+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
@@ -16371,7 +16371,7 @@ msgstr "QSL-Karte drucken"
 
 #: application/views/logbookadvanced/index.php:862
 msgid "Attach to Contest"
-msgstr "Zum Contest hinzufügen"
+msgstr "Zu Contest hinzufügen"
 
 #: application/views/logbookadvanced/index.php:863
 msgid "Detach from Contest"


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)