### PR TITLE
Apiv2 qsl

### DIFF
--- a/application/libraries/api_v2/Api_v2_resource.php
+++ b/application/libraries/api_v2/Api_v2_resource.php
@@ -83,6 +83,15 @@ abstract class Api_v2_resource {
 	];
 
 	/**
+	 * QSL confirmation type names accepted by every resource that filters on
+	 * them (Statistic ?profile=confirmations, Confirmation list). The canonical
+	 * source of truth is Logbook_model::CONFIRMATION_COLUMNS; the list is copied
+	 * here as a plain literal so it is available without the model loaded
+	 * (scope_registry() reflects over every resource at startup).
+	 */
+	protected const CONFIRMATION_TYPES = ['lotw', 'eqsl', 'qsl', 'qrz', 'clublog'];
+
+	/**
 	 * @param array      $auth { id, user_id, created_by, scopes (string[]) }
 	 * @param array|null $body Parsed JSON body, or null for verbs without one.
 	 */

--- a/application/libraries/api_v2/Api_v2_resource.php
+++ b/application/libraries/api_v2/Api_v2_resource.php
@@ -532,6 +532,33 @@ abstract class Api_v2_resource {
 	}
 
 	/**
+	 * Build the pagination meta block for list responses.
+	 *
+	 * `count` is the number of items on this page; `total` is the number across
+	 * all pages. `total_pages` and `has_more` are derived so a client knows
+	 * definitively when it has reached the last page (no need to probe for an
+	 * empty response).
+	 *
+	 * @param array $page  { page, per_page, offset }
+	 * @param int   $count Items returned on this page.
+	 * @param int   $total Items across all pages for the current filter.
+	 */
+	protected function list_meta($page, $count, $total = 0) {
+		$total = (int) $total;
+		$per_page = $page['per_page'];
+		$total_pages = $per_page > 0 ? (int) ceil($total / $per_page) : 0;
+
+		return [
+			'page'        => $page['page'],
+			'per_page'    => $per_page,
+			'count'       => $count,
+			'total'       => $total,
+			'total_pages' => $total_pages,
+			'has_more'    => $page['page'] < $total_pages,
+		];
+	}
+
+	/**
 	 * Throw a 405 with the standard error code.
 	 */
 	protected function method_not_allowed() {

--- a/application/libraries/api_v2/Confirmation_resource.php
+++ b/application/libraries/api_v2/Confirmation_resource.php
@@ -1,0 +1,144 @@
+<?php
+
+if (!defined('BASEPATH')) exit('No direct script access allowed');
+
+require_once __DIR__ . '/Api_v2_resource.php';
+
+/**
+ * API v2 - QSL confirmations resource (read-only)
+ *
+ * Lists the QSL confirmations the token owner has received, one row per
+ * (QSO, confirmation-type) pair. The API counterpart to the web UI's
+ * Confirmations page (controller Generic_qsl::searchConfirmations): a QSO
+ * confirmed via both LoTW and eQSL appears as two rows here, exactly as it
+ * does in the table on that page.
+ *
+ * This is distinct from the existing statistic profile
+ * /api/v2/statistic?profile=confirmations, which returns aggregate counts for
+ * monitoring (number of QSOs confirmed by each type). This endpoint returns
+ * the per-QSO records themselves - callsign, dates, mode/band, type - so a
+ * client can render the same view a human sees in the browser.
+ *
+ * The QSO resource's ?qsl_filter= parameter is also different: it filters the
+ * QSO list by "has at least one of these confirmations" but does not surface
+ * which type matched, nor when the confirmation arrived. This endpoint does.
+ *
+ * Route:  /api/v2/confirmation
+ * Scope:  confirmation:read
+ *
+ * Filters (all optional):
+ *   ?type=       comma list of lotw|eqsl|qsl|qrz|clublog (default: all)
+ *   ?station_id= comma-separated station ids; ownership-checked (default: all
+ *                owned by the token user)
+ *   ?since=      YYYY-MM-DD floor on the date the *confirmation* was received
+ *   ?qso_since=  YYYY-MM-DD floor on the QSO date
+ *   ?qso_until=  YYYY-MM-DD ceiling on the QSO date
+ *   ?band=       COL_BAND value, or SAT for satellite QSOs
+ *   ?mode=       matched against the mode or the submode
+ *   ?callsign=   exact match on the worked callsign
+ *   Pagination:  ?page= / ?per_page= (default 100, max 1000).
+ */
+class Confirmation_resource extends Api_v2_resource {
+
+	/** Token scope of this resource (see Api_v2_resource::required_scope()). */
+	protected $scope = 'confirmation';
+
+	/** Confirmation types accepted by the ?type= filter, same set as Statistic_resource. */
+	protected const CONFIRMATION_TYPES = ['lotw', 'eqsl', 'qsl', 'qrz', 'clublog'];
+
+	/** Default and hard-max page sizes for the list. */
+	protected const DEFAULT_PER_PAGE = 100;
+	protected const MAX_PER_PAGE     = 1000;
+
+	/**
+	 * Translated label for the registry entry of this resource's read scope.
+	 */
+	protected static function scope_labels() {
+		return ['read' => __('Read QSL confirmations')];
+	}
+
+	/**
+	 * GET /api/v2/confirmation
+	 * Filtered list of confirmations, newest first. Clubstation members below
+	 * officer level only ever see their own QSOs' confirmations - the operator
+	 * restriction mirrors the QSO resource, since a confirmation is reached
+	 * through the QSO it belongs to.
+	 */
+	public function index() {
+		$this->CI->load->model('logbook_model');
+
+		$types      = $this->parse_type_list('type', self::CONFIRMATION_TYPES) ?: self::CONFIRMATION_TYPES;
+		$since      = $this->parse_date('since');
+		$qso_since  = $this->parse_date('qso_since');
+		$qso_until  = $this->parse_date('qso_until');
+		$band       = $this->normalize_band($this->param('band'));
+		$mode       = $this->normalize_mode($this->param('mode'));
+		$callsign   = $this->normalize_callsign($this->param('callsign'));
+		$page       = $this->pagination(self::DEFAULT_PER_PAGE, self::MAX_PER_PAGE);
+		$station_ids = $this->resolve_station_ids();
+
+		// Same club-member rule as Qso_resource::index(): restricted members
+		// only ever see their own operator's QSOs.
+		$operator = $this->is_restricted_club_member() ? (string) $this->operator_callsign() : '';
+
+		$filters = [
+			'station_ids' => $station_ids,
+			'types'       => $types,
+			'since'       => $since,
+			'qso_since'   => $qso_since,
+			'qso_until'   => $qso_until,
+			'band'        => $band,
+			'mode'        => $mode,
+			'callsign'    => $callsign,
+			'operator'    => $operator,
+		];
+
+		$total = $this->CI->logbook_model->count_confirmations_list($filters);
+		$query = $this->CI->logbook_model->get_confirmations_list(
+			$filters, $page['per_page'], $page['offset']
+		);
+
+		$rows = is_object($query) ? $query->result() : [];
+		$confirmations = array_map([$this, 'format_confirmation'], $rows);
+
+		$meta = $this->list_meta($page, count($confirmations), $total);
+		$meta['filters'] = [
+			'type'      => $types,
+			'since'     => $since ?: null,
+			'qso_since' => $qso_since ?: null,
+			'qso_until' => $qso_until ?: null,
+			'band'      => $band ?: null,
+			'mode'      => $mode ?: null,
+			'callsign'  => $callsign ?: null,
+		];
+
+		$this->CI->api_v2_response->respond($confirmations, 200, $meta);
+	}
+
+	/**
+	 * Cast a DB row to its public shape. The model already aliases columns to
+	 * these names. Core fields are always present; the optional ones are
+	 * omitted entirely when empty so the payload carries only what the QSO
+	 * actually has (a HF contact has no sat_*, a gridless one no gridsquare).
+	 */
+	protected function format_confirmation($row) {
+		$out = [
+			'qso_id'            => (int) $row->qso_id,
+			'callsign'          => $row->callsign,
+			'qso_date'          => $row->qso_date,
+			'mode'              => $row->mode,
+			'band'              => $row->band,
+			'confirmation_date' => $row->confirmation_date,
+			'type'              => $row->type,
+		];
+
+		foreach (['submode', 'gridsquare', 'vucc_grids', 'sat_name', 'sat_mode'] as $opt) {
+			$value = $row->$opt ?? '';
+			if ($value !== '' && $value !== null) {
+				$out[$opt] = $value;
+			}
+		}
+
+		return $out;
+	}
+}

--- a/application/libraries/api_v2/Confirmation_resource.php
+++ b/application/libraries/api_v2/Confirmation_resource.php
@@ -43,9 +43,6 @@ class Confirmation_resource extends Api_v2_resource {
 	/** Token scope of this resource (see Api_v2_resource::required_scope()). */
 	protected $scope = 'confirmation';
 
-	/** Confirmation types accepted by the ?type= filter, same set as Statistic_resource. */
-	protected const CONFIRMATION_TYPES = ['lotw', 'eqsl', 'qsl', 'qrz', 'clublog'];
-
 	/** Default and hard-max page sizes for the list. */
 	protected const DEFAULT_PER_PAGE = 100;
 	protected const MAX_PER_PAGE     = 1000;

--- a/application/libraries/api_v2/Qso_resource.php
+++ b/application/libraries/api_v2/Qso_resource.php
@@ -894,31 +894,4 @@ class Qso_resource extends Api_v2_resource {
 	protected static function numeric_fields() {
 		return ['cqz', 'ituz', 'srx', 'stx'];
 	}
-
-	/**
-	 * Build the pagination meta block for list responses.
-	 *
-	 * `count` is the number of items on this page; `total` is the number across
-	 * all pages. `total_pages` and `has_more` are derived so a client knows
-	 * definitively when it has reached the last page (no need to probe for an
-	 * empty response).
-	 *
-	 * @param array $page  { page, per_page, offset }
-	 * @param int   $count Items returned on this page.
-	 * @param int   $total Items across all pages for the current filter.
-	 */
-	protected function list_meta($page, $count, $total = 0) {
-		$total = (int) $total;
-		$per_page = $page['per_page'];
-		$total_pages = $per_page > 0 ? (int) ceil($total / $per_page) : 0;
-
-		return [
-			'page'        => $page['page'],
-			'per_page'    => $per_page,
-			'count'       => $count,
-			'total'       => $total,
-			'total_pages' => $total_pages,
-			'has_more'    => $page['page'] < $total_pages,
-		];
-	}
 }

--- a/application/libraries/api_v2/Statistic_resource.php
+++ b/application/libraries/api_v2/Statistic_resource.php
@@ -42,9 +42,6 @@ class Statistic_resource extends Api_v2_resource {
 	/** Topics exposing instance/admin data — only for administrator tokens. */
 	protected const ADMIN_TOPICS = ['system'];
 
-	/** Confirmation types the ?type= filter accepts (see Logbook_model). */
-	protected const CONFIRMATION_TYPES = ['lotw', 'eqsl', 'qsl', 'qrz', 'clublog'];
-
 	/**
 	 * Translated label for the registry entry of this resource's read scope.
 	 */

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -23,6 +23,18 @@ class Logbook_model extends CI_Model {
 		'clublog' => ['rcvd' => 'COL_CLUBLOG_QSO_DOWNLOAD_STATUS',   'date' => 'COL_CLUBLOG_QSO_DOWNLOAD_DATE'],
 	];
 
+	// Human-readable label for each confirmation source, surfaced verbatim in
+	// the API v2 confirmation list ("type" field). Mirrors the labels the web
+	// UI's Confirmations page uses, so an API client and the UI describe the
+	// same row with the same word.
+	const CONFIRMATION_TYPE_LABELS = [
+		'lotw'    => 'LoTW',
+		'eqsl'    => 'eQSL',
+		'qsl'     => 'QSL Card',
+		'qrz'     => 'QRZ.com',
+		'clublog' => 'Clublog',
+	];
+
 	public function __construct() {
 		$this->oop_populate_modes();
 		$this->load->Model('Modes');
@@ -2531,6 +2543,107 @@ class Logbook_model extends CI_Model {
 		}
 
 		return $query->row_array() ?: array_fill_keys(array_merge(['qsos'], $types, ['confirmed']), 0);
+	}
+
+	// Per-(QSO, confirmation-type) row list for the REST API v2 confirmation
+	// endpoint. The API counterpart to the web UI's Confirmations page
+	// (Qsl_model::getConfirmations): a UNION ALL across the requested types, so
+	// a QSO confirmed via both LoTW and eQSL appears as two rows. Each part
+	// reuses the shared QSO v2 filter (_qso_v2_filter_where: station scope,
+	// band incl. SAT, mode/submode, callsign, qso dates, operator) and adds
+	// the type's own rcvd='Y' flag plus an optional received-date floor.
+	//
+	// Unlike count_confirmations_filtered(), which counts QSOs, this counts
+	// pairs: a multi-confirmed QSO contributes one row per type, not one.
+	//
+	// $filters is the set documented at _qso_v2_filter_where() plus:
+	//   types  string[]  subset of CONFIRMATION_COLUMNS keys
+	//   since  string    'Y-m-d', matched against each type's own date column
+	function get_confirmations_list($filters, $limit, $offset) {
+		$types = array_values(array_intersect($filters['types'] ?? [], array_keys(self::CONFIRMATION_COLUMNS)));
+		if (empty($filters['station_ids']) || empty($types)) {
+			return $this->db->query("SELECT * FROM " . $this->config->item('table_name') . " WHERE 1=0");
+		}
+
+		$tbl   = $this->config->item('table_name');
+		$since = $filters['since'] ?? '';
+		$parts   = [];
+		$bindings = [];
+
+		foreach ($types as $type) {
+			$cols  = self::CONFIRMATION_COLUMNS[$type];
+			$label = self::CONFIRMATION_TYPE_LABELS[$type];
+
+			// Each UNION arm needs its own bindings (incl. the IN ? array), so
+			// _qso_v2_filter_where writes into a per-arm buffer we then append
+			// in order to the query-wide bindings - placeholder order must
+			// follow SQL order, and the arms are concatenated in $types order.
+			$part_bindings = [];
+			$where = $this->_qso_v2_filter_where($filters, $part_bindings);
+			$where .= " AND qsos.`" . $cols['rcvd'] . "` = 'Y'";
+			if ($since !== '') {
+				$where .= " AND qsos.`" . $cols['date'] . "` >= ?";
+				$part_bindings[] = $since;
+			}
+
+			$parts[] = "SELECT qsos.`COL_PRIMARY_KEY` AS qso_id, qsos.`COL_CALL` AS callsign,"
+				. " qsos.`COL_TIME_ON` AS qso_date, qsos.`COL_MODE` AS mode,"
+				. " qsos.`COL_SUBMODE` AS submode, qsos.`COL_BAND` AS band,"
+				. " qsos.`COL_GRIDSQUARE` AS gridsquare, qsos.`COL_VUCC_GRIDS` AS vucc_grids,"
+				. " qsos.`COL_SAT_NAME` AS sat_name, qsos.`COL_SAT_MODE` AS sat_mode,"
+				. " qsos.`" . $cols['date'] . "` AS confirmation_date,"
+				. " '" . $label . "' AS type"
+				. " FROM " . $tbl . " qsos"
+				. $where;
+
+			foreach ($part_bindings as $b) {
+				$bindings[] = $b;
+			}
+		}
+
+		$sql = "SELECT * FROM (" . implode(" UNION ALL ", $parts) . ") AS unioned_results"
+			. " ORDER BY confirmation_date DESC, qso_id DESC"
+			. " LIMIT ? OFFSET ?";
+		$bindings[] = (int) $limit;
+		$bindings[] = (int) $offset;
+
+		return $this->db->query($sql, $bindings);
+	}
+
+	// Count of (QSO, confirmation-type) pairs across all pages for the same
+	// filter used by get_confirmations_list(), so the pagination `total`
+	// matches the listed rows. Same UNION ALL shape, reduced to a count.
+	function count_confirmations_list($filters) {
+		$types = array_values(array_intersect($filters['types'] ?? [], array_keys(self::CONFIRMATION_COLUMNS)));
+		if (empty($filters['station_ids']) || empty($types)) {
+			return 0;
+		}
+
+		$tbl   = $this->config->item('table_name');
+		$since = $filters['since'] ?? '';
+		$parts   = [];
+		$bindings = [];
+
+		foreach ($types as $type) {
+			$cols = self::CONFIRMATION_COLUMNS[$type];
+
+			$part_bindings = [];
+			$where = $this->_qso_v2_filter_where($filters, $part_bindings);
+			$where .= " AND qsos.`" . $cols['rcvd'] . "` = 'Y'";
+			if ($since !== '') {
+				$where .= " AND qsos.`" . $cols['date'] . "` >= ?";
+				$part_bindings[] = $since;
+			}
+
+			$parts[] = "SELECT 1 FROM " . $tbl . " qsos" . $where;
+
+			foreach ($part_bindings as $b) {
+				$bindings[] = $b;
+			}
+		}
+
+		$sql = "SELECT COUNT(*) AS cnt FROM (" . implode(" UNION ALL ", $parts) . ") AS unioned_results";
+		return (int) $this->db->query($sql, $bindings)->row()->cnt;
 	}
 
 	function get_qso($id, $trusted = false) {


### PR DESCRIPTION
Adds:
- scope for only reading confirmations (detail: QSO-Level) - needed for awards, notifications, etc.
- new ressource `/confirmation` for api_v2

Documentation: http://docs.wavelog.org/developer/api-v2/confirmation/

Testing-Hint:

`curl -H "Authorization: Bearer [your_v2_token]" 'https://[your_wl_instance]/api/v2/confirmation?type=lotw&since=2026-08-01' |jq .`