### PR TITLE
Fix link to current commit

### DIFF
--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -580,6 +580,7 @@
                         $commitDate = trim(exec('git log --pretty="%ci" -n1 HEAD'));
                         $line = trim(exec('git log -n 1 --pretty=%D HEAD'));
                         $pieces = explode(', ', $line);
+                        $pieceCount = count($pieces);
                         $lastFetch = trim(exec('stat -c %Y ' . realpath(APPPATH . '../') . '/.git/FETCH_HEAD'));
                         //Below is a failsafe for systems without the stat command
                         try {
@@ -587,8 +588,8 @@
                         } catch (Exception $e) {
                             $dt = new DateTime(date("Y-m-d H:i:s"));
                         }
-                        if (isset($pieces[1])) {
-                            $remote = substr($pieces[1], 0, strpos($pieces[1], '/'));
+                        if (isset($pieces[$pieceCount - 1])) {
+                            $remote = substr($pieces[$pieceCount - 1], 0, strpos($pieces[$pieceCount - 1], '/'));
                             $branch = trim(exec('git rev-parse --abbrev-ref HEAD')); // Get ONLY Name of the Branch we're on
                             $url = trim(exec('git remote get-url ' . $remote));
                             if (strpos($url, 'https://github.com') !== false) {


### PR DESCRIPTION
<img width="1111" height="184" alt="image" src="https://github.com/user-attachments/assets/f70083b0-ad51-4317-9058-f081a2089ebd" />

Link to current commit is broken if current HEAD is on tag (more piece in $line to split into). Instead of using element 1 (which contains the tag name) we should use the last element in the array.