### PR TITLE
Contest import enhancements

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -775,6 +775,42 @@ class Contesting extends CI_Controller {
 	}
 
 	/**
+	 * Deletes multiple contest sessions at once.
+	 * Endpoint: POST /contesting/batch_delete_sessions
+	 * POST: ids = comma-separated contest_session ids, delete_qsos = optional flag
+	 */
+	public function batch_delete_sessions() {
+		if ($this->input->method() !== 'post') {
+			$this->session->set_flashdata('error', __("Invalid request method."));
+			redirect('contesting');
+		}
+
+		if (!clubaccess_check(9)) {
+			$this->session->set_flashdata('error', __("Only clubstation officers can delete."));
+			redirect('contesting');
+		}
+
+		$ids = array_filter(array_map('intval', explode(',', (string)$this->input->post('ids', true))));
+		$delete_qsos = (bool) $this->input->post('delete_qsos', true);
+
+		if (empty($ids)) {
+			$this->session->set_flashdata('error', __("No contest sessions selected."));
+			redirect('contesting');
+		}
+
+		$this->load->is_loaded('contesting_model') ?: $this->load->model('contesting_model');
+		$deleted = $this->contesting_model->batch_delete_sessions($ids, $delete_qsos);
+
+		if ($deleted > 0) {
+			$this->session->set_flashdata('success', sprintf(_ngettext("%d contest session deleted.", "%d contest sessions deleted.", $deleted), $deleted));
+		} else {
+			$this->session->set_flashdata('error', __("There was an error deleting the contest sessions. Please try again."));
+		}
+
+		redirect('contesting');
+	}
+
+	/**
 	 * Inline QSO edit endpoint.
 	 * Endpoint: POST /contesting/update_qso
 	 *

--- a/application/controllers/Contesting_import.php
+++ b/application/controllers/Contesting_import.php
@@ -33,7 +33,7 @@ class Contesting_import extends CI_Controller {
 		$groups = $this->contesting_import_model->get_legacy_contest_groups();
 
 		if (empty($groups)) {
-			$this->session->set_flashdata('error', __("No historical contests found that could be imported."));
+			$this->session->set_flashdata('warning', __("No historical contests found that could be imported."));
 			redirect('contesting');
 		}
 
@@ -101,7 +101,7 @@ class Contesting_import extends CI_Controller {
 		$groups = $this->contesting_import_model->get_all_legacy_contest_groups();
 
 		if (empty($groups)) {
-			$this->session->set_flashdata('error', __("No historical contests found that could be imported."));
+			$this->session->set_flashdata('warning', __("No historical contests found that could be imported."));
 			redirect('contesting');
 		}
 

--- a/application/controllers/Contesting_import.php
+++ b/application/controllers/Contesting_import.php
@@ -49,7 +49,7 @@ class Contesting_import extends CI_Controller {
 
 	/**
 	 * Processes the legacy contest import for the current user.
-	 * POST: groups[] = "adif_name|station_id|year"
+	 * POST: groups[] = "adif_name|station_id|segment_start"
 	 */
 	public function do_import() {
 		if (!clubaccess_check(9)) {
@@ -67,11 +67,11 @@ class Contesting_import extends CI_Controller {
 			$parts = explode('|', $key);
 			if (count($parts) !== 3) continue;
 
-			[$adif_name, $station_id, $year] = $parts;
+			[$adif_name, $station_id, $segment_start] = $parts;
 			$linked = $this->contesting_import_model->import_legacy_contest_group(
 				$adif_name,
 				(int)$station_id,
-				(int)$year
+				(int)$segment_start
 			);
 			if ($linked > 0) {
 				$sessions++;
@@ -117,7 +117,7 @@ class Contesting_import extends CI_Controller {
 
 	/**
 	 * Admin-only: processes the legacy contest import for all users.
-	 * POST: groups[] = "adif_name|station_id|year|user_id"
+	 * POST: groups[] = "adif_name|station_id|segment_start|user_id"
 	 */
 	public function do_import_all() {
 		if (!$this->user_model->authorize(99)) {
@@ -135,11 +135,11 @@ class Contesting_import extends CI_Controller {
 			$parts = explode('|', $key);
 			if (count($parts) !== 4) continue;
 
-			[$adif_name, $station_id, $year, $user_id] = $parts;
+			[$adif_name, $station_id, $segment_start, $user_id] = $parts;
 			$linked = $this->contesting_import_model->import_legacy_contest_group_as_user(
 				$adif_name,
 				(int)$station_id,
-				(int)$year,
+				(int)$segment_start,
 				(int)$user_id
 			);
 			if ($linked > 0) {

--- a/application/models/Contesting_import_model.php
+++ b/application/models/Contesting_import_model.php
@@ -3,8 +3,9 @@ class Contesting_import_model extends CI_Model {
 
 	/**
 	 * Returns historical contest QSO groups not yet linked to any contest session,
-	 * scoped to the current user's stations. Groups by (COL_CONTEST_ID, station_id, year).
-	 * QSOs without a valid COL_TIME_ON are excluded.
+	 * scoped to the current user's stations. Groups by (COL_CONTEST_ID, station_id)
+	 * and splits into separate sessions wherever consecutive QSOs are at least
+	 * 72 hours apart. QSOs without a valid COL_TIME_ON are excluded.
 	 *
 	 * @return array
 	 */
@@ -45,12 +46,12 @@ class Contesting_import_model extends CI_Model {
 	 *
 	 * @param string $adif_name
 	 * @param int    $station_id
-	 * @param int    $year
-	 * @return int Number of QSOs linked, 0 on ownership failure
+	 * @param int    $segment_start Unix timestamp of the segment's first QSO
+	 * @return int Number of QSOs linked, 0 on ownership failure or unknown segment
 	 */
-	function import_legacy_contest_group($adif_name, $station_id, $year) {
+	function import_legacy_contest_group($adif_name, $station_id, $segment_start) {
 		$user_id = $this->session->userdata('user_id');
-		return $this->_do_import_legacy_group($adif_name, $station_id, $year, $user_id);
+		return $this->_do_import_legacy_group($adif_name, $station_id, $segment_start, $user_id);
 	}
 
 	/**
@@ -59,12 +60,12 @@ class Contesting_import_model extends CI_Model {
 	 *
 	 * @param string $adif_name
 	 * @param int    $station_id
-	 * @param int    $year
+	 * @param int    $segment_start Unix timestamp of the segment's first QSO
 	 * @param int    $user_id
-	 * @return int Number of QSOs linked, 0 on ownership failure
+	 * @return int Number of QSOs linked, 0 on ownership failure or unknown segment
 	 */
-	function import_legacy_contest_group_as_user($adif_name, $station_id, $year, $user_id) {
-		return $this->_do_import_legacy_group($adif_name, $station_id, $year, (int)$user_id);
+	function import_legacy_contest_group_as_user($adif_name, $station_id, $segment_start, $user_id) {
+		return $this->_do_import_legacy_group($adif_name, $station_id, $segment_start, (int)$user_id);
 	}
 
 	// -------------------------------------------------------------------------
@@ -81,14 +82,11 @@ class Contesting_import_model extends CI_Model {
 		$sql = "SELECT
 					t.COL_CONTEST_ID AS adif_name,
 					t.station_id,
-					YEAR(t.COL_TIME_ON) AS contest_year,
-					MIN(t.COL_TIME_ON) AS time_start,
-					MAX(t.COL_TIME_ON) AS time_end,
-					COUNT(*) AS qso_count,
-					MAX(c.id) AS contest_table_id,
-					COALESCE(MAX(c.name), t.COL_CONTEST_ID) AS contest_name,
-					MAX(sp.station_callsign) AS station_callsign,
-					MAX(sp.user_id) AS owner_user_id
+					t.COL_TIME_ON,
+					c.id AS contest_table_id,
+					COALESCE(c.name, t.COL_CONTEST_ID) AS contest_name,
+					sp.station_callsign,
+					sp.user_id AS owner_user_id
 				FROM {$table} t
 				LEFT JOIN contest c ON c.adifname = t.COL_CONTEST_ID
 				LEFT JOIN station_profile sp ON sp.station_id = t.station_id
@@ -98,15 +96,73 @@ class Contesting_import_model extends CI_Model {
 					AND t.COL_TIME_ON IS NOT NULL
 					AND cq.id IS NULL
 					{$user_filter}
-				GROUP BY t.COL_CONTEST_ID, t.station_id, YEAR(t.COL_TIME_ON)
-				ORDER BY time_start DESC";
+				ORDER BY t.COL_CONTEST_ID, t.station_id, t.COL_TIME_ON";
 
 		$bindings = empty($user_ids) ? [] : $user_ids;
-		$query = $this->db->query($sql, $bindings);
-		return $query->result_array();
+		$qsos = $this->db->query($sql, $bindings)->result_array();
+
+		// Group QSOs by (adif_name, station_id), then split each group into
+		// time segments so that preview rows match the sessions created on import
+		$grouped = [];
+		foreach ($qsos as $qso) {
+			$grouped[$qso['adif_name'] . '|' . $qso['station_id']][] = $qso;
+		}
+
+		$result = [];
+		foreach ($grouped as $group_qsos) {
+			foreach ($this->_segment_qsos($group_qsos) as $segment) {
+				$first = $segment[0];
+				$last  = end($segment);
+				$result[] = [
+					'adif_name'        => $first['adif_name'],
+					'station_id'       => $first['station_id'],
+					'segment_start'    => strtotime($first['COL_TIME_ON']),
+					'contest_year'     => (int)date('Y', strtotime($first['COL_TIME_ON'])),
+					'time_start'       => $first['COL_TIME_ON'],
+					'time_end'         => $last['COL_TIME_ON'],
+					'qso_count'        => count($segment),
+					'contest_table_id' => $first['contest_table_id'],
+					'contest_name'     => $first['contest_name'],
+					'station_callsign' => $first['station_callsign'],
+					'owner_user_id'    => $first['owner_user_id'],
+				];
+			}
+		}
+
+		usort($result, function ($a, $b) {
+			return $b['segment_start'] <=> $a['segment_start'];
+		});
+		return $result;
 	}
 
-	private function _do_import_legacy_group($adif_name, $station_id, $year, $user_id) {
+	/**
+	 * Splits a time-ordered list of QSOs into segments. A new segment starts
+	 * whenever two consecutive QSOs are at least 72h apart.
+	 *
+	 * @param array $qsos QSO rows ordered by COL_TIME_ON ascending
+	 * @return array Array of segments, each an array of QSO rows
+	 */
+	private function _segment_qsos(array $qsos) {
+		$segments = [];
+		$current  = [];
+		$prev_ts  = null;
+
+		foreach ($qsos as $qso) {
+			$ts = strtotime($qso['COL_TIME_ON']);
+			if ($prev_ts !== null && ($ts - $prev_ts) >= 72 * 3600) {
+				$segments[] = $current;
+				$current = [];
+			}
+			$current[] = $qso;
+			$prev_ts = $ts;
+		}
+		if (!empty($current)) {
+			$segments[] = $current;
+		}
+		return $segments;
+	}
+
+	private function _do_import_legacy_group($adif_name, $station_id, $segment_start, $user_id) {
 		$table = $this->config->item('table_name');
 
 		// Verify station belongs to the specified user
@@ -121,23 +177,36 @@ class Contesting_import_model extends CI_Model {
 		$contest_id = $this->ensure_contest_exists($adif_name);
 		$is_other   = ($contest_id === 1 && $adif_name !== 'Other');
 
-		// Fetch unlinked QSOs for this group
-		$qsos = $this->db->query(
+		// Fetch all unlinked QSOs for this contest/station combination
+		$all_qsos = $this->db->query(
 			"SELECT t.COL_PRIMARY_KEY, t.COL_TIME_ON
 			FROM {$table} t
 			LEFT JOIN contest_qsos cq ON cq.qso_id = t.COL_PRIMARY_KEY
 			WHERE t.COL_CONTEST_ID = ?
 				AND t.station_id = ?
-				AND YEAR(t.COL_TIME_ON) = ?
+				AND t.COL_TIME_ON IS NOT NULL
 				AND cq.id IS NULL
 			ORDER BY t.COL_TIME_ON ASC",
-			[$adif_name, $station_id, $year]
+			[$adif_name, $station_id]
 		)->result_array();
 
-		if (empty($qsos)) {
+		if (empty($all_qsos)) {
 			return 0;
 		}
 
+		// Re-derive the segments and pick the one starting at the requested time
+		$qsos = null;
+		foreach ($this->_segment_qsos($all_qsos) as $segment) {
+			if (strtotime($segment[0]['COL_TIME_ON']) === (int)$segment_start) {
+				$qsos = $segment;
+				break;
+			}
+		}
+		if ($qsos === null) {
+			return 0;
+		}
+
+		$year       = (int)date('Y', strtotime($qsos[0]['COL_TIME_ON']));
 		$time_start = date('Y-m-d H:i:s', strtotime($qsos[0]['COL_TIME_ON']) - 3600);
 		$time_end   = date('Y-m-d H:i:s', strtotime(end($qsos)['COL_TIME_ON']) + 3600);
 

--- a/application/models/Contesting_import_model.php
+++ b/application/models/Contesting_import_model.php
@@ -5,7 +5,8 @@ class Contesting_import_model extends CI_Model {
 	 * Returns historical contest QSO groups not yet linked to any contest session,
 	 * scoped to the current user's stations. Groups by (COL_CONTEST_ID, station_id)
 	 * and splits into separate sessions wherever consecutive QSOs are at least
-	 * 72 hours apart. QSOs without a valid COL_TIME_ON are excluded.
+	 * 72 hours apart and not within the same ISO calendar week (see
+	 * _segment_qsos). QSOs without a valid COL_TIME_ON are excluded.
 	 *
 	 * @return array
 	 */
@@ -137,7 +138,11 @@ class Contesting_import_model extends CI_Model {
 
 	/**
 	 * Splits a time-ordered list of QSOs into segments. A new segment starts
-	 * whenever two consecutive QSOs are at least 72h apart.
+	 * whenever two consecutive QSOs are at least 72h apart — unless both QSOs
+	 * fall into the same ISO calendar week (Mon-Sun). This keeps week-long
+	 * activity events with sparse QSOs (e.g. one QSO on Monday, one on Friday)
+	 * in a single session, while weekly series (same weekday every week) always
+	 * cross a week boundary and are still split.
 	 *
 	 * @param array $qsos QSO rows ordered by COL_TIME_ON ascending
 	 * @return array Array of segments, each an array of QSO rows
@@ -149,7 +154,7 @@ class Contesting_import_model extends CI_Model {
 
 		foreach ($qsos as $qso) {
 			$ts = strtotime($qso['COL_TIME_ON']);
-			if ($prev_ts !== null && ($ts - $prev_ts) >= 72 * 3600) {
+			if ($prev_ts !== null && ($ts - $prev_ts) >= 72 * 3600 && date('oW', $ts) !== date('oW', $prev_ts)) {
 				$segments[] = $current;
 				$current = [];
 			}

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -231,6 +231,32 @@ class Contesting_model extends CI_Model {
 	}
 
 	/**
+	 * Deletes multiple contest sessions for the current user.
+	 * Ownership is verified before any QSO links are touched.
+	 *
+	 * @param array $contest_session_ids IDs of the contest sessions to delete.
+	 * @param bool  $delete_qsos Also delete the linked QSOs from the logbook.
+	 * @return int Number of sessions deleted.
+	 */
+	function batch_delete_sessions(array $contest_session_ids, $delete_qsos = false) {
+		$user_id = $this->session->userdata('user_id');
+
+		// Only keep sessions actually owned by the current user
+		$placeholders = implode(',', array_fill(0, count($contest_session_ids), '?'));
+		$query = $this->db->query(
+			"SELECT id FROM contest_session WHERE id IN ({$placeholders}) AND user_id = ?",
+			array_merge($contest_session_ids, [$user_id])
+		);
+
+		$deleted = 0;
+		foreach ($query->result() as $row) {
+			$this->delete_contest_session($row->id, $delete_qsos);
+			$deleted++;
+		}
+		return $deleted;
+	}
+
+	/**
 	 * Delete a QSO from a contest. Does not delete QSO from main logbook.
 	 *
 	 * @param int $qso_id The ID of the QSO.

--- a/application/views/contesting/manager/import_legacy.php
+++ b/application/views/contesting/manager/import_legacy.php
@@ -42,9 +42,9 @@
 									<?php foreach ($groups as $row):
 										$is_other = (empty($row['contest_table_id']) || ($row['contest_table_id'] == 1 && $row['adif_name'] !== 'Other'));
 										if (!empty($all_users)) {
-											$key = $row['adif_name'] . '|' . $row['station_id'] . '|' . $row['contest_year'] . '|' . $row['owner_user_id'];
+											$key = $row['adif_name'] . '|' . $row['station_id'] . '|' . $row['segment_start'] . '|' . $row['owner_user_id'];
 										} else {
-											$key = $row['adif_name'] . '|' . $row['station_id'] . '|' . $row['contest_year'];
+											$key = $row['adif_name'] . '|' . $row['station_id'] . '|' . $row['segment_start'];
 										}
 									?>
 									<tr>

--- a/application/views/contesting/manager/import_legacy.php
+++ b/application/views/contesting/manager/import_legacy.php
@@ -99,7 +99,7 @@ document.getElementById('import-legacy-form').addEventListener('submit', functio
 		alert(decodeHtml("<?= __("Please select at least one contest to import.") ?>"));
 		return;
 	}
-	if (!confirm(decodeHtml("<?= __("Are you sure you want to import the selected contest sessions? This cannot be undone.") ?>"))) {
+	if (!confirm(decodeHtml("<?= __("Are you sure you want to import the selected contest sessions?") ?>"))) {
 		e.preventDefault();
 	}
 });

--- a/application/views/contesting/manager/import_legacy.php
+++ b/application/views/contesting/manager/import_legacy.php
@@ -12,6 +12,11 @@
 					<p class="card-text">
 						<?= __("The following contest groups were found in your logbook but are not yet linked to a contest session. Select the ones you want to import and click \"Import Selected\".") ?>
 					</p>
+					<p class="alert alert-info">
+						<i class="fas fa-info-circle me-1"></i>
+						<?= __("How grouping works:"); ?><br>
+						<?= __("QSOs are grouped by contest and station. Consecutive QSOs end up in the same session if they are less than 72 hours apart or fall into the same ISO calendar week (Monday-Sunday). This keeps week-long activity events together as one session, while weekly or monthly contest series are imported as separate sessions.") ?>
+					</p>
 					<?php if (!empty($all_users)): ?>
 						<div class="alert alert-warning">
 							<strong><?= __("Admin mode:") ?></strong>

--- a/application/views/contesting/manager/index.php
+++ b/application/views/contesting/manager/index.php
@@ -20,11 +20,13 @@
                     <p class="card-text"><?= __("Here you can manage your contests, create new, edit or export them in various formats.") ?></p>
                     <button class="btn btn-primary btn-sm" onclick="create_modal();"><i class="fas fa-plus"></i> <?= __("Create New Contest") ?></button>
                     <a class="btn btn-primary btn-sm" href="<?php echo site_url('contesting/quickstart'); ?>" target="_blank"><i class="fas fa-play"></i> <?= __("Quick Start") ?></a>
+                    <button class="btn btn-danger btn-sm" id="deleteSelectedSessions" data-bs-toggle="tooltip" title="<?= __("Delete selected contest sessions") ?>"><i class="fas fa-trash-alt"></i> <?= __("Delete Selected") ?></button>
                     <hr>
                     <div class="table-responsive" style="overflow: visible;">
                         <table id="user_contests_table" class="table-sm table table-hover table-striped table-condensed">
                             <thead>
                                 <tr>
+                                    <th><div class="form-check"><input class="form-check-input" type="checkbox" id="checkBoxAll" title="<?= __("Select all") ?>"></div></th>
                                     <th></th>
                                     <th scope="col"><?= __("Status") ?></th>
                                     <th scope="col"><?= __("Start") ?></th>
@@ -56,6 +58,7 @@
                                     }
                                     ?>
                                     <tr>
+                                        <td><div class="form-check"><input class="row-check form-check-input" type="checkbox" value="<?php echo $row['contest_session_id']; ?>"></div></td>
                                         <td><a target="_blank" href="<?php echo site_url('contesting/logging_engine') . "/" . $logging_token; ?>" class="btn btn-success btn-sm"><i class="fas fa-play"></i> <?= __("START") ?></a></td>
                                         <td><?php echo $status; ?></td>
                                         <td><?php echo !empty($row['time_start']) ? date($custom_date_format . ' H:i', strtotime($row['time_start'])) : '-'; ?></td>
@@ -113,10 +116,43 @@
     </div>
 </div>
 <div id="contestSessionModal-container"></div>
+
+<!-- Batch delete confirmation modal -->
+<div class="modal fade bg-black bg-opacity-50" id="contestBatchDeleteModal" tabindex="-1" aria-labelledby="contestBatchDeleteLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header border-bottom d-flex justify-content-between align-items-center">
+                <h5 class="modal-title" id="contestBatchDeleteLabel"><i class="fas fa-trash-alt me-2"></i><?= __("Delete Contest Sessions"); ?></h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<?= __("Close"); ?>" style="flex-shrink: 0;"></button>
+            </div>
+            <form action="<?= site_url('contesting/batch_delete_sessions'); ?>" method="post" id="contestBatchDeleteForm">
+                <div class="modal-body">
+                    <p class="text-muted"><?= __("Do you really want to delete the selected contest sessions?"); ?></p>
+                    <p><strong><?= __("Selected sessions: "); ?></strong><span id="batchDeleteCount"></span></p>
+                    <div class="form-check mt-3">
+                        <input class="form-check-input" type="checkbox" name="delete_qsos" id="batchDeleteQsosCheck" value="1">
+                        <label class="form-check-label text-danger" for="batchDeleteQsosCheck">
+                            <?= __("Also delete all QSOs logged in these sessions from the logbook"); ?>
+                        </label>
+                    </div>
+                </div>
+                <div class="modal-footer border-top">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?= __("Cancel"); ?></button>
+                    <button type="submit" class="btn btn-danger">
+                        <i class="fas fa-trash-alt me-2"></i><?= __("Delete Sessions"); ?>
+                    </button>
+                </div>
+                <input type="hidden" name="ids" id="batchDeleteIds" value="">
+            </form>
+        </div>
+    </div>
+</div>
+
 <script>
     var custom_date_format = "<?php echo $custom_date_format ?>";
     var lang_admin_contest_add_contest = '<?= __("Add a Contest"); ?>';
     var lang_error = "<?= __("Error") ?>";
+    var lang_contesting_no_selection = "<?= __("Please select at least one contest session.") ?>";
 
     document.addEventListener('DOMContentLoaded', function () {
         document.querySelectorAll('.contest-export-dropdown').forEach(function (dropdownToggle) {

--- a/assets/js/sections/contesting/manager.js
+++ b/assets/js/sections/contesting/manager.js
@@ -1,9 +1,45 @@
+var contestsTable;
+
 $(document).ready(function () {
-    $("#user_contests_table").DataTable({
-        stateSave: true,
+    contestsTable = $("#user_contests_table").DataTable({
+        stateSave: false,
+        order: [], // keep server-side order by default
+        columnDefs: [
+            { orderable: false, targets: 0 }, // checkbox column
+            { orderable: false, targets: 1 }, // start column
+        ],
         language: {
             url: getDataTablesLanguageUrl(),
         },
+    });
+
+    // Select/unselect all rows (including rows on other DataTables pages)
+    $('#checkBoxAll').on('change', function () {
+        contestsTable.$('input.row-check').prop('checked', this.checked);
+    });
+
+    // Unchecking a single row unchecks the "select all" checkbox
+    $('#user_contests_table tbody').on('change', 'input.row-check', function () {
+        if (!this.checked) {
+            $('#checkBoxAll').prop('checked', false);
+        }
+    });
+
+    // Batch delete of selected contest sessions
+    $('#deleteSelectedSessions').on('click', function () {
+        var ids = contestsTable.$('input.row-check:checked').map(function () {
+            return this.value;
+        }).get();
+
+        if (ids.length === 0) {
+            alert(lang_contesting_no_selection);
+            return;
+        }
+
+        $('#batchDeleteCount').text(ids.length);
+        $('#batchDeleteIds').val(ids.join(','));
+        $('#batchDeleteQsosCheck').prop('checked', false);
+        $('#contestBatchDeleteModal').modal('show');
     });
 });
 


### PR DESCRIPTION
This PR does two things:

1. The legacy importer which imports historical contests from the log was built to import contests which happen once a year. This is bullsh**. This changes the logic a bit so the importer creates a new session if there was no qso for 72h after the last one.
2. some UI enhancements in the contest session management