### PR TITLE
Also allow 6-digit grid lines and corners

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -222,6 +222,10 @@ class Qra {
 		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}$/', $grid)) return true;
 		// Allow 10-digit locator
 		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		// Allow 6-digit grid line
+		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		// Allow 6-digit grid corner
+		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
 		return false;
 	}
 }


### PR DESCRIPTION
As per ADIF also 6-digit grid lines and corners are allowed. So we extend our QRA validate_grid function to also cover this case. See https://adif.org.uk/317/ADIF_317_annotated.htm#QSO_Field_VUCC_GRIDS.