### PR TITLE
autoload the user_model

### DIFF
--- a/application/config/autoload.php
+++ b/application/config/autoload.php
@@ -92,7 +92,7 @@ $autoload['config'] = array('wavelog', 'bands', 'lotw', 'gettext', 'adif_propmod
 |
 */
 
-$autoload['model'] = array('user_options_model', 'logbooks_model', 'stations', 'oqrs_model');
+$autoload['model'] = array('user_model', 'user_options_model', 'logbooks_model', 'stations', 'oqrs_model');
 
 
 /* End of file autoload.php */

--- a/application/controllers/Accumulated.php
+++ b/application/controllers/Accumulated.php
@@ -7,7 +7,6 @@ class Accumulated extends CI_Controller
     function __construct() {
         parent::__construct();
 
-        $this->load->model('user_model');
         if (!$this->user_model->authorize(2)) {
             $this->session->set_flashdata('error', __("You're not allowed to do that!"));
             redirect('dashboard');

--- a/application/controllers/Activated_gridmap.php
+++ b/application/controllers/Activated_gridmap.php
@@ -5,7 +5,6 @@ class Activated_gridmap extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Activators.php
+++ b/application/controllers/Activators.php
@@ -8,7 +8,6 @@ class Activators extends CI_Controller
     {
         parent::__construct();
 
-        $this->load->model('user_model');
         if (!$this->user_model->authorize(2)) {
             $this->session->set_flashdata('error', __("You're not allowed to do that!"));
             redirect('dashboard');

--- a/application/controllers/Activatorsmap.php
+++ b/application/controllers/Activatorsmap.php
@@ -9,7 +9,6 @@ class Activatorsmap extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Adif.php
+++ b/application/controllers/Adif.php
@@ -19,7 +19,6 @@ class adif extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || (!clubaccess_check(6) && !clubaccess_check(9))) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->determine_allowed_tabs();

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -30,7 +30,6 @@ class API extends CI_Controller {
 	}
 
 	function index() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('api_model');
@@ -73,7 +72,6 @@ class API extends CI_Controller {
 	}
 
 	function edit($key) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('api_model');
@@ -113,7 +111,6 @@ class API extends CI_Controller {
 			return;
 		}
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$rights = $this->input->post('rights', TRUE);
@@ -148,7 +145,6 @@ class API extends CI_Controller {
 			return;
 		}
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$key = $this->input->post('key', TRUE);
@@ -397,7 +393,6 @@ class API extends CI_Controller {
 		$real_operator = null;	// real_operator is only filled if its a clubstation and the used key is created by an OP. otherwise its null
 		if ($this->config->item('special_callsign')) {
 			if ($userid != $created_by) {
-				$this->load->model('user_model');
 				$real_operator = $this->user_model->get_by_id($created_by)->row()->user_callsign;
 			} else {
 				$real_operator = null;
@@ -1183,7 +1178,6 @@ class API extends CI_Controller {
 		$identifier = isset($raw_input['key']) ? $raw_input['key'] : null;
 		$this->check_rate_limit('private_lookup', $identifier);
 		$user_id='';
-		$this->load->model('user_model');
 		if (!( $this->user_model->authorize($this->config->item('auth_mode') ))) {				// User not authorized?
 			$no_auth=true;
 			$this->load->model('api_model');
@@ -1396,7 +1390,6 @@ class API extends CI_Controller {
 		$this->check_rate_limit('lookup', $identifier);
 
 		$user_id = '';
-		$this->load->model('user_model');
 		if (!( $this->user_model->authorize($this->config->item('auth_mode') ))) {				// User not authorized?
 			$no_auth = true;
 			$this->load->model('api_model');

--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -16,7 +16,6 @@ class Awards extends CI_Controller {
 	{
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$map_custom = json_decode($this->optionslib->get_map_custom());

--- a/application/controllers/Backup.php
+++ b/application/controllers/Backup.php
@@ -9,7 +9,6 @@ class Backup extends CI_Controller {
 	/* User Facing Links to Backup URLs */
 	public function index()
 	{
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$data['page_title'] = __("Backup");
@@ -22,7 +21,6 @@ class Backup extends CI_Controller {
 	/* Gets all QSOs and Dumps them to logbook.adi */
 	public function adif($key = null){
 		if ($key == null) {
-			$this->load->model('user_model');
 			if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		}
 
@@ -67,7 +65,6 @@ class Backup extends CI_Controller {
 	/* Export the notes to XML */
 	public function notes($key = null) {
 		if ($key == null) {
-			$this->load->model('user_model');
 			if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		}
 

--- a/application/controllers/Band.php
+++ b/application/controllers/Band.php
@@ -10,7 +10,6 @@ class Band extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2) || !clubaccess_check(9)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Bandmap.php
+++ b/application/controllers/Bandmap.php
@@ -5,7 +5,6 @@ class Bandmap extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$this->load->model('bands');
 	}

--- a/application/controllers/Cabrillo.php
+++ b/application/controllers/Cabrillo.php
@@ -7,7 +7,6 @@ class Cabrillo extends CI_Controller {
 	public function __construct() {
         parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Callstats.php
+++ b/application/controllers/Callstats.php
@@ -8,7 +8,6 @@ class Callstats extends CI_Controller
     {
         parent::__construct();
 
-        $this->load->model('user_model');
         if (!$this->user_model->authorize(2)) {
             $this->session->set_flashdata('error', __("You're not allowed to do that!"));
             redirect('dashboard');

--- a/application/controllers/Calltester.php
+++ b/application/controllers/Calltester.php
@@ -9,7 +9,6 @@ class Calltester extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Club.php
+++ b/application/controllers/Club.php
@@ -34,7 +34,6 @@ class Club extends CI_Controller
 
     public function permissions($club_id) {
 
-		$this->load->model('user_model');
 		$this->load->model('club_model');
 		$this->load->library('form_validation');
 
@@ -88,9 +87,6 @@ class Club extends CI_Controller
 			$this->session->set_flashdata('error', __("You're not allowed to do that!")); 
 			redirect('dashboard'); 
 		}
-		if (!$this->load->is_loaded('user_model')) {
-			$this->load->model('user_model');
-		}
 
 		$query = (string) $this->input->post('query', true) ?? '';
 		if (empty($query)) {
@@ -121,7 +117,6 @@ class Club extends CI_Controller
 
 	public function alter_member() {
 		
-		$this->load->model('user_model');
 		$this->load->model('club_model');
 
 		$club_id = $this->input->post('club_id', true);
@@ -151,7 +146,6 @@ class Club extends CI_Controller
 
 	public function delete_member() {
 		
-		$this->load->model('user_model');
 		$this->load->model('club_model');
 
 		$club_id = $this->input->post('club_id', true);
@@ -176,7 +170,6 @@ class Club extends CI_Controller
 
 	public function switch_modal() {
 		
-		$this->load->model('user_model');
 		$this->load->model('club_model');
 		$this->load->library('encryption');
 

--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -77,7 +77,6 @@ class Clublog extends CI_Controller
 	 * Used for displaying the uid for manually selecting log for upload to Clublog
 	 */
 	public function export() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('clublog_model');
@@ -136,7 +135,6 @@ class Clublog extends CI_Controller
 	public function importlog() {
 		if (!($this->config->item('disable_manual_clublog'))) {
 
-			$this->load->model('user_model');
 			if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 			$data['page_title'] = __("Clublog QSL Import");

--- a/application/controllers/Components.php
+++ b/application/controllers/Components.php
@@ -9,7 +9,6 @@ class Components extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Contest_admin.php
+++ b/application/controllers/Contest_admin.php
@@ -10,7 +10,6 @@ class Contest_admin extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Contestcalendar.php
+++ b/application/controllers/Contestcalendar.php
@@ -3,7 +3,6 @@
 class Contestcalendar extends CI_Controller {
 
 	public function index() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -34,7 +34,6 @@ class Contesting extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -127,8 +126,6 @@ class Contesting extends CI_Controller {
 			redirect('contesting');
 		}
 
-		$this->load->is_loaded('user_model') ?: $this->load->model('user_model');
-
 		$session_info = $this->contesting_model->get_session_info($contest_session_id);
 		$cabrillo     = $this->contesting_model->get_exportformat_settings($contest_session_id, "cabrillo");
 		$userinfo     = $this->user_model->get_by_id($this->session->userdata('user_id'))->row();
@@ -160,8 +157,6 @@ class Contesting extends CI_Controller {
 			$this->session->set_flashdata('error', __("Contest session not found."));
 			redirect('contesting');
 		}
-
-		$this->load->is_loaded('user_model') ?: $this->load->model('user_model');
 
 		$session_info = $this->contesting_model->get_session_info($contest_session_id);
 		$reg1test     = $this->contesting_model->get_exportformat_settings($contest_session_id, "reg1test");
@@ -263,7 +258,6 @@ class Contesting extends CI_Controller {
 		$session_info = $this->contesting_model->get_session_info($contest_session_id);
 		$qsos         = $this->contesting_model->get_session_qsos_for_exportformat($contest_session_id);
 
-		$this->load->is_loaded('user_model') ?: $this->load->model('user_model');
 		$userinfo = $this->user_model->get_by_id($this->session->userdata('user_id'))->row();
 
 		$contest_id = $session_info['contest_adifname'];
@@ -333,9 +327,6 @@ class Contesting extends CI_Controller {
 
 		//load distance calculator
 		$this->load->library('Qra');
-
-		//load user model
-		$this->load->is_loaded('user_model') ?: $this->load->model('user_model');
 
 		//load userinfo
 		$userinfo = $this->user_model->get_by_id($this->session->userdata('user_id'))->row();
@@ -445,7 +436,6 @@ class Contesting extends CI_Controller {
 	 */
 	public function logging_engine($logging_token) {
 		$this->load->model('contesting_model');
-		$this->load->model('user_model');
 
 		// Decode logging token
 		$decoded_token = $this->paths->decode_contesting_logging_token($logging_token);

--- a/application/controllers/Contesting_import.php
+++ b/application/controllers/Contesting_import.php
@@ -6,7 +6,6 @@ class Contesting_import extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Continents.php
+++ b/application/controllers/Continents.php
@@ -4,7 +4,6 @@ class Continents extends CI_Controller {
 
 	public function index()
 	{
-        $this->load->model('user_model');
         $this->load->model('bands');
         $this->load->model('logbookadvanced_model');
 		$this->load->model('gridmap_model');

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -21,7 +21,6 @@ class cron extends CI_Controller {
 
 	public function index() {
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -179,7 +178,6 @@ class cron extends CI_Controller {
 	}
 
 	public function editDialog() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -193,7 +191,6 @@ class cron extends CI_Controller {
 	}
 
 	public function edit() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -227,7 +224,6 @@ class cron extends CI_Controller {
 	}
 
 	public function toogleEnableCronSwitch() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			echo json_encode(['success' => false, 'messagecategory' => 'error', 'message' => 'Not allowed']);
 			return;
@@ -247,7 +243,6 @@ class cron extends CI_Controller {
 	}
 
 	public function fetchCrons() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			echo json_encode(['success' => false, 'messagecategory' => 'error', 'message' => 'Not allowed']);
 			return;

--- a/application/controllers/Csv.php
+++ b/application/controllers/Csv.php
@@ -3,8 +3,6 @@
 class Csv extends CI_Controller {
 
 	public function index()	{
-		$this->load->model('user_model');
-
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('modes');
@@ -27,8 +25,6 @@ class Csv extends CI_Controller {
 	}
 
 	public function export()  {
-		$this->load->model('user_model');
-
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('csv_model');

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -5,7 +5,6 @@ class Dashboard extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			redirect('user/login');
 		}

--- a/application/controllers/Dayswithqso.php
+++ b/application/controllers/Dayswithqso.php
@@ -7,7 +7,6 @@ class Dayswithqso extends CI_Controller {
 	{
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Dcl.php
+++ b/application/controllers/Dcl.php
@@ -8,7 +8,6 @@ class Dcl extends CI_Controller {
 		$this->load->helper(array('form', 'url'));
 
 		if (!($this->config->item('enable_dcl_interface') ?? false)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); exit; }
-		$this->load->model('user_model');
 		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
@@ -49,7 +48,6 @@ class Dcl extends CI_Controller {
 	public function index() {
 		if (!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$this->load->library('Permissions');
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		// Load required models for page generation
@@ -85,7 +83,6 @@ class Dcl extends CI_Controller {
 		// Called from cron / without Session: iterate through stations, check for DCL-Key and upload
 		ini_set('memory_limit', '-1');
 
-		$this->load->model('user_model');
 		$this->load->model('Dcl_model');
 
 		// set the last run in cron table for the correct cron id
@@ -222,8 +219,6 @@ class Dcl extends CI_Controller {
 
 	public function delete_key() {
 		if (!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
-		$this->load->model('user_model');
-		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$this->load->model('Dcl_model');
 		$this->Dcl_model->delete_key();
 		$this->session->set_flashdata('success', __("Key(s) Deleted."));
@@ -241,7 +236,6 @@ class Dcl extends CI_Controller {
 	|
 	 */
 	function dcl_download($sync_user_id = null) {
-		$this->load->model('user_model');
 		$this->load->model('logbook_model');
 		$this->load->model('Stations');
 
@@ -253,7 +247,6 @@ class Dcl extends CI_Controller {
 	}
 
 	public function import() {	// Is only called via frontend. Cron uses "upload". within download the download is called
-		$this->load->model('user_model');
 		$this->load->model('Stations');
 		if(!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));

--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -5,7 +5,6 @@ class Debug extends CI_Controller
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -329,7 +328,6 @@ class Debug extends CI_Controller
 	public function worker_status() {
 		header('Content-Type: application/json');
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			http_response_code(403);
 			echo json_encode(['success' => false]);

--- a/application/controllers/Distancerecords.php
+++ b/application/controllers/Distancerecords.php
@@ -7,7 +7,6 @@ class Distancerecords extends CI_Controller {
     {
         parent::__construct();
 
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
     }
 

--- a/application/controllers/Distances.php
+++ b/application/controllers/Distances.php
@@ -7,7 +7,6 @@ class Distances extends CI_Controller {
     {
         parent::__construct();
 
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
     }
 

--- a/application/controllers/Dxatlas.php
+++ b/application/controllers/Dxatlas.php
@@ -3,7 +3,6 @@
 class Dxatlas extends CI_Controller {
 
 	public function index()	{
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('modes');
@@ -26,7 +25,6 @@ class Dxatlas extends CI_Controller {
 	}
 
 	public function export()  {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('dxatlas_model');
@@ -48,7 +46,6 @@ class Dxatlas extends CI_Controller {
 	}
 
 	function generateFiles($wkdArray, $cfmArray, $band) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$gridCfmArray = [];
@@ -105,7 +102,6 @@ class Dxatlas extends CI_Controller {
 	}
 
 	function makeZip($gridWkdString, $gridCfmString, $band) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$zipFileName = 'dxatlas_gridsquares_'. $band . '.zip';
 		// Prepare File

--- a/application/controllers/Dxcalendar.php
+++ b/application/controllers/Dxcalendar.php
@@ -3,7 +3,6 @@
 class Dxcalendar extends CI_Controller {
 
 	public function index()	{
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$data['page_title'] = __("DX Calendar");

--- a/application/controllers/Dxcluster.php
+++ b/application/controllers/Dxcluster.php
@@ -9,7 +9,6 @@ class Dxcluster extends CI_Controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->is_loaded('user_model') ?: $this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$this->load->is_loaded('dxcluster_model') ?: $this->load->model('dxcluster_model');
 	}

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -18,7 +18,6 @@ class eqsl extends CI_Controller {
 	// Default view when loading controller.
 	public function index() {
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -61,7 +60,6 @@ class eqsl extends CI_Controller {
 	}
 
 	public function import() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2) || !clubaccess_check(9)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -161,7 +159,6 @@ class eqsl extends CI_Controller {
 	}
 
 	public function export() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -250,7 +247,6 @@ class eqsl extends CI_Controller {
 	}
 
 	function generateResultTable($custom_date_format, $rows) {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -274,7 +270,6 @@ class eqsl extends CI_Controller {
 	}
 
 	function writeEqslNotSent($qslsnotsent, $custom_date_format) {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -313,7 +308,6 @@ class eqsl extends CI_Controller {
 	}
 
 	function image($id, $width=null) {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -327,7 +321,6 @@ class eqsl extends CI_Controller {
 
 		if ($this->Eqsl_images->get_image($id) == "No Image") {
 			$this->load->model('logbook_model');
-			$this->load->model('user_model');
 			$qso_query = $this->logbook_model->get_qso($id);
 
 			// Check if QSO exists and is accessible
@@ -521,7 +514,6 @@ class eqsl extends CI_Controller {
 	}
 
 	function bulk_download_image($id) {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -529,7 +521,6 @@ class eqsl extends CI_Controller {
 		$this->load->model('Eqsl_images');
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 		$qso_query = $this->logbook_model->get_qso($id);
 		$qso = $qso_query->row();
 		$qso_timestamp = strtotime($qso->COL_TIME_ON);
@@ -594,7 +585,6 @@ class eqsl extends CI_Controller {
 
 	public function tools() {
 		// Check logged in
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -610,7 +600,6 @@ class eqsl extends CI_Controller {
 
 	public function download() {
 		// Check logged in
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -669,7 +658,6 @@ class eqsl extends CI_Controller {
 
 	public function mark_all_sent() {
 		// Check logged in
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Generic_qsl.php
+++ b/application/controllers/Generic_qsl.php
@@ -8,7 +8,6 @@ class Generic_qsl extends CI_Controller {
 
 	function __construct() {
 		parent::__construct();
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Gridmap.php
+++ b/application/controllers/Gridmap.php
@@ -5,7 +5,6 @@ class Gridmap extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Hamsat.php
+++ b/application/controllers/Hamsat.php
@@ -9,7 +9,6 @@ class Hamsat extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Header_auth.php
+++ b/application/controllers/Header_auth.php
@@ -79,7 +79,6 @@ class Header_auth extends CI_Controller {
         }
         $external_identifier = json_encode(['iss' => $iss, 'sub' => $sub]);
 
-        $this->load->model('user_model');
         $query = $this->user_model->get_by_external_account($external_identifier);
 
         $isNewUser = false;
@@ -281,7 +280,6 @@ class Header_auth extends CI_Controller {
         }
 
 
-        $this->load->model('user_model');
         $result = $this->user_model->add(
             $mapped['user_name']                              ?? '',
             bin2hex(random_bytes(64)),                           // password is always random

--- a/application/controllers/Hrdlog.php
+++ b/application/controllers/Hrdlog.php
@@ -32,7 +32,6 @@ class Hrdlog extends CI_Controller {
      * Used for displaying the uid for manually selecting log for upload to hrdlog
      */
     public function export() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
         $this->load->model('stations');

--- a/application/controllers/Kmlexport.php
+++ b/application/controllers/Kmlexport.php
@@ -10,7 +10,6 @@
 class Kmlexport extends CI_Controller {
 
     public function index() {
-        $this->load->model('user_model');
         $this->load->model('modes');
         $this->load->model('logbook_model');
         $this->load->model('bands');
@@ -30,7 +29,6 @@ class Kmlexport extends CI_Controller {
     }
 
 	public function export() {
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		// Load Libraries
 		if(!$this->load->is_loaded('Qra')) {

--- a/application/controllers/Labels.php
+++ b/application/controllers/Labels.php
@@ -22,7 +22,6 @@ class Labels extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url', 'psr4_autoloader'));
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -8,7 +8,6 @@ class Logbook extends CI_Controller {
 
 	function index() {
 		// Check if users logged in
-		$this->load->model('user_model');
 		if($this->user_model->validate_session() == 0) {
 			// user is not logged in
 			redirect('user/login');
@@ -66,7 +65,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function jsonentity($adif) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$return['dxcc'] = $this->getentity($adif);
@@ -75,7 +73,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function json($tempcallsign, $tempband, $tempmode, $tempstation_id = null, $date = "", $count = 5) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 		session_write_close();
 
@@ -238,7 +235,6 @@ class Logbook extends CI_Controller {
 	// Helper function to get user's lookup priority setting
 	// Returns 1 for database priority, 2 for external lookup priority (default)
 	function get_lookup_priority() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 		$this->load->model('user_options_model');
 		$priority = $this->user_options_model->get_options('qso_db_search_priority', array('option_name'=>'enable', 'option_key'=>'boolean'))->row();
@@ -372,7 +368,6 @@ class Logbook extends CI_Controller {
 	*
 	*/
 	function jsonlookupgrid($gridsquare, $type, $band, $mode) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		session_write_close();
@@ -462,7 +457,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function jsonlookupdxcc($country, $type, $band, $mode) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 		session_write_close();
 
@@ -563,7 +557,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function jsonlookupcallsign($callsign, $type, $band, $mode) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 		session_write_close();
 
@@ -663,7 +656,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function view($id) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$this->load->library('DxccFlag');
@@ -704,7 +696,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function partial($lookupcall, $callbook, $callsign, $dxcc, $lotw_days, $band = null, $count = 5) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$this->load->model('logbooks_model');
@@ -1012,7 +1003,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function search_result($id="", $id2="") {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$this->load->model('logbook_model');
@@ -1086,7 +1076,6 @@ class Logbook extends CI_Controller {
 	}
 
 	private function querydb($id) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$stationsactivelogonly_sql = '';
@@ -1126,7 +1115,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function search_lotw_unconfirmed($station_id) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$clean_station_id = $this->security->xss_clean($station_id);
@@ -1178,7 +1166,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function search_incorrect_cq_zones($station_id) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$clean_station_id = $this->security->xss_clean($station_id);
@@ -1225,7 +1212,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function search_incorrect_itu_zones($station_id) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$clean_station_id = $this->security->xss_clean($station_id);
@@ -1275,7 +1261,6 @@ class Logbook extends CI_Controller {
 	 * Provide a dxcc search, returning results json encoded
 	 */
 	private function dxcheck($call = "", $date = "") {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		if ($date == ''){
@@ -1288,7 +1273,6 @@ class Logbook extends CI_Controller {
 	}
 
 	private function getentity($adif) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 		$this->load->model("logbook_model");
 
@@ -1299,7 +1283,6 @@ class Logbook extends CI_Controller {
 
 	/* return station bearing */
 	function searchbearing() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$locator = xss_clean($this->input->post('grid'));
@@ -1344,7 +1327,6 @@ class Logbook extends CI_Controller {
 
 	/* return distance */
 	function searchdistance() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$locator = xss_clean($this->input->post('grid'));
@@ -1382,7 +1364,6 @@ class Logbook extends CI_Controller {
 
 	/* return station bearing */
 	function bearing($locator, $unit = 'M', $station_id = null, $ant_path = null) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		if(!$this->load->is_loaded('Qra')) {
@@ -1417,7 +1398,6 @@ class Logbook extends CI_Controller {
 
 	/* return distance */
 	function distance($locator, $station_id = null, $ant_path = null) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$distance = 0;
@@ -1451,7 +1431,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function qralatlng($qra) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		if(!$this->load->is_loaded('Qra')) {
@@ -1462,7 +1441,6 @@ class Logbook extends CI_Controller {
 	}
 
 	function qralatlngjson() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
 		$qra = xss_clean($this->input->post('qra'));

--- a/application/controllers/Logbookadvanced.php
+++ b/application/controllers/Logbookadvanced.php
@@ -11,7 +11,6 @@ class Logbookadvanced extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url', 'psr4_autoloader'));
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -13,7 +13,6 @@ class Lookup extends CI_Controller {
 	{
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -40,7 +40,6 @@ class Lotw extends CI_Controller {
 	*/
 	public function index() {
 		$this->load->library('Permissions');
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		// Load required models for page generation
@@ -85,7 +84,6 @@ class Lotw extends CI_Controller {
 	|
 	*/
 	public function cert_upload() {
-		$this->load->model('user_model');
 		$this->load->model('dxcc');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
@@ -111,7 +109,6 @@ class Lotw extends CI_Controller {
 	|
 	*/
 	public function do_cert_upload() {
-		$this->load->model('user_model');
 		$this->load->model('dxcc');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
@@ -186,7 +183,6 @@ class Lotw extends CI_Controller {
 	*/
 	public function lotw_upload() {
 
-		$this->load->model('user_model');
 		$this->user_model->authorize(2);
 
 		// set the last run in cron table for the correct cron id
@@ -406,7 +402,6 @@ class Lotw extends CI_Controller {
 	|
 	*/
     public function delete_cert($cert_id) {
-    	$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
     	$this->load->model('Lotw_model');
@@ -429,7 +424,6 @@ class Lotw extends CI_Controller {
 	|
 	*/
 	public function decrypt_key($file, $password = "") {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$results = array();
@@ -675,7 +669,6 @@ class Lotw extends CI_Controller {
 
 		unlink($filepath);
 
-		$this->load->model('user_model');
 		if ($this->user_model->authorize(2)) {	// Only Output results if authorized User
 			if(isset($data['lotw_table_headers'])) {
 				if($display_view == TRUE) {
@@ -713,7 +706,6 @@ class Lotw extends CI_Controller {
 	|
 	*/
 	function lotw_download($sync_user_id = null) {
-		$this->load->model('user_model');
 		$this->load->model('logbook_model');
 		$this->load->model('Stations');
 
@@ -934,7 +926,6 @@ class Lotw extends CI_Controller {
 	}
 
 	public function check_lotw_credentials () {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -1020,7 +1011,6 @@ class Lotw extends CI_Controller {
 	}
 
 	public function import() {	// Is only called via frontend. Cron uses "upload". within download the download is called
-		$this->load->model('user_model');
 		$this->load->model('Stations');
 		if(!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));

--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -7,7 +7,6 @@ class Map extends CI_Controller {
 	{
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -22,7 +21,6 @@ class Map extends CI_Controller {
 	 * QSO Map with country selection and OpenStreetMap
 	 */
 	public function qso_map() {
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(99)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Mode.php
+++ b/application/controllers/Mode.php
@@ -11,7 +11,6 @@ class Mode extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Notes.php
+++ b/application/controllers/Notes.php
@@ -5,7 +5,6 @@ class Notes extends CI_Controller {
     // Ensure only authorized users can access Notes controller
     function __construct() {
         parent::__construct();
-        $this->load->model('user_model');
         if (!$this->user_model->authorize(2)) {
             $this->session->set_flashdata('error', __("You're not allowed to do that!"));
             redirect('dashboard');

--- a/application/controllers/Operator.php
+++ b/application/controllers/Operator.php
@@ -8,7 +8,6 @@ class Operator extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -10,7 +10,6 @@ class Options extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 
@@ -315,8 +314,6 @@ class Options extends CI_Controller {
 	}
 
 	function sendTestMail() {
-		$this->load->model('user_model');
-
 		$id = $this->session->userdata('user_id');
 
 		$email = $this->user_model->get_user_email_by_id($id);

--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -263,7 +263,6 @@ class Oqrs extends CI_Controller {
 
 	private function _alert_oqrs_request($postdata, $station_ids) {
 		foreach ($station_ids as $id) {
-			$this->load->model('user_model');
 
 			$email = $this->user_model->get_email_address($id);
 
@@ -392,7 +391,6 @@ class Oqrs extends CI_Controller {
 	}
 
 	private function _check_auth() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { 
 			$this->session->set_flashdata('error', __("You're not allowed to do that!")); 
 			redirect('dashboard');

--- a/application/controllers/Qrbcalc.php
+++ b/application/controllers/Qrbcalc.php
@@ -9,7 +9,6 @@ class Qrbcalc extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -195,7 +195,6 @@ class Qrz extends CI_Controller {
 	 * Used for displaying the uid for manually selecting log for upload to qrz
 	 */
 	public function export() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('stations');
@@ -282,7 +281,6 @@ class Qrz extends CI_Controller {
 	}
 
 	public function import_qrz() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$data['page_title'] = __("QRZ QSL Import");
@@ -300,7 +298,6 @@ class Qrz extends CI_Controller {
 	} // end function
 
 	function download($user_id_to_load = null, $lastqrz = null, $show_views = false) {
-		$this->load->model('user_model');
 		$this->load->model('logbook_model');
 
 		$this->load->model('cron_model');
@@ -335,7 +332,6 @@ class Qrz extends CI_Controller {
 			log_message('error', "No station profiles with a QRZ API Key found.");
 		}
 
-		$this->load->model('user_model');
 		if ($this->user_model->authorize(2)) {	// Only Output results if authorized User
 			if(isset($data['tableheaders'])) {
 				if ($data['table'] != '') {

--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -8,7 +8,6 @@ class Qsl extends CI_Controller {
 
     function __construct() {
         parent::__construct();
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		if(($this->config->item('disable_qsl') ?? false)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); exit; }
     }
@@ -45,7 +44,6 @@ class Qsl extends CI_Controller {
 
     // Deletes QSL Card
     public function delete() {
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
         $id = $this->input->post('id');
         $this->load->model('Qsl_model');
@@ -53,7 +51,6 @@ class Qsl extends CI_Controller {
     }
 
     public function uploadqsl() {
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
         $qsoid = $this->input->post('qsoid');

--- a/application/controllers/Qslpostcard.php
+++ b/application/controllers/Qslpostcard.php
@@ -11,7 +11,6 @@ class Qslpostcard extends CI_Controller {
     public function __construct() {
         parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Qslprint.php
+++ b/application/controllers/Qslprint.php
@@ -7,7 +7,6 @@ class QSLPrint extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 
 		// Check if users logged in
 
@@ -20,7 +19,6 @@ class QSLPrint extends CI_Controller {
 	public function index($station_id = 'All')
 	{
 		// Check if users logged in
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('stations');
@@ -155,7 +153,6 @@ class QSLPrint extends CI_Controller {
 		}
 
 		$this->load->model('qslprint_model');
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 			// Update Logbook to Mark Paper Card Sent

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -4,7 +4,6 @@ class QSO extends CI_Controller {
 
 	function __construct() {
 		parent::__construct();
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$last_qso_count = empty($this->session->userdata('qso_page_last_qso_count')) ? QSO_PAGE_DEFAULT_QSOS_COUNT : $this->session->userdata('qso_page_last_qso_count');
@@ -16,7 +15,6 @@ class QSO extends CI_Controller {
 		$this->load->library('qra');
 		$this->load->model('stations');
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 		$this->load->model('usermodes');
 		$this->load->model('bands');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
@@ -303,7 +301,6 @@ class QSO extends CI_Controller {
 	function edit() {
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 		$this->load->model('modes');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$query = $this->logbook_model->qso_info($this->uri->segment(3));
@@ -464,7 +461,6 @@ class QSO extends CI_Controller {
 	function edit_ajax() {
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 		$this->load->model('modes');
 		$this->load->model('bands');
 		$this->load->model('contest_admin_model');
@@ -493,7 +489,6 @@ class QSO extends CI_Controller {
 	function qso_save_ajax() {
 		$this->load->library('form_validation');
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard');
 		}
@@ -517,7 +512,6 @@ class QSO extends CI_Controller {
 
 	function qsl_rcvd($id, $method) {
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		// Update Logbook to Mark Paper Card Received
@@ -534,7 +528,6 @@ class QSO extends CI_Controller {
 		$method = str_replace('"', "", $this->input->post("method", TRUE));
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 
 		header('Content-Type: application/json');
 
@@ -555,7 +548,6 @@ class QSO extends CI_Controller {
 		$method = str_replace('"', "", $this->input->post("method", TRUE));
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 
 		header('Content-Type: application/json');
 
@@ -576,7 +568,6 @@ class QSO extends CI_Controller {
 		$method = str_replace('"', "", $this->input->post("method", TRUE));
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 
 		header('Content-Type: application/json');
 
@@ -597,7 +588,6 @@ class QSO extends CI_Controller {
 		$method = str_replace('"', "", $this->input->post("method", TRUE));
 
 		$this->load->model('logbook_model');
-		$this->load->model('user_model');
 
 		header('Content-Type: application/json');
 
@@ -884,7 +874,6 @@ class QSO extends CI_Controller {
 
 	function log_qso() {
 		// Check if users logged in
-		$this->load->model('user_model');
 		if ($this->user_model->validate_session() == 0) {
 			// user is not logged in
 			$this->session->set_flashdata('warning', __("You have to be logged in to access this URL."));

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -4,7 +4,6 @@ class Radio extends CI_Controller {
 
 	public function index() {
 		// Check Auth
-		$this->load->model('user_model');
 
 		// Check if users logged in
 
@@ -28,7 +27,6 @@ class Radio extends CI_Controller {
 
 	function status() {
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		session_write_close();
@@ -74,7 +72,6 @@ class Radio extends CI_Controller {
 				echo "<tr>";
 				echo "<td>" . $row->radio . "</td>";
 
-				$this->load->model('user_model');
 				if ($this->session->userdata('clubstation') == 1 && clubaccess_check(9)) {
 					$operator = $this->user_model->get_by_id($row->operator)->row();
 					if ($operator) {
@@ -167,10 +164,7 @@ class Radio extends CI_Controller {
 
 		$clean_id = $this->security->xss_clean($id);
 
-		$this->load->model('user_model');
-
 		// Check if users logged in
-
 		if ($this->user_model->validate_session() == 0) {
 			// user is not logged in
 			// Return Json data
@@ -317,7 +311,6 @@ class Radio extends CI_Controller {
 		$clean_id = $this->security->xss_clean($id);
 
 		// Check Auth
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(3)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -343,7 +336,6 @@ class Radio extends CI_Controller {
 		$clean_radio_id = $this->input->post('radio_id', TRUE);
 		
 		// Check Auth
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(3)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -359,7 +351,6 @@ class Radio extends CI_Controller {
 
 	function release_default_radio() {
 		// Check Auth
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(3)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');

--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -9,7 +9,6 @@ class Satellite extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Sattimers.php
+++ b/application/controllers/Sattimers.php
@@ -5,7 +5,6 @@ class Sattimers extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -6,7 +6,6 @@ class Search extends CI_Controller {
 		parent::__construct();
 
 		$this->load->helper(array('form', 'url'));
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Simplefle.php
+++ b/application/controllers/Simplefle.php
@@ -3,7 +3,6 @@
 class SimpleFLE extends CI_Controller {
 
     public function index() {
-        $this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 

--- a/application/controllers/Station.php
+++ b/application/controllers/Station.php
@@ -11,7 +11,6 @@ class Station extends CI_Controller
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if (($this->router->method == 'stationProfileCoords') && $this->user_model->authorize(2) && ((clubaccess_check(3) || clubaccess_check(6)))) { return; }	// Allow Clubmembers and Clubmembers ADIF to access list_locations
 		if (!$this->user_model->authorize(2) || !clubaccess_check(9)) { 
 			$this->session->set_flashdata('error', __("You're not allowed to do that!")); 

--- a/application/controllers/Stationsetup.php
+++ b/application/controllers/Stationsetup.php
@@ -11,7 +11,6 @@ class Stationsetup extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if (($this->router->method == 'list_locations') && $this->user_model->authorize(2) && ((clubaccess_check(3) || clubaccess_check(6)))) { return; }	// Allow Clubmembers and Clubmembers ADIF to access list_locations
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}

--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -5,7 +5,6 @@ class Statistics extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -14,7 +13,6 @@ class Statistics extends CI_Controller {
 
 
 	public function index() {
-		$this->load->model('user_model');
 		$this->load->model('bands');
 
 		// Render User Interface

--- a/application/controllers/Themes.php
+++ b/application/controllers/Themes.php
@@ -13,7 +13,6 @@ class Themes extends CI_Controller {
 	{
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Timeline.php
+++ b/application/controllers/Timeline.php
@@ -6,7 +6,6 @@ class Timeline extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Timeplotter.php
+++ b/application/controllers/Timeplotter.php
@@ -7,7 +7,6 @@ class Timeplotter extends CI_Controller {
     {
         parent::__construct();
 
-        $this->load->model('user_model');
         if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
     }
 

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -18,7 +18,6 @@ class Update extends CI_Controller {
 	}
 
 	public function index() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$data['page_title'] = __("Updates");

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -6,7 +6,6 @@ class User extends CI_Controller {
 
 	public function index()
 	{
-		$this->load->model('user_model');
 		$this->load->library('form_validation');
 
 		if (!$this->load->is_loaded('encryption')) {
@@ -58,7 +57,6 @@ class User extends CI_Controller {
 
 	public function actions_modal() {
 
-		$this->load->model('user_model');
 		$this->load->library('encryption');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
@@ -107,7 +105,6 @@ class User extends CI_Controller {
 	}
 
 	public function unlock($uid) {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		if ($this->user_model->exists_by_id($uid)) {
@@ -125,7 +122,6 @@ class User extends CI_Controller {
 	}
 
 	public function convert() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$user_id = $this->input->post('user_id', true) ?? '';
@@ -149,7 +145,6 @@ class User extends CI_Controller {
 	}
 
 	function add() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$data['existing_languages'] = $this->config->item('languages');
@@ -408,7 +403,6 @@ class User extends CI_Controller {
 	}
 
 	function edit() {
-		$this->load->model('user_model');
 		if ( ($this->session->userdata('user_id') == '') || ((!$this->user_model->authorize(99)) && ($this->session->userdata('user_id') != $this->uri->segment(3))) ) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		if (!clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$query = $this->user_model->get_by_id($this->uri->segment(3));
@@ -1165,7 +1159,6 @@ class User extends CI_Controller {
 	}
 
 	function profile() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$query = $this->user_model->get_by_id($this->session->userdata('user_id'));
 		$q = $query->row();
@@ -1184,7 +1177,6 @@ class User extends CI_Controller {
 	}
 
 	function delete() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 		$query = $this->user_model->get_by_id($this->uri->segment(3));
 
@@ -1229,7 +1221,6 @@ class User extends CI_Controller {
 	public function theme_switch() {
 		header('Content-Type: application/json');
 
-		$this->load->model('user_model');
 
 		if (!$this->user_model->authorize(2)) {
 			echo json_encode(array('status' => 'error', 'message' => __("You're not allowed to do that!")));
@@ -1290,7 +1281,6 @@ class User extends CI_Controller {
 			$this->session->set_flashdata('success', __("Congrats! Wavelog was successfully installed. You can now login for the first time."));
 		}
 
-		$this->load->model('user_model');
 		$query = $this->user_model->get($this->input->post('user_name', true));
 
 		$this->load->library('form_validation');
@@ -1451,7 +1441,6 @@ class User extends CI_Controller {
 	}
 
 	function logout($custom_message = null, $hard_logout = true, $enable_idp = true) {
-		$this->load->model('user_model');
 
 		$user_name = $this->session->userdata('user_name');
 
@@ -1486,7 +1475,6 @@ class User extends CI_Controller {
 	 * Form Data to create the first station location
 	 */
 	function firstlogin_wizard_form() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->library('form_validation');
@@ -1558,7 +1546,6 @@ class User extends CI_Controller {
 			else
 			{
 				// Check email address exists
-				$this->load->model('user_model');
 				$email = $this->input->post('email', TRUE);
 
 				$check_email = $this->user_model->check_email_address($email);
@@ -1625,7 +1612,6 @@ class User extends CI_Controller {
 		if ($this->input->is_ajax_request()) { // just additional, to make sure request is from ajax
 			if ($this->input->post('submit_allowed')) {
 
-				$this->load->model('user_model');
 
 				if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
@@ -1645,7 +1631,6 @@ class User extends CI_Controller {
 				else
 				{
 					// Check email address exists
-					$this->load->model('user_model');
 
 					$check_email = $this->user_model->check_email_address($data->user_email);
 
@@ -1726,7 +1711,6 @@ class User extends CI_Controller {
 			else
 			{
 				// Lets reset the password!
-				$this->load->model('user_model');
 
 				$this->user_model->reset_password($this->input->post('password', true), $reset_code);
 				$this->session->set_flashdata('notice', 'Password Reset.');
@@ -1795,9 +1779,6 @@ class User extends CI_Controller {
 		if (!$this->load->is_loaded('encryption')) {
 			$this->load->library('encryption');
 		}
-
-		// Load the user model
-		$this->load->model('user_model');
 
 		// Precheck: If the encryption key is still default, we can't impersonate another user for security reasons
 		if ($this->config->item('encryption_key') == 'flossie1234555541') {
@@ -1892,16 +1873,12 @@ class User extends CI_Controller {
 	}
 
 	public function stop_impersonate_modal() {
-		// Load the user model
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(3)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->view('user/modals/stop_impersonate_modal');
 	}
 
 	public function stop_impersonate() {
-		// Load the user model
-		$this->load->model('user_model');
 
 		// there is no source_uid, there is probably something fishy going on. So we clear the session at this point
 		$source_uid = $this->session->userdata('source_uid') ?? false;

--- a/application/controllers/User_options.php
+++ b/application/controllers/User_options.php
@@ -4,7 +4,6 @@ class User_Options extends CI_Controller {
 
 	function __construct() {
 		parent::__construct();
-		$this->load->model('user_model');
 		$this->load->model('user_options_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}

--- a/application/controllers/Usermode.php
+++ b/application/controllers/Usermode.php
@@ -11,7 +11,6 @@ class Usermode extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/controllers/Webadif.php
+++ b/application/controllers/Webadif.php
@@ -6,7 +6,6 @@ class Webadif extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if (!$this->user_model->authorize(2)) {
 			$this->session->set_flashdata('error', __("You're not allowed to do that!"));
 			redirect('dashboard');
@@ -97,7 +96,6 @@ class Webadif extends CI_Controller {
 	 * Used for displaying the uid for manually selecting log for upload to webADIF consumer
 	 */
 	public function export() {
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(2) || !clubaccess_check(9)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 
 		$this->load->model('stations');

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -83,7 +83,6 @@ class Widgets extends CI_Controller {
 		$this->load->model('oqrs_model');
 		$this->load->model('publicsearch');
 		$this->load->model('stationsetup_model');
-		$this->load->model('user_model');
 		
 		$data['slug'] = $this->security->xss_clean($slug);
 
@@ -417,7 +416,6 @@ class Widgets extends CI_Controller {
 	 * @return object
 	 */
 	private function get_user_by_slug($slug) {
-		$this->load->model('user_model');
 		$user_result = $this->user_model->get_by_slug($slug);
 		if ($user_result->num_rows() == 0) {
 			throw new \Exception(__("User not found by slug"));

--- a/application/controllers/Zonechecker.php
+++ b/application/controllers/Zonechecker.php
@@ -13,7 +13,6 @@ class Zonechecker extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		$this->load->model('user_model');
 		if(!$this->user_model->authorize(99)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); }
 	}
 

--- a/application/helpers/custom_map_style_helper.php
+++ b/application/helpers/custom_map_style_helper.php
@@ -12,10 +12,6 @@ if (!function_exists('map_style_options')) {
 	{
 		$CI =& get_instance();
 
-		if (!isset($CI->user_model)) {
-			$CI->load->model('user_model');
-		}
-
 		$themes = $CI->user_model->getUserThemes();
 
 		$options = ['map-follow' => 'Follow active theme'];

--- a/application/libraries/EqslBulkDownloader.php
+++ b/application/libraries/EqslBulkDownloader.php
@@ -25,7 +25,6 @@ class EqslBulkDownloader {
 		$this->ci =& get_instance();
 		$this->ci->load->library('electronicqsl');
 		$this->ci->load->library('upload_guard');
-		$this->ci->load->model('user_model');
 		$this->ci->load->model('logbook_model');
 
 		// Get image path

--- a/application/models/Api_model.php
+++ b/application/models/Api_model.php
@@ -138,7 +138,6 @@ class API_Model extends CI_Model {
 		// Also update last_seen in user table
 		$user_id = $this->key_userid($key);
 
-		$this->load->model('user_model');
 		$this->user_model->set_last_seen($user_id);
 	}
 

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -3,7 +3,6 @@
 	class Cat extends CI_Model {
 
 		function update($result, $user_id, $operator) {
-			$this->load->model('User_model');
 			$timestamp = gmdate("Y-m-d H:i:s");
 
 			if (isset($result['prop_mode'])) {

--- a/application/models/Club_model.php
+++ b/application/models/Club_model.php
@@ -24,7 +24,6 @@ class Club_model extends CI_Model {
         }
 
         // admin is always allowed
-        $this->load->model('user_model');
         if ($user_id != NULL) {
             if ($this->user_model->get_by_id($user_id)->row()->user_type == 99) {
                 return true;

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4817,7 +4817,6 @@ class Logbook_model extends CI_Model {
 	}
 
 	function import_bulk($records, $station_id = "0", $skipDuplicate = true, $markClublog = false, $markLotw = false, $dxccAdif = false, $markQrz = false, $markEqsl = false, $markHrd = false, $markDcl = false, $skipexport = false, $operatorName = false, $apicall = false, $skipStationCheck = false, $skipGridCheck = false) {
-		$this->load->model('user_model');
 		$custom_errors['errormessage'] = '';
 		$critical_errors = [];
 		$validation_errors = [];

--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -841,7 +841,6 @@ class Logbookadvanced_model extends CI_Model {
     }
 
 	public function updateQsl($ids, $user_id, $method, $sent) {
-		$this->load->model('user_model');
 
 		if(!$this->user_model->authorize(2)) {
 			return array('message' => 'Error');
@@ -884,7 +883,6 @@ class Logbookadvanced_model extends CI_Model {
 	}
 
 	public function updateQslReceived($ids, $user_id, $method, $sent) {
-		$this->load->model('user_model');
 
 		if(!$this->user_model->authorize(2)) {
 			return array('message' => 'Error');

--- a/application/models/Logbooks_model.php
+++ b/application/models/Logbooks_model.php
@@ -32,7 +32,6 @@ class Logbooks_model extends CI_Model {
 				$this->set_logbook_active($logbook_id);
 
 				// update user session data
-				$this->load->model('user_model');
 				$this->user_model->update_session($this->session->userdata('user_id'));
 			}
 			return $logbook_id;

--- a/application/models/Staticmap_model.php
+++ b/application/models/Staticmap_model.php
@@ -28,7 +28,6 @@ class Staticmap_model extends CI_Model {
         //===============================================================================================================================
 
         $this->load->model('Stations');
-        $this->load->model('user_model');
         $this->load->model('stationsetup_model');
 
         if (!$this->load->is_loaded('Qra')) {

--- a/application/models/Visitor_model.php
+++ b/application/models/Visitor_model.php
@@ -114,7 +114,6 @@ class Visitor_model extends CI_Model {
 	}
 
 	function get_user_default_confirmation($userid) {
-		$this->load->model('user_model');
 		return $this->user_model->get_by_id($userid)->row()->user_default_confirmation ?? '';
 	}
 }


### PR DESCRIPTION
The 'Hams of Note' update was broken, because the Quick Theme Switcher relies on the user_model in the header (which is loaded on every page). The user_model is necessary for everything in every model. Therefore it makes sense to autoload it. 

With an autoloaded user_model the HON Update is fixed aswell.