### PR TITLE
Guard eQSL-View

### DIFF
--- a/application/views/eqslcard/index.php
+++ b/application/views/eqslcard/index.php
@@ -25,7 +25,7 @@
       $custom_date_format = $this->config->item('qso_date_format');
    }
 
-    if (is_array($qslarray->result())) {
+    if (isset($qslarray) && $qslarray->num_rows() > 0) {
         echo '<table class="eqsltable table table-sm table-bordered table-hover table-striped table-condensed">
         <thead>
         <tr>


### PR DESCRIPTION
Bug, if no station_profile is linked / no QSO yet

1. User active station logbook = zero linked station locations → Logbooks_model::list_logbook_relationships() returns [-1] 
2. Eqsl_images::eqsl_qso_list() sees `[0] === -1` - bare return; (null) 
3. Controller Eqsl.php sets `$data['qslarray'] = null`.
4. View eqslcard/index.php does `is_array($qslarray->result())` - since its null-it fails with a 500