### PR TITLE
Add a Run Now action to Cron Manager

### DIFF
--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -166,6 +166,9 @@ class cron extends CI_Controller {
 			echo json_encode(['success' => false, 'messagecategory' => 'error', 'message' => __("You're not allowed to do that!")]);
 			return;
 		}
+		// Release the session lock: the job runs synchronously and would otherwise
+		// block every other request of this user (with the file session driver) until it finishes.
+		session_write_close();
 
 		$cron = $this->cron_model->cron($this->input->post('id', true))->row();
 		if ($cron === null) {
@@ -337,14 +340,20 @@ class cron extends CI_Controller {
 		}
 
 		// Prevent manual and scheduled executions of the same cronjob from overlapping.
-		$lock_handle = fopen(sys_get_temp_dir() . '/wavelog_cron_' . md5(FCPATH . ':' . $cron->id) . '.lock', 'c');
-		if ($lock_handle === false) {
-			return ['success' => false, 'locked' => false, 'response' => '', 'error' => 'Unable to acquire cronjob lock.', 'url' => $url];
-		}
-		if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
-			fclose($lock_handle);
+		// Load cache driver for locking mechanism.
+		$this->load->driver('cache', [
+			'adapter' => $this->config->item('cache_adapter') ?? 'file',
+			'backup' => $this->config->item('cache_backup') ?? 'file',
+			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''
+		]);
+		$lock_key = 'cron_lock_' . md5($cron->id);
+		if ($this->cache->get($lock_key)) {
 			return ['success' => false, 'locked' => true, 'response' => '', 'error' => '', 'url' => $url];
 		}
+
+		// Lock for 12 hours to prevent overlapping executions of the same cronjob.
+		// some big instances have really really long cron runs
+		$this->cache->save($lock_key, time(), 43200);
 
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);
@@ -357,8 +366,8 @@ class cron extends CI_Controller {
 		$response = curl_exec($ch);
 		$error = $response === false ? curl_error($ch) : '';
 
-		flock($lock_handle, LOCK_UN);
-		fclose($lock_handle);
+		// invalidate the cache so the job can run next time
+		$this->cache->delete($lock_key);
 		return [
 			'success' => $response !== false,
 			'locked' => false,

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -109,36 +109,19 @@ class cron extends CI_Controller {
 							echo "CRON: " . $cron->id . " -> is due: " . $isdue_result . "\n";
 							echo "CRON: " . $cron->id . " -> RUNNING...\n";
 
-							if (ENVIRONMENT == "docker") {
-								// In Docker, we use the localhost[:80] to call the cron directly inside the container
-								$url = 'http://localhost/' . $cron->function;
-								log_message('debug', 'Docker Environment detected. Using URL: ' . $url);
-							} else {
-								// In other environments, we use the local_url() function to get the default url
-								// Even this local_url() helper created in https://github.com/wavelog/wavelog/pull/795 is not really necessary anymore
-								// we keep it in case of users do fancy things with it. It doesn't hurt to have it here as it usually returns the base_url
-								// from the config.php file.
-								$url = local_url() . $cron->function;
-							}
+							$cron_result = $this->triggerCron($cron);
 							if (ENVIRONMENT == "development") {
-								echo "CRON: " . $cron->id . " -> URL: " . $url . "\n";
+								echo "CRON: " . $cron->id . " -> URL: " . $cron_result['url'] . "\n";
 							}
 
-							$ch = curl_init();
-							curl_setopt($ch, CURLOPT_URL, $url);
-							curl_setopt($ch, CURLOPT_HEADER, false);
-							curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
-							curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-							if ($this->config->item('cron_allow_insecure') ?? false == true) {
-								curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-							}
-							$crun = curl_exec($ch);
-
-							if ($crun !== false) {
-								echo "CRON: " . $cron->id . " -> CURL Result: " . $crun . "\n";
+							if ($cron_result['locked']) {
+								echo "CRON: " . $cron->id . " -> already running. skipped.\n";
+								$set_status = false;
+							} else if ($cron_result['success']) {
+								echo "CRON: " . $cron->id . " -> CURL Result: " . $cron_result['response'] . "\n";
 								$status = 'healthy';
 							} else {
-								echo "ERROR: Something went wrong with " . $cron->id . "; Message: " . $crun . "\n";
+								echo "ERROR: Something went wrong with " . $cron->id . "; Message: " . $cron_result['error'] . "\n";
 								$status = 'failed';
 							}
 						} else {
@@ -174,6 +157,42 @@ class cron extends CI_Controller {
 		} else {
 			log_message('error', 'CRON: PHP Version '. PHP_VERSION . ' not supported. Minimum Version is: ' . $this->min_php_version);
 			echo 'CRON: PHP Version '. PHP_VERSION . ' not supported. Minimum Version is: ' . $this->min_php_version . "\n";
+		}
+	}
+
+	public function runNow() {
+		if (!$this->user_model->authorize(99)) {
+			header("Content-type: application/json");
+			echo json_encode(['success' => false, 'messagecategory' => 'error', 'message' => __("You're not allowed to do that!")]);
+			return;
+		}
+
+		$cron = $this->cron_model->cron($this->input->post('id', true))->row();
+		if ($cron === null) {
+			header("Content-type: application/json");
+			echo json_encode(['success' => false, 'messagecategory' => 'error', 'message' => __('Cronjob not found.')]);
+			return;
+		}
+
+		if ($cron->enabled != 1) {
+			header("Content-type: application/json");
+			echo json_encode(['success' => false, 'messagecategory' => 'warning', 'message' => __('Disabled cronjobs cannot be run.')]);
+			return;
+		}
+
+		$cron_result = $this->triggerCron($cron);
+		header("Content-type: application/json");
+
+		if ($cron_result['locked']) {
+			echo json_encode(['success' => false, 'messagecategory' => 'warning', 'message' => __('Cronjob is already running.')]);
+			return;
+		}
+
+		if ($cron_result['success']) {
+			echo json_encode(['success' => true, 'messagecategory' => 'success', 'message' => __('Cronjob triggered.')]);
+		} else {
+			log_message('error', 'CRON: Manual execution of ' . $cron->id . ' failed: ' . $cron_result['error']);
+			echo json_encode(['success' => false, 'messagecategory' => 'error', 'message' => __('Cronjob execution failed.')]);
 		}
 	}
 
@@ -259,6 +278,7 @@ class cron extends CI_Controller {
 			$single->cron_last_run = $cron->last_run ?? __("never");
 			$single->cron_next_run = ($cron->enabled == '1') ? ($cron->next_run ?? __("calculating...")) : __("never");
 			$single->cron_edit = $this->cronEdit2html($cron->id);
+			$single->cron_run = $this->cronRun2html($cron->id, $cron->enabled);
 			$single->cron_enabled = $this->cronEnabled2html($cron->id, $cron->enabled);
 			array_push($hres, $single);
 		}
@@ -292,6 +312,12 @@ class cron extends CI_Controller {
 		return $htmlret;
 	}
 
+	private function cronRun2html($id, $enabled) {
+		$disabled = ($enabled == '1') ? '' : ' disabled';
+		$htmlret = '<button id="' . $id . '" class="runCron btn btn-outline-success btn-sm"' . $disabled . '>' . __("Run Now") . '</button>';
+		return $htmlret;
+	}
+
 	private function cronEnabled2html($id, $enabled) {
 		if ($enabled == '1') {
 			$checked = 'checked';
@@ -300,6 +326,46 @@ class cron extends CI_Controller {
 		}
 		$htmlret = '<div class="form-check form-switch"><input name="cron_enable_switch" class="form-check-input enableCronSwitch" type="checkbox" role="switch" id="' . $id . '" ' . $checked . '></div>';
 		return $htmlret;
+	}
+
+	private function triggerCron($cron) {
+		if (ENVIRONMENT == "docker") {
+			$url = 'http://localhost/' . $cron->function;
+			log_message('debug', 'Docker Environment detected. Using URL: ' . $url);
+		} else {
+			$url = local_url() . $cron->function;
+		}
+
+		// Prevent manual and scheduled executions of the same cronjob from overlapping.
+		$lock_handle = fopen(sys_get_temp_dir() . '/wavelog_cron_' . md5(FCPATH . ':' . $cron->id) . '.lock', 'c');
+		if ($lock_handle === false) {
+			return ['success' => false, 'locked' => false, 'response' => '', 'error' => 'Unable to acquire cronjob lock.', 'url' => $url];
+		}
+		if (!flock($lock_handle, LOCK_EX | LOCK_NB)) {
+			fclose($lock_handle);
+			return ['success' => false, 'locked' => true, 'response' => '', 'error' => '', 'url' => $url];
+		}
+
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_HEADER, false);
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog Updater');
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		if ($this->config->item('cron_allow_insecure') ?? false == true) {
+			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+		}
+		$response = curl_exec($ch);
+		$error = $response === false ? curl_error($ch) : '';
+
+		flock($lock_handle, LOCK_UN);
+		fclose($lock_handle);
+		return [
+			'success' => $response !== false,
+			'locked' => false,
+			'response' => $response,
+			'error' => $error,
+			'url' => $url
+		];
 	}
 
 	private function get_mastercron_status() {

--- a/application/views/cron/index.php
+++ b/application/views/cron/index.php
@@ -58,7 +58,15 @@
         </div>
         <div class="card-body">
             <?php if (version_compare(PHP_VERSION, $min_php_version) >= 0) { ?>
-                <?php if ($mastercron['status_class'] != 'danger') { ?>
+                <?php if ($mastercron['status_class'] == 'danger') { ?>
+                    <div class="text-center">
+                        <h4><?= __("Your Mastercron isn't running."); ?><br>
+                        <?= __("Copy the cron above to a external cron service or into your server's cron to use this cron manager."); ?></h4>
+                        <p><?= __("On a basic linux server with shell access use this command to edit your crons:"); ?>
+                        <pre><code>crontab -e</code></pre>
+                        </p>
+                    </div>
+                <?php } ?>
                     <div class="table-responsive">
                         <table id="cron_table" style="width:100%" class="crontable table table-sm table-striped">
                             <thead>
@@ -70,6 +78,7 @@
                                     <th><?= __("Last Run"); ?></th>
                                     <th><?= __("Next Run"); ?></th>
                                     <th><?= __("Edit"); ?></th>
+                                    <th><?= __("Run Now"); ?></th>
                                     <th>I/O</th>
                                 </tr>
                             </thead>
@@ -101,6 +110,7 @@
                                                                                 echo __("never");
                                                                             } ?></td>
                                         <td style="vertical-align: middle;"><button id="<?php echo $cron->id; ?>" class="editCron btn btn-outline-primary btn-sm"><i class="fas fa-edit"></i></button></td>
+                                        <td style="vertical-align: middle;"><button id="<?php echo $cron->id; ?>" class="runCron btn btn-outline-success btn-sm" <?php if ($cron->enabled != '1') { echo 'disabled'; } ?>><?= __("Run Now"); ?></button></td>
                                         <td style="vertical-align: middle;">
                                             <div class="form-check form-switch"><input name="cron_enable_switch" class="form-check-input enableCronSwitch" type="checkbox" role="switch" id="<?php echo $cron->id; ?>" <?php if ($cron->enabled ?? '0') {
                                                                                                                                                                                                                             echo 'checked';
@@ -111,15 +121,6 @@
                             </tbody>
                         </table>
                     </div>
-                <?php } else { ?>
-                    <div class="text-center">
-                        <h4><?= __("Your Mastercron isn't running."); ?><br>
-                        <?= __("Copy the cron above to a external cron service or into your server's cron to use this cron manager."); ?></h4>
-                        <p><?= __("On a basic linux server with shell access use this command to edit your crons:"); ?>
-                        <pre><code>crontab -e</code></pre>
-                        </p>
-                    </div>
-                <?php } ?>
             <?php } else { ?>
                 <div class="alert alert-danger" role="alert">
                     <?= sprintf(__("You need to upgrade your PHP version. Minimum version is %s. Your Version is %s"), $min_php_version, PHP_VERSION);?>

--- a/assets/js/sections/cron.js
+++ b/assets/js/sections/cron.js
@@ -69,6 +69,7 @@ function modalEventListener() {
 	});
 }
 
+var message_timer;
 function displayMessages(category, message) {
 	var html_class;
 	var message_area = $('#cron_message_area');
@@ -83,11 +84,12 @@ function displayMessages(category, message) {
 		html_class = 'alert alert-info';
 	}
 
-	message_area.show();
-	message_area.addClass(html_class);
+	message_area.stop(true).css('opacity', '').show();
+	message_area.attr('class', html_class);	// replace, don't add: earlier categories must not linger
 	message_area.text(message);
 
-	setTimeout(function () {
+	clearTimeout(message_timer);
+	message_timer = setTimeout(function () {
 		message_area.fadeOut();
 	}, 7000);
 }

--- a/assets/js/sections/cron.js
+++ b/assets/js/sections/cron.js
@@ -5,6 +5,10 @@ $(document).ready(function () {
 		editCronDialog(e);
 	});
 
+	$(document).on('click', '.runCron', async function (e) {	// Dynamic binding, since element doesn't exists when loading this JS
+		runCron(e.currentTarget);
+	});
+
 	$(document).on('click', '.enableCronSwitch', async function (e) {	// Dynamic binding, since element doesn't exists when loading this JS
 		toggleEnableCronSwitch(e.currentTarget.id, this);
 	});
@@ -142,6 +146,31 @@ function editCron() {
 
 }
 
+function runCron(button) {
+	var $button = $(button);
+	$button.prop('disabled', true);
+
+	$.ajax({
+		url: base_url + 'index.php/cron/runNow',
+		type: 'post',
+		dataType: 'json',
+		data: {
+			id: button.id
+		},
+		success: function (response) {
+			displayMessages(response.messagecategory, response.message);
+			reloadCrons();
+		},
+		error: function (response) {
+			var message = response.responseJSON && response.responseJSON.message ? response.responseJSON.message : 'The query failed for a unknown reason';
+			displayMessages('error', message);
+		},
+		complete: function () {
+			$button.prop('disabled', false);
+		}
+	});
+}
+
 function humanReadableInEditDialog() {
 	var exp_inputID = $('#edit_cron_expression_custom');
 	var exp_dropdownID = $('#edit_cron_expression_dropdown');
@@ -234,6 +263,7 @@ function loadCronTable(rows) {
 		data.push(cron.cron_last_run);
 		data.push(cron.cron_next_run);
 		data.push(cron.cron_edit);
+		data.push(cron.cron_run);
 		data.push(cron.cron_enabled);
 
 		let createdRow = table.row.add(data).index();
@@ -241,4 +271,3 @@ function loadCronTable(rows) {
 	table.draw();
 	init_expression_tooltips();
 }
-


### PR DESCRIPTION
## What changed

I added a Run Now action for enabled cron jobs in Cron Manager. This is related to #1393 - it dispatches the configured job through its existing internal path instead of waiting for the next master-cron tick.

When master cron is not running, the existing warning and setup guidance remain visible above the job table so an administrator can recover individual jobs. A per-job lock prevents manual and scheduled runs from overlapping; an occupied job returns a warning. Manual actions report dispatch status without changing the scheduler health tracking.

## Testing

- `git diff --check`
- `node --check assets/js/sections/cron.js`
