### PR TITLE
Fix OQRS 500 on malformed time and lookup color warnings

### DIFF
--- a/application/controllers/Oqrs.php
+++ b/application/controllers/Oqrs.php
@@ -146,6 +146,12 @@ class Oqrs extends CI_Controller {
 
 		$postdata = $this->input->post(NULL, TRUE); // index is null means we get all postdata, TRUE means we XSS clean everything
 		$this->load->model('oqrs_model');
+		$err = $this->_validate_oqrs_times($postdata);
+		if ($err !== null) {
+			$this->output->set_status_header(400)->set_content_type('application/json')
+				->set_output(json_encode(['error' => $err]));
+			return;
+		}
 		$this->oqrs_model->save_not_in_log($postdata);
 		array_push($station_ids, $this->input->post('station_id', TRUE));
 		$this->_alert_oqrs_request($postdata, $station_ids);
@@ -194,6 +200,12 @@ class Oqrs extends CI_Controller {
 	public function save_oqrs_request() {
 		$postdata = $this->input->post(NULL, TRUE); // index is null means we get all postdata, TRUE means we XSS clean everything
 		$this->load->model('oqrs_model');
+		$err = $this->_validate_oqrs_times($postdata);
+		if ($err !== null) {
+			$this->output->set_status_header(400)->set_content_type('application/json')
+				->set_output(json_encode(['error' => $err]));
+			return;
+		}
 		$station_ids = $this->oqrs_model->save_oqrs_request($postdata);
 		$this->_alert_oqrs_request($postdata, $station_ids);
 	}
@@ -201,6 +213,12 @@ class Oqrs extends CI_Controller {
 	public function save_oqrs_request_grouped() {
 		$postdata = $this->input->post(NULL, TRUE); // index is null means we get all postdata, TRUE means we XSS clean everything
 		$this->load->model('oqrs_model');
+		$err = $this->_validate_oqrs_times($postdata);
+		if ($err !== null) {
+			$this->output->set_status_header(400)->set_content_type('application/json')
+				->set_output(json_encode(['error' => $err]));
+			return;
+		}
 		$station_ids = $this->oqrs_model->save_oqrs_request_grouped($postdata);
 		$this->_alert_oqrs_request($postdata, $station_ids);
 	}
@@ -259,6 +277,17 @@ class Oqrs extends CI_Controller {
         $data['qsos'] = $this->oqrs_model->search_log_time_date($time, $formatted_date, $band, $mode);
 
 		$this->load->view('oqrs/qsolist', $data);
+	}
+
+	private function _validate_oqrs_times(&$postdata) {
+		foreach ($postdata['qsos'] ?? [] as $i => $qso) {
+			$t = $this->oqrs_model->normalize_time($qso[1] ?? '');
+			if ($t === null) {
+				return __("Invalid time format. Please use HH:MM (e.g. 08:31).");
+			}
+			$postdata['qsos'][$i][1] = $t;
+		}
+		return null;
 	}
 
 	private function _alert_oqrs_request($postdata, $station_ids) {

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -153,9 +153,24 @@ class OptionsLib {
             foreach($result->result() as $options) {
                 if ($options->option_name == 'icon') {
                     $jsonout[$options->option_key] = json_decode($options->option_value,true);
-                } else  {
+                } else {
                     $jsonout[$options->option_name.'_'.$options->option_key]=$options->option_value;
                 }
+            }
+
+            if (count($jsonout) == 0) {
+                $jsonout['qso'] = array(
+                    "icon" => "fas fa-dot-circle",
+                    "color" => "#ff0000"
+                );
+                $jsonout['qsoconfirm'] = array(
+                    "icon" => "fas fa-dot-circle",
+                    "color" => "#00aa00"
+                );
+                $jsonout['station'] = array(
+                    "icon" => "fas fa-broadcast-tower",
+                    "color" => "#0000ff"
+                );
             }
 
         } else {

--- a/application/models/Oqrs_model.php
+++ b/application/models/Oqrs_model.php
@@ -395,6 +395,14 @@ class Oqrs_model extends CI_Model {
 		return null;
 	}
 
+	function normalize_time($raw) {
+		if (preg_match('/^(\d{1,2}):?(\d{2})$/', trim((string)$raw), $m)
+			&& $m[1] < 24 && $m[2] < 60) {
+			return sprintf('%02d:%02d', $m[1], $m[2]);
+		}
+		return null;
+	}
+
 	function add_oqrs_to_print_queue($id) {
 		$sql = 'SELECT * FROM oqrs join station_profile on oqrs.station_id = station_profile.station_id WHERE oqrs.id = ? AND station_profile.user_id = ?';
 		$binding = [$id, $this->session->userdata('user_id')];

--- a/application/views/oqrs/notinlogform.php
+++ b/application/views/oqrs/notinlogform.php
@@ -1,3 +1,4 @@
+<script> var lang_oqrs_request_failed = "<?= __("Request failed. Please try again."); ?>"; </script>
 <br />
 <?= __("If you can't find your QSO in the log, please fill out the form below. You will be contacted after the log has been checked."); ?><br />
 <table style="width:100%"

--- a/application/views/oqrs/request.php
+++ b/application/views/oqrs/request.php
@@ -1,3 +1,4 @@
+<script> var lang_oqrs_request_failed = "<?= __("Request failed. Please try again."); ?>"; </script>
 
 <?php if ($qslinfo != '') {
     echo '<br />QSL information <br /><br />';

--- a/application/views/oqrs/request_grouped.php
+++ b/application/views/oqrs/request_grouped.php
@@ -1,3 +1,5 @@
+<script> var lang_oqrs_request_failed = "<?= __("Request failed. Please try again."); ?>"; </script>
+
 <br />
 <?php if ($result) { ?>
 <?= __("The following QSO(s) were found. Please fill out the date and time and submit your request."); ?>

--- a/assets/js/sections/oqrs.js
+++ b/assets/js/sections/oqrs.js
@@ -152,6 +152,10 @@ function saveNotInLogRequest() {
                     $(".stationinfo").empty();
                     $(".searchinfo").empty();
                     $(".stationinfo").append('<br /><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Your not in log query has been saved!</div>');
+                },
+                error: function(xhr) {
+                    var msg = (xhr.responseJSON && xhr.responseJSON.error) || lang_oqrs_request_failed;
+                    $(".searchinfo").prepend('<div class="alertinfo"><br /><div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' + msg + '</div></div>');
                 }
             });
         }
@@ -271,6 +275,10 @@ function submitOqrsRequest() {
                     $(".stationinfo").empty();
                     $(".searchinfo").empty();
                     $(".stationinfo").append('<br /><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Your QSL request has been saved!</div>');
+                },
+                error: function(xhr) {
+                    var msg = (xhr.responseJSON && xhr.responseJSON.error) || lang_oqrs_request_failed;
+                    $(".searchinfo").prepend('<div class="alertinfo"><br /><div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' + msg + '</div></div>');
                 }
             });
         }
@@ -317,6 +325,10 @@ function submitOqrsRequestGrouped() {
                     $(".stationinfo").empty();
                     $(".searchinfo").empty();
                     $(".stationinfo").append('<br /><div class="alert alert-success"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>Your QSL request has been saved!</div>');
+                },
+                error: function(xhr) {
+                    var msg = (xhr.responseJSON && xhr.responseJSON.error) || lang_oqrs_request_failed;
+                    $(".searchinfo").prepend('<div class="alertinfo"><br /><div class="alert alert-danger"><a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' + msg + '</div></div>');
                 }
             });
         }


### PR DESCRIPTION
Fix OQRS 500 on malformed time and lookup color warnings

if someone enters "08H32" instead of "08:32" as time, OQRS fails with 500

this PR fixes it:
- Validate/normalize OQRS time input before DB insert
- reject whole batch with translatable error. 

Bonus: Seed map_custom defaults for users without config in get_map_custom().