### PR TITLE
Try to fix grid corner-activations

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -292,53 +292,30 @@ function get_bearing($lat1, $lon1, $lat2, $lon2) {
 function qra2latlong($strQRA) {
 	$strQRA = preg_replace('/\s+/', '', $strQRA);
 	if (substr_count($strQRA, ',') > 0) {
-		if (substr_count($strQRA, ',') == 3) {
-			// Handle grid corners
-			$grids = explode(',', $strQRA);
-			$gridlengths = array(strlen($grids[0]), strlen($grids[1]), strlen($grids[2]), strlen($grids[3]));
-			$same = array_count_values($gridlengths);
-			if (count($same) != 1) {
-				return false;
-			}
-			$coords = array(0, 0);
-			for ($i = 0; $i < 4; $i++) {
-				$cornercoords[$i] = qra2latlong($grids[$i]);
-				$coords[0] += $cornercoords[$i][0];
-				$coords[1] += $cornercoords[$i][1];
-			}
-			return array(round($coords[0] / 4), round($coords[1] / 4));
-		} else if (substr_count($strQRA, ',') == 1) {
-			// Handle grid lines
-			$grids = explode(',', $strQRA);
-			if (strlen($grids[0]) != strlen($grids[1])) {
-				return false;
-			}
-			$coords = array(0, 0);
-			for ($i = 0; $i < 2; $i++) {
-				$linecoords[$i] = qra2latlong($grids[$i]);
-			}
-			if ($linecoords[0][0] != $linecoords[1][0]) {
-				$coords[0] = round((($linecoords[0][0] + $linecoords[1][0]) / 2), 1);
-			} else {
-				$coords[0] = round($linecoords[0][0], 1);
-			}
-			if ($linecoords[0][1] != $linecoords[1][1]) {
-				$coords[1] = round(($linecoords[0][1] + $linecoords[1][1]) / 2);
-			} else {
-				$coords[1] = round($linecoords[0][1]);
-			}
-			return $coords;
-		} else {
+		$grids = explode(',', $strQRA);
+		if (count($grids) != 2 && count($grids) != 4) {
 			return false;
 		}
+		$lengths = array_map('strlen', $grids);
+		if (count(array_unique($lengths)) != 1) {
+			return false;
+		}
+		$lat = 0; $lng = 0;
+		foreach ($grids as $g) {
+			$c = qra2latlong($g);
+			if (!$c) { return false; }
+			$lat += $c[0]; $lng += $c[1];
+		}
+		$n = count($grids);
+		return array($lat / $n, $lng / $n);
 	}
 
 	if ((strlen($strQRA) % 2 == 0) && (strlen($strQRA) <= 10)) {	// Check if QRA is EVEN (the % 2 does that) and smaller/equal 8
 		$strQRA = strtoupper($strQRA);
-		if (strlen($strQRA) == 2)  $strQRA .= "55";	// Only 2 Chars? Fill with center "55"
-		if (strlen($strQRA) == 4)  $strQRA .= "LL";	// Only 4 Chars? Fill with center "LL" as only A-R allowed
-		if (strlen($strQRA) == 6)  $strQRA .= "55";	// Only 6 Chars? Fill with center "55"
-		if (strlen($strQRA) == 8)  $strQRA .= "LL";	// Only 8 Chars? Fill with center "LL" as only A-R allowed
+		if     (strlen($strQRA) == 2)  $strQRA .= "55AA00AA";
+		elseif (strlen($strQRA) == 4)  $strQRA .= "MM00AA";
+		elseif (strlen($strQRA) == 6)  $strQRA .= "55AA";
+		elseif (strlen($strQRA) == 8)  $strQRA .= "MM";
 
 		if (!preg_match('/^[A-R]{2}[0-9]{2}[A-X]{2}[0-9]{2}[A-X]{2}$/', $strQRA)) {
 			return false;

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -6304,30 +6304,7 @@ class Logbook_model extends CI_Model {
 					$xbearing = $this->qra->get_bearing($this->session->userdata('user_locator'),$row->COL_GRIDSQUARE);
 				}
 			} elseif ($row->COL_VUCC_GRIDS != null) {
-				$coords = array();
-				$grids = explode(",", $row->COL_VUCC_GRIDS);
-				if (count($grids) == 2) {
-					$grid1 = $this->qra->qra2latlong(trim($grids[0]));
-					$grid2 = $this->qra->qra2latlong(trim($grids[1]));
-
-					$coords[] = array('lat' => $grid1[0], 'lng' => $grid1[1]);
-					$coords[] = array('lat' => $grid2[0], 'lng' => $grid2[1]);
-
-					$stn_loc = $this->qra->get_midpoint($coords);
-				}
-				if (count($grids) == 4) {
-					$grid1 = $this->qra->qra2latlong(trim($grids[0]));
-					$grid2 = $this->qra->qra2latlong(trim($grids[1]));
-					$grid3 = $this->qra->qra2latlong(trim($grids[2]));
-					$grid4 = $this->qra->qra2latlong(trim($grids[3]));
-
-					$coords[] = array('lat' => $grid1[0], 'lng' => $grid1[1]);
-					$coords[] = array('lat' => $grid2[0], 'lng' => $grid2[1]);
-					$coords[] = array('lat' => $grid3[0], 'lng' => $grid3[1]);
-					$coords[] = array('lat' => $grid4[0], 'lng' => $grid4[1]);
-
-					$stn_loc = $this->qra->get_midpoint($coords);
-				}
+				$stn_loc = $this->qra->qra2latlong($row->COL_VUCC_GRIDS);
 				if (($this->session->userdata('user_locator') ?? '') != '') {
 					$xbearing = $this->qra->get_bearing($this->session->userdata('user_locator'),$row->COL_VUCC_GRIDS);
 				}

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -819,29 +819,8 @@
          $lng = $stn_loc[1];
       }
    } else if ($row->COL_VUCC_GRIDS != null) {
-      $grids = explode(",", $row->COL_VUCC_GRIDS);
-      if (count($grids) == 2) {
-         $grid1 = $this->qra->qra2latlong(trim($grids[0]));
-         $grid2 = $this->qra->qra2latlong(trim($grids[1]));
-
-         $coords[]=array('lat' => $grid1[0],'lng'=> $grid1[1]);
-         $coords[]=array('lat' => $grid2[0],'lng'=> $grid2[1]);
-
-         $midpoint = $this->qra->get_midpoint($coords);
-         $lat = $midpoint[0];
-         $lng = $midpoint[1];
-      } else if (count($grids) == 4) {
-         $grid1 = $this->qra->qra2latlong(trim($grids[0]));
-         $grid2 = $this->qra->qra2latlong(trim($grids[1]));
-         $grid3 = $this->qra->qra2latlong(trim($grids[2]));
-         $grid4 = $this->qra->qra2latlong(trim($grids[3]));
-
-         $coords[]=array('lat' => $grid1[0],'lng'=> $grid1[1]);
-         $coords[]=array('lat' => $grid2[0],'lng'=> $grid2[1]);
-         $coords[]=array('lat' => $grid3[0],'lng'=> $grid3[1]);
-         $coords[]=array('lat' => $grid4[0],'lng'=> $grid4[1]);
-
-         $midpoint = $this->qra->get_midpoint($coords);
+      $midpoint = $this->qra->qra2latlong($row->COL_VUCC_GRIDS);
+      if ($midpoint) {
          $lat = $midpoint[0];
          $lng = $midpoint[1];
       } else {


### PR DESCRIPTION
Fixes an issue where QSOs are plotted at the wrong place, when working muilti-grid-activator.

issue:
- log QSO with someone on a gridcorner. e.g.: NN24,NN25,NN14,NN15 --> it is plotted southwest from corner.
- log QSO with someone on a gridline. e.g. JO41,JO40 --> it is plotted a bit south from gridline

this patch should fix it.

test and doublecheck all grid-combinations (even single grid)