### PR TITLE
Apiv2 club permissions

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -38,7 +38,7 @@ class API extends CI_Controller {
 
 		$data['api_keys'] = $this->api_model->keys();
 		$data['api_tokens'] = $this->api_v2_model->get_tokens_for_user();
-		$data['token_scopes'] = Api_v2_model::scope_registry();
+		$data['token_scopes'] = Api_v2_model::grantable_scope_registry();
 		$data['token_presets'] = Api_v2_model::preset_registry();
 		// One-time reveal: the plaintext token survives exactly one redirect.
 		$data['new_api_token'] = $this->session->flashdata('new_api_token');

--- a/application/controllers/Api_token.php
+++ b/application/controllers/Api_token.php
@@ -13,7 +13,6 @@ class Api_token extends CI_Controller {
 
 	public function __construct() {
 		parent::__construct();
-		$this->load->model('user_model');
 		$this->load->model('api_v2_model');
 	}
 
@@ -40,7 +39,7 @@ class Api_token extends CI_Controller {
 		}
 
 		$scopes = $this->input->post('scopes', TRUE);
-		$valid_scopes = array_keys(Api_v2_model::scope_registry());
+		$valid_scopes = array_keys(Api_v2_model::grantable_scope_registry());
 		$scopes = is_array($scopes) ? array_intersect($scopes, $valid_scopes) : [];
 		if (empty($scopes)) {
 			$this->session->set_flashdata('error', __("Please select at least one scope"));

--- a/application/controllers/Api_v2.php
+++ b/application/controllers/Api_v2.php
@@ -281,6 +281,10 @@ class Api_v2 extends CI_Controller {
 			throw new Api_v2_exception('not_found', 'Unknown resource: ' . $resource, 404);
 		}
 
+		if (!$class::is_available()) {
+			throw new Api_v2_exception('not_found', 'Unknown resource: ' . $resource, 404);
+		}
+
 		$body = in_array($method, ['POST', 'PUT', 'PATCH'], true) ? $this->read_json_body() : null;
 
 		return new $class($auth, $body);

--- a/application/controllers/Api_v2.php
+++ b/application/controllers/Api_v2.php
@@ -216,12 +216,18 @@ class Api_v2 extends CI_Controller {
 		// Returns 0 for a user that is no longer a member of the clubstation.
 		$permission = (int) $this->club_model->get_permission_noui($auth['user_id'], $auth['created_by']);
 		if ($permission < 1) {
-			// The token is valid, the permission behind it is not: 403, not 401.
-			throw new Api_v2_exception(
-				'club_access_revoked',
-				'The clubstation membership behind this token has been revoked',
-				403
-			);
+			// An administrator manages every clubstation in the web UI
+			// so he should be able to manage any club also via the API
+			if ($this->user_model->is_admin($auth['created_by'])) {
+				$permission = 9;
+			} else {
+				// The token is valid, the permission behind it is not: 403, not 401.
+				throw new Api_v2_exception(
+					'club_access_revoked',
+					'The clubstation membership behind this token has been revoked',
+					403
+				);
+			}
 		}
 
 		$auth['club_permission'] = $permission;

--- a/application/controllers/Club.php
+++ b/application/controllers/Club.php
@@ -19,11 +19,8 @@ class Club extends CI_Controller
 	function __construct() {
 		parent::__construct();
 
-		$this->permissions = [
-			9 => __("Club Officer"),
-			6 => __("Club Member ADIF"),
-			3 => __("Club Member"),
-		];
+		$this->load->model('club_model');
+		$this->permissions = $this->club_model->permission_levels();
 	}
 
     public function index()
@@ -34,23 +31,13 @@ class Club extends CI_Controller
 
     public function permissions($club_id) {
 
-		$this->load->model('club_model');
 		$this->load->library('form_validation');
 
 		$cid = $this->security->xss_clean($club_id);
 		$club = $this->user_model->get_by_id($cid)->row();
 
 		// Check if club managed by SSO
-		$ssoManaged = false;
-		if ($this->config->item('auth_header_enable') ?? false) {
-
-			$this->config->load('sso', true, true);
-			$directs = $this->config->item('auth_header_clubstation_direct', 'sso') ?: [];
-
-			if (!empty($directs)) {
-				$ssoManaged = key_exists($club_id, $directs);
-			}
-		}
+		$ssoManaged = $this->club_model->is_sso_managed($club_id);
 
 		if (!is_numeric($cid)) {
 			$this->session->set_flashdata('error', __("Invalid User ID!"));
@@ -116,8 +103,6 @@ class Club extends CI_Controller
 	}
 
 	public function alter_member() {
-		
-		$this->load->model('club_model');
 
 		$club_id = $this->input->post('club_id', true);
 		$user_id = $this->input->post('user_id', true);
@@ -135,7 +120,7 @@ class Club extends CI_Controller
 		$this->club_model->alter_member($club_id, $user_id, $p_level);
 
 		if ($this->input->post('notify_user', true) == 'on') {
-			if (!$this->notification($user_id, $club_id, $this->input->post('notify_message', true))) {
+			if (!$this->club_model->notify_member($user_id, $club_id, $this->input->post('notify_message', true))) {
 				$this->session->set_flashdata('error', __("User could not be notified. Please check your email settings."));
 			}
 		}
@@ -145,8 +130,6 @@ class Club extends CI_Controller
 	}
 
 	public function delete_member() {
-		
-		$this->load->model('club_model');
 
 		$club_id = $this->input->post('club_id', true);
 		$user_id = $this->input->post('user_id', true);
@@ -169,8 +152,7 @@ class Club extends CI_Controller
 	}
 
 	public function switch_modal() {
-		
-		$this->load->model('club_model');
+
 		$this->load->library('encryption');
 
 		$cid = $this->input->post('club_id', true);
@@ -191,58 +173,4 @@ class Club extends CI_Controller
 		$this->load->view('club/clubswitch_modal', $data);
 	}
 
-	private function notification($user_id, $club_id, $message) {
-
-		$this->load->library('email');
-		$this->load->model('club_model');
-
-		switch ($message) {
-			case 'new_member':
-				$view = 'email/club/new_member';
-				break;
-			case 'modified_member':
-				$view = 'email/club/modified_member';
-				break;
-			default:
-				log_message('error', "Club Notification; Can't notify user - Invalid message type.");
-				$this->session->set_flashdata('error', __("Invalid message type."));
-				redirect('club/permissions/'.$club_id);
-				die;
-		}
-		
-		$config = [
-			'protocol' => $this->optionslib->get_option('emailProtocol'),
-			'smtp_crypto' => $this->optionslib->get_option('smtpEncryption'),
-			'smtp_host' => $this->optionslib->get_option('smtpHost'),
-			'smtp_port' => $this->optionslib->get_option('smtpPort'),
-			'smtp_user' => $this->optionslib->get_option('smtpUsername'),
-			'smtp_pass' => $this->optionslib->get_option('smtpPassword'),
-			'crlf' => "\r\n",
-			'newline' => "\r\n"
-		];
-		if(!$this->email->initialize($config)) {
-			log_message('error', "Club Notification; Can't notify user - Email can't be initialized.");
-			$this->session->set_flashdata('error', __("Email can't be initialized. Check the email settings."));
-			redirect('club/permissions/'.$club_id);
-		}
-
-		$user = $this->user_model->get_by_id($user_id)->row();
-		$club = $this->user_model->get_by_id($club_id)->row();
-		$permission = $this->club_model->get_permission($club_id, $user_id);
-		$permission_level = $this->permissions[$permission] ?? __("Unknown");
-
-		$mail_data['user_callsign'] = $user->user_callsign;
-		$mail_data['club_callsign'] = $club->user_callsign;
-		$mail_data['permission_level'] = $permission_level;
-
-		$message = $this->email->load($view, $mail_data, $user->user_language);
-
-		$this->email->from($this->optionslib->get_option('emailAddress'), $this->optionslib->get_option('emailSenderName'));
-		$this->email->to($user->user_email);
-		$this->email->subject($message['subject']);
-		$this->email->message($message['body']);
-
-		return $this->email->send();
-	}
-	
 }

--- a/application/libraries/api_v2/Api_v2_resource.php
+++ b/application/libraries/api_v2/Api_v2_resource.php
@@ -179,6 +179,23 @@ abstract class Api_v2_resource {
 	}
 
 	/**
+	 * Whether the *current session* may hand out this resource's scopes when
+	 * creating a token. The counterpart to is_available(): that one answers
+	 * whether the resource exists on this instance at all, this one whether the
+	 * user in front of the token dialog has any use for it.
+	 *
+	 * Only the token UI asks (Api_v2_model::grantable_scope_registry()), and
+	 * only for resources that are available already. The dispatcher must never
+	 * call it - a token outlives the session that created it, and a request
+	 * carries no session at all.
+	 *
+	 * @return bool
+	 */
+	public static function is_grantable() {
+		return true;
+	}
+
+	/**
 	 * Translated labels for this resource's scopes, keyed by suffix
 	 * ("read" | "write" | "delete"). Override in each resource; the strings
 	 * must be static __() literals so po_gen.sh can extract them. The base

--- a/application/libraries/api_v2/Api_v2_resource.php
+++ b/application/libraries/api_v2/Api_v2_resource.php
@@ -167,6 +167,18 @@ abstract class Api_v2_resource {
 	}
 
 	/**
+	 * Whether this resource exists on this instance. If the same function 
+	 * exists in the ressource itself, it will be called instead of this one.
+	 * This allows to disable a resources based on other parameters. This 
+	 * function is the default for any ressource which does not redefine it.
+	 *
+	 * @return bool
+	 */
+	public static function is_available() {
+		return true;
+	}
+
+	/**
 	 * Translated labels for this resource's scopes, keyed by suffix
 	 * ("read" | "write" | "delete"). Override in each resource; the strings
 	 * must be static __() literals so po_gen.sh can extract them. The base

--- a/application/libraries/api_v2/Club_resource.php
+++ b/application/libraries/api_v2/Club_resource.php
@@ -5,26 +5,42 @@ if (!defined('BASEPATH')) exit('No direct script access allowed');
 require_once __DIR__ . '/Api_v2_resource.php';
 
 /**
- * API v2 - Club members resource (read-only)
+ * API v2 - Clubstation members resource
  *
- * Lists the members of a clubstation, the v2 equivalent of the v1
- * list_clubmembers endpoint. Only a club officer (permission level 9) using a
- * member-issued token may read the list: the token owner is the clubstation and
- * the token creator is the member acting on its behalf, so a token where owner
- * == creator (a personal token) is never a club officer.
+ * Lists and manages the members of a clubstation, the v2 equivalent of the v1
+ * list_clubmembers endpoint plus the permission handling of the web UI
+ * (controllers/Club.php). Only a club officer (permission level 9) using a
+ * member-issued token may use it: the token owner is the clubstation and the
+ * token creator is the member acting on its behalf, so a token where owner ==
+ * creator (a personal token) is never a club officer.
+ *
+ * The clubstation is implicit - it is the token owner - so the path id
+ * addresses the member: /api/v2/club/{user_id}.
  *
  * Route:  /api/v2/club
- * Scope:  club:read
+ * Scope:  club:read / club:write / club:delete
  */
 class Club_resource extends Api_v2_resource {
 
 	/** Token scope of this resource (see Api_v2_resource::required_scope()). */
 	protected $scope = 'club';
 
-	/** Registry label for this resource's scope (see scope_definitions()). */
+	/**
+	 * The whole resource only exists while the clubstation feature is on.
+	 * This overrides the default is_available() of Api_v2_resource, which always returns
+	 * true.
+	 */
+	public static function is_available() {
+		$CI =& get_instance();
+		return (bool) $CI->config->item('special_callsign');
+	}
+
+	/** Registry labels for this resource's scopes (see scope_definitions()). */
 	protected static function scope_labels() {
 		return [
-			'read' => __('Read club members'),
+			'read'   => __('Read club members'),
+			'write'  => __('Manage club member permissions'),
+			'delete' => __('Remove club members'),
 		];
 	}
 
@@ -33,34 +49,267 @@ class Club_resource extends Api_v2_resource {
 	 * The clubstation's members (callsign, user_name, p_level).
 	 */
 	public function index() {
-		$club_id    = $this->user_id();
-		$created_by = $this->auth['created_by'];
-
-		$this->require_club_level(9);
-
-		$this->CI->load->model('club_model');
-		$club_perm = $this->CI->club_model->get_permission_noui($club_id, $created_by);
-
-		// Officer check: the acting member (created_by) must hold p_level 9 on the
-		// clubstation (club_id), and must not be the clubstation itself.
-		if ($club_id == $created_by || (int) ($club_perm ?? 0) !== 9) {
-			throw new Api_v2_exception('forbidden', 'Token is not a club officer', 403);
-		}
+		$this->require_permission_level(9);
 
 		$members = [];
-		foreach ($this->CI->club_model->get_club_members($club_id) as $member) {
-			$members[] = [
-				'user_firstname' => $member->user_firstname,
-				'user_lastname'  => $member->user_lastname,
-				'user_locator'    => $member->user_locator,
-				'callsign'  => $member->user_callsign,
-				'user_name' => $member->user_name,
-				'user_email' => $member->user_email,
-				'permission_level'   => (int) $member->p_level,
-				'user_language' => $member->user_language,
-			];
+		foreach ($this->CI->club_model->get_club_members($this->user_id()) as $member) {
+			$members[] = $this->format_member($member);
 		}
 
 		$this->CI->api_v2_response->respond($members, 200, ['count' => count($members)]);
+	}
+
+	/**
+	 * GET /api/v2/club/{user_id}
+	 * A single member of the clubstation.
+	 */
+	public function show($user_id) {
+		$this->require_permission_level(9);
+
+		$member = $this->find_member($user_id);
+		if ($member === null) {
+			throw new Api_v2_exception('not_found', 'User is not a member of this clubstation', 404);
+		}
+
+		$this->CI->api_v2_response->respond($this->format_member($member));
+	}
+
+	/**
+	 * POST /api/v2/club
+	 * Add a member to the clubstation.
+	 * Body: { user_id, permission_level, notify? }
+	 */
+	public function create() {
+		$this->require_write();
+		$this->require_permission_level(9);
+		$this->require_not_sso_managed();
+
+		$body = $this->body();
+		$this->require_scalar_fields($body);
+
+		// The id comes from the body here, so a missing or malformed one is a
+		// validation error rather than an unknown URL.
+		if (!isset($body['user_id']) || !is_numeric($body['user_id'])) {
+			throw new Api_v2_exception('validation_error', 'user_id must be a numeric user id', 400, ['field' => 'user_id']);
+		}
+		$user_id = (int) $body['user_id'];
+
+		$this->require_manageable_member($user_id);
+		$level = $this->parse_permission_level($body);
+
+		// Changing an existing membership is what PATCH is for; creating one
+		// twice must not silently overwrite the level already granted.
+		if ((int) $this->CI->club_model->get_permission_noui($this->user_id(), $user_id) > 0) {
+			throw new Api_v2_exception('conflict', 'User is already a member of this clubstation', 409);
+		}
+
+		$this->CI->club_model->alter_member($this->user_id(), $user_id, $level);
+
+		$this->respond_member($user_id, $body, 'new_member', 201);
+	}
+
+	/**
+	 * PATCH /api/v2/club/{user_id}
+	 * Change a member's permission level.
+	 * Body: { permission_level, notify? }
+	 */
+	public function update($user_id) {
+		$this->require_write();
+		$this->require_permission_level(9);
+		$this->require_not_sso_managed();
+
+		$body = $this->body();
+		$this->require_scalar_fields($body);
+
+		$user_id = $this->require_manageable_member($user_id);
+		$level = $this->parse_permission_level($body);
+
+		// No upsert: adding a member is POST.
+		if ((int) $this->CI->club_model->get_permission_noui($this->user_id(), $user_id) === 0) {
+			throw new Api_v2_exception('not_found', 'User is not a member of this clubstation', 404);
+		}
+
+		$this->CI->club_model->alter_member($this->user_id(), $user_id, $level);
+
+		$this->respond_member($user_id, $body, 'modified_member', 200);
+	}
+
+	/**
+	 * DELETE /api/v2/club/{user_id}
+	 * Remove a member from the clubstation, together with the v1 API keys and rig
+	 * control sessions it created for the club (Club_model::delete_member()). Its
+	 * v2 tokens survive and are refused with club_access_revoked instead.
+	 */
+	public function delete($user_id) {
+		$this->require_delete();
+		$this->require_permission_level(9);
+		$this->require_not_sso_managed();
+
+		$user_id = $this->require_manageable_member($user_id);
+
+		// Without this a DELETE on a non-member would report success.
+		if ((int) $this->CI->club_model->get_permission_noui($this->user_id(), $user_id) === 0) {
+			throw new Api_v2_exception('not_found', 'User is not a member of this clubstation', 404);
+		}
+
+		if (!$this->CI->club_model->delete_member($this->user_id(), $user_id)) {
+			throw new Api_v2_exception('internal_error', 'User could not be removed from the clubstation', 500);
+		}
+
+		$this->CI->api_v2_response->no_content();
+	}
+
+	// --- Internal helpers --------------------------------------------------
+
+	/**
+	 * Every operation here is officer-only. Api_v2::resolve_club_context()
+	 * fills club_permission for club tokens only, and only while the
+	 * clubstation feature is on, so this one check covers a personal token, a
+	 * member below officer level and a disabled feature alike.
+	 *
+	 * @throws Api_v2_exception 403
+	 */
+	protected function require_permission_level($level) {
+		if (!is_numeric($level) || (int) $level < 1) {
+			throw new Api_v2_exception('internal_error', 'Invalid permission level', 500);
+		}
+
+		$this->CI->load->model('club_model');
+
+		if ((int) $this->club_permission() !== (int) $level) {
+			throw new Api_v2_exception('forbidden', 'Token is not a club officer', 403);
+		}
+	}
+
+	/**
+	 * Refuse writes to a clubstation whose memberships an identity provider
+	 * owns. Those are granted and revoked on login, so a write here would be
+	 * undone without warning - the web UI disables the form for the same reason.
+	 *
+	 * @throws Api_v2_exception 409
+	 */
+	protected function require_not_sso_managed() {
+		if ($this->CI->club_model->is_sso_managed($this->user_id())) {
+			throw new Api_v2_exception('conflict', 'Club membership is managed by the identity provider', 409);
+		}
+	}
+
+	/**
+	 * Verify a user id may be managed as a member of this clubstation.
+	 *
+	 * @param mixed $user_id Id from the path or the request body.
+	 * @return int The validated user id.
+	 * @throws Api_v2_exception 400/403/404
+	 */
+	protected function require_manageable_member($user_id) {
+		if (!is_numeric($user_id) || (int) $user_id < 1) {
+			throw new Api_v2_exception('not_found', 'Unknown user', 404);
+		}
+		$user_id = (int) $user_id;
+
+		if ($user_id === (int) $this->user_id()) {
+			throw new Api_v2_exception('validation_error', 'A clubstation cannot be a member of itself', 400);
+		}
+
+		// An officer must not be able to lock themselves out of their own club
+		// through the API; changing your own level stays a web UI operation.
+		if ($user_id === (int) $this->auth['created_by']) {
+			throw new Api_v2_exception('forbidden', 'Cannot modify your own club membership', 403);
+		}
+
+		$user = $this->CI->user_model->get_by_id($user_id);
+		if ($user === null || $user->num_rows() === 0) {
+			throw new Api_v2_exception('not_found', 'Unknown user', 404);
+		}
+
+		// Mirrors the member search of the web UI, which only offers regular
+		// accounts (User_model::search_users() filters on clubstation = 0).
+		if ((int) $user->row()->clubstation === 1) {
+			throw new Api_v2_exception('validation_error', 'A clubstation cannot be a member of a clubstation', 400);
+		}
+
+		return $user_id;
+	}
+
+	/**
+	 * Read and validate the permission level from the request body against the
+	 * levels the web UI offers (Club_model::permission_levels()).
+	 *
+	 * @throws Api_v2_exception 400
+	 */
+	protected function parse_permission_level($body) {
+		$allowed = array_keys($this->CI->club_model->permission_levels());
+
+		if (!isset($body['permission_level']) || !is_numeric($body['permission_level'])
+			|| !in_array((int) $body['permission_level'], $allowed, true)) {
+			throw new Api_v2_exception(
+				'validation_error',
+				'permission_level must be one of: ' . implode(', ', $allowed),
+				400,
+				['field' => 'permission_level', 'allowed' => $allowed]
+			);
+		}
+
+		return (int) $body['permission_level'];
+	}
+
+	/**
+	 * Send the response for a create/update, optionally notifying the member
+	 * first. A failed mail is reported in the meta rather than failing the
+	 * request: the permission itself was granted either way.
+	 *
+	 * @param int    $user_id  The member the operation acted on.
+	 * @param array  $body     Decoded request body (read for the notify flag).
+	 * @param string $template 'new_member' or 'modified_member'.
+	 * @param int    $status   201 on create, 200 on update.
+	 */
+	protected function respond_member($user_id, $body, $template, $status) {
+		$meta = null;
+		// no notification by default
+		if (filter_var($body['notify'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
+			$meta = ['notified' => (bool) $this->CI->club_model->notify_member($user_id, $this->user_id(), $template)];
+		}
+
+		$headers = ($status === 201)
+			? ['Location' => base_url('index.php/api/v2/club/' . $user_id)]
+			: [];
+
+		$this->CI->api_v2_response->respond($this->format_member($this->find_member($user_id)), $status, $meta, $headers);
+	}
+
+	/**
+	 * A single member row of this clubstation, or null when the user is not a
+	 * member. Clubs have a handful of members, so filtering the existing list
+	 * query is cheaper than a new model method.
+	 *
+	 * @return object|null
+	 */
+	protected function find_member($user_id) {
+		if (!is_numeric($user_id)) {
+			return null;
+		}
+		foreach ($this->CI->club_model->get_club_members($this->user_id()) as $member) {
+			if ((int) $member->user_id === (int) $user_id) {
+				return $member;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Shape a club member row into the public API representation.
+	 */
+	protected function format_member($member) {
+		return [
+			'user_id'          => (int) $member->user_id,
+			'user_firstname'   => $member->user_firstname,
+			'user_lastname'    => $member->user_lastname,
+			'user_locator'     => $member->user_locator,
+			'callsign'         => $member->user_callsign,
+			'user_name'        => $member->user_name,
+			'user_email'       => $member->user_email,
+			'permission_level' => (int) $member->p_level,
+			'user_language'    => $member->user_language,
+		];
 	}
 }

--- a/application/libraries/api_v2/Club_resource.php
+++ b/application/libraries/api_v2/Club_resource.php
@@ -9,21 +9,32 @@ require_once __DIR__ . '/Api_v2_resource.php';
  *
  * Lists and manages the members of a clubstation, the v2 equivalent of the v1
  * list_clubmembers endpoint plus the permission handling of the web UI
- * (controllers/Club.php). Only a club officer (permission level 9) using a
- * member-issued token may use it: the token owner is the clubstation and the
- * token creator is the member acting on its behalf, so a token where owner ==
- * creator (a personal token) is never a club officer.
+ * (controllers/Club.php). The path id addresses the *member*:
+ * /api/v2/club/{user_id}.
  *
- * The clubstation is implicit - it is the token owner - so the path id
- * addresses the member: /api/v2/club/{user_id}.
+ * Two kinds of token reach this resource, mirroring who may open
+ * club/permissions/<id> in the web UI:
  *
- * Route:  /api/v2/club
+ *  - A club token whose creator is an officer (permission level 9). The
+ *    clubstation is implicit - it is the token owner - so ?club_id= is optional
+ *    and may only name that same club.
+ *  - A personal token of a Wavelog administrator. Administrators manage every
+ *    clubstation (Club_model::club_authorize()), so there is nothing implicit
+ *    about which one they mean: ?club_id= is mandatory.
+ *
+ * Anything else - a personal token of a regular user, a club token below
+ * officer level - is refused with 403.
+ *
+ * Route:  /api/v2/club[/{user_id}][?club_id=]
  * Scope:  club:read / club:write / club:delete
  */
 class Club_resource extends Api_v2_resource {
 
 	/** Token scope of this resource (see Api_v2_resource::required_scope()). */
 	protected $scope = 'club';
+
+	/** @var int|null Memoized result of resolve_club(). */
+	protected $club_id = null;
 
 	/**
 	 * The whole resource only exists while the clubstation feature is on.
@@ -33,6 +44,25 @@ class Club_resource extends Api_v2_resource {
 	public static function is_available() {
 		$CI =& get_instance();
 		return (bool) $CI->config->item('special_callsign');
+	}
+
+	/**
+	 * Only sessions that could actually use these scopes are offered them: an
+	 * officer inside a clubstation, or an administrator outside one. A regular
+	 * user has no club to address and would end up with a token that can only
+	 * ever answer 403.
+	 */
+	public static function is_grantable() {
+		$CI =& get_instance();
+
+		// Inside a clubstation the permission level decides. The two cases have
+		// to stay separate because clubaccess_check() returns true outside one.
+		if ($CI->session->userdata('clubstation') == 1) {
+			return clubaccess_check(9);
+		}
+
+		// Outside: administrators only, who name the club with ?club_id=.
+		return (bool) $CI->user_model->authorize(99);
 	}
 
 	/** Registry labels for this resource's scopes (see scope_definitions()). */
@@ -46,13 +76,27 @@ class Club_resource extends Api_v2_resource {
 
 	/**
 	 * GET /api/v2/club
-	 * The clubstation's members (callsign, user_name, p_level).
+	 *
+	 * The clubstation's members (callsign, user_name, p_level) - or, for an
+	 * administrator who named no club, the list of clubstations to choose from.
+	 * That is where the club_id every other call needs comes from, so refusing
+	 * it with a 400 would leave them nowhere to look it up.
 	 */
 	public function index() {
-		$this->require_permission_level(9);
+		$club_id = $this->resolve_club(false);
+
+		if ($club_id === null) {
+			$clubs = [];
+			foreach ($this->CI->club_model->get_all_clubstations() as $club) {
+				$clubs[] = $this->format_clubstation($club);
+			}
+
+			$this->CI->api_v2_response->respond($clubs, 200, ['count' => count($clubs)]);
+			return;
+		}
 
 		$members = [];
-		foreach ($this->CI->club_model->get_club_members($this->user_id()) as $member) {
+		foreach ($this->CI->club_model->get_club_members($club_id) as $member) {
 			$members[] = $this->format_member($member);
 		}
 
@@ -64,7 +108,7 @@ class Club_resource extends Api_v2_resource {
 	 * A single member of the clubstation.
 	 */
 	public function show($user_id) {
-		$this->require_permission_level(9);
+		$this->resolve_club();
 
 		$member = $this->find_member($user_id);
 		if ($member === null) {
@@ -81,7 +125,7 @@ class Club_resource extends Api_v2_resource {
 	 */
 	public function create() {
 		$this->require_write();
-		$this->require_permission_level(9);
+		$club_id = $this->resolve_club();
 		$this->require_not_sso_managed();
 
 		$body = $this->body();
@@ -99,11 +143,11 @@ class Club_resource extends Api_v2_resource {
 
 		// Changing an existing membership is what PATCH is for; creating one
 		// twice must not silently overwrite the level already granted.
-		if ((int) $this->CI->club_model->get_permission_noui($this->user_id(), $user_id) > 0) {
+		if ((int) $this->CI->club_model->get_permission_noui($club_id, $user_id) > 0) {
 			throw new Api_v2_exception('conflict', 'User is already a member of this clubstation', 409);
 		}
 
-		$this->CI->club_model->alter_member($this->user_id(), $user_id, $level);
+		$this->CI->club_model->alter_member($club_id, $user_id, $level);
 
 		$this->respond_member($user_id, $body, 'new_member', 201);
 	}
@@ -115,7 +159,7 @@ class Club_resource extends Api_v2_resource {
 	 */
 	public function update($user_id) {
 		$this->require_write();
-		$this->require_permission_level(9);
+		$club_id = $this->resolve_club();
 		$this->require_not_sso_managed();
 
 		$body = $this->body();
@@ -125,11 +169,11 @@ class Club_resource extends Api_v2_resource {
 		$level = $this->parse_permission_level($body);
 
 		// No upsert: adding a member is POST.
-		if ((int) $this->CI->club_model->get_permission_noui($this->user_id(), $user_id) === 0) {
+		if ((int) $this->CI->club_model->get_permission_noui($club_id, $user_id) === 0) {
 			throw new Api_v2_exception('not_found', 'User is not a member of this clubstation', 404);
 		}
 
-		$this->CI->club_model->alter_member($this->user_id(), $user_id, $level);
+		$this->CI->club_model->alter_member($club_id, $user_id, $level);
 
 		$this->respond_member($user_id, $body, 'modified_member', 200);
 	}
@@ -141,17 +185,17 @@ class Club_resource extends Api_v2_resource {
 	 */
 	public function delete($user_id) {
 		$this->require_delete();
-		$this->require_permission_level(9);
+		$club_id = $this->resolve_club();
 		$this->require_not_sso_managed();
 
 		$user_id = $this->require_manageable_member($user_id);
 
 		// Without this a DELETE on a non-member would report success.
-		if ((int) $this->CI->club_model->get_permission_noui($this->user_id(), $user_id) === 0) {
+		if ((int) $this->CI->club_model->get_permission_noui($club_id, $user_id) === 0) {
 			throw new Api_v2_exception('not_found', 'User is not a member of this clubstation', 404);
 		}
 
-		if (!$this->CI->club_model->delete_member($this->user_id(), $user_id)) {
+		if (!$this->CI->club_model->delete_member($club_id, $user_id)) {
 			throw new Api_v2_exception('internal_error', 'User could not be removed from the clubstation', 500);
 		}
 
@@ -161,10 +205,83 @@ class Club_resource extends Api_v2_resource {
 	// --- Internal helpers --------------------------------------------------
 
 	/**
-	 * Every operation here is officer-only. Api_v2::resolve_club_context()
-	 * fills club_permission for club tokens only, and only while the
-	 * clubstation feature is on, so this one check covers a personal token, a
-	 * member below officer level and a disabled feature alike.
+	 * The clubstation this request acts on, after checking that the token may
+	 * act on it at all. Every handler starts here; the result is memoized, so
+	 * the internal helpers can simply ask again instead of passing it around.
+	 *
+	 * The access check runs either way - $required only decides what happens
+	 * when an administrator names no club: a 400, or a null the caller answers
+	 * differently (index() lists the clubstations instead).
+	 *
+	 * @param bool $required Whether an administrator must supply club_id.
+	 * @return int|null club_id, or null for an administrator who named none.
+	 * @throws Api_v2_exception 400 when an administrator omits club_id,
+	 *                          403 when the token may not manage this club,
+	 *                          404 when club_id is not a clubstation.
+	 */
+	protected function resolve_club($required = true) {
+		if ($this->club_id !== null) {
+			return $this->club_id;
+		}
+
+		$this->CI->load->model('club_model');
+		$requested = $this->param('club_id');
+
+		// Club token: the clubstation is the token owner, and officer level is
+		// what separates managing members from merely logging QSOs.
+		if ($this->club_permission() !== null) {
+			$this->require_permission_level(9);
+
+			if ($requested !== null && (int) $requested !== (int) $this->user_id()) {
+				throw new Api_v2_exception('forbidden', 'club_id does not match the clubstation behind this token', 403);
+			}
+
+			return $this->club_id = (int) $this->user_id();
+		}
+
+		// Personal token: only an administrator gets this far, and only by
+		// naming the club - they have no implicit one. Judged on the creator,
+		// which for a personal token is the owner itself.
+		if (!$this->CI->user_model->is_admin($this->auth['created_by'])) {
+			throw new Api_v2_exception('forbidden', 'Token is neither a club officer nor an admin', 403);
+		}
+
+		if ($requested === null) {
+			// Left unmemoized: null is the "not resolved yet" marker.
+			if (!$required) {
+				return null;
+			}
+			throw new Api_v2_exception(
+				'validation_error',
+				'club_id is required for an administrator token',
+				400,
+				['field' => 'club_id']
+			);
+		}
+
+		// A club_id that was supplied but is unusable is an error either way -
+		// answering with the clubstation list would hide the typo.
+		if (!is_numeric($requested) || (int) $requested < 1) {
+			throw new Api_v2_exception(
+				'validation_error',
+				'club_id must be a numeric user id',
+				400,
+				['field' => 'club_id']
+			);
+		}
+
+		$club = $this->CI->user_model->get_by_id((int) $requested);
+		if ($club === null || $club->num_rows() === 0 || (int) $club->row()->clubstation !== 1) {
+			throw new Api_v2_exception('not_found', 'Unknown clubstation', 404);
+		}
+
+		return $this->club_id = (int) $requested;
+	}
+
+	/**
+	 * Guard an operation behind a clubstation permission level. Only reached
+	 * for club tokens; resolve_club() handles the administrator path, where
+	 * there is no membership to grade.
 	 *
 	 * @throws Api_v2_exception 403
 	 */
@@ -172,8 +289,6 @@ class Club_resource extends Api_v2_resource {
 		if (!is_numeric($level) || (int) $level < 1) {
 			throw new Api_v2_exception('internal_error', 'Invalid permission level', 500);
 		}
-
-		$this->CI->load->model('club_model');
 
 		if ((int) $this->club_permission() !== (int) $level) {
 			throw new Api_v2_exception('forbidden', 'Token is not a club officer', 403);
@@ -188,7 +303,7 @@ class Club_resource extends Api_v2_resource {
 	 * @throws Api_v2_exception 409
 	 */
 	protected function require_not_sso_managed() {
-		if ($this->CI->club_model->is_sso_managed($this->user_id())) {
+		if ($this->CI->club_model->is_sso_managed($this->resolve_club())) {
 			throw new Api_v2_exception('conflict', 'Club membership is managed by the identity provider', 409);
 		}
 	}
@@ -206,13 +321,16 @@ class Club_resource extends Api_v2_resource {
 		}
 		$user_id = (int) $user_id;
 
-		if ($user_id === (int) $this->user_id()) {
+		if ($user_id === $this->resolve_club()) {
 			throw new Api_v2_exception('validation_error', 'A clubstation cannot be a member of itself', 400);
 		}
 
 		// An officer must not be able to lock themselves out of their own club
-		// through the API; changing your own level stays a web UI operation.
-		if ($user_id === (int) $this->auth['created_by']) {
+		// through the API; changing your own level stays a web UI operation. An
+		// administrator reaches every club through the UI regardless, so the
+		// rule would only get in their way.
+		if ($user_id === (int) $this->auth['created_by']
+			&& !$this->CI->user_model->is_admin($this->auth['created_by'])) {
 			throw new Api_v2_exception('forbidden', 'Cannot modify your own club membership', 403);
 		}
 
@@ -266,7 +384,7 @@ class Club_resource extends Api_v2_resource {
 		$meta = null;
 		// no notification by default
 		if (filter_var($body['notify'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
-			$meta = ['notified' => (bool) $this->CI->club_model->notify_member($user_id, $this->user_id(), $template)];
+			$meta = ['notified' => (bool) $this->CI->club_model->notify_member($user_id, $this->resolve_club(), $template)];
 		}
 
 		$headers = ($status === 201)
@@ -287,12 +405,25 @@ class Club_resource extends Api_v2_resource {
 		if (!is_numeric($user_id)) {
 			return null;
 		}
-		foreach ($this->CI->club_model->get_club_members($this->user_id()) as $member) {
+		foreach ($this->CI->club_model->get_club_members($this->resolve_club()) as $member) {
 			if ((int) $member->user_id === (int) $user_id) {
 				return $member;
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Shape a clubstation row into the public API representation. Deliberately
+	 * thin: this is a directory an administrator picks a club_id from, not the
+	 * clubstation's account data.
+	 */
+	protected function format_clubstation($club) {
+		return [
+			'club_id'      => (int) $club->user_id,
+			'callsign'     => $club->user_callsign,
+			'member_count' => (int) $club->member_count,
+		];
 	}
 
 	/**

--- a/application/libraries/api_v2/Club_resource.php
+++ b/application/libraries/api_v2/Club_resource.php
@@ -136,9 +136,8 @@ class Club_resource extends Api_v2_resource {
 
 	/**
 	 * DELETE /api/v2/club/{user_id}
-	 * Remove a member from the clubstation, together with the v1 API keys and rig
-	 * control sessions it created for the club (Club_model::delete_member()). Its
-	 * v2 tokens survive and are refused with club_access_revoked instead.
+	 * Remove a member from the clubstation, together with the API keys and rig
+	 * control sessions it created for the club (Club_model::delete_member()).
 	 */
 	public function delete($user_id) {
 		$this->require_delete();

--- a/application/libraries/api_v2/Club_resource.php
+++ b/application/libraries/api_v2/Club_resource.php
@@ -430,7 +430,7 @@ class Club_resource extends Api_v2_resource {
 	 * Shape a club member row into the public API representation.
 	 */
 	protected function format_member($member) {
-		return [
+		$data = [
 			'user_id'          => (int) $member->user_id,
 			'user_firstname'   => $member->user_firstname,
 			'user_lastname'    => $member->user_lastname,
@@ -441,5 +441,12 @@ class Club_resource extends Api_v2_resource {
 			'permission_level' => (int) $member->p_level,
 			'user_language'    => $member->user_language,
 		];
+
+		$removable = ['user_firstname', 'user_lastname', 'user_locator', 'user_name', 'user_email', 'user_language'];
+		foreach (array_intersect((array) $this->CI->config->item('apiv2_hide_userdata'), $removable) as $field) {
+			unset($data[$field]);
+		}
+
+		return $data;
 	}
 }

--- a/application/libraries/api_v2/Statistic_resource.php
+++ b/application/libraries/api_v2/Statistic_resource.php
@@ -109,8 +109,7 @@ class Statistic_resource extends Api_v2_resource {
 	 * token's user_id (there is no session in the API), gating the admin topics.
 	 */
 	protected function is_admin() {
-		$user = $this->CI->user_model->get_by_id($this->user_id())->row();
-		return $user !== null && (int) $user->user_type === 99;
+		return $this->CI->user_model->is_admin($this->user_id());
 	}
 
 	// --- Topics ------------------------------------------------------------

--- a/application/models/Api_v2_model.php
+++ b/application/models/Api_v2_model.php
@@ -45,6 +45,9 @@ class Api_v2_model extends CI_Model {
 			if (!class_exists($class) || !is_subclass_of($class, 'Api_v2_resource')) {
 				continue;
 			}
+			if (!$class::is_available()) {
+				continue;
+			}
 			$registry += $class::scope_definitions();
 		}
 

--- a/application/models/Api_v2_model.php
+++ b/application/models/Api_v2_model.php
@@ -31,11 +31,33 @@ class Api_v2_model extends CI_Model {
 	 */
 	public static function scope_registry() {
 		static $registry = null;
-		if ($registry !== null) {
-			return $registry;
+		if ($registry === null) {
+			$registry = self::collect_scopes();
 		}
 
+		return $registry;
+	}
+
+	/**
+	 * The subset of scope_registry() the current session may actually hand out.
+	 *
+	 * Not memoized: the session can change within a request (impersonation).
+	 */
+	public static function grantable_scope_registry() {
+		return self::collect_scopes(true);
+	}
+
+	/**
+	 * Walk the resource classes and collect their scope definitions.
+	 *
+	 * @param bool $grantable Also require is_grantable(), i.e. filter down to
+	 *                        what the current session may hand out. Availability
+	 *                        is checked either way, which is what keeps the
+	 *                        grantable set a subset of the full registry.
+	 */
+	private static function collect_scopes($grantable = false) {
 		$registry = [];
+
 		foreach (glob(APPPATH . 'libraries/api_v2/*_resource.php') as $file) {
 			require_once $file;
 			// Convention: file "<Resource>_resource.php" holds class
@@ -46,6 +68,9 @@ class Api_v2_model extends CI_Model {
 				continue;
 			}
 			if (!$class::is_available()) {
+				continue;
+			}
+			if ($grantable && !$class::is_grantable()) {
 				continue;
 			}
 			$registry += $class::scope_definitions();
@@ -70,7 +95,7 @@ class Api_v2_model extends CI_Model {
 	 * @return array<string,array{name:string,description:string,icon:string,class:string,scopes:string[]}>
 	 */
 	public static function preset_registry() {
-		$all = array_keys(self::scope_registry());
+		$all = array_keys(self::grantable_scope_registry());
 		$read_only = array_values(array_filter($all, function ($scope) {
 			return substr($scope, -5) === ':read';
 		}));
@@ -293,7 +318,6 @@ class Api_v2_model extends CI_Model {
 		$this->db->where('id', (int) $token_id);
 		$this->db->update('api_token');
 
-		$this->load->model('user_model');
 		$this->user_model->set_last_seen($user_id);
 	}
 }

--- a/application/models/Api_v2_model.php
+++ b/application/models/Api_v2_model.php
@@ -238,6 +238,28 @@ class Api_v2_model extends CI_Model {
 	}
 
 	/**
+	 * Delete the tokens a member issued for a clubstation.
+	 *
+	 * @param int      $club_id The clubstation.
+	 * @param int|null $user_id One member, or null for every member of the club.
+	 */
+	function revoke_club_tokens($club_id, $user_id = null) {
+		if (!is_numeric($club_id) || (int) $club_id < 1) {
+			return;
+		}
+
+		$this->db->where('user_id', (int) $club_id);
+		if ($user_id !== null) {
+			$this->db->where('created_by', (int) $user_id);
+		} else {
+			// A clubstation can hold tokens of its own (club_direct login);
+			// those belong to the account, not to a membership.
+			$this->db->where('created_by !=', (int) $club_id);
+		}
+		$this->db->delete('api_token');
+	}
+
+	/**
 	 * Metadata of a single token, for the whoami endpoint (Token_resource).
 	 * Never exposes the hash; the plaintext token is not stored at all.
 	 *

--- a/application/models/Club_model.php
+++ b/application/models/Club_model.php
@@ -193,7 +193,24 @@ class Club_model extends CI_Model {
     }
 
     /**
-     * 
+     * Get every Clubstation on this instance with its number of members.
+     *
+     * @return array
+     */
+    function get_all_clubstations() {
+
+        $sql = 'SELECT users.user_id, users.user_callsign, COUNT(club_permissions.id) AS member_count
+                FROM users
+                LEFT JOIN club_permissions ON club_permissions.club_id = users.user_id
+                WHERE users.clubstation = 1
+                GROUP BY users.user_id, users.user_callsign
+                ORDER BY users.user_callsign;';
+
+        return $this->db->query($sql)->result();
+    }
+
+    /**
+     *
      * Add Club Member
      * 
      * @param int $club_id

--- a/application/models/Club_model.php
+++ b/application/models/Club_model.php
@@ -3,6 +3,39 @@
 class Club_model extends CI_Model {
 
     /**
+     * Permission levels a club member can hold, level => label.
+     *
+     * @return array
+     */
+    function permission_levels() {
+        return [
+            9 => __("Club Officer"),
+            6 => __("Club Member ADIF"),
+            3 => __("Club Member"),
+        ];
+    }
+
+    /**
+     * Whether this clubstation's memberships are managed by an identity
+     * provider. 
+     *
+     * @param int $club_id
+     *
+     * @return boolean
+     */
+    function is_sso_managed($club_id) {
+
+        if (!($this->config->item('auth_header_enable') ?? false)) {
+            return false;
+        }
+
+        $this->config->load('sso', true, true);
+        $directs = $this->config->item('auth_header_clubstation_direct', 'sso') ?: [];
+
+        return key_exists($club_id, $directs);
+    }
+
+    /**
      * Authorization for Club Features
      * 
      * @param int $level
@@ -226,11 +259,74 @@ class Club_model extends CI_Model {
         try {
             $this->db->query('DELETE FROM club_permissions WHERE club_id = ? AND user_id = ?', [$club_id, $user_id]);
             $this->db->query('DELETE FROM api WHERE user_id = ? AND created_by = ?', [$club_id, $user_id]);
+            // The v2 tokens in `api_token` deliberately survive: the dispatcher
+            // re-checks the membership on every request and answers 403
+            // club_access_revoked, so re-adding the member restores access
+            // without them having to create a new token.
             $this->db->query('DELETE FROM cat WHERE user_id = ? AND operator = ?', [$club_id, $user_id]);
             return true;
         } catch (Exception $e) {
             log_message('error', 'Error deleting Club Member: ' . $e->getMessage());
             return false;
         }
+    }
+
+    /**
+     * Notify a club member about their new or changed permission level.
+     *
+     * @param int    $user_id
+     * @param int    $club_id
+     * @param string $message 'new_member' or 'modified_member'
+     *
+     * @return boolean
+     */
+    function notify_member($user_id, $club_id, $message) {
+
+        $this->load->library('email');
+
+        switch ($message) {
+            case 'new_member':
+                $view = 'email/club/new_member';
+                break;
+            case 'modified_member':
+                $view = 'email/club/modified_member';
+                break;
+            default:
+                log_message('error', "Club Notification; Can't notify user - Invalid message type.");
+                return false;
+        }
+
+        $config = [
+            'protocol' => $this->optionslib->get_option('emailProtocol'),
+            'smtp_crypto' => $this->optionslib->get_option('smtpEncryption'),
+            'smtp_host' => $this->optionslib->get_option('smtpHost'),
+            'smtp_port' => $this->optionslib->get_option('smtpPort'),
+            'smtp_user' => $this->optionslib->get_option('smtpUsername'),
+            'smtp_pass' => $this->optionslib->get_option('smtpPassword'),
+            'crlf' => "\r\n",
+            'newline' => "\r\n"
+        ];
+        if (!$this->email->initialize($config)) {
+            log_message('error', "Club Notification; Can't notify user - Email can't be initialized.");
+            return false;
+        }
+
+        $user = $this->user_model->get_by_id($user_id)->row();
+        $club = $this->user_model->get_by_id($club_id)->row();
+        $permission = $this->get_permission_noui($club_id, $user_id);
+        $permission_level = $this->permission_levels()[$permission] ?? __("Unknown");
+
+        $mail_data['user_callsign'] = $user->user_callsign;
+        $mail_data['club_callsign'] = $club->user_callsign;
+        $mail_data['permission_level'] = $permission_level;
+
+        $message = $this->email->load($view, $mail_data, $user->user_language);
+
+        $this->email->from($this->optionslib->get_option('emailAddress'), $this->optionslib->get_option('emailSenderName'));
+        $this->email->to($user->user_email);
+        $this->email->subject($message['subject']);
+        $this->email->message($message['body']);
+
+        return $this->email->send();
     }
 }

--- a/application/models/Club_model.php
+++ b/application/models/Club_model.php
@@ -257,12 +257,11 @@ class Club_model extends CI_Model {
         }
 
         try {
+            $this->load->model('api_v2_model');
+
             $this->db->query('DELETE FROM club_permissions WHERE club_id = ? AND user_id = ?', [$club_id, $user_id]);
             $this->db->query('DELETE FROM api WHERE user_id = ? AND created_by = ?', [$club_id, $user_id]);
-            // The v2 tokens in `api_token` deliberately survive: the dispatcher
-            // re-checks the membership on every request and answers 403
-            // club_access_revoked, so re-adding the member restores access
-            // without them having to create a new token.
+            $this->api_v2_model->revoke_club_tokens($club_id, $user_id);
             $this->db->query('DELETE FROM cat WHERE user_id = ? AND operator = ?', [$club_id, $user_id]);
             return true;
         } catch (Exception $e) {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -1161,6 +1161,12 @@ class User_Model extends CI_Model {
 			return false;
 		}
 
+		$this->load->model('api_v2_model');
+		$this->api_v2_model->revoke_club_tokens($user_id);
+
+		$this->db->query("DELETE FROM api WHERE user_id = ? AND created_by != ?", [$user_id, $user_id]);
+		$this->db->query("DELETE FROM cat WHERE user_id = ? AND operator != ?", [$user_id, $user_id]);
+
 		$this->db->trans_complete();
 
 		return $this->db->trans_status();

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -874,6 +874,20 @@ class User_Model extends CI_Model {
 		return $this->db->update('users', array('user_stylesheet' => xss_clean($foldername)));
 	}
 
+	/**
+	 * Whether a user is a Wavelog administrator (user_type 99)
+	 *
+	 * @param int $user_id
+	 * @return boolean
+	 */
+	function is_admin($user_id) {
+		$u = $this->get_by_id($user_id);
+		if ($u->num_rows() == 0) {
+			return false;
+		}
+		return $u->row()->user_type == 99;
+	}
+
 	// FUNCTION: bool authorize($level)
 	// Checks a user's level of access against the given $level
 	function authorize($level) {


### PR DESCRIPTION
Refactored the Club API v2. Documentation is already pushed since API v2 is not released yet https://docs.wavelog.org/developer/api-v2/club/
Short summary:
- allows now to manage member permissions
- admins can list all clubs and manage member permissions even without being a member (just like in the ui)
- club scope is unavailable for normal users (was a bug)