### PR TITLE
Add "OK-OM SSB Liga" to contest list

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 286;
+$config['migration_version'] = 287;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/287_add_ok_om_ssb_league.php
+++ b/application/migrations/287_add_ok_om_ssb_league.php
@@ -1,0 +1,36 @@
+<?php
+
+defined('BASEPATH') or exit('No direct script access allowed');
+
+/*
+	Add the Czech-Slovak SSB League (Česko-slovenská SSB liga) to the contest list.
+	https://ssbliga.nagano.cz/
+*/
+
+class Migration_add_ok_om_ssb_league extends CI_Migration {
+
+	public function up() {
+
+		$contests = array(
+			array('name' => 'OK-OM SSB Liga', 'adifname' => 'OK-OM-SSB-LEAGUE', 'active' => 1),
+		);
+
+		foreach ($contests as $contest) {
+			$exists = $this->db->where('adifname', $contest['adifname'])
+							->get('contest')
+							->num_rows() > 0;
+
+			if (!$exists) {
+				$this->db->insert('contest', $contest);
+			}
+		}
+
+	}
+
+	public function down() {
+
+		$this->db->where_in('adifname', array('OK-OM-SSB-LEAGUE'));
+		$this->db->delete('contest');
+
+	}
+}


### PR DESCRIPTION
Adds the Czech-Slovak SSB League (https://ssbliga.nagano.cz/) to the contest table via migration 287, using ADIF contest id OK-OM-SSB-LEAGUE.