### PR TITLE
Fix colspan in club permissions table

### DIFF
--- a/application/views/club/permissions.php
+++ b/application/views/club/permissions.php
@@ -47,7 +47,7 @@
                                             <td><i class="fas fa-check text-success"></i></td>
                                         </tr>
                                         <tr class="empty-row">
-                                            <td colspan="3"></td>
+                                            <td colspan="4"></td>
                                         </tr>
                                         <tr>
                                             <td><?= __("Log QSOs via API"); ?></td>
@@ -56,7 +56,7 @@
                                             <td><i class="fas fa-check text-success"></i></td>
                                         </tr>
                                         <tr class="empty-row">
-                                            <td colspan="3"></td>
+                                            <td colspan="4"></td>
                                         </tr>
                                         <tr>
                                             <td><?= __("Edit a QSO"); ?></td>
@@ -77,7 +77,7 @@
                                             <td><i class="fas fa-check text-success"></i></td>
                                         </tr>
                                         <tr class="empty-row">
-                                            <td colspan="3"></td>
+                                            <td colspan="4"></td>
                                         </tr>
                                         <tr>
                                             <td><?= __("Delete a QSO"); ?></td>
@@ -107,7 +107,7 @@
                                             <td><i class="fas fa-check text-success"></i></td>
                                         </tr>
                                         <tr class="empty-row">
-                                            <td colspan="3"></td>
+                                            <td colspan="4"></td>
                                         </tr>
                                         <tr>
                                             <td><?= __("Manage Third-Party services"); ?></td>
@@ -116,7 +116,7 @@
                                             <td><i class="fas fa-check text-success"></i></td>
                                         </tr>
                                         <tr class="empty-row">
-                                            <td colspan="3"></td>
+                                            <td colspan="4"></td>
                                         </tr>
                                         <tr>
                                             <td><?= __("Import QSO per ADIF"); ?></td>


### PR DESCRIPTION
Seems some colspans were not updated in commint https://github.com/wavelog/wavelog/pull/2636/changes/8366bc594b46f68d662908b574ab709ab25b4683 within PR https://github.com/wavelog/wavelog/pull/2636:

<img width="1292" height="1149" alt="Screenshot from 2026-07-09 07-58-09" src="https://github.com/user-attachments/assets/7cb6d6a5-f81b-4f8d-925f-1bea19a80678" />
