### PR TITLE
Hide station export button from unallowed users

### DIFF
--- a/application/views/stationsetup/locationlist.php
+++ b/application/views/stationsetup/locationlist.php
@@ -128,6 +128,7 @@
 						$(node).removeClass('dt-button').addClass('btn btn-primary');
 					},
 				},
+				<?php if (!($cd_p_level == 3) && !($cd_p_level == 6)) { // ClubOfficer (9) and normal User can export/import, while ClubMember (ADIF) (3,6) can only see. ?>
 				{
 					text: '<?= _pgettext("Station Locations", "Export All Locations") ?>',
 					className: 'mb-1 btn btn-sm btn-primary', // same Bootstrap style
@@ -138,7 +139,6 @@
 						$(node).removeClass('dt-button').addClass('btn btn-primary');
 					}
 				},
-				<?php if (!($cd_p_level == 3) && !($cd_p_level == 6)) { // ClubOfficer (9) and normal User can import, while ClubOfficer (ADIF) (3,6) can only see. ?>
 				{
 				text: '<?= _pgettext("Station Locations", "Import Locations") ?>',
 				className: 'mb-1 btn btn-sm btn-primary',


### PR DESCRIPTION
Station location listing (stationsetup/list_locations) displayed "Export All Locations" to all users, regardless of their authorization level. Station location export is blocked to Clubmember and Clubmember ADIF (level 3,6) by the controller. Clicking the button by a level 3 or 6 user returned a generic failure message as a result.

This PR moves the user level check to also include the export button with the import button. Both buttons are hidden to users without permissions to export/import.