### PR TITLE
[Advanced Logbook] Search exact callsign as default

### DIFF
--- a/application/models/Logbookadvanced_model.php
+++ b/application/models/Logbookadvanced_model.php
@@ -282,7 +282,7 @@ class Logbookadvanced_model extends CI_Model {
 				$conditions[] = "COL_CALL <> ''";
 			} else {
 				$conditions[] = "COL_CALL like ?";
-				$binding[] = $this->wildcardPattern(trim($searchCriteria['dx']), 'both');
+				$binding[] = $this->wildcardPattern(trim($searchCriteria['dx']), 'none');
 			}
 		}
 		if ($searchCriteria['dx'] == '') {


### PR DESCRIPTION
Requested here #3500.

This also makes sense, since @int2001 implemented wildcard support in text search inputs in the advanced logbook.