### PR TITLE
[API v2] Extensions of QSO and Statistic Ressource

### DIFF
--- a/application/libraries/api_v2/Api_v2_resource.php
+++ b/application/libraries/api_v2/Api_v2_resource.php
@@ -413,6 +413,23 @@ abstract class Api_v2_resource {
 	}
 
 	/**
+	 * Normalise a ?callsign= filter: '' when absent, else uppercased (COL_CALL is
+	 * stored uppercase). Validated with the same loose rule as the QSO import
+	 * (letters, digits, / and -), so junk like spaces or commas is rejected with
+	 * a 400 instead of silently matching nothing.
+	 */
+	protected function normalize_callsign($raw) {
+		if ($raw === null || $raw === '') {
+			return '';
+		}
+		$this->CI->load->model('logbook_model');
+		if (!$this->CI->logbook_model->is_valid_callsign($raw)) {
+			throw new Api_v2_exception('validation_error', 'Invalid callsign', 400);
+		}
+		return strtoupper(trim($raw));
+	}
+
+	/**
 	 * Parse a comma-separated query parameter into a validated lowercase list,
 	 * or null when the parameter is absent. Values outside $allowed produce a
 	 * 400 carrying the allowed list, so a client can correct itself.

--- a/application/libraries/api_v2/Qso_resource.php
+++ b/application/libraries/api_v2/Qso_resource.php
@@ -59,6 +59,7 @@ class Qso_resource extends Api_v2_resource {
 	 *
 	 * Filters (all optional):
 	 *   ?station_id= comma-separated, ownership-checked; default: all owned
+	 *   ?callsign=   exact match on the worked callsign (e.g. HB9HIL)
 	 *   ?band=       single band filter (e.g. 20m or SAT)
 	 *   ?mode=       single mode/submode filter (e.g. SSB or FT8)
 	 *   ?qsl_filter= comma list of lotw|qsl|eqsl|clublog (OR-combined)
@@ -91,6 +92,7 @@ class Qso_resource extends Api_v2_resource {
 		$station_ids = $this->resolve_station_ids();
 		$band        = $this->normalize_band($this->param('band'));
 		$mode        = $this->normalize_mode($this->param('mode'));
+		$callsign    = $this->normalize_callsign($this->param('callsign'));
 		$qsl_filter  = $this->parse_qsl_filter();
 		$since_id    = $this->parse_since_id();
 
@@ -123,10 +125,10 @@ class Qso_resource extends Api_v2_resource {
 
 		// Total across all pages for the same filter, so a client can find the
 		// last page without probing for an empty response.
-		$total = $this->CI->logbook_model->count_qsos_filtered($station_ids, $band, $mode, $qsl_filter, $since_id, $operator);
+		$total = $this->CI->logbook_model->count_qsos_filtered($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $operator);
 
 		$query = $this->CI->logbook_model->get_qsos_filtered(
-			$station_ids, $band, $mode, $qsl_filter, $since_id, $order, $page['per_page'], $page['offset'], $operator
+			$station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $order, $page['per_page'], $page['offset'], $operator
 		);
 
 		$rows = is_object($query) ? $query->result() : [];

--- a/application/libraries/api_v2/Qso_resource.php
+++ b/application/libraries/api_v2/Qso_resource.php
@@ -64,6 +64,8 @@ class Qso_resource extends Api_v2_resource {
 	 *   ?mode=       single mode/submode filter (e.g. SSB or FT8)
 	 *   ?qsl_filter= comma list of lotw|qsl|eqsl|clublog (OR-combined)
 	 *   ?since_id=   only QSOs with a primary key greater than this (default 0)
+	 *   ?qso_since=  YYYY-MM-DD, oldest QSO date to include (whole day)
+	 *   ?qso_until=  YYYY-MM-DD, newest QSO date to include (whole day)
 	 * Pagination: ?page= / ?per_page= (max 5000; default 50 for JSON, 1000 for
 	 *             ADIF), or ?limit= as a shortcut for the newest N QSOs (overrides
 	 *             page/per_page).
@@ -95,6 +97,8 @@ class Qso_resource extends Api_v2_resource {
 		$callsign    = $this->normalize_callsign($this->param('callsign'));
 		$qsl_filter  = $this->parse_qsl_filter();
 		$since_id    = $this->parse_since_id();
+		$qso_since   = $this->parse_date('qso_since');
+		$qso_until   = $this->parse_date('qso_until');
 
 		// ADIF sync needs ascending-by-id order (so lastfetchedid advances); the
 		// JSON browse list is newest-first.
@@ -125,10 +129,13 @@ class Qso_resource extends Api_v2_resource {
 
 		// Total across all pages for the same filter, so a client can find the
 		// last page without probing for an empty response.
-		$total = $this->CI->logbook_model->count_qsos_filtered($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $operator);
+		$total = $this->CI->logbook_model->count_qsos_filtered(
+			$station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, $operator
+		);
 
 		$query = $this->CI->logbook_model->get_qsos_filtered(
-			$station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $order, $page['per_page'], $page['offset'], $operator
+			$station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until,
+			$order, $page['per_page'], $page['offset'], $operator
 		);
 
 		$rows = is_object($query) ? $query->result() : [];

--- a/application/libraries/api_v2/Qso_resource.php
+++ b/application/libraries/api_v2/Qso_resource.php
@@ -127,15 +127,24 @@ class Qso_resource extends Api_v2_resource {
 		// JSON list and the ADIF export alike, since both run the same query.
 		$operator = $this->is_restricted_club_member() ? (string) $this->operator_callsign() : '';
 
+		$filters = [
+			'station_ids' => $station_ids,
+			'callsign'    => $callsign,
+			'band'        => $band,
+			'mode'        => $mode,
+			'qsl_filter'  => $qsl_filter,
+			'since_id'    => $since_id,
+			'qso_since'   => $qso_since,
+			'qso_until'   => $qso_until,
+			'operator'    => $operator,
+		];
+
 		// Total across all pages for the same filter, so a client can find the
 		// last page without probing for an empty response.
-		$total = $this->CI->logbook_model->count_qsos_filtered(
-			$station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, $operator
-		);
+		$total = $this->CI->logbook_model->count_qsos_filtered($filters);
 
 		$query = $this->CI->logbook_model->get_qsos_filtered(
-			$station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until,
-			$order, $page['per_page'], $page['offset'], $operator
+			$filters, $order, $page['per_page'], $page['offset']
 		);
 
 		$rows = is_object($query) ? $query->result() : [];

--- a/application/libraries/api_v2/Statistic_resource.php
+++ b/application/libraries/api_v2/Statistic_resource.php
@@ -181,19 +181,25 @@ class Statistic_resource extends Api_v2_resource {
 
 		$station_ids = $this->owner_station_ids();
 
-		// Positional, in the order count_confirmations_filtered() declares them;
-		// only $group_by is appended per call below.
-		$args = [$station_ids, $types, $band, $mode, $since, $qso_since, $qso_until];
+		$filters = [
+			'station_ids' => $station_ids,
+			'types'       => $types,
+			'since'       => $since,
+			'qso_since'   => $qso_since,
+			'qso_until'   => $qso_until,
+			'band'        => $band,
+			'mode'        => $mode,
+		];
 
 		return [
 			'counts'  => $this->shape_confirmations(
-				$this->CI->logbook_model->count_confirmations_filtered(...array_merge($args, ['']))
+				$this->CI->logbook_model->count_confirmations_filtered($filters)
 			),
 			'by_band' => array_map([$this, 'shape_confirmations'],
-				$this->CI->logbook_model->count_confirmations_filtered(...array_merge($args, ['band']))
+				$this->CI->logbook_model->count_confirmations_filtered($filters, 'band')
 			),
 			'by_mode' => array_map([$this, 'shape_confirmations'],
-				$this->CI->logbook_model->count_confirmations_filtered(...array_merge($args, ['mode']))
+				$this->CI->logbook_model->count_confirmations_filtered($filters, 'mode')
 			),
 			'filters' => [
 				'type'      => $types,

--- a/application/libraries/api_v2/Statistic_resource.php
+++ b/application/libraries/api_v2/Statistic_resource.php
@@ -162,6 +162,7 @@ class Statistic_resource extends Api_v2_resource {
 	 *   type      comma list of lotw|eqsl|qsl|qrz|clublog (default: all)
 	 *   since     YYYY-MM-DD floor on the date a confirmation was *received*
 	 *   qso_since YYYY-MM-DD floor on the date the *QSO* was made
+	 *   qso_until YYYY-MM-DD ceiling on the date the *QSO* was made
 	 *   band      COL_BAND value, or SAT for satellite QSOs
 	 *   mode      matched against the mode or the submode
 	 *
@@ -174,12 +175,15 @@ class Statistic_resource extends Api_v2_resource {
 		$types = $this->parse_type_list('type', self::CONFIRMATION_TYPES) ?: self::CONFIRMATION_TYPES;
 		$since = $this->parse_date('since');
 		$qso_since = $this->parse_date('qso_since');
+		$qso_until = $this->parse_date('qso_until');
 		$band = $this->normalize_band($this->param('band'));
 		$mode = $this->normalize_mode($this->param('mode'));
 
 		$station_ids = $this->owner_station_ids();
 
-		$args = [$station_ids, $types, $band, $mode, $since, $qso_since];
+		// Positional, in the order count_confirmations_filtered() declares them;
+		// only $group_by is appended per call below.
+		$args = [$station_ids, $types, $band, $mode, $since, $qso_since, $qso_until];
 
 		return [
 			'counts'  => $this->shape_confirmations(
@@ -195,6 +199,7 @@ class Statistic_resource extends Api_v2_resource {
 				'type'      => $types,
 				'since'     => $since ?: null,
 				'qso_since' => $qso_since ?: null,
+				'qso_until' => $qso_until ?: null,
 				'band'      => $band ?: null,
 				'mode'      => $mode ?: null,
 			],

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2300,13 +2300,14 @@ class Logbook_model extends CI_Model {
 	// appended in placeholder order.
 	//
 	// $station_ids  int[]   station-location ids (already ownership-checked)
+	// $callsign     string  '' for none, else an exact match on COL_CALL
 	// $band         string  '' for none, 'SAT', or a COL_BAND value
 	// $mode         string  '' for none, else a COL_MODE or COL_SUBMODE value
 	// $qsl_filter   array   any of lotw|qsl|eqsl|clublog (OR-combined)
 	// $since_id     int     0 for none, else COL_PRIMARY_KEY > $since_id
 	// $qso_since    string  '' for none, else 'Y-m-d' floor on COL_TIME_ON
 	// $operator     string  '' for none, else restrict to that COL_OPERATOR
-	private function _qso_v2_filter_where($station_ids, $band, $mode, $qsl_filter, $since_id, $qso_since, &$bindings, $operator = '') {
+	private function _qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, &$bindings, $operator = '') {
 		$where = " WHERE qsos.`station_id` IN ?";
 		$bindings[] = $station_ids;
 
@@ -2315,6 +2316,11 @@ class Logbook_model extends CI_Model {
 		if ($operator !== null && $operator !== '') {
 			$where .= " AND upper(qsos.`COL_OPERATOR`) = ?";
 			$bindings[] = strtoupper($operator);
+		}
+
+		if ($callsign !== null && $callsign !== '') {
+			$where .= " AND upper(qsos.`COL_CALL`) = ?";
+			$bindings[] = strtoupper($callsign);
 		}
 
 		if ((int) $since_id > 0) {
@@ -2365,14 +2371,14 @@ class Logbook_model extends CI_Model {
 	// rendered as JSON or as ADIF (via AdifHelper). $order is 'id_asc' (ascending
 	// primary key, for incremental ADIF sync) or 'time_desc' (newest first, for
 	// browsing). Filtering is shared with count_qsos_filtered().
-	function get_qsos_filtered($station_ids, $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $order = 'time_desc', $limit = 50, $offset = 0, $operator = '') {
+	function get_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $order = 'time_desc', $limit = 50, $offset = 0, $operator = '') {
 		if (empty($station_ids)) {
 			return $this->db->query("SELECT * FROM " . $this->config->item('table_name') . " WHERE 1=0");
 		}
 
 		$tbl = $this->config->item('table_name');
 		$bindings = [];
-		$where = $this->_qso_v2_filter_where($station_ids, $band, $mode, $qsl_filter, $since_id, '', $bindings, $operator);
+		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, '', $bindings, $operator);
 
 		$sql = "SELECT qsos.*, station_profile.*, dxcc_entities.name AS station_country
 			FROM {$tbl} qsos
@@ -2393,13 +2399,13 @@ class Logbook_model extends CI_Model {
 
 	// Count QSOs for the REST API v2 QSO endpoint, using the exact same filter as
 	// get_qsos_filtered() so `total` matches the paginated result set.
-	function count_qsos_filtered($station_ids, $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $operator = '') {
+	function count_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $operator = '') {
 		if (empty($station_ids)) {
 			return 0;
 		}
 
 		$bindings = [];
-		$where = $this->_qso_v2_filter_where($station_ids, $band, $mode, $qsl_filter, $since_id, '', $bindings, $operator);
+		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, '', $bindings, $operator);
 		$sql = "SELECT COUNT(*) AS cnt FROM " . $this->config->item('table_name') . " qsos" . $where;
 
 		return (int) $this->db->query($sql, $bindings)->row()->cnt;
@@ -2489,7 +2495,7 @@ class Logbook_model extends CI_Model {
 			array_unshift($columns, "{$group_expr} as `{$group_by}`");
 		}
 
-		$where = $this->_qso_v2_filter_where($station_ids, $band, $mode, null, 0, $qso_since, $bindings);
+		$where = $this->_qso_v2_filter_where($station_ids, '', $band, $mode, null, 0, $qso_since, $bindings);
 
 		$sql = "SELECT " . implode(", ", $columns)
 			. " FROM " . $this->config->item('table_name') . " qsos"

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2306,8 +2306,9 @@ class Logbook_model extends CI_Model {
 	// $qsl_filter   array   any of lotw|qsl|eqsl|clublog (OR-combined)
 	// $since_id     int     0 for none, else COL_PRIMARY_KEY > $since_id
 	// $qso_since    string  '' for none, else 'Y-m-d' floor on COL_TIME_ON
+	// $qso_until    string  '' for none, else 'Y-m-d' ceiling on COL_TIME_ON
 	// $operator     string  '' for none, else restrict to that COL_OPERATOR
-	private function _qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, &$bindings, $operator = '') {
+	private function _qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, &$bindings, $operator = '') {
 		$where = " WHERE qsos.`station_id` IN ?";
 		$bindings[] = $station_ids;
 
@@ -2332,6 +2333,12 @@ class Logbook_model extends CI_Model {
 		if ($qso_since !== null && $qso_since !== '') {
 			$where .= " AND qsos.`COL_TIME_ON` >= ?";
 			$bindings[] = $qso_since . ' 00:00:00';
+		}
+
+		// Same for the upper bound: the given day still counts in full.
+		if ($qso_until !== null && $qso_until !== '') {
+			$where .= " AND qsos.`COL_TIME_ON` <= ?";
+			$bindings[] = $qso_until . ' 23:59:59';
 		}
 
 		if ($band !== null && $band !== '') {
@@ -2371,14 +2378,14 @@ class Logbook_model extends CI_Model {
 	// rendered as JSON or as ADIF (via AdifHelper). $order is 'id_asc' (ascending
 	// primary key, for incremental ADIF sync) or 'time_desc' (newest first, for
 	// browsing). Filtering is shared with count_qsos_filtered().
-	function get_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $order = 'time_desc', $limit = 50, $offset = 0, $operator = '') {
+	function get_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $qso_since = '', $qso_until = '', $order = 'time_desc', $limit = 50, $offset = 0, $operator = '') {
 		if (empty($station_ids)) {
 			return $this->db->query("SELECT * FROM " . $this->config->item('table_name') . " WHERE 1=0");
 		}
 
 		$tbl = $this->config->item('table_name');
 		$bindings = [];
-		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, '', $bindings, $operator);
+		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, $bindings, $operator);
 
 		$sql = "SELECT qsos.*, station_profile.*, dxcc_entities.name AS station_country
 			FROM {$tbl} qsos
@@ -2399,13 +2406,13 @@ class Logbook_model extends CI_Model {
 
 	// Count QSOs for the REST API v2 QSO endpoint, using the exact same filter as
 	// get_qsos_filtered() so `total` matches the paginated result set.
-	function count_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $operator = '') {
+	function count_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $qso_since = '', $qso_until = '', $operator = '') {
 		if (empty($station_ids)) {
 			return 0;
 		}
 
 		$bindings = [];
-		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, '', $bindings, $operator);
+		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, $bindings, $operator);
 		$sql = "SELECT COUNT(*) AS cnt FROM " . $this->config->item('table_name') . " qsos" . $where;
 
 		return (int) $this->db->query($sql, $bindings)->row()->cnt;
@@ -2495,7 +2502,7 @@ class Logbook_model extends CI_Model {
 			array_unshift($columns, "{$group_expr} as `{$group_by}`");
 		}
 
-		$where = $this->_qso_v2_filter_where($station_ids, '', $band, $mode, null, 0, $qso_since, $bindings);
+		$where = $this->_qso_v2_filter_where($station_ids, '', $band, $mode, null, 0, $qso_since, '', $bindings);
 
 		$sql = "SELECT " . implode(", ", $columns)
 			. " FROM " . $this->config->item('table_name') . " qsos"

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2325,7 +2325,7 @@ class Logbook_model extends CI_Model {
 		}
 
 		if (($filters['callsign'] ?? '') !== '') {
-			$where .= " AND upper(qsos.`COL_CALL`) = ?";
+			$where .= " AND qsos.`COL_CALL` = ?";
 			$bindings[] = strtoupper($filters['callsign']);
 		}
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2299,68 +2299,73 @@ class Logbook_model extends CI_Model {
 	// diverge. Every column is referenced through the `qsos` alias. Bindings are
 	// appended in placeholder order.
 	//
-	// $station_ids  int[]   station-location ids (already ownership-checked)
-	// $callsign     string  '' for none, else an exact match on COL_CALL
-	// $band         string  '' for none, 'SAT', or a COL_BAND value
-	// $mode         string  '' for none, else a COL_MODE or COL_SUBMODE value
-	// $qsl_filter   array   any of lotw|qsl|eqsl|clublog (OR-combined)
-	// $since_id     int     0 for none, else COL_PRIMARY_KEY > $since_id
-	// $qso_since    string  '' for none, else 'Y-m-d' floor on COL_TIME_ON
-	// $qso_until    string  '' for none, else 'Y-m-d' ceiling on COL_TIME_ON
-	// $operator     string  '' for none, else restrict to that COL_OPERATOR
-	private function _qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, &$bindings, $operator = '') {
+	// $filters keys, all optional but for station_ids; an absent or empty value
+	// means "do not filter on this":
+	//   station_ids  int[]   station-location ids (already ownership-checked)
+	//   callsign     string  exact match on COL_CALL
+	//   band         string  'SAT' or a COL_BAND value
+	//   mode         string  a COL_MODE or COL_SUBMODE value
+	//   qsl_filter   array   any of lotw|qsl|eqsl|clublog (OR-combined)
+	//   since_id     int     COL_PRIMARY_KEY > since_id
+	//   qso_since    string  'Y-m-d' floor on COL_TIME_ON
+	//   qso_until    string  'Y-m-d' ceiling on COL_TIME_ON
+	//   operator     string  restrict to that COL_OPERATOR
+	//
+	// Unknown keys are ignored, so a caller can hand in its whole filter set even
+	// when part of it is consumed elsewhere (see count_confirmations_filtered()).
+	private function _qso_v2_filter_where($filters, &$bindings) {
 		$where = " WHERE qsos.`station_id` IN ?";
-		$bindings[] = $station_ids;
+		$bindings[] = $filters['station_ids'];
 
 		// Clubstation members below officer level only ever see their own QSOs.
 		// Compared uppercased, the same way the ADIF export filters it.
-		if ($operator !== null && $operator !== '') {
+		if (($filters['operator'] ?? '') !== '') {
 			$where .= " AND upper(qsos.`COL_OPERATOR`) = ?";
-			$bindings[] = strtoupper($operator);
+			$bindings[] = strtoupper($filters['operator']);
 		}
 
-		if ($callsign !== null && $callsign !== '') {
+		if (($filters['callsign'] ?? '') !== '') {
 			$where .= " AND upper(qsos.`COL_CALL`) = ?";
-			$bindings[] = strtoupper($callsign);
+			$bindings[] = strtoupper($filters['callsign']);
 		}
 
-		if ((int) $since_id > 0) {
+		if ((int) ($filters['since_id'] ?? 0) > 0) {
 			$where .= " AND qsos.`COL_PRIMARY_KEY` > ?";
-			$bindings[] = (int) $since_id;
+			$bindings[] = (int) $filters['since_id'];
 		}
 
 		// Date-only floor on the QSO time, inclusive of the whole given day.
-		if ($qso_since !== null && $qso_since !== '') {
+		if (($filters['qso_since'] ?? '') !== '') {
 			$where .= " AND qsos.`COL_TIME_ON` >= ?";
-			$bindings[] = $qso_since . ' 00:00:00';
+			$bindings[] = $filters['qso_since'] . ' 00:00:00';
 		}
 
 		// Same for the upper bound: the given day still counts in full.
-		if ($qso_until !== null && $qso_until !== '') {
+		if (($filters['qso_until'] ?? '') !== '') {
 			$where .= " AND qsos.`COL_TIME_ON` <= ?";
-			$bindings[] = $qso_until . ' 23:59:59';
+			$bindings[] = $filters['qso_until'] . ' 23:59:59';
 		}
 
-		if ($band !== null && $band !== '') {
-			if ($band === 'SAT') {
+		if (($filters['band'] ?? '') !== '') {
+			if ($filters['band'] === 'SAT') {
 				$where .= " AND qsos.`col_prop_mode` = 'SAT'";
 			} else {
 				$where .= " AND qsos.`col_prop_mode` != 'SAT' AND qsos.`col_band` = ?";
-				$bindings[] = $band;
+				$bindings[] = $filters['band'];
 			}
 		}
 
 		// Match either the main mode or the submode, so e.g. mode=FT8 finds both
 		// QSOs stored as COL_MODE=FT8 and as COL_MODE=MFSK/COL_SUBMODE=FT8.
-		if ($mode !== null && $mode !== '') {
+		if (($filters['mode'] ?? '') !== '') {
 			$where .= " AND (qsos.`col_mode` = ? OR qsos.`col_submode` = ?)";
-			$bindings[] = $mode;
-			$bindings[] = $mode;
+			$bindings[] = $filters['mode'];
+			$bindings[] = $filters['mode'];
 		}
 
-		if (!empty($qsl_filter)) {
+		if (!empty($filters['qsl_filter'])) {
 			$clauses = [];
-			foreach ($qsl_filter as $method) {
+			foreach ($filters['qsl_filter'] as $method) {
 				if (isset(self::CONFIRMATION_COLUMNS[$method])) {
 					$clauses[] = "qsos.`" . self::CONFIRMATION_COLUMNS[$method]['rcvd'] . "` = 'Y'";
 				}
@@ -2377,15 +2382,16 @@ class Logbook_model extends CI_Model {
 	// the full COL_* plus station_profile columns, so the same result set can be
 	// rendered as JSON or as ADIF (via AdifHelper). $order is 'id_asc' (ascending
 	// primary key, for incremental ADIF sync) or 'time_desc' (newest first, for
-	// browsing). Filtering is shared with count_qsos_filtered().
-	function get_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $qso_since = '', $qso_until = '', $order = 'time_desc', $limit = 50, $offset = 0, $operator = '') {
-		if (empty($station_ids)) {
+	// browsing). $filters is the set documented at _qso_v2_filter_where() and is
+	// shared verbatim with count_qsos_filtered().
+	function get_qsos_filtered($filters, $order = 'time_desc', $limit = 50, $offset = 0) {
+		if (empty($filters['station_ids'])) {
 			return $this->db->query("SELECT * FROM " . $this->config->item('table_name') . " WHERE 1=0");
 		}
 
 		$tbl = $this->config->item('table_name');
 		$bindings = [];
-		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, $bindings, $operator);
+		$where = $this->_qso_v2_filter_where($filters, $bindings);
 
 		$sql = "SELECT qsos.*, station_profile.*, dxcc_entities.name AS station_country
 			FROM {$tbl} qsos
@@ -2406,13 +2412,13 @@ class Logbook_model extends CI_Model {
 
 	// Count QSOs for the REST API v2 QSO endpoint, using the exact same filter as
 	// get_qsos_filtered() so `total` matches the paginated result set.
-	function count_qsos_filtered($station_ids, $callsign = '', $band = '', $mode = '', $qsl_filter = null, $since_id = 0, $qso_since = '', $qso_until = '', $operator = '') {
-		if (empty($station_ids)) {
+	function count_qsos_filtered($filters) {
+		if (empty($filters['station_ids'])) {
 			return 0;
 		}
 
 		$bindings = [];
-		$where = $this->_qso_v2_filter_where($station_ids, $callsign, $band, $mode, $qsl_filter, $since_id, $qso_since, $qso_until, $bindings, $operator);
+		$where = $this->_qso_v2_filter_where($filters, $bindings);
 		$sql = "SELECT COUNT(*) AS cnt FROM " . $this->config->item('table_name') . " qsos" . $where;
 
 		return (int) $this->db->query($sql, $bindings)->row()->cnt;
@@ -2469,18 +2475,19 @@ class Logbook_model extends CI_Model {
 	// mode incl. submode, qso_since/qso_until) and adds per-type received-date
 	// filtering.
 	//
-	// $types     string[]  subset of the CONFIRMATION_COLUMNS keys
-	// $since     string    '' or 'Y-m-d', matched against each type's date column
-	// $qso_since string    '' or 'Y-m-d', floor on COL_TIME_ON
-	// $qso_until string    '' or 'Y-m-d', ceiling on COL_TIME_ON
-	// $group_by  string    '' for grand totals, else 'band' or 'mode'
+	// $filters carries the QSO filters from _qso_v2_filter_where() plus two keys
+	// only this counter knows:
+	//   types  string[]  subset of the CONFIRMATION_COLUMNS keys
+	//   since  string    'Y-m-d', matched against each type's own date column
+	//
+	// $group_by is '' for grand totals, else 'band' or 'mode'.
 	//
 	// Returns an assoc array of counts when ungrouped, else a list of rows each
 	// carrying the group key plus the same counts.
-	function count_confirmations_filtered($station_ids, $types, $band = '', $mode = '', $since = '', $qso_since = '', $qso_until = '', $group_by = '') {
-		$types = array_values(array_intersect($types, array_keys(self::CONFIRMATION_COLUMNS)));
+	function count_confirmations_filtered($filters, $group_by = '') {
+		$types = array_values(array_intersect($filters['types'] ?? [], array_keys(self::CONFIRMATION_COLUMNS)));
 
-		if (empty($station_ids) || empty($types)) {
+		if (empty($filters['station_ids']) || empty($types)) {
 			if ($group_by !== '') {
 				return [];
 			}
@@ -2490,7 +2497,7 @@ class Logbook_model extends CI_Model {
 		// Select bindings are consumed before the WHERE bindings, so the count
 		// columns must be built first.
 		$bindings = [];
-		$columns = $this->_confirmation_count_columns($types, $since, $bindings);
+		$columns = $this->_confirmation_count_columns($types, $filters['since'] ?? '', $bindings);
 
 		// Whitelisted grouping expressions — never interpolate caller input here.
 		// The mode key prefers the submode so e.g. FT8 does not vanish into MFSK,
@@ -2504,7 +2511,7 @@ class Logbook_model extends CI_Model {
 			array_unshift($columns, "{$group_expr} as `{$group_by}`");
 		}
 
-		$where = $this->_qso_v2_filter_where($station_ids, '', $band, $mode, null, 0, $qso_since, $qso_until, $bindings);
+		$where = $this->_qso_v2_filter_where($filters, $bindings);
 
 		$sql = "SELECT " . implode(", ", $columns)
 			. " FROM " . $this->config->item('table_name') . " qsos"

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2466,16 +2466,18 @@ class Logbook_model extends CI_Model {
 
 	// Confirmation counts per QSL type for the REST API v2 statistic endpoint.
 	// Reuses the QSO v2 filter (station scope, band incl. the SAT special case,
-	// mode incl. submode, qso_since) and adds per-type received-date filtering.
+	// mode incl. submode, qso_since/qso_until) and adds per-type received-date
+	// filtering.
 	//
 	// $types     string[]  subset of the CONFIRMATION_COLUMNS keys
 	// $since     string    '' or 'Y-m-d', matched against each type's date column
-	// $qso_since string    '' or 'Y-m-d', matched against COL_TIME_ON
+	// $qso_since string    '' or 'Y-m-d', floor on COL_TIME_ON
+	// $qso_until string    '' or 'Y-m-d', ceiling on COL_TIME_ON
 	// $group_by  string    '' for grand totals, else 'band' or 'mode'
 	//
 	// Returns an assoc array of counts when ungrouped, else a list of rows each
 	// carrying the group key plus the same counts.
-	function count_confirmations_filtered($station_ids, $types, $band = '', $mode = '', $since = '', $qso_since = '', $group_by = '') {
+	function count_confirmations_filtered($station_ids, $types, $band = '', $mode = '', $since = '', $qso_since = '', $qso_until = '', $group_by = '') {
 		$types = array_values(array_intersect($types, array_keys(self::CONFIRMATION_COLUMNS)));
 
 		if (empty($station_ids) || empty($types)) {
@@ -2502,7 +2504,7 @@ class Logbook_model extends CI_Model {
 			array_unshift($columns, "{$group_expr} as `{$group_by}`");
 		}
 
-		$where = $this->_qso_v2_filter_where($station_ids, '', $band, $mode, null, 0, $qso_since, '', $bindings);
+		$where = $this->_qso_v2_filter_where($station_ids, '', $band, $mode, null, 0, $qso_since, $qso_until, $bindings);
 
 		$sql = "SELECT " . implode(", ", $columns)
 			. " FROM " . $this->config->item('table_name') . " qsos"


### PR DESCRIPTION
This PR extends the QSO and Statistics ressource with:

- qso endpoint now accepts callsign filter
- qso endpoint now accepts qso_since and qso_until filter
- statistic endpoint now accepts qso_until filter (qso_since was already there)

Since the function had a lot of parameters I simplified that by using an array instead which results in an more easy to maintain code