### PR TITLE
Set session-active-profile on profile-change

### DIFF
--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -323,6 +323,8 @@ class Stations extends CI_Model {
 		$this->db->where('user_id', $this->session->userdata('user_id'));
 		$this->db->where('station_id', $clean_new);
 		$this->db->update('station_profile', $newdefault);
+
+		$this->session->set_userdata('station_profile_id', $clean_new);
 	}
 
 	function edit_favourite($id) {


### PR DESCRIPTION
When changing "active station-profile" it's only changed in Database, but not in session.

e.g.:
- Profile "A" is active after login
- Go to Stationsetup and set "Profle B" as active
- Open Logging-page. Still "Profile A" active.

only change here is: immediate effect of changing active profile

