### PR TITLE
Feature/custom map theme style（Customize for each user）

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -64,7 +64,7 @@ $autoload['libraries'] = array('database', 'session', 'curl', 'OptionsLib', 'Pat
 |	$autoload['helper'] = array('url', 'file');
 */
 
-$autoload['helper'] = array('url', 'security', 'language', 'club');
+$autoload['helper'] = array('url', 'security', 'language', 'club', 'custom_map_style');
 
 
 /*

--- a/application/config/custom_map_style.php
+++ b/application/config/custom_map_style.php
@@ -1,0 +1,51 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+|--------------------------------------------------------------------------
+| Custom Map Styles Configuration
+|--------------------------------------------------------------------------
+|
+| These styles are used for customizing the map appearance.
+| This page defines the mapping results for the `tile_styles` values ​
+| ​within the database's custom user map and implements string translation 
+| for the title via the layout page.
+| Note: After adding the entry here using the template below, 
+|       please go to `assets/css/custom_map_style`, create a CSS file 
+|       with the name you just specified, and define your custom styles within it.
+*/
+
+$config['tile_styles'] = [
+
+    '0' => [
+        'css' => 'map-follow',
+        'title' => 'Follow Theme',
+    ],
+
+    '1' => [
+        'css' => 'map-light',
+        'title' => 'Light',
+    ],
+
+    '2' => [
+        'css' => 'map-gray',
+        'title' => 'Gray',
+    ],
+
+    '3' => [
+        'css' => 'map-night',
+        'title' => 'Night',
+
+    ],
+
+    '4' => [
+        'css' => 'map-high-contrast',
+        'title' => 'High Contrast',
+    ],
+
+    '5' => [
+        'css' => 'map-superhero',
+        'title' => 'Superhero',
+    ],
+
+];

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -986,6 +986,7 @@ class User extends CI_Controller {
 				$data['user_map_qsoconfirm_color'] = "#00AA00";
 				$data['user_map_unworked_color'] = "#FF0000";
 				$data['user_map_gridsquare_show'] = "0";
+				$data['user_map_tile_style'] = "0";
 			}
 			$data['map_icon_select'] = array(
 				'station'=>array('0', 'fas fa-home', 'fas fa-broadcast-tower', 'fas fa-user', 'fas fa-dot-circle' ),
@@ -1065,9 +1066,11 @@ class User extends CI_Controller {
 							$this->user_options_model->set_option('map_custom','icon',array($icon=>$json), $user_id);
 						}
 						$this->user_options_model->set_option('map_custom','gridsquare',array('show'=>xss_clean($this->input->post('user_map_gridsquare_show', true))), $user_id);
+						$this->user_options_model->set_option('map_custom','tile',array('style' => xss_clean($this->input->post('user_map_tile_style', true))),$user_id);
 					} else {
 						$this->user_options_model->del_option('map_custom','icon', null, $user_id);
 						$this->user_options_model->del_option('map_custom','gridsquare', null, $user_id);
+						$this->user_options_model->del_option('map_custom','tile', null, $user_id);
 					}
 					$this->user_options_model->set_option('header_menu', 'locations_quickswitch', array('boolean'=>xss_clean($this->input->post('user_locations_quickswitch', true))), $user_id);
 					$this->user_options_model->set_option('header_menu', 'utc_headermenu', array('boolean'=>xss_clean($this->input->post('user_utc_headermenu', true))), $user_id);

--- a/application/helpers/custom_map_style_helper.php
+++ b/application/helpers/custom_map_style_helper.php
@@ -1,0 +1,37 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+if (!function_exists('map_css_file')) {
+
+    function map_css_file()
+    {
+        $CI =& get_instance();
+
+        $CI->config->load('custom_map_style');
+
+        $styles = $CI->config->item('tile_styles');
+
+        $map_custom = json_decode($CI->optionslib->get_map_custom(), true);
+
+        $style = $map_custom['tile_style'] ?? '0';
+
+        if (isset($styles[$style])) {
+            return $styles[$style]['css'];
+        }
+
+        return $styles['0']['css'];
+    }
+}
+
+if (!function_exists('map_style_options')) {
+
+    function map_style_options()
+    {
+        $CI =& get_instance();
+
+        $CI->config->load('custom_map_style');
+
+        return $CI->config->item('tile_styles');
+    }
+}

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -305,6 +305,7 @@ class User_Model extends CI_Model {
 				['map_custom', 'icon',                    'qsoconfirm',                    '{"icon":"fas fa-dot-circle","color":"#00ff00"}'],
 				['map_custom', 'icon',                    'station',                       '{"icon":"fas fa-broadcast-tower","color":"#0000ff"}'],
 				['map_custom', 'gridsquare',              'show',                          '0'],
+				['map_custom', 'tile',           	      'style',                         '0'],
 				['hamsat',     'hamsat_key',              'api',                           $user_hamsat_key],
 				['hamsat',     'hamsat_key',              'workable',                      $user_hamsat_workable_only],
 				['qso_tab',    'iota',                    'show',                          (($user_iota_to_qso_tab    ?? 'off') == "on" ? 1 : 0)],

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -45,6 +45,7 @@
 	<!-- Maps -->
 	<link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/js/leaflet/leaflet.css'); ?>" />
 	<link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/js/leaflet/Control.FullScreen.css'); ?>" />
+	<link rel="stylesheet" type="text/css" href="<?= $this->paths->cache_buster('/assets/css/custom_map_style/' . map_css_file() . '.css'); ?>" />
 
 	<?php if ($this->uri->segment(1) == "search" && $this->uri->segment(2) == "filter") { ?>
 		<link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/css/query-builder.default.min.css'); ?>" />

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -689,6 +689,17 @@
 										</div>
 										<label class="d-block mb-0" for="user_map_gridsquare_show"><?= __("Show Locator"); ?></label>
 									</div>
+									<?php if(!isset($user_map_tile_style)) { $user_map_tile_style = '0'; } ?>
+									<div class="mb-3">	<!-- Custom Map Tile Style -->
+										<label for="user_map_tile_style"><?= __("Map Tile Style"); ?></label>
+										<?php $styles = map_style_options(); $current = $user_map_tile_style ?? '0'; ?>
+											<select class="form-select"	id="tile_style" name="tile_style" > 
+												<?php foreach ($styles as $id => $style): ?>
+													<option value="<?= $id; ?>" <?= $current == $id ? 'selected' : ''; ?> ><?= __($style['title'] ?? 'Null'); ?></option>
+												<?php endforeach; ?>
+											</select>
+									    <small class="form-text text-muted"><?= __("Choose the map tile rendering method; this will override the theme settings."); ?></small>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -693,7 +693,7 @@
 									<div class="mb-3">	<!-- Custom Map Tile Style -->
 										<label for="user_map_tile_style"><?= __("Map Tile Style"); ?></label>
 										<?php $styles = map_style_options(); $current = $user_map_tile_style ?? '0'; ?>
-											<select class="form-select"	id="tile_style" name="tile_style" > 
+											<select class="form-select"	id="user_map_tile_style" name="user_map_tile_style" > 
 												<?php foreach ($styles as $id => $style): ?>
 													<option value="<?= $id; ?>" <?= $current == $id ? 'selected' : ''; ?> ><?= __($style['title'] ?? 'Null'); ?></option>
 												<?php endforeach; ?>

--- a/application/views/visitor/exportmap/header.php
+++ b/application/views/visitor/exportmap/header.php
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="<?php echo $this->paths->cache_buster('/assets/fontawesome/css/all.min.css'); ?>">
 
   <link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/js/leaflet/leaflet.css'); ?>" />
+  <link rel="stylesheet" type="text/css" href="<?= $this->paths->cache_buster('/assets/css/custom_map_style/' . map_css_file() . '.css'); ?>" />
 
   <link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/css/loading.min.css'); ?>" />
   <link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/css/ldbtn.min.css'); ?>" />

--- a/application/views/visitor/layout/header.php
+++ b/application/views/visitor/layout/header.php
@@ -21,6 +21,7 @@
 
     <!-- Maps -->
     <link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/js/leaflet/leaflet.css'); ?>" />
+	<link rel="stylesheet" type="text/css" href="<?= $this->paths->cache_buster('/assets/css/custom_map_style/' . map_css_file() . '.css'); ?>" />
 
 	<link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/css/loading.min.css'); ?>" />
 	<link rel="stylesheet" type="text/css" href="<?php echo $this->paths->cache_buster('/assets/css/ldbtn.min.css'); ?>" />

--- a/assets/css/custom_map_style/map-follow.css
+++ b/assets/css/custom_map_style/map-follow.css
@@ -1,0 +1,7 @@
+/*
+ Follow Theme
+
+ intentionally empty
+
+ All style rules from Theme
+*/

--- a/assets/css/custom_map_style/map-gray.css
+++ b/assets/css/custom_map_style/map-gray.css
@@ -1,0 +1,26 @@
+/*
+ Grayscale optimized map tiles
+
+*/
+.leaflet-tile {
+    filter: contrast(1.3) grayscale(0.8) !important;
+}
+
+path.grid-rectangle {
+	stroke: rgba(0, 0, 0, 0.09);
+}
+
+span.grid-text > font {
+	color: rgba(0, 0, 0, 0.09) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-unworked > font {
+	color: rgba(0, 0, 0, .4) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-worked > font {
+	color: rgba(0, 0, 0, 1) !important;
+	font-weight: 400 !important;
+}

--- a/assets/css/custom_map_style/map-high-contrast.css
+++ b/assets/css/custom_map_style/map-high-contrast.css
@@ -1,0 +1,26 @@
+/*
+ High Contrast optimized map tiles
+
+*/
+.leaflet-tile {
+    filter: saturate(2.2) grayscale(0.8) contrast(1.2) !important;
+}
+
+path.grid-rectangle {
+	stroke: rgba(0, 0, 0, 0.2 );
+}
+
+span.grid-text > font {
+	color: rgba(0, 0, 0, 0.4 ) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-unworked > font {
+	color: rgba(0, 0, 0, 0.2 ) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-worked > font {
+	color: rgba(0, 0, 0, 0.4 ) !important;
+	font-weight: 400 !important;
+}

--- a/assets/css/custom_map_style/map-light.css
+++ b/assets/css/custom_map_style/map-light.css
@@ -1,0 +1,28 @@
+/*
+ Light optimized map tiles
+
+ CSS no filter, style from your map server.
+
+*/
+.leaflet-tile {
+    filter: none !important;
+}
+
+path.grid-rectangle {
+	stroke: rgba(97, 97, 97, 0.2);
+}
+
+span.grid-text > font {
+	color: rgb(97, 97, 97, 0.8) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-unworked > font {
+	color: rgb(97, 97, 97, 0.8) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-worked > font {
+	color: rgb(255, 255, 255) !important;
+	font-weight: 400 !important;
+}

--- a/assets/css/custom_map_style/map-night.css
+++ b/assets/css/custom_map_style/map-night.css
@@ -1,0 +1,26 @@
+/*
+ Night(dark) optimized map tiles
+    This option from darkly theme, but you can use any dark theme you want.
+*/
+.leaflet-tile {
+    filter: invert() hue-rotate(180deg) grayscale(0.8) brightness(1.2) !important;
+}
+
+path.grid-rectangle {
+	stroke: rgba(200, 200, 200, 0.5);
+}
+
+span.grid-text > font {
+	color: rgba(255, 255, 255, 1) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-unworked > font {
+	color: rgba(255, 255, 255, .4) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-worked > font {
+	color: rgba(255, 255, 255, 1) !important;
+	font-weight: 400 !important;
+}

--- a/assets/css/custom_map_style/map-superhero.css
+++ b/assets/css/custom_map_style/map-superhero.css
@@ -1,0 +1,28 @@
+/*
+ Superhero Map Style
+ This is a built-in theme, So All style rules from Theme.
+
+*/
+
+.leaflet-tile {
+	filter: invert() hue-rotate(180deg) sepia(100%) hue-rotate(180deg) !important;
+}
+
+path.grid-rectangle {
+	stroke: rgba(200, 200, 200, 0.5);
+}
+
+span.grid-text > font {
+	color: rgba(255, 255, 255, 1) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-unworked > font {
+	color: rgba(255, 255, 255, .4) !important;
+	font-weight: 400 !important;
+}
+
+span.grid-text-worked > font {
+	color: rgba(255, 255, 255, 1) !important;
+	font-weight: 400 !important;
+}

--- a/install/assets/install.sql
+++ b/install/assets/install.sql
@@ -3795,6 +3795,7 @@ INSERT INTO `user_options` VALUES
 (1,'map_custom','icon','qso','{\"icon\":\"fas fa-dot-circle\",\"color\":\"#ff0000\"}'),
 (1,'map_custom','icon','qsoconfirm','{\"icon\":\"fas fa-check-circle\",\"color\":\"#00aa00\"}'),
 (1,'map_custom','gridsquare','show','0'),
+(1,'map_custom','tile','style','0'),
 (1,'map_custom','icon','station','{\"icon\":\"fas fa-home\",\"color\":\"#0000ff\"}'),
 (1,'map_custom','icon','unworked','{\"icon\":\"\",\"color\":\"#ff0000\"}');
 UNLOCK TABLES;


### PR DESCRIPTION
To begin with, I discovered during use that the current map is tightly coupled with the existing theme, making it impossible to modify styles independently to achieve decoupling; furthermore, I wanted to use light-colored map tiles within a dark theme. This was my original motivation for developing this module.

Implementation method: This is achieved by using CSS rules with higher specificity than the existing styles. The overall architecture facilitates future extensibility and adheres to the principle of on-demand loading; to implement it, you simply need to define a new ID in the corresponding configuration file and create a CSS file with the matching name in the `assets/custom_map_style` directory.（PS：Regular testing confirms it works well across various map modules.）
<img width="1536" height="825" alt="workflow" src="https://github.com/user-attachments/assets/fcb13a68-094b-4eac-9730-805ba7581638" />

Final result:
<img width="1327" height="776" alt="1" src="https://github.com/user-attachments/assets/e5cf4ca1-e81a-4613-8591-aba2c60e5627" />
<img width="649" height="289" alt="2" src="https://github.com/user-attachments/assets/7db326d9-afa4-4cb8-ba07-1d8372081334" />
<img width="1412" height="718" alt="3" src="https://github.com/user-attachments/assets/267cf888-f1c3-4f6b-8e81-44f6fd67e3c6" />
<img width="1438" height="726" alt="4" src="https://github.com/user-attachments/assets/fe87a344-fc41-40ef-8595-fa28993e7ab4" />
<img width="1407" height="814" alt="5" src="https://github.com/user-attachments/assets/648faf6a-4744-4768-9296-0273f40f7949" />


This is the first PR I’ve submitted, so I might be a bit inexperienced or overly wordy. Please feel free to point out any areas that need improvement—thank you very much.