### PR TITLE
Worker live stats

### DIFF
--- a/application/controllers/Debug.php
+++ b/application/controllers/Debug.php
@@ -130,6 +130,18 @@ class Debug extends CI_Controller
 
 		$data['page_title'] = __("Debug");
 
+		$this->load->library('worker');
+		$data['worker_status_topic'] = '';
+		$data['worker_status_token'] = '';
+		$data['worker_enabled'] = $this->worker->is_enabled();
+		$urls = $this->config->item('worker_urls', 'worker');
+		$data['worker_nodes_total'] = is_array($urls) ? count($urls) : 0;
+		if ($data['worker_enabled'] && $this->worker->client_url() !== '') {
+			$debug_topic = 'worker.status';
+			$data['worker_status_topic'] = $debug_topic;
+			$data['worker_status_token'] = $this->worker->create_token($debug_topic);
+		}
+
 		$this->load->view('interface_assets/header', $data);
 		$this->load->view('debug/index');
 		$this->load->view('interface_assets/footer', $footerData);
@@ -355,21 +367,9 @@ class Debug extends CI_Controller
 		}
 
 		$vip_url = rtrim((string) $this->config->item('worker_vip', 'worker'), '/');
-		$vip     = null;
-		if ($vip_url !== '') {
-			$ch = curl_init($vip_url . '/internal/status');
-			curl_setopt_array($ch, [
-				CURLOPT_RETURNTRANSFER    => true,
-				CURLOPT_CONNECTTIMEOUT_MS => 300,
-				CURLOPT_TIMEOUT_MS        => 800,
-				CURLOPT_HTTPHEADER        => ['X-Worker-Secret: ' . $secret],
-			]);
-			curl_exec($ch);
-			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
-			$vip = ['url' => $vip_url, 'alive' => $http_code === 200];
-		}
+		$vip     = $vip_url !== '' ? ['url' => $vip_url] : null;
 
+		// fan-out to all configured workers and check their status
 		$workers = [];
 		foreach ($worker_urls as $url) {
 			$ch = curl_init($url . '/internal/status');
@@ -391,7 +391,6 @@ class Debug extends CI_Controller
 				'active_topics'     => $stats['active_topics']     ?? null,
 				'connected_clients' => $stats['connected_clients'] ?? null,
 				'worker_uptime'     => $stats['uptime']            ?? null,
-				'cluster_nodes'     => $stats['cluster_nodes']     ?? null,
 			];
 		}
 

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -165,7 +165,8 @@
                         </table>
                     </div>
                     <div id="worker-status-container">
-                        <span class="text-muted"><?= __("Loading..."); ?></span>
+                        <span class="spinner-border spinner-border-sm text-muted align-middle" role="status" aria-hidden="true"></span>
+                        <span class="text-muted align-middle"><?= __("Loading..."); ?></span>
                     </div>
                 </div>
             </div>

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -140,6 +140,30 @@
             <div class="card">
                 <div class="card-header"><?= __("Wavelog Worker Backend"); ?></div>
                 <div class="card-body">
+                    <div id="worker-status" style="display: none;">
+                        <table class="table table-sm mb-0">
+                            <thead><tr>
+                                <th><?= __("Worker"); ?></th>
+                                <th><?= __("Topics"); ?></th>
+                                <th><?= __("Clients"); ?></th>
+                                <th><?= __("Version"); ?></th>
+                                <th id="ws-cluster-head" style="display: none;"><?= __("Cluster nodes"); ?></th>
+                                <th><?= __("Uptime"); ?></th>
+                            </tr></thead>
+                            <tbody><tr>
+                                <td>
+                                    <span id="ws-badge" class="badge rounded-pill text-bg-success">
+                                        <i id="ws-live-dot" class="fas fa-circle fa-fade" style="display: none; font-size: 0.6em; vertical-align: middle;"></i> <span id="ws-state"><?= __("Online"); ?></span>
+                                    </span>&nbsp;&nbsp;<span id="ws-url"></span>
+                                </td>
+                                <td id="ws-topics">—</td>
+                                <td id="ws-clients">—</td>
+                                <td id="ws-version">—</td>
+                                <td id="ws-cluster" style="display: none;">—</td>
+                                <td id="ws-uptime" style="white-space: nowrap;">—</td>
+                            </tr></tbody>
+                        </table>
+                    </div>
                     <div id="worker-status-container">
                         <span class="text-muted"><?= __("Loading..."); ?></span>
                     </div>
@@ -840,65 +864,26 @@
 </div>
 
 <script>
+    window.workerStatusLive = <?php echo json_encode([
+        'enabled'     => (bool)($worker_enabled ?? false),
+        'topic'       => $worker_status_topic ?? '',
+        'token'       => $worker_status_token ?? '',
+        'nodesTotal'  => (int)($worker_nodes_total ?? 0),
+        'snapshotUrl' => site_url('debug/worker_status'),
+        'msg'         => [
+            'online'      => __("Online"),
+            'degraded'    => __("Degraded"),
+            'disabled'    => '<span class="badge rounded-pill text-bg-secondary">' . __("Disabled") . '</span> ' . __("Worker backend is not configured."),
+            'unreachable' => '<span class="badge rounded-pill text-bg-danger">' . __("Unreachable") . '</span> ' . __("Worker is configured but did not respond."),
+            'error'       => '<span class="badge rounded-pill text-bg-danger">' . __("Error") . '</span> ' . __("Could not fetch worker status."),
+        ],
+    ]); ?>;
+
     <?php if (file_exists(realpath(APPPATH . '../') . '/.git')) { ?>
         var local_branch = '<?php echo $branch; ?>';
     <?php } else { ?>
         var local_branch = 'n/a';
     <?php } ?>
-
-    (function () {
-        fetch('<?= site_url('debug/worker_status'); ?>')
-            .then(r => r.json())
-            .then(function (data) {
-                var container = document.getElementById('worker-status-container');
-                if (!data.success) { return; }
-                if (data.disabled) {
-                    container.innerHTML = '<span class="badge rounded-pill text-bg-secondary"><?= __("Disabled"); ?></span> <?= __("Worker backend is not configured."); ?>';
-                    return;
-                }
-                if (!data.workers || data.workers.length === 0) {
-                    container.innerHTML = '<span class="badge rounded-pill text-bg-warning"><?= __("Unreachable"); ?></span> <?= __("Worker is configured but did not respond."); ?>';
-                    return;
-                }
-
-                var html = '';
-
-                if (data.vip) {
-                    var vipBadge = data.vip.alive
-                        ? '<span class="badge rounded-pill text-bg-success"><?= __("Available"); ?></span>'
-                        : '<span class="badge rounded-pill text-bg-danger"><?= __("Offline"); ?></span>';
-                    html += '<div class="mb-2">'
-                        + '<strong>VIP</strong>&nbsp;&nbsp;' + vipBadge + '&nbsp;&nbsp;<code>' + data.vip.url + '</code>'
-                        + '</div>';
-                }
-
-                var rows = data.workers.map(function (w) {
-                    var badge = w.alive
-                        ? '<span class="badge rounded-pill text-bg-success"><?= __("Online"); ?></span>'
-                        : '<span class="badge rounded-pill text-bg-danger"><?= __("Offline"); ?></span>';
-                    return '<tr>'
-                        + '<td>' + badge + '&nbsp;&nbsp;' + w.public_url + '</td>'
-                        + '<td>' + (w.active_topics     !== null ? w.active_topics     : '—') + '</td>'
-                        + '<td>' + (w.connected_clients !== null ? w.connected_clients : '—') + '</td>'
-                        + '<td>' + (w.version           !== null ? w.version           : '—') + '</td>'
-                        + '<td>' + (w.worker_uptime     !== null ? w.worker_uptime     : '—') + '</td>'
-                        + '</tr>';
-                });
-                var thead = '<thead><tr>'
-                    + '<th><?= __("Worker"); ?></th>'
-                    + '<th><?= __("Topics"); ?></th>'
-                    + '<th><?= __("Clients"); ?></th>'
-                    + '<th><?= __("Version"); ?></th>'
-                    + '<th><?= __("Uptime"); ?></th>'
-                    + '</tr></thead>';
-                html += '<table class="table table-sm mb-0">' + thead + '<tbody>' + rows.join('') + '</tbody></table>';
-                container.innerHTML = html;
-            })
-            .catch(function () {
-                document.getElementById('worker-status-container').innerHTML =
-                    '<span class="badge rounded-pill text-bg-warning"><?= __("Error"); ?></span> <?= __("Could not fetch worker status."); ?>';
-            });
-    })();
 </script>
 
 <?php

--- a/application/views/debug/index.php
+++ b/application/views/debug/index.php
@@ -875,7 +875,7 @@
             'degraded'    => __("Degraded"),
             'disabled'    => '<span class="badge rounded-pill text-bg-secondary">' . __("Disabled") . '</span> ' . __("Worker backend is not configured."),
             'unreachable' => '<span class="badge rounded-pill text-bg-danger">' . __("Unreachable") . '</span> ' . __("Worker is configured but did not respond."),
-            'error'       => '<span class="badge rounded-pill text-bg-danger">' . __("Error") . '</span> ' . __("Could not fetch worker status."),
+            'update'      => '<span class="badge rounded-pill text-bg-warning">' . __("Outdated") . '</span> ' . __("Please update your Wavelog Worker to version 0.2.0 or newer to see the status."),
         ],
     ]); ?>;
 

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -170,6 +170,13 @@
 </script>
 
 
+<?php if ($worker_enabled ?? false) { ?>
+    <!-- Wavelog Worker JS -->
+    <script>window.WavelogWorker = <?php echo json_encode(['url' => $this->worker->client_url()]); ?>;</script>
+	<script type="text/javascript" src="<?php echo $this->paths->cache_buster('/assets/js/worker.js'); ?>"></script>
+<?php } ?>
+
+
 <!-- DATATABLES LANGUAGE -->
 <?php
 $local_code = $language['locale'];

--- a/assets/js/sections/debug.js
+++ b/assets/js/sections/debug.js
@@ -193,6 +193,17 @@ $(document).ready(function () {
 	// Cluster node x/y comes from the backend (9001 reachability), polled.
 	if (cluster) { loadCluster(); setInterval(loadCluster, 10000); }
 
+	// WS status unavailable (never connected, or connected but silent) → ask the
+	// backend (9001): worker reachable = too old for the status feed → update hint;
+	// otherwise truly unreachable.
+	function fallback() {
+		fetch(cfg.snapshotUrl).then(function (r) { return r.json(); }).then(function (data) {
+			if (data && data.disabled) { showMessage(cfg.msg.disabled); return; }
+			var alive = ((data && data.workers) || []).some(function (w) { return w.alive; });
+			showMessage(alive ? cfg.msg.update : cfg.msg.unreachable);
+		}).catch(function () { showMessage(cfg.msg.unreachable); });
+	}
+
 	// Live stats over the generic worker WS client (handles auth + reconnect).
 	var pollT, statusDeadline;
 	var conn = WavelogWorker.subscribe({
@@ -203,12 +214,12 @@ $(document).ready(function () {
 			clearInterval(pollT);
 			pollT = setInterval(function () { conn.send({ type: 'status' }); }, 4000);
 			// Connected but no status frame in time → worker too old for the status feed.
-			statusDeadline = setTimeout(function () { clearInterval(pollT); conn.close(); showMessage(cfg.msg.update); }, 3000);
+			statusDeadline = setTimeout(function () { clearInterval(pollT); conn.close(); fallback(); }, 3000);
 		},
 		onMessage: function (frame) {
 			if (frame.type === 'status' && frame.payload) { clearTimeout(statusDeadline); renderStats(frame.payload); }
 		},
 		onClose: function () { clearInterval(pollT); clearTimeout(statusDeadline); stopTick(); }, // freeze; dot stays while worker.js reconnects
-		onFailed: function () { clearInterval(pollT); showMessage(cfg.msg.unreachable); }
+		onFailed: function () { clearInterval(pollT); fallback(); }
 	});
 });

--- a/assets/js/sections/debug.js
+++ b/assets/js/sections/debug.js
@@ -194,19 +194,21 @@ $(document).ready(function () {
 	if (cluster) { loadCluster(); setInterval(loadCluster, 10000); }
 
 	// Live stats over the generic worker WS client (handles auth + reconnect).
-	var pollT;
+	var pollT, statusDeadline;
 	var conn = WavelogWorker.subscribe({
 		topic: cfg.topic,
 		token: cfg.token,
 		onOpen: function () {
 			conn.send({ type: 'status' });
 			clearInterval(pollT);
-			pollT = setInterval(function () { conn.send({ type: 'status' }); }, 3000);
+			pollT = setInterval(function () { conn.send({ type: 'status' }); }, 4000);
+			// Connected but no status frame in time → worker too old for the status feed.
+			statusDeadline = setTimeout(function () { clearInterval(pollT); conn.close(); showMessage(cfg.msg.update); }, 3000);
 		},
 		onMessage: function (frame) {
-			if (frame.type === 'status' && frame.payload) { renderStats(frame.payload); }
+			if (frame.type === 'status' && frame.payload) { clearTimeout(statusDeadline); renderStats(frame.payload); }
 		},
-		onClose: function () { clearInterval(pollT); stopTick(); }, // freeze; dot stays while worker.js reconnects
+		onClose: function () { clearInterval(pollT); clearTimeout(statusDeadline); stopTick(); }, // freeze; dot stays while worker.js reconnects
 		onFailed: function () { clearInterval(pollT); showMessage(cfg.msg.unreachable); }
 	});
 });

--- a/assets/js/sections/debug.js
+++ b/assets/js/sections/debug.js
@@ -124,3 +124,89 @@ $(document).ready(function () {
 		});
 	});
 });
+
+$(document).ready(function () {
+	var cfg = window.workerStatusLive;
+	if (!cfg) { return; }
+
+	var cluster = cfg.nodesTotal > 1;
+	var uptimeBase = null, uptimeAt = 0, tickT = null;
+
+	function val(x) { return x != null ? x : '—'; }
+
+	function fmt(s) {
+		s = Math.max(0, Math.floor(s));
+		var d = Math.floor(s / 86400); s %= 86400;
+		var h = Math.floor(s / 3600);  s %= 3600;
+		var m = Math.floor(s / 60);    s %= 60;
+		return (d ? d + 'd ' : '') + ((d || h) ? h + 'h ' : '') + m + 'm ' + s + 's';
+	}
+	function tick() { $('#ws-uptime').text(fmt(uptimeBase + (Date.now() - uptimeAt) / 1000)); }
+	function startTick() { if (!tickT) { tickT = setInterval(tick, 250); } } // sub-second so no displayed second is skipped
+	function stopTick()  { if (tickT) { clearInterval(tickT); tickT = null; } uptimeBase = null; }
+
+	function showMessage(html) { stopTick(); $('#worker-status').hide(); $('#worker-status-container').html(html); }
+	function showTable()       { $('#worker-status-container').empty(); $('#worker-status').show(); }
+
+	function setBadge(degraded) {
+		$('#ws-state').text(degraded ? cfg.msg.degraded : cfg.msg.online);
+		$('#ws-badge').removeClass('text-bg-success text-bg-warning').addClass(degraded ? 'text-bg-warning' : 'text-bg-success');
+	}
+
+	// Live stats from a WS status frame. Owns the counter cells + dot + uptime.
+	function renderStats(p) {
+		showTable();
+		$('#ws-live-dot').show();
+		if (!cluster) { setBadge(false); } // single instance: always "Online"; cluster badge is owned by the fan-out
+		$('#ws-url').text(WavelogWorker.url);
+		$('#ws-version').text(val(p.version));
+		$('#ws-topics').text(val(p.active_topics - 1));       // subtract this debug page
+		$('#ws-clients').text(val(p.connected_clients - 1));  // subtract this debug page
+		if (typeof p.uptime_seconds === 'number') {
+			uptimeBase = p.uptime_seconds; uptimeAt = Date.now();
+			startTick(); tick();
+		} else {
+			stopTick(); $('#ws-uptime').text(val(p.uptime));
+		}
+	}
+
+	// Cluster node reachability from the backend fan-out. Owns #ws-cluster + badge.
+	function renderCluster(data) {
+		if (!data || !data.success || data.disabled) { return; }
+		var workers = data.workers || [];
+		if (!workers.length) { return; }
+		var online = workers.filter(function (w) { return w.alive; }).length;
+		$('#ws-cluster-head, #ws-cluster').show();
+		$('#ws-cluster').text(online + '/' + workers.length);
+		setBadge(online < workers.length);
+	}
+	function loadCluster() {
+		fetch(cfg.snapshotUrl).then(function (r) { return r.json(); }).then(renderCluster).catch(function () {});
+	}
+
+	// No worker, or no browser WS URL / token → nothing live to show.
+	if (!cfg.enabled || !cfg.token || !(window.WavelogWorker && WavelogWorker.isAvailable())) {
+		showMessage(cfg.msg.disabled);
+		return;
+	}
+
+	// Cluster node x/y comes from the backend (9001 reachability), polled.
+	if (cluster) { loadCluster(); setInterval(loadCluster, 10000); }
+
+	// Live stats over the generic worker WS client (handles auth + reconnect).
+	var pollT;
+	var conn = WavelogWorker.subscribe({
+		topic: cfg.topic,
+		token: cfg.token,
+		onOpen: function () {
+			conn.send({ type: 'status' });
+			clearInterval(pollT);
+			pollT = setInterval(function () { conn.send({ type: 'status' }); }, 3000);
+		},
+		onMessage: function (frame) {
+			if (frame.type === 'status' && frame.payload) { renderStats(frame.payload); }
+		},
+		onClose: function () { clearInterval(pollT); stopTick(); }, // freeze; dot stays while worker.js reconnects
+		onFailed: function () { clearInterval(pollT); showMessage(cfg.msg.unreachable); }
+	});
+});

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -1,0 +1,161 @@
+/**
+ * WavelogWorker — generic browser client for the Wavelog Worker WebSocket.
+ *
+ * Loaded globally (footer.php) whenever the Worker integration is enabled; PHP
+ * sets `window.WavelogWorker = { url }` with the public client URL just before
+ * this file, which then augments that object with the client API.
+ *
+ * Any Wavelog area can open an authenticated, auto-reconnecting subscription to
+ * a worker topic without re-implementing the WS/auth/reconnect handshake:
+ *
+ *     var conn = WavelogWorker.subscribe({
+ *         topic: 'worker.status',
+ *         token: '<hmac minted server-side for this topic>',
+ *         onOpen:    function ()      {  },   // authenticated (auth_ok)
+ *         onMessage: function (frame) {  },   // every non-control frame
+ *         onClose:   function ()      {  },   // socket dropped (will reconnect)
+ *         onFailed:  function ()      {  },   // gave up / server rejected us
+ *     });
+ *     conn.send({ type: 'status' });
+ *     conn.close();
+ *
+ * The connection layer is deliberately generic: no status polling, no AJAX
+ * fallback — consumers build that on top via the callbacks.
+ */
+(function () {
+	'use strict';
+
+	var W = window.WavelogWorker = window.WavelogWorker || {};
+
+	/** True when the Worker integration exposed a client URL. */
+	W.isAvailable = function () { return !!W.url; };
+
+	/**
+	 * Open an authenticated, auto-reconnecting subscription to a topic.
+	 * @param {object} opts topic, token, onOpen, onMessage(frame), onClose,
+	 *   onReconnecting(attempt), onFailed, and optional connectTimeoutMs /
+	 *   retryDelayMs / maxRetries overrides.
+	 * @returns {{send: function, close: function, isConnected: function}}
+	 */
+	W.subscribe = function (opts) {
+		opts = opts || {};
+		var baseUrl          = (W.url || '').replace(/\/$/, '');
+		var topic            = opts.topic;
+		var token            = opts.token;
+		var connectTimeoutMs = opts.connectTimeoutMs || 3000;
+		var retryDelayMs     = opts.retryDelayMs || 2000;
+		var maxRetries       = (opts.maxRetries != null) ? opts.maxRetries : 10;
+
+		var ws = null;
+		var ready = false;          // auth_ok received
+		var settled = false;        // this attempt already resolved to a failure
+		var wantConnected = true;   // false once we give up or the caller closes
+		var attempt = 0;            // consecutive reconnect attempts (reset on auth_ok)
+		var connectTimer = null;
+		var retryTimer = null;
+
+		function hook(fn) {
+			if (typeof fn !== 'function') { return; }
+			try { fn.apply(null, Array.prototype.slice.call(arguments, 1)); } catch (e) { /* never break the state machine */ }
+		}
+
+		function clearConnectTimer() { if (connectTimer) { clearTimeout(connectTimer); connectTimer = null; } }
+
+		function teardown() {
+			clearConnectTimer();
+			clearTimeout(retryTimer);
+			if (ws) { try { ws.close(); } catch (e) {} ws = null; }
+		}
+
+		// Terminal stop: no more reconnects. Used by close() and on server rejection.
+		function giveUp(callFailed) {
+			wantConnected = false;
+			settled = true;
+			teardown();
+			if (callFailed) { hook(opts.onFailed); }
+		}
+
+		function open() {
+			var sock;
+			try {
+				sock = new WebSocket(baseUrl + '/ws?topic=' + encodeURIComponent(topic));
+			} catch (e) { fail(); return; }
+			ws = sock;
+			ready = false;
+			settled = false;
+			function isCurrent() { return sock === ws; }
+
+			clearConnectTimer();
+			connectTimer = setTimeout(function () {
+				if (isCurrent() && !ready) { fail(); }   // hung connect → retry
+			}, connectTimeoutMs);
+
+			sock.addEventListener('open', function () {
+				if (!isCurrent()) { return; }
+				sock.send(JSON.stringify({ type: 'auth', token: token }));
+			});
+
+			sock.addEventListener('message', function (event) {
+				if (!isCurrent()) { return; }
+				var msg;
+				try { msg = JSON.parse(event.data); } catch (e) { return; }
+				if (msg.type === 'auth_ok') {
+					ready = true;
+					settled = false;
+					attempt = 0;
+					clearConnectTimer();
+					hook(opts.onOpen);
+				} else if (msg.type === 'error') {
+					// Server actively rejected us (bad/expired token, unknown topic) —
+					// retrying won't help, so stop instead of hammering.
+					giveUp(true);
+				} else {
+					hook(opts.onMessage, msg);
+				}
+			});
+
+			sock.addEventListener('close', function () {
+				if (!isCurrent()) { return; }
+				ready = false;
+				hook(opts.onClose);
+				fail();
+			});
+
+			sock.addEventListener('error', function () { /* a close event always follows */ });
+		}
+
+		// Resolve a failed/closed attempt, deduplicated so the connect-timeout and
+		// the close event can never both count as a failure for the same socket.
+		function fail() {
+			if (settled) { return; }
+			settled = true;
+			clearConnectTimer();
+			ready = false;
+			if (ws) { try { ws.close(); } catch (e) {} ws = null; }
+			if (!wantConnected) { return; }
+			scheduleRetry();
+		}
+
+		function scheduleRetry() {
+			if (attempt >= maxRetries) { giveUp(true); return; }
+			attempt++;
+			hook(opts.onReconnecting, attempt);
+			clearTimeout(retryTimer);
+			retryTimer = setTimeout(function () { if (wantConnected) { open(); } }, retryDelayMs);
+		}
+
+		open();
+
+		return {
+			send: function (frame) {
+				if (ws && ready && ws.readyState === 1) {
+					ws.send(typeof frame === 'string' ? frame : JSON.stringify(frame));
+					return true;
+				}
+				return false;
+			},
+			close: function () { giveUp(false); },
+			isConnected: function () { return ready; }
+		};
+	};
+})();

--- a/assets/js/worker.js
+++ b/assets/js/worker.js
@@ -42,9 +42,9 @@
 		var baseUrl          = (W.url || '').replace(/\/$/, '');
 		var topic            = opts.topic;
 		var token            = opts.token;
-		var connectTimeoutMs = opts.connectTimeoutMs || 3000;
-		var retryDelayMs     = opts.retryDelayMs || 2000;
-		var maxRetries       = (opts.maxRetries != null) ? opts.maxRetries : 10;
+		var connectTimeoutMs = opts.connectTimeoutMs || 1500;
+		var retryDelayMs     = opts.retryDelayMs || 1000;
+		var maxRetries       = (opts.maxRetries != null) ? opts.maxRetries : 4;
 
 		var ws = null;
 		var ready = false;          // auth_ok received


### PR DESCRIPTION
Changes the behaviour of the Wavelog Worker Status in the debug view. The status is now shown live via websocket (requires worker version >= 0.2.0). 

It also adds a generic worker.js which can be reused in other parts of Wavelog to make elements worker/ws ready. This does not affect the compatibility in the worker use in contesting.

Next step will be to make elements in Wavelog worker/ws ready