### PR TITLE
Fix Reg1Test EDI Mode Code for unspecified machine generated modes

### DIFF
--- a/application/libraries/Reg1testformat.php
+++ b/application/libraries/Reg1testformat.php
@@ -201,7 +201,9 @@ class Reg1testformat {
          case 'ATV':
             return 9;
          default:
-            return 0;
+            // all other modes are most likely machine generated and according to the IARU R1 handbook should be marked with mode code 7
+            // https://www.iaru-r1.org/wp-content/uploads/2026/02/VHF_Handbook_V10_03_final.pdf
+            return 7;
       }
    }
 }


### PR DESCRIPTION
addresses #3461 

IARU R1 handbook specifies EDI Mode code 7 (historically RTTY/Digital) for all machine generated modes, unfortunately without specifiying which modes. 

Since with SSB, CW, AM and FM all human generated modes are clearly defined, I implemented the "not defined" case to be 7 instead of an invalid 0 under the assumption that everything that is NOT human generated and well defined must be machine generated.

If a new human generated mode at any time emerges in contesting in the future and Reg1Test defines a new mode code, we will have to add that anyway.