### PR TITLE
[Contesting] Serial Reservation in MultiOP Sessions

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -460,6 +460,12 @@ class Contesting extends CI_Controller {
 			redirect('contesting');
 		}
 
+		// if cache driver is dummy and serial numbers are required, log an error message
+		if (in_array('serial', $data['session_info']['exchangefields'] ?? [], true)
+			&& $this->cache->get_loaded_driver() === 'dummy') {
+			log_message('error', 'Contest logger: no cache is available (dummy adapter), so serial numbers cannot be handed out per operator. Configure Redis/Valkey, Memcached, APCu or the file cache.');
+		}
+
 		// Per-user map preferences (night shadow / path line / station marker).
 		// Stored in user_options (bound to user_id), default all on except grid (needs more ressources)
 		$this->load->model('user_options_model');
@@ -618,6 +624,7 @@ class Contesting extends CI_Controller {
 				$callbook_lookup  = (bool) $this->input->post('callbook_lookup', true);
 				$custom_name    = trim($this->input->post('custom_name', true) ?? '');
 				$serial_per_band = (bool) $this->input->post('serial_per_band', true);
+				$serial_scope    = $this->_parseSerialScope($this->input->post('serial_scope', true));
 
 				$parameter_array = [
 					'exchangetype'    => $exchangetype,
@@ -626,6 +633,7 @@ class Contesting extends CI_Controller {
 					'callbook_lookup' => $callbook_lookup,
 					'custom_name'     => $custom_name,
 					'serial_per_band' => $serial_per_band,
+					'serial_scope'    => $serial_scope,
 				];
 
 				$result = $this->contesting_model->create_contest_session($contest_adif_id, $session_start, $session_end, $station_location, $session_notes, false, $parameter_array);
@@ -680,6 +688,7 @@ class Contesting extends CI_Controller {
 				$callbook_lookup  = (bool) $this->input->post('callbook_lookup', true);
 				$custom_name    = trim($this->input->post('custom_name', true) ?? '');
 				$serial_per_band = (bool) $this->input->post('serial_per_band', true);
+				$serial_scope    = $this->_parseSerialScope($this->input->post('serial_scope', true));
 
 				$parameter_array = [
 					'exchangetype'    => $exchangetype,
@@ -688,6 +697,7 @@ class Contesting extends CI_Controller {
 					'callbook_lookup' => $callbook_lookup,
 					'custom_name'     => $custom_name,
 					'serial_per_band' => $serial_per_band,
+					'serial_scope'    => $serial_scope,
 				];
 
 				$result = $this->contesting_model->update_contest_session($contest_session_id, $contest_id, $time_start, $time_end, $station_id, $notes, $parameter_array);
@@ -1095,6 +1105,30 @@ class Contesting extends CI_Controller {
 	}
 
 	/**
+	 * Resolves which serial pool a request belongs to.
+	 *
+	 * @param array $session_info Result of Contesting_model::get_session_info()
+	 * @param string|null $band Band reported by the client.
+	 * @return array [band, operator], each null when the pool is not scoped by it.
+	 */
+	private function _serialPool($session_info, $band = null) {
+		$pool_band = null;
+		$pool_operator = null;
+
+		if (!empty($session_info['serial_per_band'])) {
+			// Format check only, no db required here
+			$band = strtolower(trim($band ?? ''));
+			$pool_band = preg_match('/^\d{1,4}(\.\d{1,2})?(mm|cm|m)$/', $band) ? $band : '';
+		}
+
+		if (($session_info['serial_scope'] ?? 'station') === 'operator') {
+			$pool_operator = strtoupper(trim($this->session->userdata('operator_callsign') ?: $this->session->userdata('user_callsign')));
+		}
+
+		return [$pool_band, $pool_operator];
+	}
+
+	/**
 	 * Sync Endpoint for Contest Engine
 	 * Handles bidirectional communication (Commands + Requests)
 	 * Endpoint: POST /contesting/heartbeat
@@ -1241,6 +1275,20 @@ class Contesting extends CI_Controller {
 				// Link QSO to contest session
 				if (is_array($save_result) && !empty($save_result['qso_id'])) {
 					$this->contesting_model->link_qso($save_result['qso_id'], $session_info['contest_session_id']);
+
+					// Keep the counter ahead of the log: if the operator overrode the
+					// serial in the form by hand, the counter would otherwise hand the
+					// same number out again.
+					if (!empty($command['data']['serial_sent'])) {
+						list($pool_band, $pool_operator) = $this->_serialPool($session_info, $command['data']['band'] ?? null);
+						$this->contesting_model->serial_bump(
+							$session_info['contest_session_id'],
+							$pool_band,
+							$pool_operator,
+							$command['data']['serial_sent']
+						);
+					}
+
 					// Notify worker clients about new QSO if worker is available
 					if ($this->worker_available) {
 						$this->worker->publish('contest_session.' . $session_info['contest_session_id'], ['type' => 'sync_required']);
@@ -1350,6 +1398,54 @@ class Contesting extends CI_Controller {
 				$fresh = $this->contesting_model->get_session_info($session_info['contest_session_id']);
 				$response['data']['session_settings'] = $fresh;
 				$this->cache->save($cache_key, $response['data']['session_settings'], 3600); // Cache for 1h
+				break;
+
+			case 'serial_state':
+				$this->load->is_loaded('contesting_model') ?: $this->load->model('contesting_model');
+				list($pool_band, $pool_operator) = $this->_serialPool($session_info, $request['band'] ?? null);
+				$response['data']['next_serial'] = $this->contesting_model->serial_peek(
+					$session_info['contest_session_id'],
+					$pool_band,
+					$pool_operator
+				);
+				break;
+
+			case 'claim_serial':
+				$this->load->is_loaded('contesting_model') ?: $this->load->model('contesting_model');
+				list($pool_band, $pool_operator) = $this->_serialPool($session_info, $request['band'] ?? null);
+				$claimed = $this->contesting_model->serial_claim(
+					$session_info['contest_session_id'],
+					$pool_band,
+					$pool_operator
+				);
+
+				$response['data']['claimed_serial'] = ($claimed === false) ? null : $claimed;
+
+				// Let the other operators refresh their preview right away.
+				if ($claimed !== false && $this->worker_available) {
+					$this->worker->publish('contest_session.' . $session_info['contest_session_id'], ['type' => 'serial_changed']);
+				}
+				break;
+
+			case 'release_serial':
+				$this->load->is_loaded('contesting_model') ?: $this->load->model('contesting_model');
+				list($pool_band, $pool_operator) = $this->_serialPool($session_info, $request['band'] ?? null);
+				$released = $this->contesting_model->serial_release(
+					$session_info['contest_session_id'],
+					$pool_band,
+					$pool_operator,
+					$request['serial'] ?? 0
+				);
+				$response['data']['next_serial'] = $this->contesting_model->serial_peek(
+					$session_info['contest_session_id'],
+					$pool_band,
+					$pool_operator
+				);
+
+				// Only a successful rollback changes anything for the others.
+				if ($released && $this->worker_available) {
+					$this->worker->publish('contest_session.' . $session_info['contest_session_id'], ['type' => 'serial_changed']);
+				}
 				break;
 
 			default:
@@ -1737,6 +1833,16 @@ class Contesting extends CI_Controller {
 		}
 		$fields = array_values(array_filter($decoded, fn($f) => in_array($f, $allowed)));
 		return $fields ?: ['exchange'];
+	}
+
+	/**
+	 * Normalise the serial number scope of a contest session.
+	 *
+	 * @param string|null $scope Raw POST value.
+	 * @return string Either 'station' or 'operator'.
+	 */
+	private function _parseSerialScope($scope) {
+		return in_array($scope, ['station', 'operator'], true) ? $scope : 'station';
 	}
 
 	private function _fieldsToLegacyType($fields) {

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -92,6 +92,7 @@ class Contesting_model extends CI_Model {
 			$row['callbook_lookup'] = $settings['callbook_lookup'] ?? true;
 			$row['custom_name']     = $settings['custom_name']     ?? '';
 			$row['serial_per_band'] = $settings['serial_per_band'] ?? false;
+			$row['serial_scope']    = $settings['serial_scope']    ?? 'station';
 		} else {
 			$row['copyexchangeto']  = '';
 			$row['exchangefields']  = ['exchange'];
@@ -99,6 +100,7 @@ class Contesting_model extends CI_Model {
 			$row['callbook_lookup'] = true;
 			$row['custom_name']     = '';
 			$row['serial_per_band'] = false;
+			$row['serial_scope']    = 'station';
 		}
 		unset($row['settings']);
 		return $row;
@@ -119,6 +121,7 @@ class Contesting_model extends CI_Model {
 			'callbook_lookup' => true,
 			'custom_name'     => '',
 			'serial_per_band' => false,
+			'serial_scope'    => 'station',
 		];
 
 		return json_encode(array_merge($defaults, $parameter_array));
@@ -133,7 +136,7 @@ class Contesting_model extends CI_Model {
 	 * @param int $station_location The station location (station_id).
 	 * @param string $session_notes Notes for the session.
 	 * @param bool $return_id If true, returns the inserted session ID instead of a boolean.
-	 * @param array $parameter_array Session settings (exchangetype, copyexchangeto, exchangefields, callbook_lookup, custom_name, serial_per_band). Missing keys fall back to defaults.
+	 * @param array $parameter_array Session settings (exchangetype, copyexchangeto, exchangefields, callbook_lookup, custom_name, serial_per_band, serial_scope). Missing keys fall back to defaults.
 	 * @return bool True on success, false on failure. If $return_id is true, returns the inserted session ID instead.
 	 */
 	function create_contest_session($contest_adif_id, $session_start, $session_end, $station_location, $session_notes, $return_id = false, $parameter_array = []) {
@@ -171,7 +174,7 @@ class Contesting_model extends CI_Model {
 	 * @param string $time_end The end time of the session.
 	 * @param int $station_id The station location (station_id).
 	 * @param string $notes Notes for the session.
-	 * @param array $parameter_array Session settings (exchangetype, copyexchangeto, exchangefields, callbook_lookup, custom_name, serial_per_band). Missing keys fall back to defaults.
+	 * @param array $parameter_array Session settings (exchangetype, copyexchangeto, exchangefields, callbook_lookup, custom_name, serial_per_band, serial_scope). Missing keys fall back to defaults.
 	 * @return bool True on success, false on failure.
 	 */
 	function update_contest_session($contest_session_id, $contest_id, $time_start, $time_end, $station_id, $notes, $parameter_array = []) {
@@ -619,5 +622,165 @@ class Contesting_model extends CI_Model {
 
 		return $this->db->query($sql, $bindings);
 		
+	}
+
+	const SERIAL_COUNTER_TTL = 259200; // 72 hours
+
+	private function _load_cache() {
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
+			'adapter'    => $this->config->item('cache_adapter')    ?? 'file',
+			'backup'     => $this->config->item('cache_backup')     ?? 'file',
+			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''
+		]);
+	}
+
+	/**
+	 * Builds the cache key of a serial pool.
+	 *
+	 * @param int $contest_session_id
+	 * @param string|null $band Current band, ignored unless the session counts per band.
+	 * @param string|null $operator Current operator callsign, ignored unless the session counts per operator.
+	 * @return string
+	 */
+	private function _serial_cache_key($contest_session_id, $band = null, $operator = null) {
+		return 'contest_serial_' . (int) $contest_session_id . '_' . strtolower(trim($band ?? '')) . '_' . strtoupper(trim($operator ?? ''));
+	}
+
+	/**
+	 * Seeds a serial counter from the QSOs already logged in the session.
+	 *
+	 * @param string $key Cache key of the pool.
+	 * @param int $contest_session_id
+	 * @param string|null $band Set to scope the pool to a band.
+	 * @param string|null $operator Set to scope the pool to an operator.
+	 * @return int The highest serial already used, 0 if the session is empty.
+	 */
+	private function _serial_init($key, $contest_session_id, $band = null, $operator = null) {
+		$filter = '';
+		$bindings = [$contest_session_id];
+
+		if (!empty($band)) {
+			$filter .= ' AND lb.COL_BAND = ?';
+			$bindings[] = $band;
+		}
+		if (!empty($operator)) {
+			$filter .= ' AND lb.COL_OPERATOR = ?';
+			$bindings[] = $operator;
+		}
+
+		$sql = "SELECT MAX(lb.COL_STX) AS max_serial
+				FROM contest_qsos cq
+				JOIN " . $this->config->item('table_name') . " lb ON lb.COL_PRIMARY_KEY = cq.qso_id
+				WHERE cq.contest_session_id = ? {$filter}";
+
+		$row = $this->db->query($sql, $bindings)->row_array();
+		$current = (int) ($row['max_serial'] ?? 0);
+
+		$this->cache->save($key, $current, self::SERIAL_COUNTER_TTL);
+		return $current;
+	}
+
+	/**
+	 * Returns the serial the next claim would most likely get, without
+	 * consuming it.
+	 *
+	 * @param int $contest_session_id
+	 * @param string|null $band
+	 * @param string|null $operator
+	 * @return int
+	 */
+	function serial_peek($contest_session_id, $band = null, $operator = null) {
+		$this->_load_cache();
+
+		$key = $this->_serial_cache_key($contest_session_id, $band, $operator);
+		$current = $this->cache->get($key);
+
+		if ($current === FALSE) {
+			$current = $this->_serial_init($key, $contest_session_id, $band, $operator);
+		}
+
+		return (int) $current + 1;
+	}
+
+	/**
+	 * Hands out the next serial number and marks it as used.
+	 *
+	 * @param int $contest_session_id
+	 * @param string|null $band
+	 * @param string|null $operator
+	 * @return int|false The claimed serial, or false if the cache cannot count.
+	 */
+	function serial_claim($contest_session_id, $band = null, $operator = null) {
+		$this->_load_cache();
+
+		$key = $this->_serial_cache_key($contest_session_id, $band, $operator);
+		$current = $this->cache->get($key);
+
+		if ($current === FALSE) {
+			$current = $this->_serial_init($key, $contest_session_id, $band, $operator);
+		}
+
+		$next = (int) $current + 1;
+
+		if (!$this->cache->save($key, $next, self::SERIAL_COUNTER_TTL)) {
+			log_message('error', 'Contest serial counter could not be stored for key ' . $key . ' (cache adapter: ' . $this->cache->get_loaded_driver() . ')');
+			return false;
+		}
+
+		return $next;
+	}
+
+	/**
+	 * Gives a claimed serial back when it was never logged.
+	 *
+	 * @param int $contest_session_id
+	 * @param string|null $band
+	 * @param string|null $operator
+	 * @param int $serial The serial being given back.
+	 * @return bool True if the counter was rolled back.
+	 */
+	function serial_release($contest_session_id, $band = null, $operator = null, $serial = 0) {
+		$serial = (int) $serial;
+		if ($serial < 1) {
+			return false;
+		}
+
+		$this->_load_cache();
+
+		$key = $this->_serial_cache_key($contest_session_id, $band, $operator);
+		$current = $this->cache->get($key);
+
+		if ($current === FALSE || (int) $current !== $serial) {
+			return false;
+		}
+
+		return (bool) $this->cache->save($key, $serial - 1, self::SERIAL_COUNTER_TTL);
+	}
+
+	/**
+	 * Raises the counter if a QSO was logged with a serial above it.
+	 *
+	 * @param int $contest_session_id
+	 * @param string|null $band
+	 * @param string|null $operator
+	 * @param int $serial The serial that was actually logged.
+	 * @return void
+	 */
+	function serial_bump($contest_session_id, $band = null, $operator = null, $serial = 0) {
+		$serial = (int) $serial;
+		if ($serial < 1) {
+			return;
+		}
+
+		$this->_load_cache();
+
+		$key = $this->_serial_cache_key($contest_session_id, $band, $operator);
+		$current = $this->cache->get($key);
+
+		if ($current !== FALSE && (int) $current >= $serial) {
+			return;
+		}
+
+		$this->cache->save($key, $serial, self::SERIAL_COUNTER_TTL);
 	}
 }

--- a/application/views/contesting/logger/components/qso-form.php
+++ b/application/views/contesting/logger/components/qso-form.php
@@ -92,8 +92,8 @@ $config = [
 
 							<!-- Serial Sent / Received (shown only when exchangetype has serial) -->
 							<div class="serial-field col-field" style="display:none;">
-								<label for="qso-serial-sent" class="form-label fw-bold mb-1 small text-uppercase"><?= __("Nr. S"); ?><span id="qso-serial-perband-badge" class="badge bg-secondary ms-1 text-lowercase" style="display:none;"><?= _pgettext("Count serial number in contesting per Band; is an option in contesting manager.","per band"); ?></span></label>
-								<input type="number" id="qso-serial-sent" name="serial_sent" class="form-control text-center fw-bold no-spinner" min="1" tabindex="-1">
+								<label for="qso-serial-sent" class="form-label fw-bold mb-1 small text-uppercase"><?= __("Nr. S"); ?><span id="qso-serial-perband-badge" class="badge bg-secondary ms-1 text-lowercase" style="display:none;"><?= _pgettext("Count serial number in contesting per Band; is an option in contesting manager.","per band"); ?></span><span id="qso-serial-perop-badge" class="badge bg-secondary ms-1 text-lowercase" style="display:none;"><?= _pgettext("Count serial number in contesting per Operator; is an option in contesting manager.","per op"); ?></span></label>
+								<input type="number" id="qso-serial-sent" name="serial_sent" class="form-control text-center fw-bold no-spinner" min="1" tabindex="-1" title="<?= __("Red: preview only. Green: this number is reserved for you."); ?>">
 							</div>
 							<div class="serial-field col-field" style="display:none;">
 								<label for="qso-serial-received" class="form-label fw-bold mb-1 small text-uppercase"><?= __("Nr. R"); ?></label>

--- a/application/views/contesting/manager/components/session_modal.php
+++ b/application/views/contesting/manager/components/session_modal.php
@@ -143,6 +143,14 @@
                         <small class="text-muted d-block mt-1"><?= __("When enabled, the sent serial number starts at 1 on each band instead of running continuously across the whole contest (required by some multi-op categories).") ?></small>
                     </div>
                     <div class="mb-4">
+                        <label for="serial_scope" class="form-label"><?= __("Serial Number Series") ?></label>
+                        <select class="form-select" id="serial_scope" name="serial_scope">
+                            <option value="station"  <?php if (!isset($session_info) || ($session_info['serial_scope'] ?? 'station') === 'station')  echo 'selected'; ?>><?= __("Shared by all operators") ?></option>
+                            <option value="operator" <?php if (isset($session_info) && ($session_info['serial_scope'] ?? 'station') === 'operator') echo 'selected'; ?>><?= __("One series per operator") ?></option>
+                        </select>
+                        <small class="text-muted d-block mt-2"><?= __("Serial numbers are handed out by the server so the same number is never used twice, even when several operators log at the same time. Most contests expect a single shared series per station.") ?></small>
+                    </div>
+                    <div class="mb-4">
                         <label for="session_notes" class="form-label"><?= __("Session Notes") ?></label>
                         <textarea class="form-control" id="session_notes" name="session_notes" rows="3" placeholder="<?= __("Add any additional information about this session..."); ?>"><?php if (isset($session_info)) echo htmlspecialchars($session_info['comment'] ?? ''); ?></textarea>
                         <small class="text-muted d-block mt-2"><?= __("Optional: Any additional details or notes"); ?></small>

--- a/assets/css/contesting/components/qso-form.css
+++ b/assets/css/contesting/components/qso-form.css
@@ -91,3 +91,10 @@
 	flex: 2 1 0;
 	min-width: 100px;
 }
+
+#qso-serial-sent.serial-unclaimed {
+	color: var(--bs-danger, #dc3545);
+}
+#qso-serial-sent.serial-claimed {
+	color: var(--bs-success, #198754);
+}

--- a/assets/js/sections/contesting/contest_engine/app.js
+++ b/assets/js/sections/contesting/contest_engine/app.js
@@ -125,6 +125,10 @@ import { SettingsSyncHandler } from './core/settings-sync.js';
                     if (payload?.type === 'settings_changed') {
                         syncEngine.triggerNow();
                     }
+                    // Another operator took or gave back a serial — refresh the preview.
+                    if (payload?.type === 'serial_changed') {
+                        syncEngine.triggerNow();
+                    }
                 };
                 // Surface connection health as toasts.
                 wsTransport.onConnectTimeout = () => {

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -20,6 +20,10 @@ class QsoFormComponent {
 		this._bearingInfo = null;
 		this.callbookLookupToken = 0;
 		this.nextSerialSent = 1;
+		this.serialClaimed = false;
+		this.serialClaimState = null;
+		this.serialServerKnown = false;
+		this.serialReleaseSerial = null;
 		this.exchangeType = null;
 
 		if (!this.container) {
@@ -137,6 +141,23 @@ class QsoFormComponent {
 		const perBandBadge = this.container.querySelector('#qso-serial-perband-badge');
 		if (perBandBadge) perBandBadge.style.display = this.serialPerBand ? '' : 'none';
 
+		this.serialScope = sessionInfo.serial_scope ?? 'station';
+		const perOpBadge = this.container.querySelector('#qso-serial-perop-badge');
+		if (perOpBadge) perOpBadge.style.display = this.serialScope === 'operator' ? '' : 'none';
+
+		// Only club stations can have several operators sharing a session, so only
+		// there does it help to see whether a number is still a preview.
+		this.serialColourEnabled = !!window.ContestLoggerConfig?.isClubStation;
+		const serialSentInput = this.container.querySelector('#qso-serial-sent');
+		if (serialSentInput) {
+			if (this.serialColourEnabled) {
+				serialSentInput.classList.add('serial-unclaimed');
+			} else {
+				serialSentInput.classList.remove('serial-unclaimed', 'serial-claimed');
+				serialSentInput.removeAttribute('title');
+			}
+		}
+
 		let fields = Array.isArray(sessionInfo.exchangefields) && sessionInfo.exchangefields.length > 0
 			? sessionInfo.exchangefields
 			: ['exchange'];
@@ -166,6 +187,10 @@ class QsoFormComponent {
 		}
 
 		this._applyFieldOrder(fields);
+
+		if (hasSerial) {
+			this.syncEngine?.triggerNow();
+		}
 	}
 
 	_applyFieldOrder(fields) {
@@ -207,12 +232,14 @@ class QsoFormComponent {
 	computeNextSerial() {
 		const allQsos = Array.from(this.dataStore.getPattern('qso.*').values());
 		const currentBand = this.serialPerBand ? this.radioComponent?.getBand() : null;
+		const currentOp = this.serialScope === 'operator' ? this.currentOperator : null;
 		let maxSerial = 0;
 		allQsos.forEach(qso => {
 			if (currentBand) {
 				const qsoBand = qso.band || this.convertQrgToBand(parseInt(qso.frequency));
 				if (qsoBand !== currentBand) return;
 			}
+			if (currentOp && (qso.operator ?? '').toUpperCase() !== currentOp) return;
 			const s = parseInt(qso.serial_sent, 10);
 			if (Number.isFinite(s) && s > maxSerial) maxSerial = s;
 		});
@@ -224,20 +251,88 @@ class QsoFormComponent {
 		if (input) input.value = this.nextSerialSent;
 	}
 
+	/**
+	 * Refreshes the preview from the local log.
+	 */
+	refreshSerialPreview() {
+		if (this.serialClaimed || this.serialServerKnown) return;
+		this.nextSerialSent = this.computeNextSerial();
+		this.updateSerialSentDisplay();
+	}
+
+	/**
+	 * Applies the red (preview) / green (claimed) state to the sent serial field.
+	 *
+	 * @param {boolean} claimed
+	 */
+	setSerialClaimedState(claimed) {
+		this.serialClaimed = claimed;
+		if (!this.serialColourEnabled) return;
+		const input = this.container.querySelector('#qso-serial-sent');
+		if (!input) return;
+		input.classList.toggle('serial-claimed', claimed);
+		input.classList.toggle('serial-unclaimed', !claimed);
+	}
+
+	/**
+	 * Asks the server for a binding serial number.
+	 */
+	claimSerial() {
+		if (this.serialClaimed || this.serialClaimState) return;
+		if (!this.exchangeFields?.includes('serial')) return;
+
+		this.serialClaimState = 'wanted';
+		this.syncEngine?.triggerNow();
+	}
+
 	registerSyncHandler() {
 		if (!this.syncEngine) return;
 
 		this.syncEngine.registerSyncHandler('qso.*', {
 			buildRequest: () => null,
-			buildRequests: (dataStore) => [{
-				type: 'check_sync',
-				client_qso_count: dataStore.getSyncedQSOCount(),
-				since_ts: this.lastSeenTs ?? 0,
-				since_id: this.lastSeenId ?? 0
-			}],
+			buildRequests: (dataStore) => {
+				const requests = [{
+					type: 'check_sync',
+					client_qso_count: dataStore.getSyncedQSOCount(),
+					since_ts: this.lastSeenTs ?? 0,
+					since_id: this.lastSeenId ?? 0
+				}];
+				if (this.exchangeFields?.includes('serial')) {
+					if (this.serialClaimState === 'sent') {
+						console.warn('QSO Form: serial claim went unanswered, keeping local number');
+						this.serialClaimState = null;
+					}
+
+					let releasing = false;
+					if (this.serialReleaseSerial !== null) {
+						requests.push({
+							type: 'release_serial',
+							serial: this.serialReleaseSerial,
+							band: this.radioComponent?.getBand() ?? null
+						});
+						this.serialReleaseSerial = null;
+						releasing = true;
+					}
+
+					if (this.serialClaimState === 'wanted') {
+						this.serialClaimState = 'sent';
+						requests.push({
+							type: 'claim_serial',
+							band: this.radioComponent?.getBand() ?? null
+						});
+					} else if (!releasing && !this.serialClaimState && !this.serialClaimed) {
+						requests.push({
+							type: 'serial_state',
+							band: this.radioComponent?.getBand() ?? null
+						});
+					}
+				}
+				return requests;
+			},
 			buildCommands: (dataStore) => this.buildQsoCommands(dataStore),
 			canHandle: (responseData) => {
-				return responseData.saved_qsos !== undefined || responseData.needs_resync !== undefined;
+				return responseData.saved_qsos !== undefined || responseData.needs_resync !== undefined
+					|| responseData.next_serial !== undefined || responseData.claimed_serial !== undefined;
 			},
 			processResponse: (responseData, dataStore) => {
 				this.processQsoSyncResponse(responseData, dataStore);
@@ -264,6 +359,7 @@ class QsoFormComponent {
 				if (e.key !== ' ') return;
 				e.preventDefault();
 				if (!callsignInputEl.value.trim()) return;
+				this.claimSerial();
 				const visibleInputs = Array.from(
 					this.container.querySelectorAll('input[type="text"], input[type="number"]')
 				).filter(el => el.offsetParent !== null);
@@ -272,6 +368,11 @@ class QsoFormComponent {
 				if (next) next.focus();
 			});
 		}
+
+		['#qso-serial-received', '#qso-exchange-received', '#qso-gridsquare-received'].forEach(sel => {
+			const el = this.container.querySelector(sel);
+			if (el) el.addEventListener('focusin', () => this.claimSerial());
+		});
 
 		// Enter key in input fields logs QSO
 		const inputs = this.container.querySelectorAll('input[type="text"], input[type="number"]');
@@ -303,10 +404,12 @@ class QsoFormComponent {
 		this.dataStore.subscribe('config.selected_band', () => {
 			const callsign = this.container.querySelector('#qso-callsign')?.value.trim().toUpperCase() || '';
 			this.updateWorkedBeforeWarning(callsign);
-			// Per-band serial: recompute the next number for the newly selected band
+			// Per-band serial: the band switch moves us to a different counter, so
+			// what the server told us about the old one no longer applies. Show a
+			// local estimate until the next heartbeat reports the new band's series.
 			if (this.serialPerBand) {
-				this.nextSerialSent = this.computeNextSerial();
-				this.updateSerialSentDisplay();
+				this.serialServerKnown = false;
+				this.refreshSerialPreview();
 			}
 		});
 
@@ -1105,8 +1208,7 @@ class QsoFormComponent {
 		sorted.forEach(qso => this.addQSOToTable(qso));
 		this.updateQSOCount();
 
-		this.nextSerialSent = this.computeNextSerial();
-		this.updateSerialSentDisplay();
+		this.refreshSerialPreview();
 
 		const exchangeSentInput = this.container.querySelector('#qso-exchange-sent');
 		if (exchangeSentInput) exchangeSentInput.value = this.getLastExchangeSent();
@@ -1162,8 +1264,7 @@ class QsoFormComponent {
 		this.updateQSOCount();
 		this.applyCallsignFilter();
 
-		this.nextSerialSent = this.computeNextSerial();
-		this.updateSerialSentDisplay();
+		this.refreshSerialPreview();
 
 		console.debug(`QSO Form: Resynced table (server=${eventData?.server ?? '?'}, protected=${eventData?.protected ?? '?'})`);
 	}
@@ -1303,7 +1404,7 @@ class QsoFormComponent {
 		return sorted[0]?.exchange_sent ?? '';
 	}
 
-	clearForm() {
+	clearForm(serialUsed = false) {
 		if (!this.container) return;
 
 		const callsignInput = this.container.querySelector('#qso-callsign');
@@ -1340,6 +1441,16 @@ class QsoFormComponent {
 		this.callbookLookupToken++;
 		this.dataStore?.emit('qso_location_updated', null);
 		this.scpComponent?.clearResults();
+
+		const heldSerial = this.serialClaimed ? parseInt(this.nextSerialSent, 10) : null;
+		this.setSerialClaimedState(false);
+
+		if (heldSerial && this.exchangeFields?.includes('serial')) {
+			if (!serialUsed && Number.isFinite(heldSerial)) {
+				this.serialReleaseSerial = heldSerial;
+			}
+			this.syncEngine?.triggerNow();
+		}
 	}
 
 	buildQsoCommands(dataStore) {
@@ -1351,6 +1462,7 @@ class QsoFormComponent {
 				tmp_id: qso.tmpId,
 				callsign: qso.callsign,
 				frequency: qso.frequency,
+				band: qso.band ?? null,
 				mode: qso.mode,
 				rst_sent: qso.rst_sent,
 				rst_rcvd: qso.rst_rcvd,
@@ -1378,6 +1490,28 @@ class QsoFormComponent {
 	}
 
 	processQsoSyncResponse(responseData, dataStore) {
+		if (this.serialClaimState === 'sent') {
+			this.serialClaimState = null;
+			const claimed = parseInt(responseData.claimed_serial, 10);
+			if (Number.isFinite(claimed) && claimed > 0) {
+				this.serialServerKnown = true;
+				this.nextSerialSent = claimed;
+				this.updateSerialSentDisplay();
+				this.setSerialClaimedState(true);
+			} else {
+				console.warn('QSO Form: serial not claimed, keeping local number');
+			}
+		}
+
+		if (responseData.next_serial !== undefined && !this.serialClaimed) {
+			const hint = parseInt(responseData.next_serial, 10);
+			if (Number.isFinite(hint) && hint > 0) {
+				this.serialServerKnown = true;
+				this.nextSerialSent = hint;
+				this.updateSerialSentDisplay();
+			}
+		}
+
 		if (responseData.saved_qsos && responseData.saved_qsos.length > 0) {
 			this.processSavedQsos(responseData.saved_qsos, dataStore);
 			console.debug(`QSO Form: ${responseData.saved_qsos.length} QSO(s) saved to server`);
@@ -1554,8 +1688,7 @@ class QsoFormComponent {
 		});
 
 		this.updateQSOCount();
-		this.nextSerialSent = this.computeNextSerial();
-		this.updateSerialSentDisplay();
+		this.refreshSerialPreview();
 	}
 
 	/**
@@ -1678,6 +1811,7 @@ class QsoFormComponent {
 			gridsquare_sent: gridsquareSent,
 			gridsquare_rcvd: gridsquareRcvd,
 			frequency: frequency,
+			band: this.radioComponent.getBand() ?? null,
 			mode: mode,
 			date: new Date().toISOString().split('T')[0],
 			time: new Date().toISOString().split('T')[1].substring(0, 8),
@@ -1738,7 +1872,8 @@ class QsoFormComponent {
 		if (this.scpComponent) {
 			this.scpComponent.clearResults();
 		}
-		this.clearForm();
+		// The serial went into the QSO, so it must not be offered back to the series.
+		this.clearForm(true);
 	}
 }
 


### PR DESCRIPTION
The new contesting lacks an important feature. In multi-operator sessions we need a serial reservation logik to block serials and prevent the same serial exchanged twice in qsos. This PR adds a sophisticated serial reservation logik. I'll also add some documentation in docs (once done, I'll comment the link here in this PR)