### PR TITLE
Catch empty Aurora-information

### DIFF
--- a/application/models/Hamqsl_model.php
+++ b/application/models/Hamqsl_model.php
@@ -76,6 +76,13 @@ class Hamqsl_model extends CI_Model {
 		// Convert the entire <solardata> node to an associative array
 		$solarinformation = json_decode(json_encode($solardata), true);
 
+		// Empty XML elements (e.g. <aurora></aurora> when HAMqsl has no report)
+		foreach ($solarinformation as $key => $value) {
+			if (is_array($value) && empty($value)) {
+				$solarinformation[$key] = '';
+			}
+		}
+
 		// Format the 'updated' field if it exists
 		if (isset($solarinformation['updated'])) {
 			$timestamp = strtotime($solarinformation['updated']);


### PR DESCRIPTION
Sometimes (e.g. 27.03.) the `<aurora>` is empty. this leads into:
- a warning on PHP-Level
- a "NaN" in UI

This Patch fixes it.