### PR TITLE
Fix annoying bug for GHz-QSOs on mobile

### DIFF
--- a/assets/js/sections/contesting/contest_engine/components/radio.js
+++ b/assets/js/sections/contesting/contest_engine/components/radio.js
@@ -401,20 +401,8 @@ class RadioComponent {
 	 * Setup QRG input type for small screens
 	 */
 	qrg_inputtype() {
-		// on small screens we change the input type of the frequency and frequency_rx fields to number to show the numeric keyboard
-		if (this.freqCalculated) {
-			this.freqCalculated.type = 'number';
-			this.freqCalculated.step = '0.001';
-			this.freqCalculated.inputMode = 'decimal';
-			this.freqCalculated.lang = 'en';
-		}
-
-		if (this.frequencyRx) {
-			this.frequencyRx.type = 'number';
-			this.frequencyRx.step = '0.001';
-			this.frequencyRx.inputMode = 'decimal';
-			this.frequencyRx.lang = 'en';
-		}
+		if (this.freqCalculated) this.freqCalculated.inputMode = 'decimal';
+		if (this.frequencyRx)    this.frequencyRx.inputMode    = 'decimal';
 	}
 
 	/**
@@ -768,9 +756,7 @@ class RadioComponent {
 		if (this.freqCalculated) {
 			// Real-time input filtering (commas to dots)
 			this.freqCalculated.addEventListener('input', () => {
-				if (window.innerWidth > 768) {
-					this.freqCalculated.value = this.freqCalculated.value.replace(',', '.');
-				}
+				this.freqCalculated.value = this.freqCalculated.value.replace(',', '.');
 			});
 
 			// Fire set_new_qrg() when user presses Enter

--- a/assets/js/sections/qrg_handler.js
+++ b/assets/js/sections/qrg_handler.js
@@ -21,8 +21,8 @@ $('#qrg_unit').on('click', function () {
 function qrg_inputtype() {
 	// on small screens we change the input type of the frequency and frequency_rx fields to number to show the numeric keyboard
 	if (window.innerWidth < 768) {
-		$('#freq_calculated').attr('type', 'number').attr('step', '0.001').attr('inputmode', 'decimal').attr('lang', 'en');
-		$('#frequency_rx').attr('type', 'number').attr('step', '0.001').attr('inputmode', 'decimal').attr('lang', 'en');
+		$('#freq_calculated').attr('type', 'number').attr('step', 'any').attr('inputmode', 'decimal').attr('lang', 'en');
+		$('#frequency_rx').attr('type', 'number').attr('step', 'any').attr('inputmode', 'decimal').attr('lang', 'en');
 	}
 }
 

--- a/assets/js/sections/qrg_handler.js
+++ b/assets/js/sections/qrg_handler.js
@@ -19,10 +19,10 @@ $('#qrg_unit').on('click', function () {
 });
 
 function qrg_inputtype() {
-	// on small screens we change the input type of the frequency and frequency_rx fields to number to show the numeric keyboard
+	// On small screens add inputmode=decimal to show the numeric keyboard.
 	if (window.innerWidth < 768) {
-		$('#freq_calculated').attr('type', 'number').attr('step', 'any').attr('inputmode', 'decimal').attr('lang', 'en');
-		$('#frequency_rx').attr('type', 'number').attr('step', 'any').attr('inputmode', 'decimal').attr('lang', 'en');
+		$('#freq_calculated').attr('inputmode', 'decimal');
+		$('#frequency_rx').attr('inputmode', 'decimal');
 	}
 }
 
@@ -163,8 +163,6 @@ $('#frequency').on('change', function () {
 });
 
 $('#freq_calculated').on('input', function () {
-	if (window.innerWidth > 768) {
-		$(this).val($(this).val().replace(',', '.'));
-	}
+	$(this).val($(this).val().replace(',', '.'));
 });
 


### PR DESCRIPTION
These bugs are there, since we have the [switch](https://github.com/wavelog/wavelog/commit/abf1e431ca2c6367a3963578a47dc90713f0dbe8) for kHz, MHz, GHz in QSO-Form.

<img width="1206" height="1016" alt="image" src="https://github.com/user-attachments/assets/cca63ddd-de28-4361-b9b0-fbf7387e5aaa" />


repro Bug 1:
- open logging page from mobile (iPhone)
- recall QO100 Fav or prepare logging for QO100 (e.g.: `2.400175` GHz)
try to log.
it fails with an Error, because stepsize is too small.

repro Bug 2:
- open logging page from mobile (iPhone) which is set to ENGLISH (OS-Language of mobile!)
- try to type in 2.400175 GHz // doesn't work, because English-fraction is a comma, not a dot. which isn't shown on android or apple.
Workaround: replace via regex to dot.


Testing:
- manual entering QRG with different units
- CAT
- Cluster check (follow QRG)