### PR TITLE
Prevent trying to print labels with no QSO

### DIFF
--- a/application/controllers/Labels.php
+++ b/application/controllers/Labels.php
@@ -139,6 +139,11 @@ class Labels extends CI_Controller {
 
 	public function printids() {
 		$ids = xss_clean(json_decode($this->input->post('id')));
+		if (empty($ids)) {
+			header('Content-Type: application/json');
+			echo json_encode(array('message' => __('No QSOs were selected')));
+			return;
+		}
 		$offset = xss_clean($this->input->post('startat'));
 		$grid = $this->input->post('grid') === "true" ? 1 : 0;
 		$via = $this->input->post('via') === "true" ? 1 : 0;

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -2307,6 +2307,17 @@ function handleQslReceived(sent, method, tag) {
 }
 
 function printlabel(id_list) {
+	if (!Array.isArray(id_list) || id_list.length === 0) {
+		BootstrapDialog.alert({
+			title: lang_gen_advanced_logbook_error,
+			message: lang_gen_advanced_logbook_select_at_least_one_row_label,
+			type: BootstrapDialog.TYPE_DANGER,
+			closable: false,
+			draggable: false,
+			callback: function () {}
+		});
+		return;
+	}
 	let markchecked = $('#markprinted')[0].checked;
 
 	$.ajax({

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -653,6 +653,17 @@ function saveAndPrintSelectedQsos(printAll) {
 
 function printLabel(printAll) {
 	const id_list = getSelectedIds();
+	if (printAll != true && id_list.length === 0) {
+		BootstrapDialog.alert({
+			title: lang_qslprint_warning,
+			message: lang_qslprint_select_at_least_one_row,
+			type: BootstrapDialog.TYPE_WARNING,
+			closable: false,
+			draggable: false,
+			callback: function () {}
+		});
+		return;
+	}
 	const options = {
 			'startat': $('#startat').val(),
 			'grid': $('#gridlabel')[0].checked,


### PR DESCRIPTION
sometimes i really don't know how users manage to do things.
i observed someone trying to print a label with no QSO. (perhaps reload / trying to call `/labels/printids` in a direct way)

This caused a 500. 

However, this one puts fences all around it. even in controller. so hopefully it's now airtight.