### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-03 14:26+0000\n"
-"PO-Revision-Date: 2026-07-02 21:25+0000\n"
-"Last-Translator: Jörg Dorgeist <wavelog@dj7nt.de>\n"
+"PO-Revision-Date: 2026-07-05 18:11+0000\n"
+"Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -10701,14 +10701,14 @@ msgstr "Winkeyer"
 #: application/views/qso/components/winkeysettings.php:54
 msgctxt "ESM mode"
 msgid "Run"
-msgstr ""
+msgstr "Run"
 
 #: application/views/contesting/logger/components/winkeyer.php:24
 #: application/views/qso/components/winkeysettings.php:58
 #: application/views/qso/components/winkeysettings.php:59
 msgctxt "ESM mode"
 msgid "S&P"
-msgstr ""
+msgstr "S&P"
 
 #: application/views/contesting/logger/components/winkeyer.php:51
 #: application/views/qso/index.php:828
@@ -10717,7 +10717,7 @@ msgstr "Verbinden"
 
 #: application/views/contesting/logger/components/winkeyer.php:53
 msgid "Toggle Run / Search & Pounce for ESM"
-msgstr ""
+msgstr "Umschalten zwischen Run / Search & Pounce für ESM"
 
 #: application/views/contesting/logger/components/winkeyer.php:73
 #: application/views/qso/index.php:856
@@ -18521,7 +18521,7 @@ msgstr "Token"
 
 #: application/views/qso/components/winkeysettings.php:46
 msgid "ESM (Enter Sends Message)"
-msgstr ""
+msgstr "ESM (Enter Sends Message)"
 
 #: application/views/qso/components/winkeysettings.php:49
 msgid ""
@@ -18531,50 +18531,56 @@ msgid ""
 "only your own call, and logging sends your report instead of a TU. Alt+Enter "
 "logs without sending."
 msgstr ""
+"Wenn aktiviert, steuert die Eingabetaste das QSO: Ein leeres Call-Feld "
+"sendet CQ, ein unklarer Call (enthält \"?\") fragt erneut, ein volles "
+"Callsign ohne Austausch sendet den Exchange und ein vollständiges QSO wird "
+"mit einem TU abgeschlossen und gelogged. Im S&P-Modus sendet die erste "
+"Eingabe nur den eigenen Call und das Loggen sendet den Exchange anstelle "
+"eines TU. Alt+Enter logged das QSO ohne etwas zu senden."
 
 #: application/views/qso/components/winkeysettings.php:55
 msgid "Unclear call (?)"
-msgstr ""
+msgstr "Unklares Rufzeichen"
 
 #: application/views/qso/components/winkeysettings.php:56
 msgid "Exchange / Report"
-msgstr ""
+msgstr "Exchange / Report"
 
 #: application/views/qso/components/winkeysettings.php:57
 msgid "Log QSO / TU"
-msgstr ""
+msgstr "QSO loggen / TU"
 
 #: application/views/qso/components/winkeysettings.php:58
 msgid "own call"
-msgstr ""
+msgstr "eigener Call"
 
 #: application/views/qso/components/winkeysettings.php:59
 msgid "exchange on log"
-msgstr ""
+msgstr "Exchange beim loggen"
 
 #: application/views/qso/components/winkeysettings.php:78
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Tastenkombinationen"
 
 #: application/views/qso/components/winkeysettings.php:82
 msgid "Send the corresponding CW macro"
-msgstr ""
+msgstr "Das entsprechende CW-Makro senden"
 
 #: application/views/qso/components/winkeysettings.php:83
 msgid "ESM on: drive the QSO (CQ / report / log); ESM off: log the QSO"
-msgstr ""
+msgstr "ESM an: das QSO führen (CQ / Bericht / Log); ESM aus: das QSO loggen"
 
 #: application/views/qso/components/winkeysettings.php:84
 msgid "Log the QSO without sending anything"
-msgstr ""
+msgstr "Das QSO loggen ohne etwas zu senden"
 
 #: application/views/qso/components/winkeysettings.php:85
 msgid "Clear the entry form"
-msgstr ""
+msgstr "Die Eingabefelder löschen"
 
 #: application/views/qso/components/winkeysettings.php:86
 msgid "In the callsign field: jump to the next empty field"
-msgstr ""
+msgstr "Im Rufzeichenfeld: zum nächsten leeren Feld springen"
 
 #: application/views/qso/edit_ajax.php:35
 msgid "Sats"

--- a/application/locale/es_ES/LC_MESSAGES/messages.po
+++ b/application/locale/es_ES/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-03 14:26+0000\n"
-"PO-Revision-Date: 2026-07-01 19:57+0000\n"
+"PO-Revision-Date: 2026-07-04 18:16+0000\n"
 "Last-Translator: David Quental <ct1drb72@gmail.com>\n"
 "Language-Team: Spanish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/es/>\n"
@@ -10701,14 +10701,14 @@ msgstr "Winkeyer"
 #: application/views/qso/components/winkeysettings.php:54
 msgctxt "ESM mode"
 msgid "Run"
-msgstr ""
+msgstr "Run"
 
 #: application/views/contesting/logger/components/winkeyer.php:24
 #: application/views/qso/components/winkeysettings.php:58
 #: application/views/qso/components/winkeysettings.php:59
 msgctxt "ESM mode"
 msgid "S&P"
-msgstr ""
+msgstr "S&P"
 
 #: application/views/contesting/logger/components/winkeyer.php:51
 #: application/views/qso/index.php:828
@@ -10717,7 +10717,7 @@ msgstr "Conectar"
 
 #: application/views/contesting/logger/components/winkeyer.php:53
 msgid "Toggle Run / Search & Pounce for ESM"
-msgstr ""
+msgstr "Alternar Run / S&P para ESM"
 
 #: application/views/contesting/logger/components/winkeyer.php:73
 #: application/views/qso/index.php:856
@@ -11971,15 +11971,15 @@ msgstr "Apagado"
 
 #: application/views/dashboard/_options_menu.php:10
 msgid "Dashboard options"
-msgstr ""
+msgstr "Opciones del panel de control"
 
 #: application/views/dashboard/_options_menu.php:12
 msgid "KPI statistics"
-msgstr ""
+msgstr "Estadísticas de KPI"
 
 #: application/views/dashboard/_options_menu.php:15
 msgid "Solar data"
-msgstr ""
+msgstr "Datos solares"
 
 #: application/views/dashboard/index.php:6
 msgid "RSTS"
@@ -12096,7 +12096,7 @@ msgstr "Al menos uno de tus certificados está caducando"
 #: application/views/dashboard/index.php:230
 #: application/views/dashboard/solar_data.php:2
 msgid "Right-click for options"
-msgstr ""
+msgstr "Haz clic derecho para opciones"
 
 #: application/views/dashboard/index.php:245
 msgid "QSOs this year"
@@ -18534,7 +18534,7 @@ msgstr "Tokens"
 
 #: application/views/qso/components/winkeysettings.php:46
 msgid "ESM (Enter Sends Message)"
-msgstr ""
+msgstr "ESM (Enter Envía Mensaje)"
 
 #: application/views/qso/components/winkeysettings.php:49
 msgid ""
@@ -18544,50 +18544,57 @@ msgid ""
 "only your own call, and logging sends your report instead of a TU. Alt+Enter "
 "logs without sending."
 msgstr ""
+"Cuando está habilitado, la tecla Enter impulsa el QSO: una llamada vacía "
+"envía CQ, una llamada no clara (con \"?\") pregunta de nuevo, una llamada "
+"completa sin intercambio envía el informe, y un QSO completo se registra con "
+"un TU. En el modo S&P, el primer Enter envía sólo tu propia llamada, y al "
+"registrar envía tu informe en lugar de un TU. Alt+Enter registra sin enviar."
 
 #: application/views/qso/components/winkeysettings.php:55
 msgid "Unclear call (?)"
-msgstr ""
+msgstr "Indicativo poco claro (?)"
 
 #: application/views/qso/components/winkeysettings.php:56
 msgid "Exchange / Report"
-msgstr ""
+msgstr "Intercambiar / Reportar"
 
 #: application/views/qso/components/winkeysettings.php:57
 msgid "Log QSO / TU"
-msgstr ""
+msgstr "Registrar QSO / TU"
 
 #: application/views/qso/components/winkeysettings.php:58
 msgid "own call"
-msgstr ""
+msgstr "indicativo proprio"
 
 #: application/views/qso/components/winkeysettings.php:59
 msgid "exchange on log"
-msgstr ""
+msgstr "intercambio en el registro"
 
 #: application/views/qso/components/winkeysettings.php:78
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Atajos de teclado"
 
 #: application/views/qso/components/winkeysettings.php:82
 msgid "Send the corresponding CW macro"
-msgstr ""
+msgstr "Envía el macro correspondiente de CW"
 
 #: application/views/qso/components/winkeysettings.php:83
 msgid "ESM on: drive the QSO (CQ / report / log); ESM off: log the QSO"
 msgstr ""
+"ESM activado: conduce el QSO (CQ / informe / registro); ESM desactivado: "
+"registra el QSO"
 
 #: application/views/qso/components/winkeysettings.php:84
 msgid "Log the QSO without sending anything"
-msgstr ""
+msgstr "Registra el QSO sin enviar nada"
 
 #: application/views/qso/components/winkeysettings.php:85
 msgid "Clear the entry form"
-msgstr ""
+msgstr "Limpiar el formulario de entrada"
 
 #: application/views/qso/components/winkeysettings.php:86
 msgid "In the callsign field: jump to the next empty field"
-msgstr ""
+msgstr "En el campo de indicativo: salta al siguiente campo vacío"
 
 #: application/views/qso/edit_ajax.php:35
 msgid "Sats"
@@ -19329,6 +19336,8 @@ msgstr "QSOs no confirmados en LoTW"
 #: application/views/search/filter.php:31 application/views/search/main.php:23
 msgid "Search is limited to station locations linked to active logbook"
 msgstr ""
+"La búsqueda está limitada a las ubicaciones de las estaciones vinculadas al "
+"libro de registros activo"
 
 #: application/views/search/filter.php:40
 msgid "Save query"
@@ -20229,6 +20238,7 @@ msgstr "Desenlazar la Localización de la Estación"
 #: application/views/stationsetup/locationlist.php:3
 msgid "Limited to station locations linked to active logbook"
 msgstr ""
+"Limitado a ubicaciones de estaciones vinculadas al libro de registros activo"
 
 #: application/views/stationsetup/locationlist.php:11
 msgid "QSO Count"
@@ -21172,16 +21182,18 @@ msgstr "Mostrar Localizador"
 
 #: application/views/user/edit.php:705
 msgid "Map Tile Style"
-msgstr ""
+msgstr "Estilo de cuadro del mapa"
 
 #: application/views/user/edit.php:709
 msgid "Null"
-msgstr ""
+msgstr "Nulo"
 
 #: application/views/user/edit.php:712
 msgid ""
 "Choose the map tile rendering method; this will override the theme settings."
 msgstr ""
+"Elige el método de renderización de los mosaicos del mapa; esto anulará la "
+"configuración del tema."
 
 #: application/views/user/edit.php:724
 msgid "Previous QSL Type"
@@ -21233,6 +21245,9 @@ msgid ""
 "expeditions cards (Top), at the bottom of the dashboard (Bottom), or hide it "
 "(Off)."
 msgstr ""
+"Mostrar datos solares y de propagación en el panel de control sobre las "
+"tarjetas de expediciones activas (Superiór), en la parte inferior del panel "
+"de control (Inferior), o ocultarlo (Apagado)."
 
 #: application/views/user/edit.php:792
 msgid "Dashboard Notification Banner"
@@ -21246,13 +21261,15 @@ msgstr ""
 
 #: application/views/user/edit.php:824
 msgid "Dashboard KPI statistics"
-msgstr ""
+msgstr "Estadísticas KPI del panel"
 
 #: application/views/user/edit.php:825
 msgid ""
 "This switches the display of the KPI statistics (Total QSOs, QSOs this year/"
 "month/today, Current Streak, Unique callsigns) on the dashboard."
 msgstr ""
+"Esto cambia la visualización de las estadísticas de los KPI (Total de QSOs, "
+"QSOs de este año/mes/hoy, Racha actual, Indicativos únicos) en el tablero."
 
 #: application/views/user/edit.php:834
 msgid "Show Fields on QSO Tab"

--- a/application/locale/it_IT/LC_MESSAGES/messages.po
+++ b/application/locale/it_IT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-03 14:26+0000\n"
-"PO-Revision-Date: 2026-07-02 21:25+0000\n"
+"PO-Revision-Date: 2026-07-04 18:16+0000\n"
 "Last-Translator: iv3cvn <ricentis@gmail.com>\n"
 "Language-Team: Italian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/it/>\n"
@@ -10667,14 +10667,14 @@ msgstr "Winkeyer"
 #: application/views/qso/components/winkeysettings.php:54
 msgctxt "ESM mode"
 msgid "Run"
-msgstr ""
+msgstr "Run"
 
 #: application/views/contesting/logger/components/winkeyer.php:24
 #: application/views/qso/components/winkeysettings.php:58
 #: application/views/qso/components/winkeysettings.php:59
 msgctxt "ESM mode"
 msgid "S&P"
-msgstr ""
+msgstr "S&P"
 
 #: application/views/contesting/logger/components/winkeyer.php:51
 #: application/views/qso/index.php:828
@@ -10683,7 +10683,7 @@ msgstr "Connetti"
 
 #: application/views/contesting/logger/components/winkeyer.php:53
 msgid "Toggle Run / Search & Pounce for ESM"
-msgstr ""
+msgstr "Cambia Run / Search & Pounce per ESM"
 
 #: application/views/contesting/logger/components/winkeyer.php:73
 #: application/views/qso/index.php:856
@@ -18480,7 +18480,7 @@ msgstr "Tokens"
 
 #: application/views/qso/components/winkeysettings.php:46
 msgid "ESM (Enter Sends Message)"
-msgstr ""
+msgstr "ESM (Enter invia messaggio)"
 
 #: application/views/qso/components/winkeysettings.php:49
 msgid ""
@@ -18490,50 +18490,58 @@ msgid ""
 "only your own call, and logging sends your report instead of a TU. Alt+Enter "
 "logs without sending."
 msgstr ""
+"Quando abilitato, il tasto Invio guida il QSO: un nominativo vuoto invia CQ, "
+"un nominativo incomplet (con \"?\") chiede di nuovo, un nominativo completl "
+"senza scambio invia il rapporto e un QSO completo viene registrato con un "
+"TU. In modalità S&P, il primo Invio invia solo il tuo nominativo e la "
+"registrazione invia il tuo rapporto invece di un TU. Alt+Invio registra "
+"senza inviare."
 
 #: application/views/qso/components/winkeysettings.php:55
 msgid "Unclear call (?)"
-msgstr ""
+msgstr "Nominativo incompleto (?)"
 
 #: application/views/qso/components/winkeysettings.php:56
 msgid "Exchange / Report"
-msgstr ""
+msgstr "Exchange / rapporto"
 
 #: application/views/qso/components/winkeysettings.php:57
 msgid "Log QSO / TU"
-msgstr ""
+msgstr "Metti a log QSO / TU"
 
 #: application/views/qso/components/winkeysettings.php:58
 msgid "own call"
-msgstr ""
+msgstr "Proprio nominativo"
 
 #: application/views/qso/components/winkeysettings.php:59
 msgid "exchange on log"
-msgstr ""
+msgstr "exchange a log"
 
 #: application/views/qso/components/winkeysettings.php:78
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Scorciatoie da tastiera"
 
 #: application/views/qso/components/winkeysettings.php:82
 msgid "Send the corresponding CW macro"
-msgstr ""
+msgstr "Invia la corrispondente macro CW"
 
 #: application/views/qso/components/winkeysettings.php:83
 msgid "ESM on: drive the QSO (CQ / report / log); ESM off: log the QSO"
 msgstr ""
+"ESM attivo: guida il QSO (CQ / rapporto / log); ESM disattivo: registra il "
+"QSO"
 
 #: application/views/qso/components/winkeysettings.php:84
 msgid "Log the QSO without sending anything"
-msgstr ""
+msgstr "Metti a log il QSO senza inviare nulla"
 
 #: application/views/qso/components/winkeysettings.php:85
 msgid "Clear the entry form"
-msgstr ""
+msgstr "Pulisci il modulo di inserimento"
 
 #: application/views/qso/components/winkeysettings.php:86
 msgid "In the callsign field: jump to the next empty field"
-msgstr ""
+msgstr "Nel campo del nominativo: passa al campo vuoto successivo"
 
 #: application/views/qso/edit_ajax.php:35
 msgid "Sats"

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-03 14:26+0000\n"
-"PO-Revision-Date: 2026-07-02 21:25+0000\n"
+"PO-Revision-Date: 2026-07-04 18:16+0000\n"
 "Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -10550,14 +10550,14 @@ msgstr "Winkeyer"
 #: application/views/qso/components/winkeysettings.php:54
 msgctxt "ESM mode"
 msgid "Run"
-msgstr ""
+msgstr "Run"
 
 #: application/views/contesting/logger/components/winkeyer.php:24
 #: application/views/qso/components/winkeysettings.php:58
 #: application/views/qso/components/winkeysettings.php:59
 msgctxt "ESM mode"
 msgid "S&P"
-msgstr ""
+msgstr "S&P"
 
 #: application/views/contesting/logger/components/winkeyer.php:51
 #: application/views/qso/index.php:828
@@ -10566,7 +10566,7 @@ msgstr "接続する"
 
 #: application/views/contesting/logger/components/winkeyer.php:53
 msgid "Toggle Run / Search & Pounce for ESM"
-msgstr ""
+msgstr "RunモードとS&Pモードの切り替え"
 
 #: application/views/contesting/logger/components/winkeyer.php:73
 #: application/views/qso/index.php:856
@@ -18277,7 +18277,7 @@ msgstr "トークン"
 
 #: application/views/qso/components/winkeysettings.php:46
 msgid "ESM (Enter Sends Message)"
-msgstr ""
+msgstr "ESM（Enterキーでメッセージを送信）"
 
 #: application/views/qso/components/winkeysettings.php:49
 msgid ""
@@ -18287,50 +18287,55 @@ msgid ""
 "only your own call, and logging sends your report instead of a TU. Alt+Enter "
 "logs without sending."
 msgstr ""
+"有効にすると、Enter キーで QSO が実行されます。空の呼び出しでは CQ が送信され"
+"、不明瞭な呼び出し (\"?\" 付き) では再度 CQ が送信され、交換のない完全な呼び"
+"出しではレポートが送信され、完全な QSO は TU とともにログに記録されます。S&P "
+"モードでは、最初の Enter キーで自分の呼び出しのみが送信され、ログ記録では TU "
+"の代わりにレポートが送信されます。Alt+Enter は送信せずにログを記録します。"
 
 #: application/views/qso/components/winkeysettings.php:55
 msgid "Unclear call (?)"
-msgstr ""
+msgstr "不明瞭な通話（？）"
 
 #: application/views/qso/components/winkeysettings.php:56
 msgid "Exchange / Report"
-msgstr ""
+msgstr "交換／レポート"
 
 #: application/views/qso/components/winkeysettings.php:57
 msgid "Log QSO / TU"
-msgstr ""
+msgstr "ログQSO / TU"
 
 #: application/views/qso/components/winkeysettings.php:58
 msgid "own call"
-msgstr ""
+msgstr "自己判断"
 
 #: application/views/qso/components/winkeysettings.php:59
 msgid "exchange on log"
-msgstr ""
+msgstr "ログに関する交換"
 
 #: application/views/qso/components/winkeysettings.php:78
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "キーボードショートカット"
 
 #: application/views/qso/components/winkeysettings.php:82
 msgid "Send the corresponding CW macro"
-msgstr ""
+msgstr "対応するCWマクロを送信します"
 
 #: application/views/qso/components/winkeysettings.php:83
 msgid "ESM on: drive the QSO (CQ / report / log); ESM off: log the QSO"
-msgstr ""
+msgstr "ESMオン：QSOを駆動（CQ/レポート/ログ）；ESMオフ：QSOをログに記録"
 
 #: application/views/qso/components/winkeysettings.php:84
 msgid "Log the QSO without sending anything"
-msgstr ""
+msgstr "何も送信せずにQSOを記録する"
 
 #: application/views/qso/components/winkeysettings.php:85
 msgid "Clear the entry form"
-msgstr ""
+msgstr "入力フォームをクリアする"
 
 #: application/views/qso/components/winkeysettings.php:86
 msgid "In the callsign field: jump to the next empty field"
-msgstr ""
+msgstr "コールサイン欄：次の空いている欄へ移動"
 
 #: application/views/qso/edit_ajax.php:35
 msgid "Sats"

--- a/application/locale/pt_PT/LC_MESSAGES/messages.po
+++ b/application/locale/pt_PT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-03 14:26+0000\n"
-"PO-Revision-Date: 2026-07-01 19:57+0000\n"
+"PO-Revision-Date: 2026-07-04 18:16+0000\n"
 "Last-Translator: David Quental <ct1drb72@gmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.wavelog.org/projects/"
 "wavelog/main-translation/pt_PT/>\n"
@@ -10663,14 +10663,14 @@ msgstr "Winkeyer"
 #: application/views/qso/components/winkeysettings.php:54
 msgctxt "ESM mode"
 msgid "Run"
-msgstr ""
+msgstr "Run"
 
 #: application/views/contesting/logger/components/winkeyer.php:24
 #: application/views/qso/components/winkeysettings.php:58
 #: application/views/qso/components/winkeysettings.php:59
 msgctxt "ESM mode"
 msgid "S&P"
-msgstr ""
+msgstr "S&P"
 
 #: application/views/contesting/logger/components/winkeyer.php:51
 #: application/views/qso/index.php:828
@@ -10679,7 +10679,7 @@ msgstr "Conectar"
 
 #: application/views/contesting/logger/components/winkeyer.php:53
 msgid "Toggle Run / Search & Pounce for ESM"
-msgstr ""
+msgstr "Alternar Run / S&P para ESM"
 
 #: application/views/contesting/logger/components/winkeyer.php:73
 #: application/views/qso/index.php:856
@@ -11932,15 +11932,15 @@ msgstr "Desligado"
 
 #: application/views/dashboard/_options_menu.php:10
 msgid "Dashboard options"
-msgstr ""
+msgstr "Opções do painel"
 
 #: application/views/dashboard/_options_menu.php:12
 msgid "KPI statistics"
-msgstr ""
+msgstr "Estatísticas de KPI"
 
 #: application/views/dashboard/_options_menu.php:15
 msgid "Solar data"
-msgstr ""
+msgstr "Dados solares"
 
 #: application/views/dashboard/index.php:6
 msgid "RSTS"
@@ -12054,7 +12054,7 @@ msgstr "Pelo menos um dos seus certificados está a expirar"
 #: application/views/dashboard/index.php:230
 #: application/views/dashboard/solar_data.php:2
 msgid "Right-click for options"
-msgstr ""
+msgstr "Clique com o botão direito para opções"
 
 #: application/views/dashboard/index.php:245
 msgid "QSOs this year"
@@ -18470,7 +18470,7 @@ msgstr "Fichas"
 
 #: application/views/qso/components/winkeysettings.php:46
 msgid "ESM (Enter Sends Message)"
-msgstr ""
+msgstr "ESM (Enter Envia Mensagem)"
 
 #: application/views/qso/components/winkeysettings.php:49
 msgid ""
@@ -18480,50 +18480,57 @@ msgid ""
 "only your own call, and logging sends your report instead of a TU. Alt+Enter "
 "logs without sending."
 msgstr ""
+"Quando ativado, a tecla Enter conduz o QSO: uma chamada vazia envia CQ, uma "
+"chamada não clara (com \"?\") pede novamente, uma chamada completa sem troca "
+"envia o relatório, e um QSO completo é registado com um TU. No modo S&P, o "
+"primeiro Enter envia apenas a sua própria chamada, e o registo envia o seu "
+"relatório em vez de um TU. Alt+Enter regista sem enviar."
 
 #: application/views/qso/components/winkeysettings.php:55
 msgid "Unclear call (?)"
-msgstr ""
+msgstr "Indicativo pouco claro (?)"
 
 #: application/views/qso/components/winkeysettings.php:56
 msgid "Exchange / Report"
-msgstr ""
+msgstr "Troca / Relatório"
 
 #: application/views/qso/components/winkeysettings.php:57
 msgid "Log QSO / TU"
-msgstr ""
+msgstr "Registar QSO / TU"
 
 #: application/views/qso/components/winkeysettings.php:58
 msgid "own call"
-msgstr ""
+msgstr "indicativo próprio"
 
 #: application/views/qso/components/winkeysettings.php:59
 msgid "exchange on log"
-msgstr ""
+msgstr "trocar no registo"
 
 #: application/views/qso/components/winkeysettings.php:78
 msgid "Keyboard shortcuts"
-msgstr ""
+msgstr "Atalhos de teclado"
 
 #: application/views/qso/components/winkeysettings.php:82
 msgid "Send the corresponding CW macro"
-msgstr ""
+msgstr "Enviar a macro CW correspondente"
 
 #: application/views/qso/components/winkeysettings.php:83
 msgid "ESM on: drive the QSO (CQ / report / log); ESM off: log the QSO"
 msgstr ""
+"ESM ligado: conduzir o QSO (CQ / relatório / registo); ESM desligado: "
+"registar o QSO"
 
 #: application/views/qso/components/winkeysettings.php:84
 msgid "Log the QSO without sending anything"
-msgstr ""
+msgstr "Regista o QSO sem enviar nada"
 
 #: application/views/qso/components/winkeysettings.php:85
 msgid "Clear the entry form"
-msgstr ""
+msgstr "Limpar o formulário de entrada"
 
 #: application/views/qso/components/winkeysettings.php:86
 msgid "In the callsign field: jump to the next empty field"
-msgstr ""
+msgstr "No campo do indicativo de chamada: avance para o próximo campo vazio"
 
 #: application/views/qso/edit_ajax.php:35
 msgid "Sats"
@@ -19261,6 +19268,8 @@ msgstr "Contactos não confirmados no LoTW"
 #: application/views/search/filter.php:31 application/views/search/main.php:23
 msgid "Search is limited to station locations linked to active logbook"
 msgstr ""
+"A pesquisa está limitada a localizações de estações ligadas ao livro de "
+"registos ativo"
 
 #: application/views/search/filter.php:40
 msgid "Save query"
@@ -20160,7 +20169,7 @@ msgstr "Desconectar localização da estação"
 
 #: application/views/stationsetup/locationlist.php:3
 msgid "Limited to station locations linked to active logbook"
-msgstr ""
+msgstr "Limitado a locais de estações ligados ao diário de bordo ativo"
 
 #: application/views/stationsetup/locationlist.php:11
 msgid "QSO Count"
@@ -21099,16 +21108,18 @@ msgstr "Mostrar locator"
 
 #: application/views/user/edit.php:705
 msgid "Map Tile Style"
-msgstr ""
+msgstr "Estilo de bloco do Mapa"
 
 #: application/views/user/edit.php:709
 msgid "Null"
-msgstr ""
+msgstr "Nulo"
 
 #: application/views/user/edit.php:712
 msgid ""
 "Choose the map tile rendering method; this will override the theme settings."
 msgstr ""
+"Escolha o método de renderização de blocos do mapa; isto irá sobrepor as "
+"definições do tema."
 
 #: application/views/user/edit.php:724
 msgid "Previous QSL Type"
@@ -21161,6 +21172,9 @@ msgid ""
 "expeditions cards (Top), at the bottom of the dashboard (Bottom), or hide it "
 "(Off)."
 msgstr ""
+"Mostrar dados solares e de propagação no painel acima das cartas de "
+"expedições ativas (Topo), na parte inferior do painel (Fundo), ou ocultá-los "
+"(Desligado)."
 
 #: application/views/user/edit.php:792
 msgid "Dashboard Notification Banner"
@@ -21174,13 +21188,15 @@ msgstr ""
 
 #: application/views/user/edit.php:824
 msgid "Dashboard KPI statistics"
-msgstr ""
+msgstr "Estatísticas do painel KPI"
 
 #: application/views/user/edit.php:825
 msgid ""
 "This switches the display of the KPI statistics (Total QSOs, QSOs this year/"
 "month/today, Current Streak, Unique callsigns) on the dashboard."
 msgstr ""
+"Isto altera a visualização das estatísticas KPI (Total de QSOs, QSOs deste "
+"ano/mês/hoje, Sequência atual, Indicativos únicos) no painel."
 
 #: application/views/user/edit.php:834
 msgid "Show Fields on QSO Tab"

--- a/application/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/application/locale/zh_CN/LC_MESSAGES/messages.po
@@ -32,7 +32,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-02 13:31+0000\n"
-"PO-Revision-Date: 2026-07-03 14:26+0000\n"
+"PO-Revision-Date: 2026-07-04 18:16+0000\n"
 "Last-Translator: \"Shen RuiQin(BH4FJN)\" <jerry19980425@gmail.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://"
 "translate.wavelog.org/projects/wavelog/main-translation/zh_Hans/>\n"
@@ -6004,7 +6004,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:45
 msgid "Worked Counties"
-msgstr ""
+msgstr "通联的（郡）县"
 
 #: application/views/awards/counties/index.php:47
 #, php-format
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:52
 msgid "Confirmed Counties"
-msgstr ""
+msgstr "确认的（郡）县"
 
 #: application/views/awards/counties/index.php:54
 #, php-format
@@ -21415,6 +21415,11 @@ msgid ""
 "only your own call, and logging sends your report instead of a TU. Alt+Enter "
 "logs without sending."
 msgstr ""
+"启用此功能后，Enter 键将控制 QSO 流程：输入为空时发送 CQ；呼号不完整（含“?”）"
+"时请求对方重发；输入完整呼号但未包含交换信息时发送信号报告；输入完整 QSO 信息"
+"后则发送 TU 并记录日志。在 S&P 模式下，首次按下 Enter 键仅发送本方呼号，而记"
+"录日志时发送的是信号报告而非 TU。使用 Alt+Enter 组合键可在不发送信息的情况下"
+"记录日志。"
 
 #: application/views/qso/components/winkeysettings.php:55
 msgid "Unclear call (?)"

--- a/application/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/application/locale/zh_CN/LC_MESSAGES/messages.po
@@ -32,7 +32,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-02 13:31+0000\n"
-"PO-Revision-Date: 2026-07-02 21:25+0000\n"
+"PO-Revision-Date: 2026-07-03 14:26+0000\n"
 "Last-Translator: \"Shen RuiQin(BH4FJN)\" <jerry19980425@gmail.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://"
 "translate.wavelog.org/projects/wavelog/main-translation/zh_Hans/>\n"
@@ -5997,7 +5997,7 @@ msgstr ""
 #: application/views/awards/counties/index.php:54
 #, php-format
 msgid "%s%% of worked"
-msgstr ""
+msgstr "%s%% 已完成"
 
 #: application/views/awards/counties/index.php:59
 msgid "Remaining Counties"
@@ -6005,7 +6005,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:61
 msgid "Based on current worked count"
-msgstr ""
+msgstr "基于当前已完成工作量的统计"
 
 #: application/views/awards/counties/index.php:66
 #: application/views/awards/dxcc/index.php:41
@@ -6054,7 +6054,7 @@ msgstr "已确认"
 
 #: application/views/awards/counties/index.php:80
 msgid "Remaining"
-msgstr ""
+msgstr "剩余"
 
 #: application/views/awards/counties/index.php:81
 #: application/views/awards/dxcc/index.php:287
@@ -6068,7 +6068,7 @@ msgstr "已完成通联"
 #: application/views/awards/dxcc/index.php:361
 #: application/views/awards/dxcc/progress.php:5
 msgid "Confirmed Progress"
-msgstr "已确认的通联"
+msgstr "已确认通联"
 
 #: application/views/awards/counties/index.php:110
 #: application/views/awards/counties/state_ajax.php:32
@@ -11536,7 +11536,7 @@ msgstr "仪表盘选项"
 
 #: application/views/dashboard/_options_menu.php:12
 msgid "KPI statistics"
-msgstr ""
+msgstr "KPI 统计"
 
 #: application/views/dashboard/_options_menu.php:15
 msgid "Solar data"
@@ -11641,7 +11641,7 @@ msgstr "你至少一张证书即将过期"
 #: application/views/dashboard/index.php:230
 #: application/views/dashboard/solar_data.php:2
 msgid "Right-click for options"
-msgstr ""
+msgstr "点击右键获取选项"
 
 #: application/views/dashboard/index.php:245
 msgid "QSOs this year"
@@ -17783,7 +17783,7 @@ msgstr "仅为通联美国各州显示总结。"
 
 #: application/views/qso/components/fav_modal.php:5
 msgid "Save Favourite"
-msgstr ""
+msgstr "保存收藏"
 
 #: application/views/qso/components/fav_modal.php:9
 msgid "e.g. 20m SSB, SO-50, portable setup"
@@ -20344,7 +20344,7 @@ msgstr "禁用仪表盘上的全局通知横幅。"
 
 #: application/views/user/edit.php:824
 msgid "Dashboard KPI statistics"
-msgstr ""
+msgstr "仪表盘KPI统计"
 
 #: application/views/user/edit.php:825
 msgid ""


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)