### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-01 06:03+0000\n"
-"PO-Revision-Date: 2026-07-29 12:05+0000\n"
+"PO-Revision-Date: 2026-08-01 06:16+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
@@ -1547,7 +1547,7 @@ msgstr "Bestätigungen"
 
 #: application/controllers/Gridlookup.php:32
 msgid "CQ Zones"
-msgstr ""
+msgstr "CQ Zonen"
 
 #: application/controllers/Gridlookup.php:32
 #: application/controllers/Gridlookup.php:33
@@ -1558,12 +1558,12 @@ msgstr "Zonen"
 
 #: application/controllers/Gridlookup.php:66
 msgid "States / Provinces"
-msgstr ""
+msgstr "Staaten / Provinzen"
 
 #: application/controllers/Gridlookup.php:75
 #: application/views/interface_assets/header.php:328
 msgid "Gridsquare Lookup"
-msgstr ""
+msgstr "Locator Suche"
 
 #: application/controllers/Gridmap.php:12
 #: application/views/interface_assets/header.php:164
@@ -10995,11 +10995,11 @@ msgctxt ""
 "Count serial number in contesting per Operator; is an option in contesting "
 "manager."
 msgid "per op"
-msgstr ""
+msgstr "pro OP"
 
 #: application/views/contesting/logger/components/qso-form.php:96
 msgid "Red: preview only. Green: this number is reserved for you."
-msgstr ""
+msgstr "Rot: nur Vorschau. Grün: Diese Nummer ist für dich reserviert."
 
 #: application/views/contesting/logger/components/qso-form.php:99
 #: application/views/contesting/logger/components/qso-form.php:153
@@ -11700,15 +11700,15 @@ msgstr ""
 
 #: application/views/contesting/manager/components/session_modal.php:146
 msgid "Serial Number Series"
-msgstr ""
+msgstr "Seriennummernreihe"
 
 #: application/views/contesting/manager/components/session_modal.php:148
 msgid "Shared by all operators"
-msgstr ""
+msgstr "Von allen Operatoren geteilt"
 
 #: application/views/contesting/manager/components/session_modal.php:149
 msgid "One series per operator"
-msgstr ""
+msgstr "Eine Serie pro Operator"
 
 #: application/views/contesting/manager/components/session_modal.php:151
 msgid ""
@@ -11716,6 +11716,10 @@ msgid ""
 "twice, even when several operators log at the same time. Most contests "
 "expect a single shared series per station."
 msgstr ""
+"Seriennummern werden vom Server vergeben, sodass dieselbe Nummer nie zweimal "
+"verwendet wird, selbst wenn mehrere Operatoren gleichzeitig loggen. Die "
+"meisten Contests erwarten eine einzige gemeinsame Seriennummer pro "
+"Rufzeichen (nicht Operator!)."
 
 #: application/views/contesting/manager/components/session_modal.php:154
 msgid "Session Notes"
@@ -14207,34 +14211,36 @@ msgstr "Zurück zum Dashboard"
 msgid ""
 "Invalid gridsquare — use 2, 4, 6, 8 or 10 characters (e.g. FN, FN31, FN31pr)."
 msgstr ""
+"Ungültiges Locatorfeld — Verwenden Sie 2, 4, 6, 8 oder 10 Zeichen (z.B. FN, "
+"FN31, FN31pr)."
 
 #: application/views/gridlookup/index.php:25
 msgid "2, 4, 6, 8 or 10 character Maidenhead locator"
-msgstr ""
+msgstr "2, 4, 6, 8 oder 10-stelliger Maidenhead-Locator"
 
 #: application/views/gridlookup/index.php:25
 msgid "e.g. FN31pr"
-msgstr ""
+msgstr "z.B. FN31pr"
 
 #: application/views/gridlookup/index.php:26
 msgid "to"
-msgstr ""
+msgstr "zu"
 
 #: application/views/gridlookup/index.php:29
 msgid "Optional second gridsquare for distance and bearing"
-msgstr ""
+msgstr "Optionales zweiter Locator für Entfernung und Peilung"
 
 #: application/views/gridlookup/index.php:29
 msgid "e.g. JN58qm"
-msgstr ""
+msgstr "z.B. JN58qm"
 
 #: application/views/gridlookup/index.php:30
 msgid "Go"
-msgstr ""
+msgstr "Los"
 
 #: application/views/gridlookup/index.php:34
 msgid "Maidenhead grid"
-msgstr ""
+msgstr "Maidenhead-Locator"
 
 #: application/views/gridmap/index.php:27
 msgid "View a map of worked / confirmed gridsquares"

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-29 14:47+0000\n"
-"PO-Revision-Date: 2026-07-28 05:36+0000\n"
+"PO-Revision-Date: 2026-07-30 09:11+0000\n"
 "Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -423,27 +423,27 @@ msgstr "APIキー %s は削除されました"
 
 #: application/controllers/Api_token.php:37
 msgid "Please provide a token name"
-msgstr ""
+msgstr "トークン名を入力してください"
 
 #: application/controllers/Api_token.php:46
 msgid "Please select at least one scope"
-msgstr ""
+msgstr "少なくとも1つの範囲を選択してください"
 
 #: application/controllers/Api_token.php:68
 msgid "API Token generated"
-msgstr ""
+msgstr "APIトークンが生成されました"
 
 #: application/controllers/Api_token.php:70
 msgid "API Token could not be generated"
-msgstr ""
+msgstr "APIトークンを生成できませんでした"
 
 #: application/controllers/Api_token.php:90
 msgid "Invalid API Token"
-msgstr ""
+msgstr "無効なAPIトークン"
 
 #: application/controllers/Api_token.php:97
 msgid "API Token has been deleted"
-msgstr ""
+msgstr "APIトークンが削除されました"
 
 #: application/controllers/Awards.php:30
 #: application/views/interface_assets/header.php:190
@@ -4117,77 +4117,79 @@ msgstr "市 / 区 / 郡"
 
 #: application/libraries/api_v2/Club_resource.php:27
 msgid "Read club members"
-msgstr ""
+msgstr "クラブメンバーを読む"
 
 #: application/libraries/api_v2/Lookup_resource.php:44
 msgid "Look up callsigns and grids"
-msgstr ""
+msgstr "コールサインとグリッドを調べる"
 
 #: application/libraries/api_v2/Qso_resource.php:48
 msgid "Read QSOs"
-msgstr ""
+msgstr "QSOを読む"
 
 #: application/libraries/api_v2/Qso_resource.php:49
 msgid "Create and update QSOs"
-msgstr ""
+msgstr "QSOの作成と更新"
 
 #: application/libraries/api_v2/Qso_resource.php:50
 msgid "Delete QSOs"
-msgstr ""
+msgstr "交信を削除する"
 
 #: application/libraries/api_v2/Radio_resource.php:30
 msgid "Read radios"
-msgstr ""
+msgstr "ラジオを読む"
 
 #: application/libraries/api_v2/Radio_resource.php:31
 msgid "Create and update radios"
-msgstr ""
+msgstr "ラジオの作成と更新"
 
 #: application/libraries/api_v2/Radio_resource.php:32
 msgid "Delete radios"
-msgstr ""
+msgstr "ラジオボタンを削除する"
 
 #: application/libraries/api_v2/Station_resource.php:45
 msgid "Read station locations"
-msgstr ""
+msgstr "シャックの位置を確認する"
 
 #: application/libraries/api_v2/Station_resource.php:46
 msgid "Create and update station locations"
-msgstr ""
+msgstr "シャックの場所を作成および更新する"
 
 #: application/libraries/api_v2/Station_resource.php:47
 msgid "Delete station locations"
-msgstr ""
+msgstr "シャックの場所を削除する"
 
 #: application/libraries/api_v2/Statistic_resource.php:52
 msgid "Read statistics"
-msgstr ""
+msgstr "統計情報を読む"
 
 #: application/models/Api_v2_model.php:77
 msgid " (min. 2.1.0)"
-msgstr ""
+msgstr " （最低2.1.0"
 
 #: application/models/Api_v2_model.php:78
 msgid ""
 "Radio control and QSO upload from WSJT-X, JTDX and friends. Requires at "
 "least version 2.1.0 of WaveLogGate."
 msgstr ""
+"WSJT-X、JTDXなどの無線機からの無線制御および交信データのアップロードに対応。"
+"WaveLogGateのバージョン2.1.0以上が必要です。"
 
 #: application/models/Api_v2_model.php:84
 msgid "Read-only"
-msgstr ""
+msgstr "読み取り専用"
 
 #: application/models/Api_v2_model.php:85
 msgid "Read access to everything, no changes to your data."
-msgstr ""
+msgstr "すべてのデータへの読み取りアクセスのみ可能で、データの変更は一切できません。"
 
 #: application/models/Api_v2_model.php:91
 msgid "Statistics only"
-msgstr ""
+msgstr "統計情報のみ"
 
 #: application/models/Api_v2_model.php:92
 msgid "Statistics only, no changes to your data."
-msgstr ""
+msgstr "統計情報のみであり、お客様のデータに変更を加えることはありません。"
 
 #: application/models/Club_model.php:185
 msgid "Invalid Permission Level!"
@@ -5738,7 +5740,7 @@ msgstr "状態"
 #: application/views/api/components/create_token_modal.php:5
 #: application/views/api/index.php:189
 msgid "Create a new API Token"
-msgstr ""
+msgstr "新しいAPIトークンを作成する"
 
 #: application/views/api/components/create_token_modal.php:6
 #: application/views/api/components/new_token_modal.php:7
@@ -5767,34 +5769,36 @@ msgid ""
 "Create a token with granular permissions (scopes). The token is shown only "
 "once when it is created, so copy it right away."
 msgstr ""
+"きめ細かな権限（スコープ）を持つトークンを作成します。トークンは作成時に一度"
+"だけ表示されるため、すぐにコピーしてください。"
 
 #: application/views/api/components/create_token_modal.php:13
 msgid "Token Name"
-msgstr ""
+msgstr "トークン名"
 
 #: application/views/api/components/create_token_modal.php:14
 msgid "e.g. My logging tool"
-msgstr ""
+msgstr "例：私のログツール"
 
 #: application/views/api/components/create_token_modal.php:15
 msgid "A name to help you recognise this token later."
-msgstr ""
+msgstr "後でこのトークンを識別するのに役立つ名前。"
 
 #: application/views/api/components/create_token_modal.php:18
 msgid "Expiration"
-msgstr ""
+msgstr "有効期限"
 
 #: application/views/api/components/create_token_modal.php:20
 msgid "30 days"
-msgstr ""
+msgstr "30日間"
 
 #: application/views/api/components/create_token_modal.php:21
 msgid "90 days"
-msgstr ""
+msgstr "90日間"
 
 #: application/views/api/components/create_token_modal.php:22
 msgid "1 year"
-msgstr ""
+msgstr "1年"
 
 #: application/views/api/components/create_token_modal.php:23
 #: application/views/api/index.php:154 application/views/api/index.php:157
@@ -5805,26 +5809,28 @@ msgstr "一度もない"
 
 #: application/views/api/components/create_token_modal.php:25
 msgid "When the token should stop working."
-msgstr ""
+msgstr "トークンが機能しなくなるべき時。"
 
 #: application/views/api/components/create_token_modal.php:27
 msgid ""
 "A token that never expires stays valid until you delete it manually. This is "
 "possible, but not recommended for security reasons."
 msgstr ""
+"有効期限のないトークンは、手動で削除するまで有効なままです。これは可能ですが"
+"、セキュリティ上の理由から推奨されません。"
 
 #: application/views/api/components/create_token_modal.php:34
 #: application/views/api/index.php:136
 msgid "Scopes"
-msgstr ""
+msgstr "スコープ"
 
 #: application/views/api/components/create_token_modal.php:35
 msgid "Select which parts of the API v2 this token may access."
-msgstr ""
+msgstr "このトークンがアクセスできるAPI v2のどの部分を選択してください。"
 
 #: application/views/api/components/create_token_modal.php:63
 msgid "Please select at least one scope."
-msgstr ""
+msgstr "少なくとも1つの範囲を選択してください。"
 
 #: application/views/api/components/create_token_modal.php:67
 #: application/views/satellite/pass.php:149
@@ -5836,6 +5842,8 @@ msgid ""
 "Don't know which scopes you need? Pick the tool you want to use and we "
 "select the scopes for you."
 msgstr ""
+"どのスコープが必要かわからない？使用したいツールを選択すれば、弊社が最適な"
+"スコープを選定します。"
 
 #: application/views/api/components/create_token_modal.php:78
 #: application/views/awards/wpx/index.php:152
@@ -5852,7 +5860,7 @@ msgstr "リセット"
 msgid ""
 "A preset replaces your current selection. You can still adjust the scopes "
 "afterwards."
-msgstr ""
+msgstr "プリセットは現在の選択を上書きします。その後もスコープの調整は可能です。"
 
 #: application/views/api/components/create_token_modal.php:87
 #: application/views/club/clubswitch_modal.php:15
@@ -5878,7 +5886,7 @@ msgstr "キャンセル"
 
 #: application/views/api/components/create_token_modal.php:89
 msgid "Create Token"
-msgstr ""
+msgstr "トークンを作成する"
 
 #: application/views/api/components/edit_legacy.php:15
 msgid "Editing Description for API Key"
@@ -5915,15 +5923,17 @@ msgstr "保存"
 
 #: application/views/api/components/new_token_modal.php:6
 msgid "New API Token"
-msgstr ""
+msgstr "新しいAPIトークン"
 
 #: application/views/api/components/new_token_modal.php:12
 msgid "Copy this token now. For security reasons it will not be shown again."
 msgstr ""
+"このトークンを今すぐコピーしてください。セキュリティ上の理由から、この"
+"トークンは二度と表示されません。"
 
 #: application/views/api/components/new_token_modal.php:14
 msgid "Your API Token"
-msgstr ""
+msgstr "APIトークン"
 
 #: application/views/api/components/new_token_modal.php:17
 #: application/views/api/index.php:19 application/views/api/index.php:54
@@ -5934,13 +5944,15 @@ msgstr "クリップボードにコピー"
 
 #: application/views/api/index.php:8
 msgid "Legacy API Keys (API v1)"
-msgstr ""
+msgstr "旧APIキー（API v1）"
 
 #: application/views/api/index.php:11
 msgid ""
 "New integrations should use the API v2 tokens below, if the third party "
 "system supports it."
 msgstr ""
+"新規連携を行う際は、サードパーティシステムが対応している場合、下記のAPI v2"
+"トークンを使用してください。"
 
 #: application/views/api/index.php:11
 msgid ""
@@ -5965,7 +5977,7 @@ msgstr ""
 
 #: application/views/api/index.php:13
 msgid "Links to 3rd-Party-Software which works with Wavelog API v1:"
-msgstr ""
+msgstr "Wavelog API v1と連携するサードパーティ製ソフトウェアへのリンク："
 
 #: application/views/api/index.php:16
 msgid "More Tools"
@@ -6061,7 +6073,7 @@ msgstr "テスト"
 
 #: application/views/api/index.php:79
 msgid "<noname>"
-msgstr ""
+msgstr "<名前なし>"
 
 #: application/views/api/index.php:79
 #, php-format
@@ -6082,7 +6094,7 @@ msgstr "読み取り専用キーを作成する"
 
 #: application/views/api/index.php:120
 msgid "API Tokens (API v2)"
-msgstr ""
+msgstr "APIトークン（API v2）"
 
 #: application/views/api/index.php:123
 msgid ""
@@ -6090,21 +6102,26 @@ msgid ""
 "(scopes). The token is shown only once when it is created, so copy it right "
 "away."
 msgstr ""
+"APIトークンは、REST API v2へのアクセス権を、きめ細かな権限（スコープ）ととも"
+"に付与します。トークンは作成時に一度だけ表示されるため、すぐにコピーしてくだ"
+"さい。"
 
 #: application/views/api/index.php:124
 #, php-format
 msgid "The API v2 documentation can be found %shere%s."
-msgstr ""
+msgstr "API v2のドキュメントは以下にあります。 %s ここに%s 。"
 
 #: application/views/api/index.php:125
 msgid "The API v2 base URL for this Wavelog instance is"
-msgstr ""
+msgstr "この Wavelog インスタンスの API v2 ベース URL は次のとおりです"
 
 #: application/views/api/index.php:127
 msgid ""
 "On Clubstations the API Tokens are personal and not shared. Clubstation "
 "users can only see their own tokens."
 msgstr ""
+"Clubstationでは、APIトークンは個人専用であり、共有されません。Clubstation"
+"ユーザーは自分のトークンのみを表示できます。"
 
 #: application/views/api/index.php:135
 #: application/views/awards/iota/index.php:210
@@ -6139,7 +6156,7 @@ msgstr "名前"
 
 #: application/views/api/index.php:138
 msgid "Expires"
-msgstr ""
+msgstr "有効期限切れ"
 
 #: application/views/api/index.php:159
 msgid "Expired"
@@ -6148,11 +6165,13 @@ msgstr "期限切れ"
 #: application/views/api/index.php:169
 #, php-format
 msgid "Are you sure you want delete the API Token %s?"
-msgstr ""
+msgstr "APIトークンを削除してもよろしいですか？ %s ?"
 
 #: application/views/api/index.php:184
 msgid "You have no API Tokens yet. Click on the button below to create one."
 msgstr ""
+"まだAPIトークンをお持ちではありません。下のボタンをクリックして作成してくださ"
+"い。"
 
 #: application/views/awards/73on73/index.php:5
 #: application/views/awards/73on73/index.php:13

--- a/application/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/application/locale/sv_SE/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-29 14:47+0000\n"
-"PO-Revision-Date: 2026-07-29 10:54+0000\n"
+"PO-Revision-Date: 2026-07-30 09:11+0000\n"
 "Last-Translator: \"Jorgen Dahl, NU1T\" <sm6srw@arrl.net>\n"
 "Language-Team: Swedish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/sv/>\n"
@@ -4166,29 +4166,31 @@ msgstr "Läs statistik"
 
 #: application/models/Api_v2_model.php:77
 msgid " (min. 2.1.0)"
-msgstr ""
+msgstr " (min. 2.1.0)"
 
 #: application/models/Api_v2_model.php:78
 msgid ""
 "Radio control and QSO upload from WSJT-X, JTDX and friends. Requires at "
 "least version 2.1.0 of WaveLogGate."
 msgstr ""
+"Radiokontroll och QSO-uppladdning från WSJT-X, JTDX och vänner. Kräver minst "
+"version 2.1.0 av WaveLogGate."
 
 #: application/models/Api_v2_model.php:84
 msgid "Read-only"
-msgstr ""
+msgstr "Endast läsning"
 
 #: application/models/Api_v2_model.php:85
 msgid "Read access to everything, no changes to your data."
-msgstr ""
+msgstr "Läsåtkomst till allt, inga ändringar av dina data."
 
 #: application/models/Api_v2_model.php:91
 msgid "Statistics only"
-msgstr ""
+msgstr "Endast statistik"
 
 #: application/models/Api_v2_model.php:92
 msgid "Statistics only, no changes to your data."
-msgstr ""
+msgstr "Endast statistik, inga ändringar i dina data."
 
 #: application/models/Club_model.php:185
 msgid "Invalid Permission Level!"
@@ -5840,6 +5842,8 @@ msgid ""
 "Don't know which scopes you need? Pick the tool you want to use and we "
 "select the scopes for you."
 msgstr ""
+"Vet du inte vilken räckvidd du behöver? Välj verktyget du vill använda så "
+"väljer vi räckvidden åt dig."
 
 #: application/views/api/components/create_token_modal.php:78
 #: application/views/awards/wpx/index.php:152
@@ -5857,6 +5861,8 @@ msgid ""
 "A preset replaces your current selection. You can still adjust the scopes "
 "afterwards."
 msgstr ""
+"En förinställning ersätter ditt aktuella val. Du kan fortfarande justera "
+"räckvidden i efterhand."
 
 #: application/views/api/components/create_token_modal.php:87
 #: application/views/club/clubswitch_modal.php:15


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)