### PR TITLE
simplify

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -110,9 +110,7 @@ class Contesting extends CI_Controller {
 
 		$session_id = $this->contesting_model->create_contest_session($contest_adif_id, $session_start, $session_end, $station_location, $session_notes, true);
 
-		$logging_token = $this->paths->create_contesting_logging_token($session_id);
-
-		redirect('contesting/logging_engine/' . $logging_token);
+		redirect('contesting/logging_engine/' . $session_id);
 	}
 
 	/**
@@ -434,41 +432,26 @@ class Contesting extends CI_Controller {
 	/**
 	 * This starts the main logging engine for contesting
 	 */
-	public function logging_engine($logging_token) {
+	public function logging_engine($contest_session_id = 0) {
 		$this->load->model('contesting_model');
 
-		// Decode logging token
-		$decoded_token = $this->paths->decode_contesting_logging_token($logging_token);
-		if (!$decoded_token || !isset($decoded_token['contest_session_id'])) {
-			$this->session->set_flashdata('error', __("Invalid logging token."));
-			redirect('contesting');
-		}
+		$contest_session_id = intval($contest_session_id);
 
 		// Security Check: Ensure the user is authorized for this contest session
-		$source_uid = $this->session->userdata('source_uid') ?: $this->session->userdata('user_id');
-		if ($decoded_token['user_id'] != $source_uid) {
-			$this->session->set_flashdata('error', __("You are not authorized to access this contest session."));
-			redirect('contesting');
-		}
-
-		if (!$this->contesting_model->check_user_contest($decoded_token['contest_session_id'])) {
+		if (!$contest_session_id || !$this->contesting_model->check_user_contest($contest_session_id)) {
 			$this->session->set_flashdata('error', __("You are not authorized to access this contest session."));
 			redirect('contesting');
 		}
 
 		// setting up worker if available
-		$worker_topic = 'contest_session.' . $decoded_token['contest_session_id']; // shared topic for all operators in this contest session
+		$worker_topic = 'contest_session.' . $contest_session_id; // shared topic for all operators in this contest session
 		if ($this->worker_available) {
 			$this->worker->register_topic($worker_topic);
-		}
 
-		if ($this->worker_available && $decoded_token) {
 			$data['worker_client_url'] = $this->worker->client_url();
 			$data['worker_topic']      = $worker_topic;
 			$data['worker_token']      = $this->worker->create_token($worker_topic);
 		}
-
-		$contest_session_id = $decoded_token['contest_session_id'];
 
 		// Load session data
 		$data['session_info'] = $this->contesting_model->get_session_info($contest_session_id);
@@ -1100,12 +1083,10 @@ class Contesting extends CI_Controller {
 			// update_session keeps an existing operator_callsign, so override it explicitly.
 			$this->session->set_userdata('operator_callsign', strtoupper(trim($op->user_callsign)));
 
-			// Fresh token now carries the new operator as token user_id (reads source_uid).
-			$token = $this->paths->create_contesting_logging_token($contest_session_id);
-
+			// Reload the engine; it picks up the new operator from the session.
 			echo json_encode([
 				'success'  => true,
-				'redirect' => site_url('contesting/logging_engine') . '/' . $token,
+				'redirect' => site_url('contesting/logging_engine') . '/' . intval($contest_session_id),
 			]);
 		} catch (Exception $e) {
 			http_response_code(400);

--- a/application/libraries/Paths.php
+++ b/application/libraries/Paths.php
@@ -206,27 +206,4 @@ class Paths {
         }
         return base_url($filepath);
     }
-
-    // Creates contesting logging token
-    function create_contesting_logging_token($contest_session_id) {
-        $CI = &get_instance();
-        
-        // In case of clubstation, we need the source_uid so we can determine the actual operator
-        // Is there no source_uid, we either clubstation support is disabled or the user is not operating in it's own account and we can use the user_id
-        $user_id = $CI->session->userdata('source_uid') ?: $CI->session->userdata('user_id');
-
-        $logging_token_payload = [
-            'user_id' => intval($user_id),
-            'timestamp' => time(),
-            'contest_session_id' => intval($contest_session_id)
-        ];
-
-        return urlencode(base64_encode(json_encode($logging_token_payload)));
-    }
-
-    function decode_contesting_logging_token($logging_token) {
-        $CI = &get_instance();
-        $decoded_token = $CI->security->xss_clean(json_decode(base64_decode(urldecode($logging_token)), true));
-        return $decoded_token;
-    }
 }

--- a/application/views/contesting/manager/index.php
+++ b/application/views/contesting/manager/index.php
@@ -39,9 +39,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <?php foreach ($my_contests as $row) {
-                                    $logging_token = $this->paths->create_contesting_logging_token($row['contest_session_id']);
-                                ?>
+                                <?php foreach ($my_contests as $row) { ?>
                                     <?php
                                     $now = time();
                                     $start = !empty($row['time_start']) ? strtotime($row['time_start']) : null;
@@ -59,7 +57,7 @@
                                     ?>
                                     <tr>
                                         <td><div class="form-check"><input class="row-check form-check-input" type="checkbox" value="<?php echo $row['contest_session_id']; ?>"></div></td>
-                                        <td><a target="_blank" href="<?php echo site_url('contesting/logging_engine') . "/" . $logging_token; ?>" class="btn btn-success btn-sm"><i class="fas fa-play"></i> <?= __("START") ?></a></td>
+                                        <td><a target="_blank" href="<?php echo site_url('contesting/logging_engine') . "/" . $row['contest_session_id']; ?>" class="btn btn-success btn-sm"><i class="fas fa-play"></i> <?= __("START") ?></a></td>
                                         <td><?php echo $status; ?></td>
                                         <td><?php echo !empty($row['time_start']) ? date($custom_date_format . ' H:i', strtotime($row['time_start'])) : '-'; ?></td>
                                         <td><?php echo !empty($row['time_end']) ? date($custom_date_format . ' H:i', strtotime($row['time_end'])) : '-'; ?></td>


### PR DESCRIPTION
The contesting token which is applied in the URL when starting the new contesting engine was initially implemented to possibly use it for other data or authentication. Since the development of the new contesting engine was more streamlined and closer on the core it was basically without any use and the controller checked session for authentication. I left it because it worked and didn't want to change a running system. 

Now it popped up, that depending on the payload the base64 encoding does use `=` and other characters for padding. I expected that and encoded them. But it turns out it does not work as expected and it may happen, that base64encode uses characters which are not included in CI3 allowed chars list. 

Therefore we just use the contesting sesssion ID for validation. Simple and easy

tnx to @DB4SCW for this heads up