### PR TITLE
fix workerstat

### DIFF
--- a/assets/js/sections/debug.js
+++ b/assets/js/sections/debug.js
@@ -160,8 +160,8 @@ $(document).ready(function () {
 		if (!cluster) { setBadge(false); } // single instance: always "Online"; cluster badge is owned by the fan-out
 		$('#ws-url').text(WavelogWorker.url);
 		$('#ws-version').text(val(p.version));
-		$('#ws-topics').text(val(p.active_topics - 1));       // subtract this debug page
-		$('#ws-clients').text(val(p.connected_clients - 1));  // subtract this debug page
+		$('#ws-topics').text(val(p.active_topics));
+		$('#ws-clients').text(val(p.connected_clients));
 		if (typeof p.uptime_seconds === 'number') {
 			uptimeBase = p.uptime_seconds; uptimeAt = Date.now();
 			startTick(); tick();


### PR DESCRIPTION
I thought it would be a good idea and intuitive to reduce the worker stat in the debug view by one so it does not count the connection of the debug view itself. But I was wrong.. This is the opposite of intuitive :-D 