### PR TITLE
Public Punchcard

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -27,6 +27,8 @@ class Visitor extends CI_Controller {
 		} else {
 			if (!empty($params) && $params[0] == "mini") {
 				$this->mini($method);
+			} elseif (!empty($params) && $params[0] == "punchcard") {
+				$this->punchcard($method);
 			} else {
 				$this->index($method);
 			}
@@ -205,6 +207,119 @@ class Visitor extends CI_Controller {
 			}
 		}
 	}
+
+	public function punchcard($public_slug) {
+
+		// Check slug passed and is valid
+		if ($this->security->xss_clean($public_slug, TRUE) === FALSE) {
+
+			// Public Slug failed the XSS test
+			log_message('error', '[Visitor] XSS Attack detected on public_slug ' . $public_slug);
+			show_404(__("Unknown Public Page."));
+		} else {
+
+			// Checked slug passed and clean
+			log_message('info', '[Visitor] public_slug ' . $public_slug . ' loaded (punchcard)');
+
+			// Load necessary models
+			$this->load->model('logbooks_model');
+
+			if ($this->logbooks_model->public_slug_exists($public_slug)) {
+
+				// Load the public view
+				$logbook_id = $this->logbooks_model->public_slug_exists_logbook_id($public_slug);
+
+				if ($logbook_id != false) {
+
+					// Get associated station locations for mysql queries
+					$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($logbook_id);
+
+					if ($logbooks_locations_array[0] === -1) {
+						show_404(__("Empty Logbook"));
+					}
+				} else {
+					log_message('error', $public_slug . ' has no associated station locations');
+					show_404(__("Unknown Public Page."));
+					die;
+				}
+
+				$yr = (int) date('Y');
+
+				$this->load->model('dayswithqso_model');
+				$raw = $this->dayswithqso_model->getPunchvals($yr, $logbooks_locations_array);
+
+				// Bucket counts into color levels and index by date key
+				$counts = [];
+				$total = 0;
+				if ($raw) {
+					foreach ($raw as $p) {
+						$n = (int) $p->qsos;
+						$col = $n <= 0 ? 0 : ($n <= 3 ? 3 : ($n <= 6 ? 6 : ($n <= 12 ? 12 : ($n <= 24 ? 24 : 48))));
+						$key = $p->date;
+						$counts[$key] = ['n' => $n, 'col' => $col];
+						$total += $n;
+					}
+				}
+
+				// Build 53-week (Mon-start) continuous grid for the year
+				$weeks = [];
+				$monthLabels = [];
+				$start = new DateTime($yr . '-01-01');
+				$end = new DateTime($yr . '-12-31');
+				$isoDays = (int) $start->format('N'); // 1=Mon .. 7=Sun
+				$cursor = clone $start;
+				$cursor->modify('-' . ($isoDays - 1) . ' days'); // back up to Monday
+				$lastMonth = -1;
+				$weekIdx = 0;
+				while ($cursor <= $end) {
+					for ($d = 1; $d <= 7; $d++) {
+						if ($cursor < $start || $cursor > $end) {
+							$weeks[$weekIdx][$d] = null;
+						} else {
+							$key = $cursor->format('Y-n-j');
+							$cell = $counts[$key] ?? null;
+							// In-range day always emits a cell; no-QSO days fall back to
+							// the zero bucket so they render as the lowest gray.
+							$weeks[$weekIdx][$d] = [
+								'date'  => $cursor->format('Y-m-d'),
+								'n'     => $cell['n'] ?? 0,
+								'col'   => $cell['col'] ?? 0,
+							];
+
+							$curMonth = (int) $cursor->format('n');
+							if ($d <= 4 && $curMonth !== $lastMonth) {
+								$monthLabels[$weekIdx] = $curMonth;
+								$lastMonth = $curMonth;
+							}
+						}
+						$cursor->modify('+1 day');
+					}
+					$weekIdx++;
+				}
+
+				// Theme resolution (?theme=<folder>, validated; defaults to light)
+				$this->load->model('themes_model');
+				$reqTheme = $this->input->get('theme', TRUE);
+				$mode = 'light';
+				if ($reqTheme !== null && ($this->themes_model->get_theme_mode($reqTheme) ?? '') === 'dark') {
+					$mode = 'dark';
+				}
+
+				$data['slug'] = $public_slug;
+				$data['weeks'] = $weeks;
+				$data['monthLabels'] = $monthLabels;
+				$data['total'] = $total;
+				$data['mode'] = $mode;
+				$data['yr'] = $yr;
+
+				$this->load->view('visitor/punchcard', $data);
+			} else {
+				log_message('error', '[Visitor] Public slug not found: ' . $public_slug);
+				show_404(__("Unknown Public Page."));
+			}
+		}
+	}
+
 
 	public function map() {
 		$this->load->model('logbook_model');

--- a/application/models/Dayswithqso_model.php
+++ b/application/models/Dayswithqso_model.php
@@ -186,12 +186,16 @@ class Dayswithqso_model extends CI_Model
         return $query->result();
     }
 
-    function getPunchvals($yr) {
-	    $this->load->model('logbooks_model');
-	    $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+    function getPunchvals($yr, $locations = null) {
+	    if ($locations === null) {
+		    $this->load->model('logbooks_model');
+		    $logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
-	    if ($logbooks_locations_array[0] === -1) {
-		    return null;
+		    if ($logbooks_locations_array[0] === -1) {
+			    return null;
+		    }
+	    } else {
+		    $logbooks_locations_array = $locations;
 	    }
 
 	    $location_list = "'".implode("','",$logbooks_locations_array)."'";

--- a/application/views/visitor/punchcard.php
+++ b/application/views/visitor/punchcard.php
@@ -104,7 +104,7 @@ body.dark td.day.empty { background-color: transparent; }
 <div class="pc-container">
   <div class="pc-header">
     <?= __("QSOs per Year"); ?> <?php echo htmlspecialchars($yr, ENT_QUOTES); ?>
-    <span class="pc-quantity"><?php echo (int) $total; ?> <?= __("QSOs"); ?></span>
+    <span class="pc-quantity"><?php echo (int) $total; ?> <?= _ngettext("QSO", "QSOs", $total); ?></span>
   </div>
   <div class="pc-body">
     <table class="pc">

--- a/application/views/visitor/punchcard.php
+++ b/application/views/visitor/punchcard.php
@@ -1,0 +1,173 @@
+<?php $numWeeks = count($weeks); ?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title><?= __("QSOs per Year"); ?> <?= htmlspecialchars($yr, ENT_QUOTES); ?></title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: Menlo, Consolas, monospace;
+  background-color: <?php echo $mode === 'dark' ? '#1e1e1e' : '#fff'; ?>;
+  color: <?php echo $mode === 'dark' ? '#ddd' : '#333'; ?>;
+  padding: 16px;
+}
+.pc-container {
+  max-width: 760px;
+  margin: 0 auto;
+  border: 1px solid <?php echo $mode === 'dark' ? '#333' : '#D8D8D8'; ?>;
+  border-radius: 5px;
+  background-color: <?php echo $mode === 'dark' ? '#1e1e1e' : '#fff'; ?>;
+  overflow: hidden;
+}
+.pc-header {
+  position: relative;
+  background-color: <?php echo $mode === 'dark' ? '#2c2c2c' : '#F5F5F5'; ?>;
+  border-bottom: 1px solid <?php echo $mode === 'dark' ? '#444' : '#D8D8D8'; ?>;
+  color: <?php echo $mode === 'dark' ? '#fff' : '#000'; ?>;
+  font-size: 15px;
+  font-weight: bold;
+  padding: 7px 10px;
+}
+.pc-quantity {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  color: <?php echo $mode === 'dark' ? '#777' : '#aaa'; ?>;
+  font-size: 10px;
+  font-weight: normal;
+}
+.pc-body { padding: 10px; overflow-x: auto; }
+
+table.pc {
+  border-collapse: separate; border-spacing: 3px;
+  table-layout: fixed;
+  width: <?php echo (16 + 10 * $numWeeks + 3 * ($numWeeks + 2)); ?>px;
+}
+table.pc th, table.pc td {
+  width: 10px; height: 10px;
+  padding: 0; font-size: 9px; font-weight: normal;
+  text-align: center; vertical-align: middle;
+  shape-rendering: crispedges;
+}
+table.pc td.lbl {
+  width: auto; min-width: 12px;
+  color: <?php echo $mode === 'dark' ? '#777' : '#999'; ?>;
+  text-align: right; padding-right: 4px;
+}
+table.pc th.mlbl {
+  color: <?php echo $mode === 'dark' ? '#777' : '#AAA'; ?>;
+  text-align: left; padding-bottom: 3px;
+  font-weight: normal;
+  white-space: nowrap; overflow: visible;
+}
+
+/* color buckets - light palette */
+td.day { background-color: #eee; }
+td.day[data-col="3"]  { background-color: #c3dbda; }
+td.day[data-col="6"]  { background-color: #5caeaa; }
+td.day[data-col="12"] { background-color: #277672; }
+td.day[data-col="24"] { background-color: #075652; }
+td.day[data-col="48"] { background-color: #004642; }
+td.day.empty { background-color: transparent; }
+
+body.dark td.day { background-color: #333; }
+body.dark td.day[data-col="3"]  { background-color: #8bd8d1; }
+body.dark td.day[data-col="6"]  { background-color: #76beb7; }
+body.dark td.day[data-col="12"] { background-color: #62a39c; }
+body.dark td.day[data-col="24"] { background-color: #4b837e; }
+body.dark td.day[data-col="48"] { background-color: #395b58; }
+body.dark td.day.empty { background-color: transparent; }
+
+.pc-summary {
+  color: <?php echo $mode === 'dark' ? '#aaa' : '#aaa'; ?>;
+  font-size: 12px;
+  margin: 8px 10px 10px;
+  display: flex; justify-content: space-between; align-items: center;
+  flex-wrap: wrap; gap: 6px;
+}
+.pc-legend { font-size: 12px; }
+.pc-legend span.swatch {
+  display: inline-block; width: 10px; height: 10px;
+  margin: 0 2px; vertical-align: middle; shape-rendering: crispedges;
+}
+.pc-legend .s0 { background-color: <?php echo $mode === 'dark' ? '#333' : '#eee'; ?>; }
+.pc-legend .s1 { background-color: <?php echo $mode === 'dark' ? '#8bd8d1' : '#c3dbda'; ?>; }
+.pc-legend .s2 { background-color: <?php echo $mode === 'dark' ? '#76beb7' : '#5caeaa'; ?>; }
+.pc-legend .s3 { background-color: <?php echo $mode === 'dark' ? '#62a39c' : '#277672'; ?>; }
+.pc-legend .s4 { background-color: <?php echo $mode === 'dark' ? '#4b837e' : '#075652'; ?>; }
+.pc-legend .s5 { background-color: <?php echo $mode === 'dark' ? '#395b58' : '#004642'; ?>; }
+</style>
+</head>
+<body class="<?php echo $mode === 'dark' ? 'dark' : ''; ?>">
+<div class="pc-container">
+  <div class="pc-header">
+    <?= __("QSOs per Year"); ?> <?php echo htmlspecialchars($yr, ENT_QUOTES); ?>
+    <span class="pc-quantity"><?php echo (int) $total; ?> <?= __("QSOs"); ?></span>
+  </div>
+  <div class="pc-body">
+    <table class="pc">
+      <colgroup>
+        <col style="width:16px">
+        <?php for ($w = 0; $w < $numWeeks; $w++): ?>
+          <col style="width:10px">
+        <?php endfor; ?>
+      </colgroup>
+      <?php
+      $monthNames = [1=>'Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+      $weekdayLabels = [1=>'M',2=>'',3=>'W',4=>'',5=>'F',6=>'',7=>'S'];
+      ?>
+      <thead>
+        <tr>
+          <th class="mlbl"></th>
+          <?php for ($w = 0; $w < $numWeeks; $w++): ?>
+            <th class="mlbl">
+              <?php if (isset($monthLabels[$w])): ?>
+                <?php echo htmlspecialchars($monthNames[$monthLabels[$w]], ENT_QUOTES); ?>
+              <?php endif; ?>
+            </th>
+          <?php endfor; ?>
+        </tr>
+      </thead>
+      <tbody>
+        <?php for ($d = 1; $d <= 7; $d++): ?>
+          <tr>
+            <td class="lbl"><?php echo $weekdayLabels[$d] ?? ''; ?></td>
+            <?php for ($w = 0; $w < $numWeeks; $w++): ?>
+              <?php $cell = $weeks[$w][$d] ?? null; ?>
+              <?php if ($cell === null): ?>
+                <td class="day empty"></td>
+              <?php else: ?>
+                <?php
+                $col = (int) $cell['col'];
+                $titleDate = htmlspecialchars($cell['date'], ENT_QUOTES);
+                $titleCount = (int) $cell['n'];
+                $titleText = $titleCount === 0
+                    ? $titleDate . ': ' . __("No QSOs")
+                    : $titleDate . ': ' . $titleCount . ' ' . ($titleCount === 1 ? __("QSO") : __("QSOs"));
+                ?>
+                <td class="day"<?php echo $col > 0 ? ' data-col="' . $col . '"' : ''; ?> title="<?php echo $titleText; ?>"></td>
+              <?php endif; ?>
+            <?php endfor; ?>
+          </tr>
+        <?php endfor; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="pc-summary">
+    <div class="pc-legend">
+      <?= __("Less"); ?>
+      <span class="swatch s0"></span>
+      <span class="swatch s1"></span>
+      <span class="swatch s2"></span>
+      <span class="swatch s3"></span>
+      <span class="swatch s4"></span>
+      <span class="swatch s5"></span>
+      <?= __("More"); ?>
+    </div>
+    <div><?= __("Calendar with QSOs"); ?></div>
+  </div>
+</div>
+</body>
+</html>

--- a/application/views/visitor/punchcard.php
+++ b/application/views/visitor/punchcard.php
@@ -145,7 +145,7 @@ body.dark td.day.empty { background-color: transparent; }
                 $titleCount = (int) $cell['n'];
                 $titleText = $titleCount === 0
                     ? $titleDate . ': ' . __("No QSOs")
-                    : $titleDate . ': ' . $titleCount . ' ' . ($titleCount === 1 ? __("QSO") : __("QSOs"));
+                    : $titleDate . ': ' . $titleCount . ' ' . _ngettext("QSO", "QSOs", $titleCount);
                 ?>
                 <td class="day"<?php echo $col > 0 ? ' data-col="' . $col . '"' : ''; ?> title="<?php echo $titleText; ?>"></td>
               <?php endif; ?>


### PR DESCRIPTION
Adds a public punchcard to wavelog.
The punchcard from "Analyze -> Days with QSOs -> QSO of the Year" are now public available, if the User enabled public-slugs at his logbook.

it shows the actual year

it can be reached via `/[slug]/punchcard` in the same way as `/[slug]/mini`.
the punchcard is rendered "standalone" without JS, so one could embed it into - e.g. - qrz.com or other pages.

a theme param can be passed: example: `?theme=darkly`

Going to add documentation after merge

<img width="810" height="221" alt="image" src="https://github.com/user-attachments/assets/05a06789-cd6c-4edc-bf8f-1139f12a7c92" />
