### PR TITLE
This one fixes an error introduced by quick theme switcher

### DIFF
--- a/application/controllers/Activated_gridmap.php
+++ b/application/controllers/Activated_gridmap.php
@@ -4,6 +4,9 @@ class Activated_gridmap extends CI_Controller {
 
 	function __construct() {
 		parent::__construct();
+
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
 	public function index() {

--- a/application/controllers/Activated_gridmap.php
+++ b/application/controllers/Activated_gridmap.php
@@ -6,7 +6,7 @@ class Activated_gridmap extends CI_Controller {
 		parent::__construct();
 
 		$this->load->model('user_model');
-		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
+		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
 	public function index() {

--- a/application/controllers/Gridmap.php
+++ b/application/controllers/Gridmap.php
@@ -6,7 +6,7 @@ class Gridmap extends CI_Controller {
 		parent::__construct();
 
 		$this->load->model('user_model');
-		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
+		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
     public function index() {

--- a/application/controllers/Gridmap.php
+++ b/application/controllers/Gridmap.php
@@ -4,6 +4,9 @@ class Gridmap extends CI_Controller {
 
 	function __construct() {
 		parent::__construct();
+
+		$this->load->model('user_model');
+		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
     public function index() {


### PR DESCRIPTION
Since these controllers didn't load the user_model in the constructor, the quick theme switcher failed in gridsquare map and activated gridsquares.

Thanks @HB9HIL for giving me the heads up.