### PR TITLE
Fav names

### DIFF
--- a/application/controllers/User_options.php
+++ b/application/controllers/User_options.php
@@ -21,6 +21,7 @@ class User_Options extends CI_Controller {
 		} else {
 			$option_name=$obj['band'].'/'.$obj['mode'];
 		}
+		$option_name = mb_substr($option_name, 0, 45);
 		$this->user_options_model->set_option('Favourite',$option_name, $obj);
 		$jsonout['success']=1;
 		header('Content-Type: application/json');

--- a/application/controllers/User_options.php
+++ b/application/controllers/User_options.php
@@ -14,7 +14,9 @@ class User_Options extends CI_Controller {
 		foreach($obj as $option_key => $option_value) {
 			$obj[$option_key]=$this->security->xss_clean($option_value);
 		}
-		if ($obj['sat_name'] ?? '' != '') {
+		if (($obj['fav_name'] ?? '') !== '') {
+			$option_name = $obj['fav_name'];
+		} elseif ($obj['sat_name'] ?? '' != '') {
 			$option_name=$obj['sat_name'].'/'.$obj['mode'];
 		} else {
 			$option_name=$obj['band'].'/'.$obj['mode'];

--- a/application/views/qso/components/fav_modal.php
+++ b/application/views/qso/components/fav_modal.php
@@ -1,0 +1,19 @@
+<div class="modal fade" id="fav_modal" tabindex="-1" aria-labelledby="fav_modal_label" aria-hidden="true">
+	<div class="modal-dialog modal-dialog-centered">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h5 class="modal-title" id="fav_modal_label"><i class="fas fa-star me-2"></i><?= __("Save Favourite"); ?></h5>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= __("Close"); ?>"></button>
+			</div>
+			<div class="modal-body">
+				<label for="fav_name_input" class="form-label"><?= __("Name"); ?></label>
+				<input type="text" class="form-control" id="fav_name_input" maxlength="100" autocomplete="off" placeholder="<?= __("e.g. 20m SSB, SO-50, portable setup"); ?>">
+				<div id="fav_name_error" class="text-danger small mt-2" style="display:none;"><?= __("Please enter a name."); ?></div>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?= __("Cancel"); ?></button>
+				<button type="button" class="btn btn-success" id="fav_modal_save"><i class="fas fa-check-circle me-1"></i><?= __("Save"); ?></button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/application/views/qso/components/fav_modal.php
+++ b/application/views/qso/components/fav_modal.php
@@ -3,7 +3,6 @@
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title" id="fav_modal_label"><i class="fas fa-star me-2"></i><?= __("Save Favourite"); ?></h5>
-				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= __("Close"); ?>"></button>
 			</div>
 			<div class="modal-body">
 				<label for="fav_name_input" class="form-label"><?= __("Name"); ?></label>

--- a/application/views/qso/components/fav_modal.php
+++ b/application/views/qso/components/fav_modal.php
@@ -6,7 +6,7 @@
 			</div>
 			<div class="modal-body">
 				<label for="fav_name_input" class="form-label"><?= __("Name"); ?></label>
-				<input type="text" class="form-control" id="fav_name_input" maxlength="100" autocomplete="off" placeholder="<?= __("e.g. 20m SSB, SO-50, portable setup"); ?>">
+				<input type="text" class="form-control" id="fav_name_input" maxlength="45" autocomplete="off" placeholder="<?= __("e.g. 20m SSB, SO-50, portable setup"); ?>">
 				<div id="fav_name_error" class="text-danger small mt-2" style="display:none;"><?= __("Please enter a name."); ?></div>
 			</div>
 			<div class="modal-footer">

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -118,7 +118,7 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" id="fav_item" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-star"></i></a>
     <div class="dropdown-menu">
-      <a class="dropdown-item" href="#" id="fav_add"><?= __("Add Band/Mode to Favs"); ?></a>
+      <a class="dropdown-item" href="#" id="fav_add"><?= __("Add to Favs"); ?></a>
       <div class="dropdown-divider"></div>
       <div id="fav_menu"></div>
     </div>
@@ -922,6 +922,8 @@ if (typeof window.DX_WATERFALL_FIELD_MAP === 'undefined') {
 </div>
 
 </div>
+
+<?php $this->load->view('qso/components/fav_modal'); ?>
 
 <script>
 	var station_callsign = "<?php echo $station_callsign; ?>";

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -721,7 +721,7 @@ function get_fav() {
 		success: function (result) {
 			$("#fav_menu").empty();
 			for (const key in result) {
-				$("#fav_menu").append('<label class="dropdown-item" style="display: flex; justify-content: space-between;"><span id="fav_recall">' + key + '</span><span class="badge bg-danger" id="fav_del" name="' + key + '"><i class="fas fa-trash-alt"></i></span></label>');
+				$("#fav_menu").append('<label class="dropdown-item" style="display: flex; justify-content: space-between;"><span class="me-2" id="fav_recall">' + key + '</span><span class="badge bg-danger" id="fav_del" name="' + key + '"><i class="fas fa-trash-alt"></i></span></label>');
 			}
 			favs = result;
 		}

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -736,7 +736,6 @@ function save_fav() {
 	$('#fav_name_input').val(suggested);
 	$('#fav_name_error').hide();
 	bootstrap.Modal.getOrCreateInstance(document.getElementById('fav_modal')).show();
-	setTimeout(function () { $('#fav_name_input').trigger('focus').select(); }, 200);
 }
 
 function submit_fav() {
@@ -777,6 +776,10 @@ $('#fav_name_input').on("keydown", function (e) {
 		e.preventDefault();
 		submit_fav();
 	}
+});
+
+$('#fav_modal').on('shown.bs.modal', function () {
+	$('#fav_name_input').trigger('focus').select();
 });
 
 $('#fav_modal').on('hidden.bs.modal', function () {

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -729,7 +729,24 @@ function get_fav() {
 }
 
 function save_fav() {
+	var sat = $('#sat_name').val();
+	var mode = $('#mode').val();
+	var band = $('#band').val();
+	var suggested = sat ? sat + '/' + mode : band + '/' + mode;
+	$('#fav_name_input').val(suggested);
+	$('#fav_name_error').hide();
+	bootstrap.Modal.getOrCreateInstance(document.getElementById('fav_modal')).show();
+	setTimeout(function () { $('#fav_name_input').trigger('focus').select(); }, 200);
+}
+
+function submit_fav() {
+	var name = $('#fav_name_input').val().trim();
+	if (name === '') {
+		$('#fav_name_error').show();
+		return;
+	}
 	var payload = {};
+	payload.fav_name = name;
 	payload.sat_name = $('#sat_name').val();
 	payload.sat_mode = $('#sat_mode').val();
 	payload.band_rx = $('#band_rx').val();
@@ -745,10 +762,27 @@ function save_fav() {
 		contentType: "application/json; charset=utf-8",
 		data: JSON.stringify(payload),
 		success: function (result) {
+			bootstrap.Modal.getOrCreateInstance(document.getElementById('fav_modal')).hide();
 			get_fav();
 		}
 	});
 }
+
+$('#fav_modal_save').on("click", function () {
+	submit_fav();
+});
+
+$('#fav_name_input').on("keydown", function (e) {
+	if (e.key === 'Enter') {
+		e.preventDefault();
+		submit_fav();
+	}
+});
+
+$('#fav_modal').on('hidden.bs.modal', function () {
+	$('#fav_name_input').val('');
+	$('#fav_name_error').hide();
+});
 
 
 if (qso_manual == 0) {


### PR DESCRIPTION
Issue:
- Favs only allowed one Fav per Band / Sat and Mode.
- Favs were automatically named.

since @CrazyBasti was looking for an alternative in #3399, this one fixes both issues. One can now freely name the FAV and save multiple ones per Band/Mode

Please(!) be aware of one very important thing to keep the hamspirit alive:
- When doing QSOs via Brandmeister-DMR, set Propagation "Internet assisted" to the QSO / Fav
- When doing QSOs via Repeater, set Propagation "Repeater" to the QSO / Fav

<img width="1280" height="884" alt="telegram-cloud-photo-size-2-5339261604907915852-y" src="https://github.com/user-attachments/assets/7ff62043-663c-48ce-a8af-89ab6b42bbaf" />

<img width="949" height="612" alt="image" src="https://github.com/user-attachments/assets/850e746b-ce9c-4cb7-a15e-f4b8172409d8" />


Testinghints:
- Chose different QRGs (TX/RX), different Propmodes, SATs, etc. and save them as FAV
- Recall them