### PR TITLE
Only count LoTW confirmations for VUCC award calculations

### DIFF
--- a/application/models/Vucc.php
+++ b/application/models/Vucc.php
@@ -175,7 +175,7 @@ class VUCC extends CI_Model
     }
 
     /*
-     * Makes a list of all gridsquares on chosen band with info about lotw and qsl
+     * Makes a list of all gridsquares on chosen band with info about lotw
      * Optimized to fetch all callsigns in a single query instead of one per grid
      */
     function vucc_details($band, $type) {
@@ -191,7 +191,6 @@ class VUCC extends CI_Model
         // Process col_gridsquare data
         foreach ($bandData['gridsquare'] as $row) {
             $grid = $row['gridsquare'];
-            $qsl = $row['qsl_confirmed'] ? 'Y' : '';
             $lotw = $row['lotw_confirmed'] ? 'Y' : '';
             $confirmed = $row['confirmed'];
 
@@ -204,11 +203,9 @@ class VUCC extends CI_Model
             }
 
             if (!isset($vuccBand[$grid])) {
-                $vuccBand[$grid]['qsl'] = $qsl;
                 $vuccBand[$grid]['lotw'] = $lotw;
             } else {
                 // Update confirmation status if already exists
-                if ($qsl) $vuccBand[$grid]['qsl'] = $qsl;
                 if ($lotw) $vuccBand[$grid]['lotw'] = $lotw;
             }
         }
@@ -216,7 +213,6 @@ class VUCC extends CI_Model
         // Process col_vucc_grids data
         foreach ($bandData['vucc_grids'] as $row) {
             $grids = explode(",", $row['col_vucc_grids']);
-            $qsl = $row['qsl_confirmed'] ? 'Y' : '';
             $lotw = $row['lotw_confirmed'] ? 'Y' : '';
             $confirmed = $row['confirmed'];
 
@@ -232,11 +228,9 @@ class VUCC extends CI_Model
                 }
 
                 if (!isset($vuccBand[$grid_four])) {
-                    $vuccBand[$grid_four]['qsl'] = $qsl;
                     $vuccBand[$grid_four]['lotw'] = $lotw;
                 } else {
                     // Update confirmation status if already exists
-                    if ($qsl) $vuccBand[$grid_four]['qsl'] = $qsl;
                     if ($lotw) $vuccBand[$grid_four]['lotw'] = $lotw;
                 }
             }
@@ -336,7 +330,7 @@ class VUCC extends CI_Model
     }
 
     /*
-     * Fetches VUCC data for a specific band with QSL/LoTW confirmation details
+     * Fetches VUCC data for a specific band with LoTW confirmation details
      * Returns data in a single query per band
      */
     private function get_vucc_band_data($band) {
@@ -359,9 +353,7 @@ class VUCC extends CI_Model
 
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
-            MAX(CASE WHEN col_qsl_rcvd='Y' THEN 1 ELSE 0 END) as qsl_confirmed,
-            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as lotw_confirmed,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as lotw_confirmed
             FROM " . $this->config->item('table_name') . " log
             WHERE log.station_id IN (" . $location_list . ")
                 AND log.col_gridsquare <> ''"
@@ -384,9 +376,7 @@ class VUCC extends CI_Model
 
         $sql2 = "SELECT
             DISTINCT col_vucc_grids,
-            MAX(CASE WHEN col_qsl_rcvd='Y' THEN 1 ELSE 0 END) as qsl_confirmed,
-            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as lotw_confirmed,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as lotw_confirmed
             FROM " . $this->config->item('table_name') . "
             WHERE station_id IN (" . $location_list . ")
                 AND col_vucc_grids <> ''"
@@ -439,7 +429,7 @@ class VUCC extends CI_Model
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
             col_band,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . " log
             WHERE log.station_id IN (" . $location_list . ")
                 AND log.col_gridsquare <> ''
@@ -456,7 +446,7 @@ class VUCC extends CI_Model
         $sql2 = "SELECT
             DISTINCT col_vucc_grids,
             col_band,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . "
             WHERE station_id IN (" . $location_list . ")
                 AND col_vucc_grids <> ''
@@ -490,7 +480,7 @@ class VUCC extends CI_Model
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
             col_prop_mode as col_band,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . " log
             WHERE log.station_id IN (" . $location_list . ")
                 AND log.col_gridsquare <> ''
@@ -507,7 +497,7 @@ class VUCC extends CI_Model
         $sql2 = "SELECT
             DISTINCT col_vucc_grids,
             col_prop_mode as col_band,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . "
             WHERE station_id IN (" . $location_list . ")
                 AND col_vucc_grids <> ''
@@ -594,7 +584,7 @@ class VUCC extends CI_Model
 
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . " log
             INNER JOIN bands b ON (b.band = log.col_band)
             WHERE log.station_id IN (" . $location_list . ")
@@ -626,7 +616,7 @@ class VUCC extends CI_Model
 
         $sql2 = "SELECT
             DISTINCT col_vucc_grids,
-            MAX(CASE WHEN (col_qsl_rcvd='Y' OR col_lotw_qsl_rcvd='Y') THEN 1 ELSE 0 END) as confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . "
             WHERE station_id IN (" . $location_list . ")
                 AND col_vucc_grids <> ''"

--- a/application/models/Vucc.php
+++ b/application/models/Vucc.php
@@ -3,12 +3,12 @@
 class VUCC extends CI_Model
 {
 
-	private $logbooks_locations_array;
-	public function __construct()
-	{
-		$this->load->model('logbooks_model');
-		$this->logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
-	}
+    private $logbooks_locations_array;
+    public function __construct()
+    {
+        $this->load->model('logbooks_model');
+        $this->logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+    }
 
     /*
      *  Fetches worked and confirmed gridsquare on each band and total
@@ -38,7 +38,7 @@ class VUCC extends CI_Model
 
         // Get combined data (2 queries instead of 4 per band)
         $combinedData = $this->get_vucc_combined_data_all_bands();
-		$combinedData2 = $this->get_vucc_combined_data_sat();
+        $combinedData2 = $this->get_vucc_combined_data_sat();
 
         // Process col_gridsquare data
         if (!empty($combinedData['gridsquare'])) {
@@ -98,7 +98,7 @@ class VUCC extends CI_Model
             }
         }
 
-		 // Process col_gridsquare data
+        // Process col_gridsquare data
         if (!empty($combinedData2['gridsquare'])) {
             foreach ($combinedData2['gridsquare'] as $row) {
                 $grid = $row['gridsquare'];
@@ -174,7 +174,7 @@ class VUCC extends CI_Model
         return $vuccArray;
     }
 
-	/*
+    /*
      * Makes a list of all gridsquares on chosen band with info about lotw and qsl
      * Optimized to fetch all callsigns in a single query instead of one per grid
      */
@@ -273,8 +273,8 @@ class VUCC extends CI_Model
             return [];
         }
 
-		$location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
-		$bindings = array();
+        $location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
+        $bindings = array();
 
         // Build band condition
         if ($band == 'SAT') {
@@ -346,9 +346,9 @@ class VUCC extends CI_Model
 
         $results = ['gridsquare' => [], 'vucc_grids' => []];
 
-		$location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
+        $location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
 
-		$bindings1 = array();
+        $bindings1 = array();
 
         if ($band == 'SAT') {
             $bandCondition1 = " and log.col_prop_mode = 'SAT'";
@@ -401,8 +401,8 @@ class VUCC extends CI_Model
         return $results;
     }
 
-	function grid_detail($gridsquare, $band) {
-		$location_list = "'".implode("','",$this->logbooks_locations_array)."'";
+    function grid_detail($gridsquare, $band) {
+        $location_list = "'".implode("','",$this->logbooks_locations_array)."'";
         $sql = "select COL_CALL from " . $this->config->item('table_name') .
                 " where station_id in (" . $location_list . ")" .
                 " and (col_gridsquare like '" . $gridsquare. "%'
@@ -434,7 +434,7 @@ class VUCC extends CI_Model
 
         // Query 1: Get col_gridsquare data for ALL bands with worked/confirmed status
         // GROUP BY both gridsquare and band to get per-band statistics
-		$location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
+        $location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
 
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
@@ -471,7 +471,7 @@ class VUCC extends CI_Model
         return $results;
     }
 
-	/*
+    /*
      * Fetches VUCC data for ALL bands in 2 queries (optimized)
      * Similar approach to CQ model's getCqZoneData()
      * Returns data with band information included for processing
@@ -485,7 +485,7 @@ class VUCC extends CI_Model
 
         // Query 1: Get col_gridsquare data for ALL bands with worked/confirmed status
         // GROUP BY both gridsquare and band to get per-band statistics
-		$location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
+        $location_list = "'" . implode("','", $this->logbooks_locations_array) . "'";
 
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
@@ -522,9 +522,9 @@ class VUCC extends CI_Model
         return $results;
     }
 
-	/*
-    * Builds the array to display worked/confirmed vucc on dashboard page
-    */
+    /*
+     * Builds the array to display worked/confirmed vucc on dashboard page
+     */
     function fetchVuccSummary($band = 'All') {
         // Use associative arrays for O(1) lookups instead of O(n) in_array()
         $totalGridWorked = [];
@@ -568,7 +568,7 @@ class VUCC extends CI_Model
         return $vuccArray;
     }
 
-	private function get_vucc_combined_data($band = 'All') {
+    private function get_vucc_combined_data($band = 'All') {
         if (!$this->logbooks_locations_array) {
             return ['gridsquare' => [], 'vucc_grids' => []];
         }
@@ -579,7 +579,7 @@ class VUCC extends CI_Model
 
         // Query 1: Get col_gridsquare data with worked/confirmed status
         $bandCondition1 = '';
-		$bindings1 = array();
+        $bindings1 = array();
 
         if ($band != 'All') {
             if ($band == 'SAT') {
@@ -612,7 +612,7 @@ class VUCC extends CI_Model
         // Note: col_vucc_grids has NO band filter when band='All' (includes SAT)
         $bandCondition2 = '';
 
-		$bindings2 = array();
+        $bindings2 = array();
 
         if ($band != 'All') {
             if ($band == 'SAT') {

--- a/application/models/Vucc.php
+++ b/application/models/Vucc.php
@@ -191,8 +191,7 @@ class VUCC extends CI_Model
         // Process col_gridsquare data
         foreach ($bandData['gridsquare'] as $row) {
             $grid = $row['gridsquare'];
-            $lotw = $row['lotw_confirmed'] ? 'Y' : '';
-            $confirmed = $row['confirmed'];
+            $confirmed = $row['confirmed'] ? 'Y' : '';
 
             // Filter based on type
             if ($type == 'worked' && $confirmed) {
@@ -203,18 +202,14 @@ class VUCC extends CI_Model
             }
 
             if (!isset($vuccBand[$grid])) {
-                $vuccBand[$grid]['lotw'] = $lotw;
-            } else {
-                // Update confirmation status if already exists
-                if ($lotw) $vuccBand[$grid]['lotw'] = $lotw;
+                $vuccBand[$grid]['lotw'] = $confirmed;
             }
         }
 
         // Process col_vucc_grids data
         foreach ($bandData['vucc_grids'] as $row) {
             $grids = explode(",", $row['col_vucc_grids']);
-            $lotw = $row['lotw_confirmed'] ? 'Y' : '';
-            $confirmed = $row['confirmed'];
+            $confirmed = $row['confirmed'] ? 'Y' : '';
 
             foreach ($grids as $key) {
                 $grid_four = strtoupper(substr(trim($key), 0, 4));
@@ -228,10 +223,7 @@ class VUCC extends CI_Model
                 }
 
                 if (!isset($vuccBand[$grid_four])) {
-                    $vuccBand[$grid_four]['lotw'] = $lotw;
-                } else {
-                    // Update confirmation status if already exists
-                    if ($lotw) $vuccBand[$grid_four]['lotw'] = $lotw;
+                    $vuccBand[$grid_four]['lotw'] = $confirmed;
                 }
             }
         }
@@ -353,7 +345,7 @@ class VUCC extends CI_Model
 
         $sql1 = "SELECT
             DISTINCT UPPER(SUBSTRING(col_gridsquare, 1, 4)) as gridsquare,
-            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as lotw_confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . " log
             WHERE log.station_id IN (" . $location_list . ")
                 AND log.col_gridsquare <> ''"
@@ -376,7 +368,7 @@ class VUCC extends CI_Model
 
         $sql2 = "SELECT
             DISTINCT col_vucc_grids,
-            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as lotw_confirmed
+            MAX(CASE WHEN col_lotw_qsl_rcvd='Y' THEN 1 ELSE 0 END) as confirmed
             FROM " . $this->config->item('table_name') . "
             WHERE station_id IN (" . $location_list . ")
                 AND col_vucc_grids <> ''"

--- a/application/views/awards/vucc/band.php
+++ b/application/views/awards/vucc/band.php
@@ -17,8 +17,7 @@
                 <th>' . __("Gridsquare") . '</th>';
 
             if ($type != 'worked') {
-                echo '<th>' . __("QSL") . '</th>
-                    <th>' . __("LoTW") . '</th>';
+                echo '<th>' . __("LoTW") . '</th>';
             } else {
                 echo '<th>' . __("Call") . '</th>';
             }
@@ -31,8 +30,7 @@
                     <td><a href=\'javascript:displayContacts("'. $vucc .'","'. $band . '","All","All","All","VUCC")\'>'. $vucc .'</a></td>';
 
                 if ($type != 'worked') {
-                    echo '<td>'. $value['qsl'] . '</td>
-                        <td>'. $value['lotw'] .'</td>';
+                    echo '<td>'. $value['lotw'] . '</td>';
                 } else {
                     echo '<td>'. $value['call'] .'</td>';
                 }


### PR DESCRIPTION
This removes the (paper) QSL cards from the VUCC count calculations. Even if cards are to be accepted those should be checked by VUCC card checker and then returned as confirmed via LoTW. So we shall not count locally available (and unchecked) paper QSLs. 
(This PR also refactors some whitespace in VUCC model)