### PR TITLE
Errorpage: fallback if no lang // Qra: Better handling

### DIFF
--- a/application/controllers/Errors.php
+++ b/application/controllers/Errors.php
@@ -23,6 +23,9 @@ class Errors extends CI_Controller {
 		$data['message1'] = __("QRZ? ... no reply.");
 		$data['message2'] = __("Nobody is transmitting on this frequency.");
 
+		$language = function_exists('current_language') ? current_language() : null;
+		$data['language'] = $language ?: ['code' => 'en', 'direction' => 'ltr'];
+
 		// Keep the HTTP status correct (404_override otherwise yields 200).
 		$this->output->set_status_header(404);
 

--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -68,7 +68,10 @@ class Qra {
 	function get_bearing($tx, $rx, $ant_path = null) {
 		$my = qra2latlong($tx);
 		$stn = qra2latlong($rx);
-		return get_bearing($my[0], $my[1], $stn[0], $stn[1], $ant_path);
+		if ($my !== false && $stn !== false) {
+			return get_bearing($my[0], $my[1], $stn[0], $stn[1], $ant_path);
+		}
+		return false;
 	}
 
 	/*


### PR DESCRIPTION
Error: warns if no language was set (e.g.: no session) - this one falls back to en in this case
Qra: fails if grids are not set - better guarding.

corresponding errors:

`Severity: Warning --> Undefined variable $language /var/www/html/application/views/errors/html/error_404.php 2`
`Severity: Warning --> Trying to access array offset on false /var/www/html/application/libraries/Qra.php 71`