### PR TITLE
Fix cabrillo

### DIFF
--- a/application/controllers/Cabrillo.php
+++ b/application/controllers/Cabrillo.php
@@ -47,7 +47,7 @@ class Cabrillo extends CI_Controller {
 
 		//get data from upload
 		$contest_id = $this->input->post('contest_id', false) ?? '';
-		$data = array('upload_data' => $this->upload->data());
+		$data['upload_data'] = $this->upload->data();
 
 		//set memory limit to allow big files
 		ini_set('memory_limit', '-1');

--- a/application/libraries/Cbr_parser.php
+++ b/application/libraries/Cbr_parser.php
@@ -57,7 +57,9 @@ class CBR_Parser
                 $parts = explode(': ', $line, 2);
 
                 //collect header information
-                $header[$parts[0]] = trim($parts[1]);
+                if (count($parts) === 2) {
+                    $header[$parts[0]] = trim($parts[1]);
+                }
 
                 //skip to next line
                 continue;


### PR DESCRIPTION
Bug:
Take broken cbr-file (create one - text in it) and upload it via ADIF-Import / Cabrillo-Import.

Result:
```
Severity: Warning --> Undefined array key 1 /var/www/html/application/libraries/Cbr_parser.php 60
Severity: Warning --> Undefined variable $page_title /var/www/html/application/views/adif/import.php 20
Severity: Warning --> Undefined variable $station_profile /var/www/html/application/views/adif/import.php 101
Severity: Warning --> Undefined variable $station_profile /var/www/html/application/views/adif/import.php 102
Severity: error --> Exception: Call to a member function result() on null /var/www/html/application/views/adif/import.php 102
```

This bug fixes it.