### PR TITLE
Fixed/custom map theme style(fixed translation）

### DIFF
--- a/application/config/custom_map_style.php
+++ b/application/config/custom_map_style.php
@@ -13,39 +13,40 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | Note: After adding the entry here using the template below, 
 |       please go to `assets/css/custom_map_style`, create a CSS file 
 |       with the name you just specified, and define your custom styles within it.
+| Note: The `map_style_label` function in the `custom_map_style_helper.php` file is responsible for translating the title of the map style.
 */
 
 $config['tile_styles'] = [
 
     '0' => [
         'css' => 'map-follow',
-        'title' => 'Follow Theme',
+        'label' => 'map_follow_theme',
     ],
 
     '1' => [
         'css' => 'map-light',
-        'title' => 'Light',
+        'label' => 'map_light',
     ],
 
     '2' => [
         'css' => 'map-gray',
-        'title' => 'Gray',
+        'label' => 'map_gray',
     ],
 
     '3' => [
         'css' => 'map-night',
-        'title' => 'Night',
+        'label' => 'map_night',
 
     ],
 
     '4' => [
         'css' => 'map-high-contrast',
-        'title' => 'High Contrast',
+        'label' => 'map_high_contrast',
     ],
 
     '5' => [
         'css' => 'map-superhero',
-        'title' => 'Superhero',
+        'label' => 'map_superhero',
     ],
 
 ];

--- a/application/helpers/custom_map_style_helper.php
+++ b/application/helpers/custom_map_style_helper.php
@@ -2,6 +2,38 @@
 
 defined('BASEPATH') OR exit('No direct script access allowed');
 
+/**
+ * Translate map style id
+ */
+if (!function_exists('map_style_label')) {
+
+    function map_style_label($label)
+    {
+        switch ($label) {
+            case 'map_follow_theme':
+                return __('Follow Theme');
+
+            case 'map_light':
+                return __('Light');
+
+            case 'map_gray':
+                return __('Gray');
+
+            case 'map_night':
+                return __('Night');
+
+            case 'map_high_contrast':
+                return __('High Contrast');
+
+            case 'map_superhero':
+                return __('Superhero');
+
+            default:
+                return $label;
+        }
+    }
+}
+
 if (!function_exists('map_css_file')) {
 
     function map_css_file()

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -706,7 +706,7 @@
 										<?php $styles = map_style_options(); $current = $user_map_tile_style ?? '0'; ?>
 											<select class="form-select"	id="user_map_tile_style" name="user_map_tile_style" > 
 												<?php foreach ($styles as $id => $style): ?>
-													<option value="<?= $id; ?>" <?= $current == $id ? 'selected' : ''; ?> ><?= __($style['title'] ?? 'Null'); ?></option>
+													<option value="<?= $id; ?>" <?= $current == $id ? 'selected' : ''; ?> ><?= map_style_label($style['label']); ?></option>
 												<?php endforeach; ?>
 											</select>
 									    <small class="form-text text-muted"><?= __("Choose the map tile rendering method; this will override the theme settings."); ?></small>

--- a/assets/css/custom_map_style/map-gray.css
+++ b/assets/css/custom_map_style/map-gray.css
@@ -7,11 +7,11 @@
 }
 
 path.grid-rectangle {
-	stroke: rgba(0, 0, 0, 0.09);
+	stroke: rgba(0, 0, 0, 0.4);
 }
 
 span.grid-text > font {
-	color: rgba(0, 0, 0, 0.09) !important;
+	color: rgba(0, 0, 0, 0.4) !important;
 	font-weight: 400 !important;
 }
 


### PR DESCRIPTION
I find that `gettext` which automatically identifies and translates strings was not working with dynamic PHP. Consequently, I modified the workflow to move string concatenation to a helper step, thereby ensuring `gettext` functions correctly.

Adjusting the transparency of the "gray style" map grid affects；Testing confirms it works correctly with map tiles from most providers.
<img width="1693" height="929" alt="工作流" src="https://github.com/user-attachments/assets/70cc94ae-96fb-4f62-9594-bb63aa59bd58" />
