### PR TITLE
Fix Lookup

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1309,6 +1309,9 @@ function reset_fields() {
 	// we do this first to avoid race conditions for slow javascript
 	pendingReferencesMap.clear();
 
+	lastLookupCallsign = null;
+	lookupInProgress = false;
+
 	$('#locator_info').text("");
 	$('#lotw_support').text("");
 	$('#lotw_support').removeClass();


### PR DESCRIPTION
Fixes a bug, which was accidently introduced by https://github.com/wavelog/wavelog/commit/8a688c9bedc58f6422885616781e9d36d57c33ed

Reproduce:
QSO-Page:
- enter DJ7NT as call followed by blur (Tab, click somewhere else, so lookup is triggered)
- press ESC or reset (because you think you missheard the call or sth. else)
- type in DJ7NT again followed by blur
- BUG: No new lookup - everything stays empty

this one fixes it, without breaking what the commit above tried to do