### PR TITLE
Simplefle syntax fix

### DIFF
--- a/application/views/simplefle/syntax_help.php
+++ b/application/views/simplefle/syntax_help.php
@@ -1,23 +1,23 @@
 <p><?= __("Before starting to log a QSO, please note the basic rules.") ?>:</p>
 <p><?= __("- Each new QSO should be on a new line.") ?></p>
 <p><?= __("- On each new line, only write data that has changed from the previous QSO.") ?></p>
-<p><?= __("To begin, ensure you have already filled in the form on the left with the date, station call, and operator's call. The main data includes the band (or QRG in MHz, e.g., '7.145'), mode, and time. After the time, you provide the first QSO, which is essentially the callsign.") ?></p>
+<p><?= sprintf(__("To begin, ensure you have already filled in the form on the left with the date, station call, and operator's call. The main data includes the band (or QRG in MHz, e.g., %s), mode, and time. After the time, you provide the first QSO, which is essentially the callsign."), "'7.145'") ?></p>
 <pre>
     20m ssb
-    2134 2m0sql
+    2134 4w7est
 </pre>
-<p><?= __("For example, a QSO that started at 21:34 (UTC) with 4W7EST on 20m SSB.") ?><p>
-<p><?= __("If you don't provide any RST information, the syntax will use 59 (599 for data). Our next QSO wasn't 59 on both sides, so we provide the information with the sent RST first. It was 2 minutes later than the first QSO.") ?></p>
+<p><?= __("For example, a QSO that started at 21:34 (UTC) with 4W7EST on 20m SSB.") ?></p>
+<p><?= __("If you don't provide any RST information, the syntax will use 59 for phone, 599 for CW and +0 dB for digital data modes. Our next QSO wasn't 59 on both sides, so we provide the information with the sent RST first. It was 2 minutes later than the first QSO.") ?></p>
 <pre>
     20m ssb
-    2134 2m0sql
+    2134 4w7est
     6 la8aja 47 46
 </pre>
 <p><?= __("The first QSO was at 21:34, and the second one 2 minutes later at 21:36. We write down 6 because this is the only data that changed here. The information about band and mode didn't change, so this data is omitted.") ?></p>
 <p><?= __("For our next QSO at 21:40 on 14th May, 2021, we changed the band to 40m but still on SSB. If no RST information is given, the syntax will use 59 for every new QSO. Therefore we can add another QSO which took place at the exact same time two days later. The date must be in format YYYY-MM-DD.") ?></p>
 <pre>
     20m ssb
-    2134 2m0sql
+    2134 4w7est
     6 la8aja 47 46
     date 2021-05-14
     40m 
@@ -32,11 +32,11 @@
 </pre>
 <p><?= __("Operator Name:") ?></p>
 <pre>
-  2112 dj3ce @Cedric
+    2112 dj3ce @Cedric
 </pre>
 <p><?= __("QSL-message (Caution! Not visible in wavelog currently!):") ?></p>
 <pre>
-  2112 dj3ce [tnx qso]
+    2112 dj3ce [tnx qso]
 </pre>
 <p><?= __("Contest exchange; serials or other exchange - or even both:") ?></p>
 <pre>
@@ -45,21 +45,25 @@
     2114 dj3ce ,12,LA.14.DL
     2114 dj3ce .14 ,12 .DL ,LA
 </pre>
-<p><?= __("Received exchange has to be prefixed with a dot '.', sent exchange with a comma ','. The last two lines are equivalent - i.e. spaces don't matter as the order doesn't as well. Exchange you have sent will automatically be included in the next QSO, if it contains received exchange, or if you use a single comma ','. To automatically increment the sent serial, use ',++' and give an initial sent exchange. To deactivate, use ',+0':") ?></p>
+<p><?= sprintf(__("Received exchange has to be prefixed with a dot %s, sent exchange with a comma %s. The last two lines are equivalent - i.e. spaces don't matter as the order doesn't as well. Each of the four lines above simply illustrates one type of exchange (serial only, text only, or both); note that the sent exchange is 'sticky': once set, it is automatically carried into the following QSOs (whenever the next line contains a received exchange or a single comma %s) until you change or wipe it. To automatically increment the sent serial, add %s to a QSO line together with an initial sent exchange (it does not work on its own line). To deactivate, use %s:"), "'.'", "','", "','", "',++'", "',+0'") ?></p>
 <pre>
-    ,++
-    2112 dj3ce ,1.12
+    2112 dj3ce ,++,1.12
     2113 dk0mm .105
 </pre>
-<p><?= __("Here, the first qso uses the set serial 1, and the second will use 2 as the serial. If you want to wipe your sent exchange, use ',-':") ?></p>
+<p><?= sprintf(__("Here, the first qso uses the set serial 1, and the second will use 2 as the serial. If you want to wipe your sent exchange, use %s:"), "',-'") ?></p>
 <pre>
     2115 dj3ce ,15,D23.1.F39
     2116 dk0mm ,-,16.1015
 </pre>
-<p><?= __("First, all previous exchange is wiped, then only a serial is set. Otherwise the previous exchange 'D23' would have been set also.") ?></p>
+<p><?= sprintf(__("First, all previous exchange is wiped, then only a serial is set. Otherwise the previous exchange %s would have been set also."), "'D23'") ?></p>
 <p><?= __("You may use the comment syntax, to fill adif-fields supported by the Wavelog-Import:") ?></p>
 <pre>
     2119 dj3ce &lt;tx_pwr:50&gt; &lt;rx_pwr:750&gt; &lt;darc_dok:F39&gt; &lt;sfi:210&gt; &lt;rig:QCX&gt; &lt;...&gt;
 </pre>
+<p><?= sprintf(__("If you log in local time instead of UTC, declare your offset once with %s (or the short form %s) followed by the signed hour offset. All following QSO times are then converted to UTC until you change the offset again:"), "'TIMEZONE'", "'TZOFS'") ?></p>
+<pre>
+    TIMEZONE +2
+    1400 dj3ce
+</pre>
+<p><?= __("Here, the QSO logged at 14:00 local time is stored as 12:00 UTC.") ?></p>
 <p><?= sprintf(__("A full summary of all commands and the necessary syntax can be found in %sthis article%s of our Wiki."), '<a href="https://docs.wavelog.org/user-guide/logbook/simple-fle/" target="_blank">', '</a>'); ?></p>
-

--- a/application/views/simplefle/syntax_help.php
+++ b/application/views/simplefle/syntax_help.php
@@ -1,69 +1,96 @@
+<style>
+.sfle-syntax pre {
+	background-color: rgba(127, 127, 127, .12);
+	border: 1px solid rgba(127, 127, 127, .30);
+	border-radius: .375rem;
+	padding: .5rem .75rem;
+}
+</style>
+<div class="sfle-syntax">
+<h5 class="mt-2 mb-2 border-bottom pb-1"><?= __("Getting started") ?></h5>
 <p><?= __("Before starting to log a QSO, please note the basic rules.") ?>:</p>
-<p><?= __("- Each new QSO should be on a new line.") ?></p>
-<p><?= __("- On each new line, only write data that has changed from the previous QSO.") ?></p>
+<ul class="mb-3">
+	<li><?= ltrim(__("- Each new QSO should be on a new line."), "- ") ?></li>
+	<li><?= ltrim(__("- On each new line, only write data that has changed from the previous QSO."), "- ") ?></li>
+</ul>
+
+<h5 class="mt-4 mb-2 border-bottom pb-1"><?= __("The first QSO") ?></h5>
 <p><?= sprintf(__("To begin, ensure you have already filled in the form on the left with the date, station call, and operator's call. The main data includes the band (or QRG in MHz, e.g., %s), mode, and time. After the time, you provide the first QSO, which is essentially the callsign."), "'7.145'") ?></p>
-<pre>
+<pre class="mb-3">
     20m ssb
     2134 4w7est
 </pre>
 <p><?= __("For example, a QSO that started at 21:34 (UTC) with 4W7EST on 20m SSB.") ?></p>
+
+<h5 class="mt-4 mb-2 border-bottom pb-1"><?= __("Signal reports (RST)") ?></h5>
 <p><?= __("If you don't provide any RST information, the syntax will use 59 for phone, 599 for CW and +0 dB for digital data modes. Our next QSO wasn't 59 on both sides, so we provide the information with the sent RST first. It was 2 minutes later than the first QSO.") ?></p>
-<pre>
+<pre class="mb-3">
     20m ssb
     2134 4w7est
     6 la8aja 47 46
 </pre>
 <p><?= __("The first QSO was at 21:34, and the second one 2 minutes later at 21:36. We write down 6 because this is the only data that changed here. The information about band and mode didn't change, so this data is omitted.") ?></p>
+
+<h5 class="mt-4 mb-2 border-bottom pb-1"><?= __("Date and time") ?></h5>
 <p><?= __("For our next QSO at 21:40 on 14th May, 2021, we changed the band to 40m but still on SSB. If no RST information is given, the syntax will use 59 for every new QSO. Therefore we can add another QSO which took place at the exact same time two days later. The date must be in format YYYY-MM-DD.") ?></p>
-<pre>
+<pre class="mb-3">
     20m ssb
     2134 4w7est
     6 la8aja 47 46
     date 2021-05-14
-    40m 
+    40m
     40 dj7nt
     day ++
     df3et
 </pre>
+
+<h5 class="mt-4 mb-2 border-bottom pb-1"><?= __("Additional information") ?></h5>
 <p><?= __("Additional informations can be submitted in the following way:") ?></p>
-<p><?= __("Notes:") ?></p>
-<pre>
+<p class="mb-1"><?= __("Notes:") ?></p>
+<pre class="mb-3">
     2112 dj3ce &lt; comment &gt;
 </pre>
-<p><?= __("Operator Name:") ?></p>
-<pre>
+<p class="mb-1"><?= __("Operator Name:") ?></p>
+<pre class="mb-3">
     2112 dj3ce @Cedric
 </pre>
-<p><?= __("QSL-message (Caution! Not visible in wavelog currently!):") ?></p>
-<pre>
+<p class="mb-1"><?= __("QSL-message (Caution! Not visible in wavelog currently!):") ?></p>
+<pre class="mb-3">
     2112 dj3ce [tnx qso]
 </pre>
+<p><?= __("You may use the comment syntax, to fill adif-fields supported by the Wavelog-Import:") ?></p>
+<pre class="mb-3">
+    2119 dj3ce &lt;tx_pwr:50&gt; &lt;rx_pwr:750&gt; &lt;darc_dok:F39&gt; &lt;sfi:210&gt; &lt;rig:QCX&gt; &lt;...&gt;
+</pre>
+
+<h5 class="mt-4 mb-2 border-bottom pb-1"><?= __("Contest exchange") ?></h5>
 <p><?= __("Contest exchange; serials or other exchange - or even both:") ?></p>
-<pre>
+<pre class="mb-3">
     2112 dj3ce ,1.12
     2113 dj3ce ,LA.DL
     2114 dj3ce ,12,LA.14.DL
     2114 dj3ce .14 ,12 .DL ,LA
 </pre>
 <p><?= sprintf(__("Received exchange has to be prefixed with a dot %s, sent exchange with a comma %s. The last two lines are equivalent - i.e. spaces don't matter as the order doesn't as well. Each of the four lines above simply illustrates one type of exchange (serial only, text only, or both); note that the sent exchange is 'sticky': once set, it is automatically carried into the following QSOs (whenever the next line contains a received exchange or a single comma %s) until you change or wipe it. To automatically increment the sent serial, add %s to a QSO line together with an initial sent exchange (it does not work on its own line). To deactivate, use %s:"), "'.'", "','", "','", "',++'", "',+0'") ?></p>
-<pre>
+<pre class="mb-3">
     2112 dj3ce ,++,1.12
     2113 dk0mm .105
 </pre>
 <p><?= sprintf(__("Here, the first qso uses the set serial 1, and the second will use 2 as the serial. If you want to wipe your sent exchange, use %s:"), "',-'") ?></p>
-<pre>
+<pre class="mb-3">
     2115 dj3ce ,15,D23.1.F39
     2116 dk0mm ,-,16.1015
 </pre>
 <p><?= sprintf(__("First, all previous exchange is wiped, then only a serial is set. Otherwise the previous exchange %s would have been set also."), "'D23'") ?></p>
-<p><?= __("You may use the comment syntax, to fill adif-fields supported by the Wavelog-Import:") ?></p>
-<pre>
-    2119 dj3ce &lt;tx_pwr:50&gt; &lt;rx_pwr:750&gt; &lt;darc_dok:F39&gt; &lt;sfi:210&gt; &lt;rig:QCX&gt; &lt;...&gt;
-</pre>
+
+<h5 class="mt-4 mb-2 border-bottom pb-1"><?= __("Time zone") ?></h5>
 <p><?= sprintf(__("If you log in local time instead of UTC, declare your offset once with %s (or the short form %s) followed by the signed hour offset. All following QSO times are then converted to UTC until you change the offset again:"), "'TIMEZONE'", "'TZOFS'") ?></p>
-<pre>
+<pre class="mb-3">
     TIMEZONE +2
     1400 dj3ce
 </pre>
 <p><?= __("Here, the QSO logged at 14:00 local time is stored as 12:00 UTC.") ?></p>
+
+<hr class="my-3">
 <p><?= sprintf(__("A full summary of all commands and the necessary syntax can be found in %sthis article%s of our Wiki."), '<a href="https://docs.wavelog.org/user-guide/logbook/simple-fle/" target="_blank">', '</a>'); ?></p>
+</div>


### PR DESCRIPTION
Syntax Help in SimpleFLE was outdated. Fixed the mistakes to reflect the real behaviour of sfle and also improved readability by adding header and sorted stuff a bit. 

Before:
<img width="1304" height="1061" alt="grafik" src="https://github.com/user-attachments/assets/db431e7e-8bb3-46c7-a959-bda15f608aad" />

After:
<img width="1305" height="1037" alt="grafik" src="https://github.com/user-attachments/assets/1359d976-b702-4fb3-9b83-c417ac1ea058" />
