### PR TITLE
[QSL Designer] Added pse/tnx qsl text

### DIFF
--- a/application/models/Qslpostcard_model.php
+++ b/application/models/Qslpostcard_model.php
@@ -689,6 +689,11 @@ class Qslpostcard_model extends CI_Model {
             return ($field === 'qso.tnx_qsl') === $received ? 'X' : '';
         }
 
+		if ($field === 'qso.pse_qsl_tnx_text') {
+            $received = in_array(strtoupper(trim($qso['COL_QSL_RCVD'] ?? '')), ['Y', 'V'], true);
+            return ($received ? 'TNX QSL' : 'PSE QSL');
+        }
+
         if ($field === 'qso.portable') {
             $mycall = strtoupper(trim($qso['COL_STATION_CALLSIGN'] ?? ''));
             return ($mycall !== '' && preg_match('#/P$#', $mycall)) ? 'X' : '';

--- a/application/views/qslpostcard/designer.php
+++ b/application/views/qslpostcard/designer.php
@@ -7,7 +7,7 @@ $qsl_field_groups = [
 	__("Date & Time")         => ['qso.qso_date', 'qso.time_on', 'qso.time', 'qso.time_utc', 'qso.day', 'qso.month', 'qso.month_name', 'qso.year'],
 	__("Station & Equipment") => ['qso.tx_power'], //['qso.rig', 'qso.my_rig', 'qso.antenna', 'qso.rx_power'], Implement later if there's demand
 	__("My References")       => ['qso.my_pota_ref', 'qso.pota_line', 'qso.my_sota_ref', 'qso.sota_line', 'qso.my_iota_ref', 'qso.iota_line', 'qso.my_grid'],
-	__("Markers")             => ['qso.pse_qsl', 'qso.tnx_qsl', 'qso.portable', 'qso.mobile'],
+	__("Markers")             => ['qso.pse_qsl', 'qso.tnx_qsl', 'qso.pse_qsl_tnx_text','qso.portable', 'qso.mobile'],
 	__("Other")               => ['qso.comment', 'qso.qsl_message', 'qso.qsl_via'],
 ];
 


### PR DESCRIPTION
I added a column that contains the text "PSE QSL" or "TNX QSL" depending on if QSL is received or not:
<img width="260" height="234" alt="image" src="https://github.com/user-attachments/assets/0f7094ff-e745-494f-8acb-64c61cff54e9" />


<img width="155" height="44" alt="image" src="https://github.com/user-attachments/assets/bb6aecbb-29be-49b4-acea-b996c999f75e" />
<img width="138" height="43" alt="image" src="https://github.com/user-attachments/assets/e7372198-6119-4317-9ecd-7e281272e24b" />

Requested by @iv3cvn #3377 
