### PR TITLE
Don't emit Az (from lookup) during SAT-OPs on websocket

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1531,7 +1531,7 @@ $("#callsign").on("focusout", function () {
 						iota: result.callsign_iota,
 						state: result.callsign_state,
 						us_county: result.callsign_us_county,
-						bearing: result.bearing,
+						bearing: ($("#sat_name").val() != "") ? null : result.bearing,
 						distance: result.callsign_distance,
 						lotw_member: result.lotw_member,
 						lotw_days: result.lotw_days,


### PR DESCRIPTION
During WS-Active and SAT-Operations the calculated Az/Ele is emitted via websocket (for rotator-use, etc.) in realtime.
If an OP looks up a call, there's a short burst which emits the Az (as seen terrestical) from the QSO-Partner.

This PR suppresses that output (to `null`) if SAT is active on the websocket.