### PR TITLE
Fix Azimuth (SAT) when call is entered

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1059,16 +1059,8 @@ function start_az_ele_ticker(tle) {
 	};
 
 	function updateAzEl() {
-		let dateParts=parseUserDate($('#start_date').val());
-		let timeParts=$("#start_time").val().split(":");
 		try {
-			var time = new Date(Date.UTC(
-				dateParts.getFullYear(),dateParts.getMonth(),dateParts.getDate(),
-				parseInt(timeParts[0]),parseInt(timeParts[1]),(parseInt(timeParts[2] ?? 0))
-			));
-			if (isNaN(time.getTime())) {
-				throw new Error("Invalid date");
-			}
+			var time = new Date();
 			var positionAndVelocity = satellite.propagate(satrec, time);
 			var gmst = satellite.gstime(time);
 			var positionEcf = satellite.eciToEcf(positionAndVelocity.position, gmst);

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1060,7 +1060,22 @@ function start_az_ele_ticker(tle) {
 
 	function updateAzEl() {
 		try {
-			var time = new Date();
+			var time;
+			if (typeof qso_manual !== 'undefined' && qso_manual == 1) {
+				// Manual / past entry: use the user-provided date + time
+				let dateParts = parseUserDate($('#start_date').val());
+				let timeParts = $("#start_time").val().split(":");
+				time = new Date(Date.UTC(
+					dateParts.getFullYear(), dateParts.getMonth(), dateParts.getDate(),
+					parseInt(timeParts[0]), parseInt(timeParts[1]), (parseInt(timeParts[2] ?? 0))
+				));
+				if (isNaN(time.getTime())) {
+					throw new Error("Invalid date");
+				}
+			} else {
+				// Real-time satellite tracking: live UTC now (independent of #start_time, which freezes on call entry)
+				time = new Date();
+			}
 			var positionAndVelocity = satellite.propagate(satrec, time);
 			var gmst = satellite.gstime(time);
 			var positionEcf = satellite.eciToEcf(positionAndVelocity.position, gmst);


### PR DESCRIPTION
Bug:

When working SAT, Az/Ele are calculated (and updated) every second based on "startQSO"-Time.
if user has enabled Start and End QSO-Time, the ticker stops when entering a call (because that's the startTime of the QSO).

this fix make the source for time independent of the start-time. So calculation moves on, even if call has been typed in/looked up.

No impact on:
- logging (SAT or HF)
- HF-Bearing
- Post QSO-Logging (for PostQSO the time of QSO counts)