### PR TITLE
[GeoJSON Map]  Updated page looks

### DIFF
--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -30,12 +30,12 @@ class Map extends CI_Controller {
 		$this->load->model('Map_model');
 		$this->load->model('stations');
 
-		// Get supported DXCC countries with state data
+		// Get supported DXCC countries (those with GeoJSON boundary data)
 		$data['supported_dxccs'] = $this->geojson->getSupportedDxccs();
 
 		$supported_country_codes = array_keys($data['supported_dxccs']);
 
-		// Fetch available countries from the logbook
+		// List all GeoJSON-supported DXCC countries, independent of the logbook
 		$data['countries'] = $this->Map_model->get_available_countries($supported_country_codes);
 
 		// Fetch station profiles
@@ -82,14 +82,6 @@ class Map extends CI_Controller {
 
 		try {
 			$qsos = $this->Map_model->get_qsos_by_country($country, $station_id);
-
-			if (empty($qsos)) {
-				while (ob_get_level()) ob_end_clean();
-				$this->output
-					->set_content_type('application/json')
-					->set_output(json_encode(['error' => 'No QSOs found with 6+ character gridsquares']));
-				return;
-			}
 		} catch (Exception $e) {
 			while (ob_get_level()) ob_end_clean();
 			$this->output
@@ -159,10 +151,16 @@ class Map extends CI_Controller {
 			ob_end_clean();
 		}
 
+		// Gridsquares that belong to the selected DXCC, used to restrict the
+		// maidenhead grid to that DXCC (same source as the gridmap).
+		$this->load->model('gridmap_model');
+		$grid_dxcc = $this->input->post('dxcc', true);
+		$grids = $grid_dxcc ? $this->gridmap_model->get_grids_for_country($grid_dxcc) : [];
+
 		// Set proper content type header
 		$this->output
 			->set_content_type('application/json')
-			->set_output(json_encode($qsos));
+			->set_output(json_encode(['qsos' => $qsos, 'grids' => $grids]));
 		}
 
 	/**

--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -44,6 +44,9 @@ class Map extends CI_Controller {
 		// Active station location, to pre-select in the location dropdown
 		$data['active_station_id'] = $this->stations->find_active();
 
+		// User's custom map colors (worked / confirmed) for the region choropleth
+		$data['user_map_custom'] = $this->optionslib->get_map_custom();
+
 		$data['homegrid'] = explode(',', $this->stations->find_gridsquare());
 
 		$data['page_title'] = __("QSO Map");

--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -44,6 +44,10 @@ class Map extends CI_Controller {
 		// Active station location, to pre-select in the location dropdown
 		$data['active_station_id'] = $this->stations->find_active();
 
+		// Worked bands for the band filter
+		$this->load->model('bands');
+		$data['bands'] = $this->bands->get_worked_bands();
+
 		// User's custom map colors (worked / confirmed) for the region choropleth
 		$data['user_map_custom'] = $this->optionslib->get_map_custom();
 
@@ -74,6 +78,7 @@ class Map extends CI_Controller {
 		$country = $this->input->post('country', true);
 		$dxcc = $this->input->post('dxcc', true);
 		$station_id = $this->input->post('station_id', true);
+		$band = $this->input->post('band', true);
 
 		if (empty($country)) {
 			while (ob_get_level()) ob_end_clean();
@@ -87,7 +92,7 @@ class Map extends CI_Controller {
 		$station_id = ($station_id === 'all') ? null : $station_id;
 
 		try {
-			$qsos = $this->Map_model->get_qsos_by_country($country, $station_id);
+			$qsos = $this->Map_model->get_qsos_by_country($country, $station_id, $band);
 		} catch (Exception $e) {
 			while (ob_get_level()) ob_end_clean();
 			$this->output

--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -41,6 +41,9 @@ class Map extends CI_Controller {
 		// Fetch station profiles
 		$data['station_profiles'] = $this->stations->all_of_user()->result();
 
+		// Active station location, to pre-select in the location dropdown
+		$data['active_station_id'] = $this->stations->find_active();
+
 		$data['homegrid'] = explode(',', $this->stations->find_gridsquare());
 
 		$data['page_title'] = __("QSO Map");

--- a/application/models/Map_model.php
+++ b/application/models/Map_model.php
@@ -19,7 +19,7 @@ class Map_model extends CI_Model {
     /**
      * Get QSOs for a specific country with 6+ character grids
      */
-    public function get_qsos_by_country($country, $station_id = null) {
+    public function get_qsos_by_country($country, $station_id = null, $band = null) {
 		if (!$this->load->is_loaded('Qra')) {
 			$this->load->library('Qra');
 		}
@@ -27,7 +27,7 @@ class Map_model extends CI_Model {
 			$this->load->library('DxccFlag');
 		}
 
-		$sql = "select COL_PRIMARY_KEY, COL_CALL, COL_GRIDSQUARE, COL_COUNTRY, COL_DXCC, COL_MODE, COL_BAND, COL_TIME_ON, COL_RST_SENT, COL_RST_RCVD, COL_QSL_RCVD, COL_LOTW_QSL_RCVD, COL_EQSL_QSL_RCVD, COL_QRZCOM_QSO_DOWNLOAD_STATUS, COL_CLUBLOG_QSO_DOWNLOAD_STATUS, station_profile.station_profile_name
+		$sql = "select COL_PRIMARY_KEY, COL_CALL, COL_GRIDSQUARE, COL_COUNTRY, COL_DXCC, COL_MODE, COL_BAND, COL_PROP_MODE, COL_SAT_NAME, COL_SAT_MODE, COL_TIME_ON, COL_RST_SENT, COL_RST_RCVD, COL_QSL_RCVD, COL_LOTW_QSL_RCVD, COL_EQSL_QSL_RCVD, COL_QRZCOM_QSO_DOWNLOAD_STATUS, COL_CLUBLOG_QSO_DOWNLOAD_STATUS, station_profile.station_profile_name
 		from " . $this->config->item('table_name') . "
 		join station_profile ON station_profile.station_id = " . $this->config->item('table_name') . ".station_id
 		where station_profile.user_id = ?
@@ -40,6 +40,15 @@ class Map_model extends CI_Model {
 		if ($station_id !== null && $station_id !== '') {
 			$sql .=	" and station_profile.station_id = ?";
 			$bindings[] = $station_id;
+		}
+
+		// Add band filter if specified
+		if ($band == 'SAT') {
+			$sql .= " and COL_PROP_MODE = ?";
+			$bindings[] = $band;
+		} elseif ($band !== null && $band !== '' && $band !== 'all') {
+			$sql .= " and COL_BAND = ?";
+			$bindings[] = $band;
 		}
 
 		$sql .= "and LENGTH(COL_GRIDSQUARE) >= 6
@@ -115,7 +124,7 @@ class Map_model extends CI_Model {
 
 		// Band/Satellite
 		$table .= '<tr>';
-		if (!empty($qso['COL_SAT_NAME'])) {
+		if (($qso['COL_PROP_MODE'] ?? '') === 'SAT') {
 			$table .= '<td>Band</td>';
 			$table .= '<td>SAT ' . htmlspecialchars($qso['COL_SAT_NAME']);
 			if (!empty($qso['COL_SAT_MODE'])) {

--- a/application/models/Map_model.php
+++ b/application/models/Map_model.php
@@ -3,20 +3,16 @@
 class Map_model extends CI_Model {
 
     /**
-     * Get available countries from the logbook with QSOs
+     * Get all DXCC countries that have GeoJSON boundary data,
+     * independent of whether they appear in the logbook.
      */
     public function get_available_countries($supported_country_codes) {
-		$sql = "select DISTINCT dxcc_entities.name AS dxcc_name, dxcc_entities.prefix, COL_DXCC, COUNT(*) as qso_count
-		from " . $this->config->item('table_name') . " thcv
-		join station_profile ON station_profile.station_id = thcv.station_id
-		join dxcc_entities ON dxcc_entities.adif = thcv.COL_DXCC
-		where station_profile.user_id = ?
-		and thcv.COL_DXCC IN (" . implode(',', array_fill(0, count($supported_country_codes), '?')) . ")
-		and LENGTH(thcv.COL_GRIDSQUARE) >= 6
-		group by dxcc_name, thcv.COL_DXCC, dxcc_entities.prefix
+		$sql = "select DISTINCT dxcc_entities.name AS dxcc_name, dxcc_entities.prefix, dxcc_entities.adif AS COL_DXCC
+		from dxcc_entities
+		where dxcc_entities.adif IN (" . implode(',', array_fill(0, count($supported_country_codes), '?')) . ")
 		order by prefix ASC";
 
-        $query = $this->db->query($sql, array_merge([$this->session->userdata('user_id')], $supported_country_codes));
+        $query = $this->db->query($sql, $supported_country_codes);
         return $query->result_array();
     }
 

--- a/application/models/Map_model.php
+++ b/application/models/Map_model.php
@@ -59,6 +59,7 @@ class Map_model extends CI_Model {
 
         // Process QSOs and convert gridsquares to coordinates
         $result = [];
+        $custom_date_format = $this->session->userdata('user_date_format') ?: $this->config->item('qso_date_format');
         foreach ($qsos as $qso) {
             $gridsquare = strtoupper(trim($qso['COL_GRIDSQUARE']));
 
@@ -68,6 +69,7 @@ class Map_model extends CI_Model {
 
                 if ($coords !== false && is_array($coords) && count($coords) >= 2) {
                     $result[] = [
+                        'id' => $qso['COL_PRIMARY_KEY'],
                         'call' => $qso['COL_CALL'],
                         'gridsquare' => $gridsquare,
                         'country' => $qso['COL_COUNTRY'],
@@ -75,6 +77,10 @@ class Map_model extends CI_Model {
                         'mode' => $qso['COL_MODE'],
                         'band' => $qso['COL_BAND'],
                         'time_on' => $qso['COL_TIME_ON'],
+                        'time_formatted' => date($custom_date_format . ' H:i', strtotime($qso['COL_TIME_ON'])),
+                        'prop_mode' => $qso['COL_PROP_MODE'] ?? '',
+                        'sat_name' => $qso['COL_SAT_NAME'] ?? '',
+                        'sat_mode' => $qso['COL_SAT_MODE'] ?? '',
                         'rst_sent' => $qso['COL_RST_SENT'],
                         'rst_rcvd' => $qso['COL_RST_RCVD'],
                         'confirmed' => ($qso['COL_QSL_RCVD'] ?? '') === 'Y'

--- a/application/models/Map_model.php
+++ b/application/models/Map_model.php
@@ -115,10 +115,11 @@ class Map_model extends CI_Model {
 		$table .= '</td>';
 		$table .= '</tr>';
 
-		// Date/Time
+		// Date/Time (user's custom date format, falling back to the configured QSO date format)
 		$table .= '<tr>';
 		$table .= '<td>Date/Time</td>';
-		$datetime = date('Y-m-d H:i', strtotime($qso['COL_TIME_ON']));
+		$custom_date_format = $this->session->userdata('user_date_format') ?: $this->config->item('qso_date_format');
+		$datetime = date($custom_date_format . ' H:i', strtotime($qso['COL_TIME_ON']));
 		$table .= '<td>' . htmlspecialchars($datetime) . '</td>';
 		$table .= '</tr>';
 

--- a/application/models/Map_model.php
+++ b/application/models/Map_model.php
@@ -27,7 +27,7 @@ class Map_model extends CI_Model {
 			$this->load->library('DxccFlag');
 		}
 
-		$sql = "select COL_PRIMARY_KEY, COL_CALL, COL_GRIDSQUARE, COL_COUNTRY, COL_DXCC, COL_MODE, COL_BAND, COL_TIME_ON, COL_RST_SENT, COL_RST_RCVD, station_profile.station_profile_name
+		$sql = "select COL_PRIMARY_KEY, COL_CALL, COL_GRIDSQUARE, COL_COUNTRY, COL_DXCC, COL_MODE, COL_BAND, COL_TIME_ON, COL_RST_SENT, COL_RST_RCVD, COL_QSL_RCVD, COL_LOTW_QSL_RCVD, COL_EQSL_QSL_RCVD, COL_QRZCOM_QSO_DOWNLOAD_STATUS, COL_CLUBLOG_QSO_DOWNLOAD_STATUS, station_profile.station_profile_name
 		from " . $this->config->item('table_name') . "
 		join station_profile ON station_profile.station_id = " . $this->config->item('table_name') . ".station_id
 		where station_profile.user_id = ?
@@ -68,6 +68,11 @@ class Map_model extends CI_Model {
                         'time_on' => $qso['COL_TIME_ON'],
                         'rst_sent' => $qso['COL_RST_SENT'],
                         'rst_rcvd' => $qso['COL_RST_RCVD'],
+                        'confirmed' => ($qso['COL_QSL_RCVD'] ?? '') === 'Y'
+                            || ($qso['COL_LOTW_QSL_RCVD'] ?? '') === 'Y'
+                            || ($qso['COL_EQSL_QSL_RCVD'] ?? '') === 'Y'
+                            || ($qso['COL_QRZCOM_QSO_DOWNLOAD_STATUS'] ?? '') === 'Y'
+                            || ($qso['COL_CLUBLOG_QSO_DOWNLOAD_STATUS'] ?? '') === 'Y',
                         'lat' => $coords[0],
                         'lng' => $coords[1],
 						'profile' => $qso['station_profile_name'],

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -22,6 +22,11 @@
 	let lang_qso_map_region = '<?= __("Region"); ?>';
 	let lang_qso_map_hover_region = '<?= __("Hover over a region"); ?>';
 	let lang_qso_map_toggle_layers = '<?= __("Toggle layers"); ?>';
+	let lang_qso_map_region_confirmed = '<?= __("Confirmed"); ?>';
+	let lang_qso_map_region_worked = '<?= __("Worked"); ?>';
+	let lang_qso_map_region_not_worked = '<?= __("Not worked"); ?>';
+	let lang_qso_map_regions_label = '<?= __("Regions worked:"); ?>';
+	let user_map_custom = JSON.parse('<?php echo $user_map_custom; ?>');
 </script>
 
 <div class="container px-3 px-lg-4 mt-3 mb-3">
@@ -80,7 +85,7 @@
 			<div class="ms-3 mb-2">
 				<small class="text-muted">
 					<i class="fas fa-info-circle"></i>
-					<?= ('Map shows QSOs with 6+ character gridsquares.') ?>
+					<?= ('Map shows QSOs with 6+ character gridsquares. The confirmed / worked / unworked regions, are only based on QSOs with gridsquares.') ?>
 				</small>
 			</div>
 			<div id="mapgeojson"></div>

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -7,92 +7,109 @@
 	let lang_gen_hamradio_gridsquares = '<?= _pgettext("Map Options", "Gridsquares"); ?>';
 </script>
 
-<div class="container">
+<div class="container px-3 px-lg-4 mt-3 mb-3">
     <h2><?= ('GeoJSON QSO Map'); ?></h2>
 
-    <div class="row mb-3 align-items-end">
-        <div class="col-auto">
-            <label for="countrySelect" class="form-label"><?= __("Select Country:"); ?></label>
-            <select class="form-select" id="countrySelect" style="min-width: 200px;">
-                <option value=""><?= __("Choose a country...") ?></option>
-                <?php foreach ($countries as $country): ?>
-                    <option value="<?php echo htmlspecialchars(ucwords(strtolower(($country['dxcc_name'])), "- (/")); ?>"
-                            data-dxcc="<?php echo htmlspecialchars($country['COL_DXCC']); ?>">
-                        <?php echo htmlspecialchars($country['prefix']) . ' - ' . htmlspecialchars(ucwords(strtolower(($country['dxcc_name'])), "- (/") . ' (' . $country['qso_count'] . ' ' . __("QSOs") . ')'); ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
+    <div class="card">
+        <div class="card-header">
+            <?= ('Plot your QSOs on a map by country and station location'); ?>
         </div>
-        <div class="col-auto">
-            <label for="locationSelect" class="form-label">Location:</label>
-            <select class="form-select" id="locationSelect" style="min-width: 200px;">
-                <option value="all">All</option>
-                <?php foreach ($station_profiles as $profile): ?>
-                    <option value="<?php echo htmlspecialchars($profile->station_id); ?>">
-                        <?php echo htmlspecialchars($profile->station_profile_name); ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-        </div>
-        <div class="col-auto">
-            <button id="loadMapBtn" class="btn btn-primary" disabled>Load Map</button>
-        </div>
-        <div class="col-auto">
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="showOnlyOutside" disabled checked>
-                <label class="form-check-label" for="showOnlyOutside">
-                    <?= ('Show only QSOs outside boundaries') ?>
-                </label>
+        <div class="card-body">
+            <div class="row mb-3 align-items-end">
+                <div class="col-auto">
+                    <label for="countrySelect" class="form-label"><?= __("Select Country:"); ?></label>
+                    <select class="form-select" id="countrySelect" style="min-width: 200px;">
+                        <option value=""><?= __("Choose a country...") ?></option>
+                        <?php foreach ($countries as $country): ?>
+                            <option value="<?php echo htmlspecialchars(ucwords(strtolower(($country['dxcc_name'])), "- (/")); ?>"
+                                    data-dxcc="<?php echo htmlspecialchars($country['COL_DXCC']); ?>">
+                                <?php echo htmlspecialchars($country['prefix']) . ' - ' . htmlspecialchars(ucwords(strtolower(($country['dxcc_name'])), "- (/")); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <label for="locationSelect" class="form-label">Location:</label>
+                    <select class="form-select" id="locationSelect" style="min-width: 200px;">
+                        <option value="all">All</option>
+                        <?php foreach ($station_profiles as $profile): ?>
+                            <option value="<?php echo htmlspecialchars($profile->station_id); ?>">
+                                <?php echo htmlspecialchars($profile->station_profile_name); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <button id="loadMapBtn" class="btn btn-primary" disabled>Load Map</button>
+                </div>
+                <div class="col-auto">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="showOnlyOutside" disabled checked>
+                        <label class="form-check-label" for="showOnlyOutside">
+                            <?= ('Show only QSOs outside boundaries') ?>
+                        </label>
+                    </div>
+                </div>
+                <div class="col-auto d-flex align-items-center">
+                    <div id="loadingSpinner" class="spinner-border text-primary d-none" role="status">
+                        <span class="visually-hidden"><?= ('Loading...') ?></span>
+                    </div>
+                    <div id="loadingText" class="ms-2 text-muted d-none"></div>
+                </div>
+            </div>
+
+            <div id="mapContainer" class="mt-3" style="display: none;">
+				<div class="mb-2">
+					<small class="text-muted">
+						<i class="fas fa-info-circle"></i>
+						<?= ('Map shows QSOs with 6+ character gridsquares.') ?>
+					</small>
+				</div>
+                <div id="mapgeojson" style="border: 1px solid #ccc;"></div>
+				<div class="coordinates mt-2" style="position: static;">
+					<div class="cohidden coord-pair"><span><?= __("Latitude") ?>:&nbsp;</span><span class="text-success fw-bold" id="latDeg"></span></div>
+					<div class="cohidden coord-pair"><span><?= __("Longitude") ?>:&nbsp;</span><span class="text-success fw-bold" id="lngDeg"></span></div>
+					<div class="cohidden coord-pair"><span><?= __("Gridsquare") ?>:&nbsp;</span><span class="text-success fw-bold" id="locator"></span></div>
+					<div class="cohidden coord-pair"><span><?= __("Distance") ?>:&nbsp;</span><span class="text-success fw-bold" id="distance"></span></div>
+					<div class="cohidden coord-pair"><span><?= __("Bearing") ?>:&nbsp;</span><span class="text-success fw-bold" id="bearing"></span></div>
+					<div class="cohidden coord-pair"><span><?= __("CQ Zone") ?>:&nbsp;</span><span class="text-success fw-bold" id="cqzonedisplay"></span></div>
+					<div class="cohidden coord-pair"><span><?= __("ITU Zone") ?>:&nbsp;</span><span class="text-success fw-bold" id="ituzonedisplay"></span></div>
+				</div>
             </div>
         </div>
-        <div class="col-auto d-flex align-items-center">
-            <div id="loadingSpinner" class="spinner-border text-primary d-none" role="status">
-                <span class="visually-hidden"><?= ('Loading...') ?></span>
-            </div>
-            <div id="loadingText" class="ms-2 text-muted d-none"></div>
-        </div>
-    </div>
-
-    <div id="mapContainer" class="mt-3" style="display: none;">
-        <div id="mapgeojson" style="border: 1px solid #ccc;"></div>
-		<div class="coordinates d-flex">
-			<div class="cohidden"><?= __("Latitude") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="latDeg"></div>
-			<div class="cohidden"><?= __("Longitude") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="lngDeg"></div>
-			<div class="cohidden"><?= __("Gridsquare") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="locator"></div>
-			<div class="cohidden"><?= __("Distance") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="distance"></div>
-			<div class="cohidden"><?= __("Bearing") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="bearing"></div>
-			<div class="cohidden"><?= __("CQ Zone") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="cqzonedisplay"></div>
-			<div class="cohidden"><?= __("ITU Zone") ?>:&nbsp;</div>
-			<div class="cohidden col-auto text-success fw-bold" id="ituzonedisplay"></div>
-		</div>
-		<div class="mt-2">
-			<small class="text-muted">
-				<i class="fas fa-info-circle"></i>
-				<?= ('Map shows QSOs with 6+ character gridsquares.') ?>
-			</small>
-		</div>
-    </div>
-
-
-
-    <div id="noDataMessage" class="alert alert-warning mt-3" style="display: none;">
-        <i class="fas fa-exclamation-triangle"></i>
-        <?= ('No QSOs with 6+ character grids found for the selected country.') ?>
     </div>
 </div>
 
 <style>
 #mapgeojson {
     border-radius: 4px;
-    height: calc(100vh - 250px);
+    height: calc(100vh - 340px);
     width: 100% !important;
     min-height: 400px;
+}
+/* Geo information bar: a responsive grid that wraps cleanly on narrow
+   screens, with reserved value widths so updating values on mousemove
+   can't shift the layout. Grid (not flex-wrap) keeps columns uniform so
+   wrapped rows stay aligned instead of going ragged. */
+#mapContainer .coordinates {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(11rem, max-content));
+    column-gap: 1.25rem;
+    row-gap: 0.3rem;
+}
+#mapContainer .coord-pair {
+    display: flex;
+    align-items: baseline;
+    white-space: nowrap;
+}
+/* Value cells reserve a fixed width so they can't resize when updated
+   on mousemove. #latDeg/#lngDeg are longer (DMS format). */
+#mapContainer .coord-pair > [id] {
+    min-width: 6rem;
+}
+#mapContainer .coord-pair > #latDeg,
+#mapContainer .coord-pair > #lngDeg {
+    min-width: 10rem;
 }
 .leaflet-popup-content {
     min-width: 200px;

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -26,6 +26,12 @@
 	let lang_qso_map_region_worked = '<?= __("Worked"); ?>';
 	let lang_qso_map_region_not_worked = '<?= __("Not worked"); ?>';
 	let lang_qso_map_regions_label = '<?= __("Regions worked:"); ?>';
+	let lang_qso_map_show_list = '<?= __("Show QSO list"); ?>';
+	let lang_qso_map_th_call = '<?= __("Callsign"); ?>';
+	let lang_qso_map_th_date = '<?= __("Date/Time"); ?>';
+	let lang_qso_map_th_band = '<?= __("Band"); ?>';
+	let lang_qso_map_th_mode = '<?= __("Mode"); ?>';
+	let lang_qso_map_th_grid = '<?= __("Gridsquare"); ?>';
 	let user_map_custom = JSON.parse('<?php echo $user_map_custom; ?>');
 </script>
 
@@ -184,7 +190,27 @@
     margin: 8px 0;
 }
 .legend-icon {
+    display: flex;
+    align-items: center;
     margin-right: 10px;
     flex-shrink: 0;
+}
+.legend-label {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+    flex: 1 1 auto;
+}
+.legend-action {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    margin-left: 8px;
+	margin-top: 8px;
+    cursor: pointer;
+}
+#legend-region-count {
+	margin-top: 8px;
+	bottom: 0px !important;
 }
 </style>

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -63,6 +63,15 @@
                     </select>
                 </div>
                 <div class="col-auto">
+                    <label for="bandSelect" class="form-label"><?= __("Band:"); ?></label>
+                    <select class="form-select" id="bandSelect" style="min-width: 120px;">
+                        <option value="all"><?= __("All") ?></option>
+                        <?php foreach ($bands as $band): ?>
+                            <option value="<?php echo htmlspecialchars($band); ?>"><?php echo htmlspecialchars(strtoupper($band)); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-auto">
                     <button id="loadMapBtn" class="btn btn-primary" disabled><?= __("Load Map") ?></button>
                 </div>
                 <div class="col-auto">

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -12,7 +12,7 @@
 
     <div class="card">
         <div class="card-header">
-            <?= ('Plot your QSOs on a map by country and station location'); ?>
+            <?= ('Plot your QSOs with a 6-character gridsquare on a map to see region'); ?>
         </div>
         <div class="card-body">
             <div class="row align-items-end">
@@ -29,7 +29,7 @@
                     </select>
                 </div>
                 <div class="col-auto">
-                    <label for="locationSelect" class="form-label">Location:</label>
+                    <label for="locationSelect" class="form-label"><?= __("Location:"); ?></label>
                     <select class="form-select" id="locationSelect" style="min-width: 200px;">
                         <option value="all">All</option>
                         <?php foreach ($station_profiles as $profile): ?>
@@ -41,7 +41,7 @@
                     </select>
                 </div>
                 <div class="col-auto">
-                    <button id="loadMapBtn" class="btn btn-primary" disabled>Load Map</button>
+                    <button id="loadMapBtn" class="btn btn-primary" disabled><?= __("Load Map") ?></button>
                 </div>
                 <div class="col-auto">
                     <div class="form-check">

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -15,7 +15,7 @@
             <?= ('Plot your QSOs on a map by country and station location'); ?>
         </div>
         <div class="card-body">
-            <div class="row mb-3 align-items-end">
+            <div class="row align-items-end">
                 <div class="col-auto">
                     <label for="countrySelect" class="form-label"><?= __("Select Country:"); ?></label>
                     <select class="form-select" id="countrySelect" style="min-width: 200px;">
@@ -58,16 +58,17 @@
                     <div id="loadingText" class="ms-2 text-muted d-none"></div>
                 </div>
             </div>
-
-            <div id="mapContainer" class="mt-3" style="display: none;">
-				<div class="mb-2">
-					<small class="text-muted">
-						<i class="fas fa-info-circle"></i>
-						<?= ('Map shows QSOs with 6+ character gridsquares.') ?>
-					</small>
-				</div>
-                <div id="mapgeojson" style="border: 1px solid #ccc;"></div>
-				<div class="coordinates mt-2" style="position: static;">
+		</div>
+		<div id="mapContainer" style="display: none;">
+			<div class="ms-3 mb-2">
+				<small class="text-muted">
+					<i class="fas fa-info-circle"></i>
+					<?= ('Map shows QSOs with 6+ character gridsquares.') ?>
+				</small>
+			</div>
+			<div id="mapgeojson"></div>
+			<div class="card-body">
+				<div class="coordinates" style="position: static;">
 					<div class="cohidden coord-pair"><span><?= __("Latitude") ?>:&nbsp;</span><span class="text-success fw-bold" id="latDeg"></span></div>
 					<div class="cohidden coord-pair"><span><?= __("Longitude") ?>:&nbsp;</span><span class="text-success fw-bold" id="lngDeg"></span></div>
 					<div class="cohidden coord-pair"><span><?= __("Gridsquare") ?>:&nbsp;</span><span class="text-success fw-bold" id="locator"></span></div>
@@ -76,15 +77,14 @@
 					<div class="cohidden coord-pair"><span><?= __("CQ Zone") ?>:&nbsp;</span><span class="text-success fw-bold" id="cqzonedisplay"></span></div>
 					<div class="cohidden coord-pair"><span><?= __("ITU Zone") ?>:&nbsp;</span><span class="text-success fw-bold" id="ituzonedisplay"></span></div>
 				</div>
-            </div>
+			</div>
         </div>
     </div>
 </div>
 
 <style>
 #mapgeojson {
-    border-radius: 4px;
-    height: calc(100vh - 340px);
+    height: calc(100vh - 350px);
     width: 100% !important;
     min-height: 400px;
 }

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -33,7 +33,8 @@
                     <select class="form-select" id="locationSelect" style="min-width: 200px;">
                         <option value="all">All</option>
                         <?php foreach ($station_profiles as $profile): ?>
-                            <option value="<?php echo htmlspecialchars($profile->station_id); ?>">
+                            <option value="<?php echo htmlspecialchars($profile->station_id); ?>"
+                                <?php echo ($profile->station_id == $active_station_id) ? 'selected' : ''; ?>>
                                 <?php echo htmlspecialchars($profile->station_profile_name); ?>
                             </option>
                         <?php endforeach; ?>

--- a/application/views/map/qso_map.php
+++ b/application/views/map/qso_map.php
@@ -5,6 +5,23 @@
 	let lang_gen_hamradio_cq_zones = '<?= _pgettext("Map Options", "CQ Zones"); ?>';
     let lang_gen_hamradio_itu_zones = '<?= _pgettext("Map Options", "ITU Zones"); ?>';
 	let lang_gen_hamradio_gridsquares = '<?= _pgettext("Map Options", "Gridsquares"); ?>';
+	let lang_qso_map_loading = '<?= __("Loading QSO data..."); ?>';
+	let lang_qso_map_loading_all = '<?= __("Loading QSOs for all countries (this may take a moment)..."); ?>';
+	let lang_qso_map_still_loading = '<?= __("Still loading... Processing large dataset, please wait..."); ?>';
+	let lang_qso_map_load_failed = '<?= __("Failed to load QSO data. Please try again."); ?>';
+	let lang_qso_map_error = '<?= __("Error:"); ?>';
+	let lang_qso_map_error_parsing = '<?= __("Error parsing response:"); ?>';
+	let lang_qso_map_outside_boundaries = '<?= __("Outside country boundaries"); ?>';
+	let lang_qso_map_inside_boundaries = '<?= __("Inside country boundaries"); ?>';
+	let lang_qso_map_legend = '<?= __("Legend"); ?>';
+	let lang_qso_map_inside_label = '<?= __("Inside boundaries"); ?>';
+	let lang_qso_map_outside_label = '<?= __("Outside boundaries"); ?>';
+	let lang_qso_map_boundaries = '<?= __("Country/State boundaries"); ?>';
+	let lang_qso_map_showing = '<?= __("Showing %s of %s total QSOs"); ?>';
+	let lang_qso_map_total_qsos = '<?= __("Total: %s QSOs with 6+ char grids"); ?>';
+	let lang_qso_map_region = '<?= __("Region"); ?>';
+	let lang_qso_map_hover_region = '<?= __("Hover over a region"); ?>';
+	let lang_qso_map_toggle_layers = '<?= __("Toggle layers"); ?>';
 </script>
 
 <div class="container px-3 px-lg-4 mt-3 mb-3">
@@ -12,7 +29,7 @@
 
     <div class="card">
         <div class="card-header">
-            <?= ('Plot your QSOs with a 6-character gridsquare on a map to see region'); ?>
+            <?= ('Map your QSOs for a country against its region boundaries — and see which contacts fall outside them.'); ?>
         </div>
         <div class="card-body">
             <div class="row align-items-end">

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -163,7 +163,8 @@ function initMap() {
                 .bindPopup(qso.popup +
                     (qso.inside_geojson === false ? '<br><span style="color: red;"><strong>⚠ Outside country boundaries</strong></span>' :
                     '<br><span style="color: green;"><strong>✓ Inside country boundaries</strong></span>'))
-                .addTo(map);
+                .addTo(map)
+                .on('mouseover', function () { this.openPopup(); });
 
             markers.push(marker);
             bounds.push([qso.lat, qso.lng]);

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -5,6 +5,34 @@ let map = null;
 let info;
 let geojsonlayer;
 
+// Region choropleth colours, taken from the user's map options (worked /
+// confirmed) with sensible fallbacks. Each subdivision is filled by status.
+function qsoMapHexToRgba(hex, alpha) {
+	if (!hex) return null;
+	hex = hex.replace(/^#/, '');
+	if (hex.length === 3) {
+		hex = hex.split('').map(function (c) { return c + c; }).join('');
+	}
+	const num = parseInt(hex, 16);
+	return 'rgba(' + ((num >> 16) & 255) + ', ' + ((num >> 8) & 255) + ', ' + (num & 255) + ', ' + alpha + ')';
+}
+let qsoMapWorkedColor = 'rgba(229, 165, 10, 0.55)';
+let qsoMapConfirmedColor = 'rgba(144, 238, 144, 0.55)';
+let qsoMapUnworkedColor = 'rgba(204, 55, 45, 0.3)'; // #CC372D fallback
+if (typeof user_map_custom !== 'undefined') {
+	if (user_map_custom.qso && user_map_custom.qso.color) {
+		qsoMapWorkedColor = qsoMapHexToRgba(user_map_custom.qso.color, 0.55);
+	}
+	if (user_map_custom.qsoconfirm && user_map_custom.qsoconfirm.color) {
+		qsoMapConfirmedColor = qsoMapHexToRgba(user_map_custom.qsoconfirm.color, 0.55);
+	}
+	if (user_map_custom.unworked && user_map_custom.unworked.color) {
+		qsoMapUnworkedColor = qsoMapHexToRgba(user_map_custom.unworked.color, 0.3);
+	}
+}
+const qsoMapIsDark = (typeof isDarkModeTheme === 'function') ? isDarkModeTheme() : false;
+const qsoMapLineColor = qsoMapIsDark ? 'rgba(255,255,255,0.45)' : 'rgba(0,0,0,0.55)';
+
 // Wait for jQuery to be loaded
 function initMap() {
     let markers = [];
@@ -170,6 +198,36 @@ function initMap() {
             bounds.push([qso.lat, qso.lng]);
         });
 
+        // Build per-region worked/confirmed status from the QSO data, to drive
+        // the choropleth fill colour of each subdivision.
+        const regionStatus = {};
+        qsos.forEach(function(qso) {
+            if (qso.state_info) {
+                const key = qso.state_info.code || qso.state_info.name;
+                if (key !== undefined && key !== null && key !== '') {
+                    if (!regionStatus[key]) regionStatus[key] = { worked: false, confirmed: false };
+                    regionStatus[key].worked = true;
+                    if (qso.confirmed) regionStatus[key].confirmed = true;
+                }
+            }
+        });
+
+        function regionStyle(feature) {
+            const key = feature.properties && (feature.properties.code || feature.properties.name);
+            const status = regionStatus[key];
+            let fillColor = qsoMapUnworkedColor;
+            if (status) {
+                fillColor = status.confirmed ? qsoMapConfirmedColor : qsoMapWorkedColor;
+            }
+            return {
+                fillColor: fillColor,
+                color: qsoMapLineColor,
+                weight: 1,
+                fillOpacity: 0.6,
+                opacity: 0.8
+            };
+        }
+
         // Try to load GeoJSON for the country/countries
         if (dxcc && supportedDxccs.includes(parseInt(dxcc))) {
             // Single country GeoJSON
@@ -180,15 +238,14 @@ function initMap() {
                 success: function(geojson) {
                     if (geojson && !geojson.error) {
                         geojsonlayer = L.geoJSON(geojson, {
-                            style: {
-                                color: '#ff0000',
-                                weight: 2,
-                                opacity: 0.5,
-                                fillOpacity: 0.2
-                            },
+                            style: regionStyle,
 							onEachFeature: onEachFeature
                         }).addTo(map);
                         geojsonLayers.push(geojsonlayer);
+
+                        // Fill in the "Regions worked: X / Y" readout in the legend
+                        const totalRegions = (geojson.features || []).length;
+                        $('#legend-region-count').text(Object.keys(regionStatus).length + ' / ' + totalRegions);
 
 
 
@@ -318,13 +375,20 @@ function initMap() {
             html += '<span>' + lang_qso_map_outside_label + ' <strong>(' + outsideCount + ')</strong></span>';
             html += '</div>';
 
-            // GeoJSON boundaries
+            // Region choropleth: confirmed / worked / not worked
             html += '<div class="legend-item">';
-            html += '<div class="legend-icon">';
-            html += '<svg width="20" height="3"><line x1="0" y1="1.5" x2="20" y2="1.5" stroke="#ff0000" stroke-width="2"/></svg>';
+            html += '<div class="legend-icon"><div style="background-color: ' + qsoMapConfirmedColor + '; width: 20px; height: 12px; border: 1px solid ' + qsoMapLineColor + '; border-radius: 2px;"></div></div>';
+            html += '<span>' + lang_qso_map_region_confirmed + '</span>';
             html += '</div>';
-            html += '<span>' + lang_qso_map_boundaries + '</span>';
+            html += '<div class="legend-item">';
+            html += '<div class="legend-icon"><div style="background-color: ' + qsoMapWorkedColor + '; width: 20px; height: 12px; border: 1px solid ' + qsoMapLineColor + '; border-radius: 2px;"></div></div>';
+            html += '<span>' + lang_qso_map_region_worked + '</span>';
             html += '</div>';
+            html += '<div class="legend-item">';
+            html += '<div class="legend-icon"><div style="background-color: ' + qsoMapUnworkedColor + '; width: 20px; height: 12px; border: 1px solid ' + qsoMapLineColor + '; border-radius: 2px;"></div></div>';
+            html += '<span>' + lang_qso_map_region_not_worked + '</span>';
+            html += '</div>';
+            html += '<div style="font-size: 12px; margin: 4px 0 8px 0;"><em>' + lang_qso_map_regions_label + ' <span id="legend-region-count">-</span></em></div>';
 
             // Total QSOs (shown differently when filtering)
             if (showOnlyOutside) {

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -165,6 +165,11 @@ function initMap() {
         let outsideCount = 0;
         let insideCount = 0;
 
+        // Count inside/outside across ALL QSOs so the legend matches the QSO lists
+        qsos.forEach(function(qso) {
+            if (qso.inside_geojson === false) { outsideCount++; } else { insideCount++; }
+        });
+
         filteredQsos.forEach(function(qso) {
             let marker;
             let icon;
@@ -177,7 +182,6 @@ function initMap() {
                     iconSize: [24, 24],
                     className: 'custom-div-icon'
                 });
-                outsideCount++;
             } else {
                 // Create green checkmark icon for QSOs inside GeoJSON
                 icon = L.divIcon({
@@ -185,7 +189,6 @@ function initMap() {
                     iconSize: [24, 24],
                     className: 'custom-div-icon'
                 });
-                insideCount++;
             }
 
             marker = L.marker([qso.lat, qso.lng], { icon: icon })
@@ -352,6 +355,55 @@ function initMap() {
 		el.innerHTML = props ? ('<b>' + props.code + ' - ' + props.name + '</b>') : '<em>' + lang_qso_map_hover_region + '</em>';
 	}
 
+    // Escape text for safe insertion into HTML
+    function escQsoHtml(s) {
+        return $('<div>').text(s == null ? '' : String(s)).html();
+    }
+
+    // Show a modal listing the QSOs inside or outside the country boundaries
+    function showQsoBoundaryList(which) {
+        var list = allQsos.filter(function(q) {
+            return which === 'outside' ? (q.inside_geojson === false) : (q.inside_geojson !== false);
+        });
+        var title = (which === 'outside' ? lang_qso_map_outside_label : lang_qso_map_inside_label) + ' (' + list.length + ')';
+        var html = '<table class="table table-sm table-striped table-hover w-100 display">' +
+            '<thead><tr>' +
+            '<th>' + lang_qso_map_th_call + '</th>' +
+            '<th>' + lang_qso_map_th_date + '</th>' +
+            '<th>' + lang_qso_map_th_band + '</th>' +
+            '<th>' + lang_qso_map_th_mode + '</th>' +
+            '<th>' + lang_qso_map_th_grid + '</th>' +
+            '</tr></thead><tbody>';
+        list.forEach(function(q) {
+            var when = q.time_formatted || '';
+            var bandDisplay = (q.prop_mode === 'SAT')
+                ? ('SAT' + (q.sat_name ? ' ' + q.sat_name : '') + (q.sat_mode ? ' (' + q.sat_mode + ')' : ''))
+                : (q.band || '');
+            html += '<tr>' +
+                '<td><a href="javascript:displayQso(' + q.id + ')">' + escQsoHtml(q.call) + '</a></td>' +
+                '<td>' + escQsoHtml(when) + '</td>' +
+                '<td>' + escQsoHtml(bandDisplay) + '</td>' +
+                '<td>' + escQsoHtml(q.mode) + '</td>' +
+                '<td>' + escQsoHtml(q.gridsquare) + '</td>' +
+                '</tr>';
+        });
+        html += '</tbody></table>';
+
+        BootstrapDialog.show({
+            title: title,
+            size: BootstrapDialog.SIZE_WIDE,
+            nl2br: false,
+            message: html,
+            onshown: function(dialog) {
+                $('table.display', dialog.getModal()).DataTable({
+                    pageLength: 25,
+                    order: [],
+                    language: { url: getDataTablesLanguageUrl() }
+                });
+            }
+        });
+    }
+
     function addLegend(insideCount, outsideCount, totalCount, showOnlyOutside) {
         const legend = L.control({ position: 'topright' });
 
@@ -365,7 +417,8 @@ function initMap() {
             html += '<div class="legend-icon">';
             html += '<div style="background-color: #28a745; color: white; width: 20px; height: 20px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: bold; font-size: 12px; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">✓</div>';
             html += '</div>';
-            html += '<span>' + lang_qso_map_inside_label + ' <strong>(' + insideCount + ')</strong></span>';
+            html += lang_qso_map_inside_label + ' <strong>(' + insideCount + ')</strong>';
+            html += '<div class="legend-action qso-map-boundary-list" data-which="inside" title="' + lang_qso_map_show_list + '"><i class="fas fa-list"></i></div>';
             html += '</div>';
 
             // Outside boundaries
@@ -373,32 +426,33 @@ function initMap() {
             html += '<div class="legend-icon">';
             html += '<div style="background-color: #ff0000; color: white; width: 20px; height: 20px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: bold; font-size: 12px; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">✕</div>';
             html += '</div>';
-            html += '<span>' + lang_qso_map_outside_label + ' <strong>(' + outsideCount + ')</strong></span>';
+            html += lang_qso_map_outside_label + ' <strong>(' + outsideCount + ')</strong>';
+            html += '<div class="legend-action qso-map-boundary-list" data-which="outside" title="' + lang_qso_map_show_list + '"><i class="fas fa-list"></i></div>';
             html += '</div>';
 
             // Region choropleth: confirmed / worked / not worked
             html += '<div class="legend-item">';
             html += '<div class="legend-icon"><div style="background-color: ' + qsoMapConfirmedColor + '; width: 20px; height: 12px; border: 1px solid ' + qsoMapLineColor + '; border-radius: 2px;"></div></div>';
-            html += '<span>' + lang_qso_map_region_confirmed + '</span>';
+            html += '<div>' + lang_qso_map_region_confirmed + '</div>';
             html += '</div>';
             html += '<div class="legend-item">';
             html += '<div class="legend-icon"><div style="background-color: ' + qsoMapWorkedColor + '; width: 20px; height: 12px; border: 1px solid ' + qsoMapLineColor + '; border-radius: 2px;"></div></div>';
-            html += '<span>' + lang_qso_map_region_worked + '</span>';
+            html += '<div>' + lang_qso_map_region_worked + '</div>';
             html += '</div>';
             html += '<div class="legend-item">';
             html += '<div class="legend-icon"><div style="background-color: ' + qsoMapUnworkedColor + '; width: 20px; height: 12px; border: 1px solid ' + qsoMapLineColor + '; border-radius: 2px;"></div></div>';
-            html += '<span>' + lang_qso_map_region_not_worked + '</span>';
+            html += '<div>' + lang_qso_map_region_not_worked + '</div>';
             html += '</div>';
-            html += '<div style="font-size: 12px; margin: 4px 0 8px 0;"><em>' + lang_qso_map_regions_label + ' <span id="legend-region-count">-</span></em></div>';
+            html += '<div style="font-size: 12px;"><div>' + lang_qso_map_regions_label + ' <span id="legend-region-count">-</span></div></div>';
 
             // Total QSOs (shown differently when filtering)
             if (showOnlyOutside) {
                 html += '<div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #ddd; font-size: 12px;">';
-                html += '<em>' + lang_qso_map_showing.replace('%s', outsideCount).replace('%s', totalCount) + '</em>';
+                html += '<div>' + lang_qso_map_showing.replace('%s', outsideCount).replace('%s', totalCount) + '</div>';
                 html += '</div>';
             } else {
                 html += '<div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #ddd; font-size: 12px;">';
-                html += '<em>' + lang_qso_map_total_qsos.replace('%s', totalCount) + '</em>';
+                html += '<div>' + lang_qso_map_total_qsos.replace('%s', totalCount) + '</div>';
                 html += '</div>';
             }
 
@@ -415,6 +469,16 @@ function initMap() {
             html += '<input type="checkbox" onclick="toggleItuZones(this.checked)" ' + (typeof ituzones_layer !== 'undefined' && ituzones_layer ? 'checked' : '') + ' style="outline: none;"><span> ' + lang_gen_hamradio_itu_zones + '</span><br>';
 
             div.innerHTML = html;
+
+            // QSO list popups for the inside/outside boundary markers
+            var listIcons = div.querySelectorAll('.qso-map-boundary-list');
+            for (var i = 0; i < listIcons.length; i++) {
+                listIcons[i].addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    showQsoBoundaryList(this.getAttribute('data-which'));
+                });
+            }
 
             // Prevent map events on the legend
             L.DomEvent.disableClickPropagation(div);

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -43,7 +43,7 @@ function initMap() {
     let legendControl = null; // Store legend control for updates
 
     // Enable/disable load button based on country selection
-    $('#countrySelect, #locationSelect').on('change', function() {
+    $('#countrySelect, #locationSelect, #bandSelect').on('change', function() {
         const countrySelected = $('#countrySelect').val();
         $('#loadMapBtn').prop('disabled', !countrySelected);
         $('#showOnlyOutside').prop('disabled', !countrySelected);
@@ -82,7 +82,8 @@ function initMap() {
             data: {
                 country: country,
                 dxcc: dxcc,
-                station_id: stationId
+                station_id: stationId,
+                band: $('#bandSelect').val()
             },
             success: function(response) {
                 clearTimeout(timeout);

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -10,6 +10,7 @@ function initMap() {
     let markers = [];
     let geojsonLayers = []; // Store multiple GeoJSON layers
     let allQsos = []; // Store all QSOs for filtering
+    let countryGrids = []; // Gridsquares belonging to the selected DXCC
     let legendAdded = false; // Track if legend has been added
     let legendControl = null; // Store legend control for updates
 
@@ -18,7 +19,7 @@ function initMap() {
         const countrySelected = $('#countrySelect').val();
         $('#loadMapBtn').prop('disabled', !countrySelected);
         $('#showOnlyOutside').prop('disabled', !countrySelected);
-        $('#mapContainer, #noDataMessage').hide();
+        $('#mapContainer').hide();
     });
 
     // Handle checkbox change
@@ -76,19 +77,12 @@ function initMap() {
                     return;
                 }
 
-                if (!Array.isArray(response)) {
-                    console.log('Response is not an array:', response);
-                    alert('Error: Expected an array of QSOs but received something else');
-                    return;
-                }
+                // Response is { qsos: [...], grids: [...] }; grids holds the
+                // gridsquares that belong to the selected DXCC, used to limit
+                // the maidenhead grid to that DXCC (like the gridmap).
+                allQsos = response.qsos || [];
+                countryGrids = response.grids || [];
 
-                if (response.length === 0) {
-                    $('#noDataMessage').show();
-                    return;
-                }
-
-                // Store all QSOs and initialize map
-                allQsos = response;
                 const showOnlyOutside = $('#showOnlyOutside').is(':checked');
                 filterAndDisplayMarkers(allQsos, showOnlyOutside);
             }
@@ -119,7 +113,10 @@ function initMap() {
             }).addTo(map);
         }
 
-		maidenhead = L.maidenheadqrb().addTo(map);
+		if (maidenhead) {
+			map.removeLayer(maidenhead);
+		}
+		maidenhead = L.maidenheadqrb({ grids: countryGrids }).addTo(map);
 		map.on('mousemove', onMapMove);
 		$('.cohidden').show();
 

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -37,14 +37,14 @@ function initMap() {
         if (!country) return;
 
         // Fetch QSO data
-        const loadingText = country === 'all' ? 'Loading QSOs for all countries (this may take a moment)...' : 'Loading QSO data...';
+        const loadingText = country === 'all' ? lang_qso_map_loading_all : lang_qso_map_loading;
         $('#loadingSpinner').removeClass('d-none');
         $('#loadingText').text(loadingText).removeClass('d-none');
         $('#loadMapBtn').prop('disabled', true);
 
         // Set timeout for long-running requests
         const timeout = setTimeout(function() {
-            $('#loadingText').text('Still loading... Processing large dataset, please wait...');
+            $('#loadingText').text(lang_qso_map_still_loading);
         }, 5000);
 
         $.ajax({
@@ -67,13 +67,13 @@ function initMap() {
                     try {
                         response = JSON.parse(response);
                     } catch (e) {
-                        alert('Error parsing response: ' + e.message);
+                        alert(lang_qso_map_error_parsing + ' ' + e.message);
                         return;
                     }
                 }
 
                 if (response.error) {
-                    alert('Error: ' + response.error);
+                    alert(lang_qso_map_error + ' ' + response.error);
                     return;
                 }
 
@@ -91,7 +91,7 @@ function initMap() {
             $('#loadingSpinner').addClass('d-none');
             $('#loadingText').addClass('d-none');
             $('#loadMapBtn').prop('disabled', false);
-            alert('Failed to load QSO data. Please try again.');
+            alert(lang_qso_map_load_failed);
         });
     });
 
@@ -161,8 +161,8 @@ function initMap() {
 
             marker = L.marker([qso.lat, qso.lng], { icon: icon })
                 .bindPopup(qso.popup +
-                    (qso.inside_geojson === false ? '<br><span style="color: red;"><strong>⚠ Outside country boundaries</strong></span>' :
-                    '<br><span style="color: green;"><strong>✓ Inside country boundaries</strong></span>'))
+                    (qso.inside_geojson === false ? '<br><span style="color: red;"><strong>⚠ ' + lang_qso_map_outside_boundaries + '</strong></span>' :
+                    '<br><span style="color: green;"><strong>✓ ' + lang_qso_map_inside_boundaries + '</strong></span>'))
                 .addTo(map)
                 .on('mouseover', function () { this.openPopup(); });
 
@@ -291,7 +291,7 @@ function initMap() {
 	function updateLegendRegion(props) {
 		var el = document.getElementById('legend-region');
 		if (!el) return;
-		el.innerHTML = props ? ('<b>' + props.code + ' - ' + props.name + '</b>') : '<em>Hover over a region</em>';
+		el.innerHTML = props ? ('<b>' + props.code + ' - ' + props.name + '</b>') : '<em>' + lang_qso_map_hover_region + '</em>';
 	}
 
     function addLegend(insideCount, outsideCount, totalCount, showOnlyOutside) {
@@ -300,14 +300,14 @@ function initMap() {
         legend.onAdd = function(map) {
             const div = L.DomUtil.create('div', 'legend');
 
-            let html = '<h4>Legend</h4>';
+            let html = '<h4>' + lang_qso_map_legend + '</h4>';
 
             // Inside boundaries
             html += '<div class="legend-item">';
             html += '<div class="legend-icon">';
             html += '<div style="background-color: #28a745; color: white; width: 20px; height: 20px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: bold; font-size: 12px; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">✓</div>';
             html += '</div>';
-            html += '<span>Inside boundaries <strong>(' + insideCount + ')</strong></span>';
+            html += '<span>' + lang_qso_map_inside_label + ' <strong>(' + insideCount + ')</strong></span>';
             html += '</div>';
 
             // Outside boundaries
@@ -315,7 +315,7 @@ function initMap() {
             html += '<div class="legend-icon">';
             html += '<div style="background-color: #ff0000; color: white; width: 20px; height: 20px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: bold; font-size: 12px; border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);">✕</div>';
             html += '</div>';
-            html += '<span>Outside boundaries <strong>(' + outsideCount + ')</strong></span>';
+            html += '<span>' + lang_qso_map_outside_label + ' <strong>(' + outsideCount + ')</strong></span>';
             html += '</div>';
 
             // GeoJSON boundaries
@@ -323,28 +323,28 @@ function initMap() {
             html += '<div class="legend-icon">';
             html += '<svg width="20" height="3"><line x1="0" y1="1.5" x2="20" y2="1.5" stroke="#ff0000" stroke-width="2"/></svg>';
             html += '</div>';
-            html += '<span>Country/State boundaries</span>';
+            html += '<span>' + lang_qso_map_boundaries + '</span>';
             html += '</div>';
 
             // Total QSOs (shown differently when filtering)
             if (showOnlyOutside) {
                 html += '<div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #ddd; font-size: 12px;">';
-                html += '<em>Showing ' + outsideCount + ' of ' + totalCount + ' total QSOs</em>';
+                html += '<em>' + lang_qso_map_showing.replace('%s', outsideCount).replace('%s', totalCount) + '</em>';
                 html += '</div>';
             } else {
                 html += '<div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #ddd; font-size: 12px;">';
-                html += '<em>Total: ' + totalCount + ' QSOs with 6+ char grids</em>';
+                html += '<em>' + lang_qso_map_total_qsos.replace('%s', totalCount) + '</em>';
                 html += '</div>';
             }
 
             // Hovered region (updates when mousing over subdivisions)
             html += '<div style="margin-top: 10px; padding-top: 8px; font-size: 14px;">';
-            html += '<h4>Region</h4>';
-            html += '<span id="legend-region"><em>Hover over a region</em></span>';
+            html += '<h4>' + lang_qso_map_region + '</h4>';
+            html += '<span id="legend-region"><em>' + lang_qso_map_hover_region + '</em></span>';
             html += '</div>';
 
             html += '<br />';
-            html += '<h4>Toggle layers</h4>';
+            html += '<h4>' + lang_qso_map_toggle_layers + '</h4>';
             html += '<input type="checkbox" onclick="toggleGridsquares(this.checked)" ' + (typeof gridsquare_layer !== 'undefined' && gridsquare_layer ? 'checked' : '') + ' style="outline: none;"><span> ' + lang_gen_hamradio_gridsquares + '</span><br>';
             html += '<input type="checkbox" onclick="toggleCqZones(this.checked)" ' + (typeof cqzones_layer !== 'undefined' && cqzones_layer ? 'checked' : '') + ' style="outline: none;"><span> ' + lang_gen_hamradio_cq_zones + '</span><br>';
             html += '<input type="checkbox" onclick="toggleItuZones(this.checked)" ' + (typeof ituzones_layer !== 'undefined' && ituzones_layer ? 'checked' : '') + ' style="outline: none;"><span> ' + lang_gen_hamradio_itu_zones + '</span><br>';

--- a/assets/js/sections/qso_map.js
+++ b/assets/js/sections/qso_map.js
@@ -228,12 +228,7 @@ function initMap() {
 
  		$('#mapContainer').show();
 
-        // Remove existing info control if it exists
-        if (info) {
-            map.removeControl(info);
-        }
-
-        // Add or update legend
+        // Add or update legend (includes the hovered-region readout)
         if (!legendAdded) {
             addLegend(insideCount, outsideCount, qsos.length, showOnlyOutside);
             legendAdded = true;
@@ -241,22 +236,6 @@ function initMap() {
             // Update existing legend counts
             updateLegend(insideCount, outsideCount, qsos.length, showOnlyOutside);
         }
-
-        // Always re-add info control after legend to ensure correct order
-        info = L.control();
-
-        info.onAdd = function (map) {
-            this._div = L.DomUtil.create('div', 'info');
-            this.update();
-            return this._div;
-        };
-
-        info.update = function (props) {
-            this._div.innerHTML = '<h4>Region</h4>' +  (props ?
-            '<b>' + props.code + ' - ' + props.name + '</b><br />' : 'Hover over a region');
-        };
-
-        info.addTo(map);
 
         // Force map to recalculate its size
         setTimeout(function() {
@@ -291,7 +270,7 @@ function initMap() {
 		});
 
 		layer.bringToFront();
-		info.update(layer.feature.properties);
+		updateLegendRegion(layer.feature.properties);
 	}
 
 	function zoomToFeature(e) {
@@ -305,7 +284,14 @@ function initMap() {
 
 	function resetHighlight(e) {
 		geojsonlayer.resetStyle(e.target);
-		info.update();
+		updateLegendRegion();
+	}
+
+	// Update the hovered-region readout inside the legend
+	function updateLegendRegion(props) {
+		var el = document.getElementById('legend-region');
+		if (!el) return;
+		el.innerHTML = props ? ('<b>' + props.code + ' - ' + props.name + '</b>') : '<em>Hover over a region</em>';
 	}
 
     function addLegend(insideCount, outsideCount, totalCount, showOnlyOutside) {
@@ -350,6 +336,12 @@ function initMap() {
                 html += '<em>Total: ' + totalCount + ' QSOs with 6+ char grids</em>';
                 html += '</div>';
             }
+
+            // Hovered region (updates when mousing over subdivisions)
+            html += '<div style="margin-top: 10px; padding-top: 8px; font-size: 14px;">';
+            html += '<h4>Region</h4>';
+            html += '<span id="legend-region"><em>Hover over a region</em></span>';
+            html += '</div>';
 
             html += '<br />';
             html += '<h4>Toggle layers</h4>';


### PR DESCRIPTION
User menu -> internal tools -> GeoJSON QSO Map

To activate, add this in the config.php:
> $config['internal_tools'] = true;

This PR does the following:

- [x] Updated looks to match other pages
- [x] Show all countries with geojson files in the dropdown, regardless if a qso exists in the log with a six char gridsquare
- [x] Show only gridsquare for the selected dxcc (like the gridsquare map)
- [x] Made infobar below map responsive
- [x] Show QSO info on mouseover instead of click
- [x] Autoselect active location in the dropdown
- [x] Add missing translation strings
- [x] Added worked/confirmed regions
- [x] Added band filter
- [x] Need to fix band when sat
- [x] Fix custom date
- [x] Add QSO lists


Should we move this page to the normal pages, so that it is not hidden behind a config switch? If so, where should we place it? It was more meant as an internal tool, however it can be used to look up which county/state/province etc you are in as well.