### PR TITLE
Contesting: Filter QSOs on type

### DIFF
--- a/assets/css/contesting/components/scp.css
+++ b/assets/css/contesting/components/scp.css
@@ -66,6 +66,13 @@
 	text-underline-offset: 2px;
 }
 
+/* Call already worked on the current band/mode — whole call turns red. */
+.scp-result-item.scp-worked .scp-callsign,
+.scp-result-item.scp-worked .scp-highlight,
+.scp-result-item.scp-worked .scp-wildcard {
+	color: var(--bs-danger, #dc3545);
+}
+
 /* Loading spinner */
 .scp-loading {
 	display: flex;

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -329,9 +329,11 @@ class QsoFormComponent {
 					this.updateDxccInfoDisplay(null);
 				}
 
-				this.updateWorkedBeforeWarning(callsign);
+			this.updateWorkedBeforeWarning(callsign);
 
-				// Trigger SCP search if component is available
+			this.applyCallsignFilter();
+
+			// Trigger SCP search if component is available
 				if (this.scpComponent && callsign.length >= 1) {
 					this.scpComponent.searchCallsign(callsign);
 				} else if (this.scpComponent && callsign.length === 0) {
@@ -581,6 +583,7 @@ class QsoFormComponent {
 	_renderQsoRow(row, qso) {
 		row.dataset.qsoId = qso.tmpId || qso.serverId;
 		if (qso.serverId) row.dataset.serverId = qso.serverId;
+		row.dataset.callsign = callsignToRaw(qso.callsign || '').toUpperCase();
 		row.dataset.sig = this._qsoRowSignature(qso);
 
 		const qsoOperator = (qso.operator ?? '').toUpperCase();
@@ -997,6 +1000,8 @@ class QsoFormComponent {
 
 		// Listen for full resync events (server -> client) to refresh table
 		this.dataStore.on('qsos_resynced', (eventData) => this.handleQSOsResynced(eventData));
+
+		this.applyCallsignFilter();
 	}
 
 	handleQSOsResynced(eventData) {
@@ -1021,6 +1026,7 @@ class QsoFormComponent {
 		const sorted = this.sortQsosByNewest(allQsos);
 		sorted.forEach(qso => this.addQSOToTable(qso));
 		this.updateQSOCount();
+		this.applyCallsignFilter();
 
 		this.nextSerialSent = this.computeNextSerial();
 		this.updateSerialSentDisplay();
@@ -1123,6 +1129,19 @@ class QsoFormComponent {
 		}
 	}
 
+	// Instant prefix search: hide rows whose callsign does not start with the
+	// current #qso-callsign value. Single source of truth = the input field, so
+	// call this (no args) after any rebuild or input change. Empty/ESC shows all.
+	applyCallsignFilter() {
+		const tbody = this.container?.querySelector('#qso-tbody');
+		if (!tbody) return;
+		const raw = callsignToRaw(this.container.querySelector('#qso-callsign')?.value || '')
+			.toUpperCase().replace(/[^A-Z0-9/]/g, '');
+		tbody.querySelectorAll('tr[data-qso-id]').forEach(row => {
+			row.style.display = (!raw || (row.dataset.callsign || '').startsWith(raw)) ? '' : 'none';
+		});
+	}
+
 	getLastExchangeSent() {
 		const allQsos = Array.from(this.dataStore.getPattern('qso.*').values());
 		if (!allQsos.length) return '';
@@ -1149,6 +1168,8 @@ class QsoFormComponent {
 
 		const gridsquareRcvdInput = this.container.querySelector('#qso-gridsquare-received');
 		if (gridsquareRcvdInput) gridsquareRcvdInput.value = '';
+
+		this.applyCallsignFilter();
 
 		this.lastDxccCallsign = null;
 		this.lastDxccInfo = null;

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -942,6 +942,26 @@ class QsoFormComponent {
 		return false;
 	}
 
+	// Set of callsigns (raw, uppercased) already worked on the current band and
+	// mode. SCP uses this to mark worked entries red. Mirrors checkWorkedBefore()
+	// but batched into one pass per render instead of one pass per call.
+	getWorkedCallsignsCurrentBandMode() {
+		const set = new Set();
+		if (!this.dataStore || !this.radioComponent) return set;
+		const currentBand = this.radioComponent.getBand();
+		const currentMode = this.radioComponent.getMode()?.toUpperCase();
+		if (!currentBand || !currentMode) return set;
+		for (const qso of this.dataStore.getPattern('qso.*').values()) {
+			const qsoBand = qso.band || this.convertQrgToBand(parseInt(qso.frequency));
+			const qsoMode = qso.submode?.toUpperCase() || qso.mode?.toUpperCase() || null;
+			if (qsoBand === currentBand && qsoMode === currentMode) {
+				const c = callsignToRaw(qso.callsign || '').toUpperCase();
+				if (c) set.add(c);
+			}
+		}
+		return set;
+	}
+
 	updateWorkedBeforeWarning(callsign) {
 		const warning = this.container?.querySelector('#qso-worked-before-warning');
 		const qsoinput = this.container?.querySelector('#qso-callsign');

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -329,11 +329,11 @@ class QsoFormComponent {
 					this.updateDxccInfoDisplay(null);
 				}
 
-			this.updateWorkedBeforeWarning(callsign);
+				this.updateWorkedBeforeWarning(callsign);
 
-			this.applyCallsignFilter();
+				this.applyCallsignFilter();
 
-			// Trigger SCP search if component is available
+				// Trigger SCP search if component is available
 				if (this.scpComponent && callsign.length >= 1) {
 					this.scpComponent.searchCallsign(callsign);
 				} else if (this.scpComponent && callsign.length === 0) {

--- a/assets/js/sections/contesting/contest_engine/components/scp.js
+++ b/assets/js/sections/contesting/contest_engine/components/scp.js
@@ -143,7 +143,20 @@ class SCPComponent {
 	}
 
 	setupEventListeners() {
-		// No local event listeners needed - search is triggered via API
+		// Re-run the current search when band/mode changes or the radio becomes
+		// ready, so worked-before (red) marks stay correct without re-typing.
+		const refresh = () => {
+			const q = document.querySelector('#qso-callsign')?.value || '';
+			if (q) this.searchCallsign(q);
+		};
+
+		const ds = window.contestApp?.ds;
+		if (ds?.subscribe) ds.subscribe('config.selected_band', refresh);
+
+		const modeEl = document.getElementById('mode');
+		if (modeEl) modeEl.addEventListener('change', refresh);
+
+		window.addEventListener('radioComponentReady', refresh);
 	}
 
 	async loadSCPData() {
@@ -448,12 +461,18 @@ class SCPComponent {
 		}
 
 		resultsContainer.style.display = 'block';
+
+		// Callsigns already worked on the current band/mode (from the QSO form).
+		// Built once per render so each item is an O(1) set lookup.
+		const worked = window.contestApp?.qsoFormComponent?.getWorkedCallsignsCurrentBandMode?.();
+
 		resultsContainer.innerHTML = matches.map(callsign => {
 			// Convert 0→Ø for display; keep raw form in data-callsign for selectCallsign
 			const displayCallsign = callsignToDisplay(callsign);
 			const highlighted = this.highlightMatch(displayCallsign, query);
+			const isWorked = !!(worked && worked.has(callsignToRaw(callsign).toUpperCase()));
 			return `
-				<div class="scp-result-item font-monospace" data-callsign="${callsign}">
+				<div class="scp-result-item font-monospace${isWorked ? ' scp-worked' : ''}" data-callsign="${callsign}">
 					<span class="scp-callsign">${highlighted}</span>
 				</div>
 			`;
@@ -511,6 +530,9 @@ class SCPComponent {
 		const qsoCallsignInput = document.querySelector('#qso-callsign');
 		if (qsoCallsignInput) {
 			qsoCallsignInput.value = callsignToDisplay(callsign);
+			// Fire input so side effects of typing run (instant-search filter,
+			// worked-before warning, SCP self-narrow) before the callbook blur lookup.
+			qsoCallsignInput.dispatchEvent(new Event('input', { bubbles: true }));
 			// Simulate a Tab press: fire blur (triggers the callbook lookup) and
 			// move focus to the next field in tab order (tabindex=2), so the
 			// operator can keep logging without pressing an extra Tab key.


### PR DESCRIPTION
When typing in a callsign, the OP isn't able to see where/with which exchange/etc. a station may already be worked.
only "worked before"-badge shows if the station was already worked on that band/mode.

this PR brings instant-search back to contesting.

Usecases:
- Station tells you worked b4. but you don't see. misstyped? now you can search and correct.
- Station tells you "tnx fer new band". you cannot check. now you can.
- Station calls you, and you've already wked it. station asks "oh, sorry, when / which xchg". now you can tell.

Pressing ESC (or after saving): Everything back to normal. 

Furthermore:
- the Call which has been wked b4 will be colored in red, if wked b4 (follows bandchange, etc.)
- click on SCP-Call triggers filter as well

<img width="1567" height="745" alt="image" src="https://github.com/user-attachments/assets/30db8e64-1868-484e-8f23-bb6a4796268c" />
