### PR TITLE
Bug: Antennaanalytics for Shortwave

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -1281,7 +1281,34 @@ class Logbook extends CI_Controller {
 	}
 
 
-	/* return station bearing */
+	/*
+	 * Resolve the operator's own locator.
+	 * Returns FALSE if a station profile was given which isn't accessible to the user.
+	 */
+	private function my_locator($station_id = null) {
+		if (isset($station_id)) {
+			// be sure that station belongs to user
+			$this->load->model('Stations');
+			if (!$this->Stations->check_station_is_accessible($station_id)) {
+				return false;
+			}
+
+			// get locator from station profile
+			return $this->Stations->profile_clean($station_id)->station_gridsquare;
+		}
+
+		if($this->session->userdata('user_locator') != null){
+			return $this->session->userdata('user_locator');
+		}
+		return $this->config->item('locator');
+	}
+
+	/*
+	 * Bearing to a grid, as JSON:
+	 *   bearing     => int degrees (long path already applied), NULL if not calculable
+	 *   distance_km => distance in km, regardless of the user's measurement base
+	 *   text        => ready-to-display string in the user's measurement base
+	 */
 	function searchbearing() {
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
@@ -1292,37 +1319,31 @@ class Logbook extends CI_Controller {
 			$this->load->library('Qra');
 		}
 
+		$payload = array('bearing' => null, 'distance_km' => null, 'text' => '');
+
 		if($locator != null) {
-			if (isset($station_id)) {
-				// be sure that station belongs to user
-				$this->load->model('Stations');
-				if (!$this->Stations->check_station_is_accessible($station_id)) {
-					return "";
+			$mylocator = $this->my_locator($station_id);
+
+			if ($mylocator !== false) {
+				if ($this->session->userdata('user_measurement_base') == NULL) {
+					$measurement_base = $this->config->item('measurement_base');
+				}
+				else {
+					$measurement_base = $this->session->userdata('user_measurement_base');
 				}
 
-				// get station profile
-				$station_profile = $this->Stations->profile_clean($station_id);
+				$bearing = $this->qra->get_bearing($mylocator, $locator, $ant_path);
+				$text = $this->qra->bearing($mylocator, $locator, $measurement_base, $ant_path);
 
-				// get locator
-				$mylocator = $station_profile->station_gridsquare;
-			} else if($this->session->userdata('user_locator') != null){
-				$mylocator = $this->session->userdata('user_locator');
-			} else {
-				$mylocator = $this->config->item('locator');
+				$payload = array(
+					'bearing' => ($bearing === false) ? null : (int)$bearing,
+					'distance_km' => $this->qra->distance($mylocator, $locator, 'K', $ant_path),
+					'text' => ($text === false) ? '' : $text,
+				);
 			}
-
-			if ($this->session->userdata('user_measurement_base') == NULL) {
-				$measurement_base = $this->config->item('measurement_base');
-			}
-			else {
-				$measurement_base = $this->session->userdata('user_measurement_base');
-			}
-
-			$bearing = $this->qra->bearing($mylocator, $locator, $measurement_base, $ant_path);
-
-			echo $bearing;
 		}
-		return "";
+
+		$this->output->set_content_type('application/json')->set_output(json_encode($payload));
 	}
 
 	/* return distance */
@@ -1337,22 +1358,9 @@ class Logbook extends CI_Controller {
 		}
 
 		if($locator != null) {
-			if (isset($station_id)) {
-				// be sure that station belongs to user
-				$this->load->model('Stations');
-				if (!$this->Stations->check_station_is_accessible($station_id)) {
-					return 0;
-				}
-
-				// get station profile
-				$station_profile = $this->Stations->profile_clean($station_id);
-
-				// get locator
-				$mylocator = $station_profile->station_gridsquare;
-			} else if($this->session->userdata('user_locator') != null){
-				$mylocator = $this->session->userdata('user_locator');
-			} else {
-				$mylocator = $this->config->item('locator');
+			$mylocator = $this->my_locator($station_id);
+			if ($mylocator === false) {
+				return 0;
 			}
 
 			$distance = $this->qra->distance($mylocator, $locator, 'K', $ant_path);
@@ -1371,22 +1379,9 @@ class Logbook extends CI_Controller {
 		}
 
 		if($locator != null) {
-			if (isset($station_id)) {
-				// be sure that station belongs to user
-				$this->load->model('Stations');
-				if (!$this->Stations->check_station_is_accessible($station_id)) {
-					return "";
-				}
-
-				// get station profile
-				$station_profile = $this->Stations->profile_clean($station_id);
-
-				// get locator
-				$mylocator = $station_profile->station_gridsquare;
-			} else if($this->session->userdata('user_locator') != null){
-				$mylocator = $this->session->userdata('user_locator');
-			} else {
-				$mylocator = $this->config->item('locator');
+			$mylocator = $this->my_locator($station_id);
+			if ($mylocator === false) {
+				return "";
 			}
 
 			$bearing = $this->qra->bearing($mylocator, $locator, $unit, $ant_path);
@@ -1406,22 +1401,9 @@ class Logbook extends CI_Controller {
 		}
 
 		if($locator != null) {
-			if (isset($station_id)) {
-				// be sure that station belongs to user
-				$this->load->model('Stations');
-				if (!$this->Stations->check_station_is_accessible($station_id)) {
-					return 0;
-				}
-
-				// get station profile
-				$station_profile = $this->Stations->profile_clean($station_id);
-
-				// get locator
-				$mylocator = $station_profile->station_gridsquare;
-			} else if($this->session->userdata('user_locator') != null){
-				$mylocator = $this->session->userdata('user_locator');
-			} else {
-				$mylocator = $this->config->item('locator');
+			$mylocator = $this->my_locator($station_id);
+			if ($mylocator === false) {
+				return 0;
 			}
 
 			$distance = $this->qra->distance($mylocator, $locator, 'K', $ant_path);

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -224,6 +224,14 @@ class Logbook extends CI_Controller {
 		if ($return['callsign_qra'] != "" || $return['callsign_qra'] != null) {
 			$return['latlng'] = $this->qralatlng($return['callsign_qra']);
 			$return['bearing'] = $this->bearing($return['callsign_qra'], $measurement_base, $station_id);
+
+			// numeric counterpart of 'bearing', used to prefill the antenna azimuth while logging
+			if(!$this->load->is_loaded('Qra')) {
+				$this->load->library('Qra');
+			}
+			$mylocator = $this->my_locator($station_id);
+			$bearing_deg = ($mylocator === false) ? false : $this->qra->get_bearing($mylocator, $return['callsign_qra']);
+			$return['bearing_deg'] = ($bearing_deg === false) ? null : (int)$bearing_deg;
 		}
 		$return['callbook_source'] = $callbook['source'] ?? '';
 

--- a/application/controllers/Statistics.php
+++ b/application/controllers/Statistics.php
@@ -306,6 +306,9 @@ class Statistics extends CI_Controller {
 		$this->load->model('stats');
 		$this->load->model('logbookadvanced_model');
 		$this->load->model('bands');
+		$this->load->model('distances_model');
+
+		$this->distances_model->backfill_missing_geodata();   // azimuthdata() ignores QSOs without ANT_AZ, so fill the gaps first
 
 		$data = array();
 

--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -210,17 +210,7 @@ class Distances_model extends CI_Model
 				$bearingdistance = $this->qra->distance($stationgrid, $qso['grid'], $measurement_base, $qso['COL_ANT_PATH']);
 				$bearingdistance_km = $this->qra->distance($stationgrid, $qso['grid'], 'K', $qso['COL_ANT_PATH']);
 
-				$updatedata = array();
-				if ($bearingdistance_km != $qso['COL_DISTANCE']) {
-					$updatedata['COL_DISTANCE'] = $bearingdistance_km;
-				}
-				$is_shortwave = trim((string)$qso['COL_PROP_MODE']) === '';   // only plain HF/VHF+ terrestrial QSOs -- SAT, EME, MS, etc. don't follow the great-circle bearing
-				if ($is_shortwave && ($qso['COL_ANT_AZ'] === null || $qso['COL_ANT_AZ'] === '')) {   // only fill if empty -- never overwrite a user/ADIF-supplied value
-					$bearing = $this->qra->get_bearing($stationgrid, $qso['grid'], $qso['COL_ANT_PATH']);
-					if ($bearing !== false) {   // unparsable qso-grid: leave the column NULL rather than stamping it with 0 (= due north)
-						$updatedata['COL_ANT_AZ'] = $bearing;
-					}
-				}
+				$updatedata = $this->geodata_update($stationgrid, $qso, false, $bearingdistance_km);
 				if (!empty($updatedata)) {
 					$this->db->where('COL_PRIMARY_KEY', $qso['COL_PRIMARY_KEY']);
 					$this->db->update($this->config->item('table_name'), $updatedata);
@@ -250,6 +240,99 @@ class Distances_model extends CI_Model
 			$data['unit'] = $unit;
 
 			return $data;
+		}
+	}
+
+	/*
+	 * Works out which geodata-columns of a single QSO need writing.
+	 * Input:  $stationgrid    gridsquare of the station_profile (uppercase, at least 6 chars)
+	 *         $qso            row containing COL_DISTANCE, COL_ANT_PATH, COL_ANT_AZ, COL_PROP_MODE and grid
+	 *         $only_if_empty  true: only fill a missing distance (Antenna Analytics repairs gaps only)
+	 *                         false: also refresh a stale distance (Distances Worked recalculates)
+	 *         $distance_km    already calculated distance in km, saves recalculating it
+	 * Returns: array of columns to update, empty if there is nothing to do
+	 */
+	private function geodata_update($stationgrid, $qso, $only_if_empty = false, $distance_km = null) {
+		if(!$this->load->is_loaded('Qra')) {
+			$this->load->library('Qra');
+		}
+		if ($distance_km === null) {
+			$distance_km = $this->qra->distance($stationgrid, $qso['grid'], 'K', $qso['COL_ANT_PATH']);
+		}
+
+		$updatedata = array();
+		$distance_missing = ($qso['COL_DISTANCE'] === null || $qso['COL_DISTANCE'] === '');
+		if ($only_if_empty ? $distance_missing : ($distance_km != $qso['COL_DISTANCE'])) {
+			$updatedata['COL_DISTANCE'] = $distance_km;
+		}
+		$is_shortwave = trim((string)$qso['COL_PROP_MODE']) === '';   // only plain HF/VHF+ terrestrial QSOs -- SAT, EME, MS, etc. don't follow the great-circle bearing
+		if ($is_shortwave && ($qso['COL_ANT_AZ'] === null || $qso['COL_ANT_AZ'] === '')) {   // only fill if empty -- never overwrite a user/ADIF-supplied value
+			$bearing = $this->qra->get_bearing($stationgrid, $qso['grid'], $qso['COL_ANT_PATH']);
+			if ($bearing !== false) {   // unparsable qso-grid: leave the column NULL rather than stamping it with 0 (= due north)
+				$updatedata['COL_ANT_AZ'] = $bearing;
+			}
+		}
+
+		return $updatedata;
+	}
+
+	/*
+	 * Fills distance and bearing for QSOs of the active logbook which are still missing them.
+	 * Called when opening a page which reads those columns (e.g. Antenna Analytics), so a log
+	 * imported without ANT_AZ/DISTANCE gets repaired without having to visit Distances Worked.
+	 * Only gaps are filled, existing values are never touched.
+	 */
+	public function backfill_missing_geodata() {
+		$this->load->model('logbooks_model');
+		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
+
+		if ($logbooks_locations_array[0] === -1) {
+			return;
+		}
+
+		$table = $this->config->item('table_name');
+
+		foreach ($logbooks_locations_array as $station_id) {
+			$station_gridsquare = $this->find_gridsquare($station_id);
+
+			if ($station_gridsquare == null) {
+				continue;
+			}
+
+			$gridsquare = explode(',', $station_gridsquare);        // A user can enter several gridsquares
+			$stationgrid = strtoupper(trim($gridsquare[0]));        // We use only the first entered gridsquare from the active profile
+			if (strlen($stationgrid) == 4) $stationgrid .= 'MM';    // adding center of grid if only 4 digits are specified
+
+			if (!$this->valid_locator($stationgrid)) {              // Broken profile-grid: skip this station, this runs while rendering a page
+				continue;
+			}
+
+			$sql = "
+				SELECT COL_PRIMARY_KEY, COL_DISTANCE, COL_ANT_PATH, COL_ANT_AZ, COL_PROP_MODE, col_gridsquare grid
+				FROM $table
+				WHERE LENGTH(col_gridsquare) > 0
+					AND station_id = ?
+					AND (
+						COL_DISTANCE IS NULL
+						OR (COL_ANT_AZ IS NULL AND (COL_PROP_MODE IS NULL OR TRIM(COL_PROP_MODE) = ''))
+					)
+			";
+
+			$qsoArray = $this->db->query($sql, array($station_id))->result_array();
+
+			if (!$qsoArray) {
+				continue;
+			}
+
+			$this->db->trans_start();
+			foreach ($qsoArray as $qso) {
+				$updatedata = $this->geodata_update($stationgrid, $qso, true);
+				if (!empty($updatedata)) {
+					$this->db->where('COL_PRIMARY_KEY', $qso['COL_PRIMARY_KEY']);
+					$this->db->update($table, $updatedata);
+				}
+			}
+			$this->db->trans_complete();
 		}
 	}
 

--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -28,7 +28,7 @@ class Distances_model extends CI_Model
 
 				$table = $this->config->item('table_name');
 				$sql = "
-					SELECT COL_PRIMARY_KEY, COL_DISTANCE, COL_ANT_PATH, col_call callsign, col_gridsquare grid
+					SELECT COL_PRIMARY_KEY, COL_DISTANCE, COL_ANT_PATH, COL_ANT_AZ, COL_PROP_MODE, col_call callsign, col_gridsquare grid
 					FROM $table
 					LEFT OUTER JOIN satellite
 						ON $table.COL_PROP_MODE = 'SAT'
@@ -209,10 +209,18 @@ class Distances_model extends CI_Model
 				$qrb['Qsos']++;                                                        // Counts up number of qsos
 				$bearingdistance = $this->qra->distance($stationgrid, $qso['grid'], $measurement_base, $qso['COL_ANT_PATH']);
 				$bearingdistance_km = $this->qra->distance($stationgrid, $qso['grid'], 'K', $qso['COL_ANT_PATH']);
+
+				$updatedata = array();
 				if ($bearingdistance_km != $qso['COL_DISTANCE']) {
-					$data = array('COL_DISTANCE' => $bearingdistance_km);
+					$updatedata['COL_DISTANCE'] = $bearingdistance_km;
+				}
+				$is_shortwave = trim((string)$qso['COL_PROP_MODE']) === '';   // only plain HF/VHF+ terrestrial QSOs -- SAT, EME, MS, etc. don't follow the great-circle bearing
+				if ($is_shortwave && ($qso['COL_ANT_AZ'] === null || $qso['COL_ANT_AZ'] === '')) {   // only fill if empty -- never overwrite a user/ADIF-supplied value
+					$updatedata['COL_ANT_AZ'] = $this->qra->get_bearing($stationgrid, $qso['grid'], $qso['COL_ANT_PATH']);
+				}
+				if (!empty($updatedata)) {
 					$this->db->where('COL_PRIMARY_KEY', $qso['COL_PRIMARY_KEY']);
-					$this->db->update($this->config->item('table_name'), $data);
+					$this->db->update($this->config->item('table_name'), $updatedata);
 				}
 				$arrayplacement = (int)($bearingdistance / 50);                                // Resolution is 50, calculates where to put result in array
 				if ($bearingdistance > $qrb['Distance']) {                              // Saves the longest QSO

--- a/application/models/Distances_model.php
+++ b/application/models/Distances_model.php
@@ -216,7 +216,10 @@ class Distances_model extends CI_Model
 				}
 				$is_shortwave = trim((string)$qso['COL_PROP_MODE']) === '';   // only plain HF/VHF+ terrestrial QSOs -- SAT, EME, MS, etc. don't follow the great-circle bearing
 				if ($is_shortwave && ($qso['COL_ANT_AZ'] === null || $qso['COL_ANT_AZ'] === '')) {   // only fill if empty -- never overwrite a user/ADIF-supplied value
-					$updatedata['COL_ANT_AZ'] = $this->qra->get_bearing($stationgrid, $qso['grid'], $qso['COL_ANT_PATH']);
+					$bearing = $this->qra->get_bearing($stationgrid, $qso['grid'], $qso['COL_ANT_PATH']);
+					if ($bearing !== false) {   // unparsable qso-grid: leave the column NULL rather than stamping it with 0 (= due north)
+						$updatedata['COL_ANT_AZ'] = $bearing;
+					}
 				}
 				if (!empty($updatedata)) {
 					$this->db->where('COL_PRIMARY_KEY', $qso['COL_PRIMARY_KEY']);

--- a/application/models/Stats.php
+++ b/application/models/Stats.php
@@ -1001,7 +1001,7 @@
 
 		$conditions[] = "COL_PROP_MODE = 'SAT'";
 
-		if ($sat !== null && $sat != "All") {
+		if ($sat !== null && $sat !== '' && $sat !== 'All') {
 			$conditions[] = "COL_SAT_NAME = ? ";
 			$binding[] = trim($sat);
 		}
@@ -1019,6 +1019,7 @@
 		$sql = "SELECT count(*) qsos, round(COL_ANT_EL) elevation FROM ".$this->config->item('table_name')."
 		LEFT JOIN satellite ON satellite.name = ".$this->config->item('table_name').".COL_SAT_NAME
 		where station_id in (" . implode(',',$logbooks_locations_array) . ") and coalesce(col_ant_el, '') <> ''";
+		$sql.=" $where";		// must be appended before the date clauses -- its bindings were pushed onto $binding first
 		if (!empty($dateFrom)) {
 			$sql.=" and COL_TIME_ON >= ? ";
 			$binding[]=$dateFrom . ' 00:00:00';
@@ -1027,7 +1028,7 @@
 			$sql.=" and COL_TIME_ON <= ? ";
 			$binding[]=$dateTo . ' 23:59:59';
 		}
-		$sql.=" $where
+		$sql.="
 		group by round(col_ant_el)
 		order by elevation asc";
 
@@ -1080,6 +1081,7 @@
 		LEFT JOIN satellite ON satellite.name = ".$this->config->item('table_name').".COL_SAT_NAME
 		where station_id in (" . implode(',',$logbooks_locations_array) . ")
 		and coalesce(col_ant_az, '') <> ''";
+		$sql.=" $where";		// must be appended before the date clauses -- its bindings were pushed onto $binding first
 		if (!empty($dateFrom)) {
 			$sql.=" and COL_TIME_ON >= ? ";
 			$binding[]=$dateFrom . ' 00:00:00';
@@ -1088,7 +1090,7 @@
 			$sql.=" and COL_TIME_ON <= ? ";
 			$binding[]=$dateTo . ' 23:59:59';
 		}
-		$sql.=" $where
+		$sql.="
 		group by round(col_ant_az)
 		order by azimuth asc";
 

--- a/application/models/Stats.php
+++ b/application/models/Stats.php
@@ -1001,12 +1001,12 @@
 
 		$conditions[] = "COL_PROP_MODE = 'SAT'";
 
-		if($sat != "All") {
+		if ($sat !== null && $sat != "All") {
 			$conditions[] = "COL_SAT_NAME = ? ";
 			$binding[] = trim($sat);
 		}
 
-		if ($orbit !== '') {
+		if (is_array($orbit) && count($orbit) > 0) {
 			$conditions[] = "orbit in ?";
 			$binding[] = $orbit;
 		}
@@ -1046,28 +1046,28 @@
 			return null;
 		}
 
-		if ($band !== 'All') {
-			if($band != "SAT") {
-				$conditions[] = "COL_BAND = ? and (COL_PROP_MODE != 'SAT' OR COL_PROP_MODE IS NULL)";
-				$binding[] = trim($band);
-			} else {
-				$conditions[] = "COL_PROP_MODE = 'SAT'";
-				if ($sat !== 'All') {
-					$conditions[] = "COL_SAT_NAME = ?";
-					$binding[] = trim($sat);
-				}
+		// sat and orbit are satellite-only filters, so they live inside the SAT branch:
+		// applying them to any other band would drop every non-satellite QSO, since the
+		// LEFT JOIN below leaves orbit NULL for those and NULL IN (...) never matches
+		if ($band === 'SAT') {
+			$conditions[] = "COL_PROP_MODE = 'SAT'";
+			if ($sat !== null && $sat !== '' && $sat !== 'All') {
+				$conditions[] = "COL_SAT_NAME = ?";
+				$binding[] = trim($sat);
 			}
+			if (is_array($orbit) && count($orbit) > 0) {
+				$conditions[] = "orbit in ?";
+				$binding[] = $orbit;
+			}
+		} elseif ($band !== 'All') {
+			$conditions[] = "COL_BAND = ? and (COL_PROP_MODE != 'SAT' OR COL_PROP_MODE IS NULL)";
+			$binding[] = trim($band);
 		}
 
 		if ($mode !== 'All') {
 			$conditions[] = "(COL_MODE = ? or COL_SUBMODE = ?)";
 			$binding[] = $mode;
 			$binding[] = $mode;
-		}
-
-		if ($orbit !== '') {
-			$conditions[] = "orbit in ?";
-			$binding[] = $orbit;
 		}
 
 		$where = trim(implode(" AND ", $conditions));

--- a/assets/js/sections/antennastats.js
+++ b/assets/js/sections/antennastats.js
@@ -2,13 +2,20 @@ var azimuthChart;
 var elevationChart;
 
 $('#band').change(function () {
-	var band = $("#band option:selected").text();
-	if (band != "SAT") {
-		$(".sats_dropdown").attr("hidden", true);
-		$(".orbits_dropdown").attr("hidden", true);
-	} else {
+	var isSat = ($('#band').val() === "SAT");
+	if (isSat) {
 		$(".sats_dropdown").removeAttr("hidden");
 		$(".orbits_dropdown").removeAttr("hidden");
+	} else {
+		$(".sats_dropdown").attr("hidden", true);
+		$(".orbits_dropdown").attr("hidden", true);
+	}
+	// the sat/orbit filters only apply to satellite QSOs, so clear them when
+	// leaving SAT and restore the all-selected default when coming back
+	$('#sat').val('All');
+	if ($('#orbit').length) {
+		$('#orbit').find('option').prop('selected', isSat);
+		$('#orbit').multiselect('refresh');
 	}
 });
 
@@ -125,8 +132,9 @@ function plot_azimuth() {
 		azimuthChart.destroy();
 	}
 	let band = $('#band').val();
-	let selectedOrbits = $('#orbit').val();
-	if (band == 'SAT' && Array.isArray(selectedOrbits) && selectedOrbits.length === 0) {
+	let isSat = (band === 'SAT');
+	let selectedOrbits = $('#orbit').val() || [];
+	if (isSat && selectedOrbits.length === 0) {
 		BootstrapDialog.alert({
 			title: 'INFO',
 			message: 'You need to select at least one orbit type location to do a search!',
@@ -139,15 +147,20 @@ function plot_azimuth() {
 		return false;
 	}
 
+	let postData = {
+		'band': band,
+		'mode': $('#mode').val()
+	};
+	// only send the satellite-only filters when actually querying satellite QSOs
+	if (isSat) {
+		postData.sat = $('#sat').val();
+		postData.orbit = selectedOrbits;
+	}
+
 	$.ajax({
 		url: base_url + 'index.php/statistics/get_azimuth_data',
 		type: 'post',
-		data: {
-			'band': $('#band').val(),
-			'mode': $('#mode').val(),
-			'sat': $('#sat').val(),
-			'orbit': $('#orbit').val()
-		},
+		data: postData,
 		success: function (tmp) {
 			var dataQso = [];
 			var labels = [];

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -456,30 +456,18 @@ function qso_edit(id) {
                             $.ajax({
                                url: base_url + 'index.php/logbook/searchbearing',
                                type: 'post',
+                               dataType: 'json',
                                data: {
                                   grid: $('#locator_edit').val(),
                                   ant_path: $('#ant_path_edit').val(),
                                   stationProfile: $('#stationProfile').val()
                                },
                                success: function(data) {
-                                  $('#locator_info_edit').html(data).fadeIn("slow");
+                                  $('#locator_info_edit').html(data.text).fadeIn("slow");
+                                  $("#distance").val(data.distance_km ?? '');
                                },
                                error: function() {
                                   $('#locator_info_edit').text("Error loading bearing!").fadeIn("slow");
-                               },
-                            });
-                            $.ajax({
-                               url: base_url + 'index.php/logbook/searchdistance',
-                               type: 'post',
-                               data: {
-                                  grid: $('#locator_edit').val(),
-                                  ant_path: $('#ant_path_edit').val(),
-                                  stationProfile: $('#stationProfile').val()
-                               },
-                               success: function(data) {
-                                  $("#distance").val(parseFloat(data));
-                               },
-                               error: function() {
                                   $('#distance').val('');
                                },
                             });
@@ -494,28 +482,17 @@ function qso_edit(id) {
                             $.ajax({
                                url: base_url + 'index.php/logbook/searchbearing',
                                type: 'post',
+                               dataType: 'json',
                                data: {
                                   grid: $(this).val(),
                                   stationProfile: $('#stationProfile').val()
                                },
                                success: function(data) {
-                                  $('#locator_info_edit').html(data).fadeIn("slow");
+                                  $('#locator_info_edit').html(data.text).fadeIn("slow");
+                                  $("#distance").val(data.distance_km ?? '');
                                },
                                error: function() {
                                   $('#locator_info_edit').text("Error loading bearing!").fadeIn("slow");
-                               },
-                            });
-                            $.ajax({
-                               url: base_url + 'index.php/logbook/searchdistance',
-                               type: 'post',
-                               data: {
-                                  grid: $(this).val(),
-                                  stationProfile: $('#stationProfile').val()
-                               },
-                               success: function(data) {
-                                  $("#distance").val(parseFloat(data));
-                               },
-                               error: function() {
                                   $("#distance").val('');
                                },
                             });

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -2831,30 +2831,18 @@ $("#locator").on("input focus", function () {
 			$.ajax({
 				url: base_url + 'index.php/logbook/searchbearing',
 				type: 'post',
+				dataType: 'json',
 				data: {
 					grid: $(this).val(),
 					ant_path: $('#ant_path').val(),
 					stationProfile: $('#stationProfile').val()
 				},
 				success: function (data) {
-					$('#locator_info').html(data).fadeIn("slow");
+					$('#locator_info').html(data.text).fadeIn("slow");
+					document.getElementById("distance").value = data.distance_km ?? '';
 				},
 				error: function () {
 					$('#locator_info').text(lang_qso_error_loading_bearing).fadeIn("slow");
-				},
-			});
-			$.ajax({
-				url: base_url + 'index.php/logbook/searchdistance',
-				type: 'post',
-				data: {
-					grid: $(this).val(),
-					ant_path: $('#ant_path').val(),
-					stationProfile: $('#stationProfile').val()
-				},
-				success: function (data) {
-					document.getElementById("distance").value = data;
-				},
-				error: function () {
 					document.getElementById("distance").value = null;
 				},
 			});
@@ -2887,30 +2875,18 @@ $("#ant_path").on("change", function () {
 		$.ajax({
 			url: base_url + 'index.php/logbook/searchbearing',
 			type: 'post',
+			dataType: 'json',
 			data: {
 				grid: $('#locator').val(),
 				ant_path: $('#ant_path').val(),
 				stationProfile: $('#stationProfile').val()
 			},
 			success: function (data) {
-				$('#locator_info').html(data).fadeIn("slow");
+				$('#locator_info').html(data.text).fadeIn("slow");
+				$('#distance').val(data.distance_km ?? '');
 			},
 			error: function () {
 				$('#locator_info').text(lang_qso_error_loading_bearing).fadeIn("slow");
-			},
-		});
-		$.ajax({
-			url: base_url + 'index.php/logbook/searchdistance',
-			type: 'post',
-			data: {
-				grid: $('#locator').val(),
-				ant_path: $('#ant_path').val(),
-				stationProfile: $('#stationProfile').val()
-			},
-			success: function (data) {
-				$('#distance').val(data);
-			},
-			error: function () {
 				$('#distance').val("");
 			},
 		});

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1053,6 +1053,7 @@ $("#sat_name").on('change', function () {
 	} else {
 		$('#lotw_support').text("");
 		$('#lotw_support').removeClass();
+		clear_auto_ant_az();		// the az/el ticker takes over the field now
 		get_sat_info();
 	}
 });
@@ -1064,6 +1065,44 @@ $("#sat_name").on('focusout', function () {
 	}
 });
 
+/*
+ * #ant_az can hold three kinds of value: typed by the operator, written by the satellite
+ * az/el ticker, or prefilled by us from the calculated bearing. Only the last one may be
+ * overwritten or cleared, so remember where the current value came from.
+ */
+let ant_az_autofilled = false;
+
+$("#ant_az").on("input", function () {
+	ant_az_autofilled = false;		// operator took over, hands off from now on
+});
+
+function set_ant_az_from_bearing(deg) {
+	// Satellite QSO: az/el belong to the TLE ticker. Any other prop mode (EME/MS/AUR/...):
+	// the antenna doesn't point along the great-circle bearing either. Both cases: hands off.
+	if ($("#sat_name").val() != "" || $('#selectPropagation').val() != '') return;
+	if ($("#ant_az").val() != '' && !ant_az_autofilled) return;
+
+	if (deg === null || deg === undefined) {
+		clear_auto_ant_az();
+		return;
+	}
+	$("#ant_az").val(deg);
+	ant_az_autofilled = true;
+}
+
+function clear_auto_ant_az() {
+	if (ant_az_autofilled) {
+		$("#ant_az").val('');
+		ant_az_autofilled = false;
+	}
+}
+
+$('#selectPropagation').on('change', function () {
+	if ($(this).val() != '') {		// great-circle bearing no longer applies
+		clear_auto_ant_az();
+	}
+});
+
 var satupdater;
 
 function stop_az_ele_ticker() {
@@ -1072,6 +1111,7 @@ function stop_az_ele_ticker() {
 	}
 	$("#ant_az").val('');
 	$("#ant_el").val('');
+	ant_az_autofilled = false;
 }
 
 function start_az_ele_ticker(tle) {
@@ -1349,7 +1389,7 @@ function reset_to_default() {
 	$("#ant_az").val("");
 	$("#ant_el").val("");
 	$("#distance").val("");
-	stop_az_ele_ticker();
+	stop_az_ele_ticker();		// also resets ant_az_autofilled
 }
 
 /* Function: reset_fields is used to reset the fields on the QSO page */
@@ -1410,6 +1450,7 @@ function reset_fields() {
 	$('#partial_view').hide();
 	$('.callsign-suggest').hide();
 	$("#distance").val("");
+	clear_auto_ant_az();
 	setRst($(".mode").val());
 	var $select = $('#sota_ref').selectize();
 	var selectize = $select[0].selectize;
@@ -1795,6 +1836,7 @@ $("#callsign").on("focusout", function () {
 					if (result.callsign_geoloc != 'grid' || result.timesWorked > 0) {
 						$('#locator').val(result.callsign_qra);
 						$('#locator_info').html(result.bearing);
+						set_ant_az_from_bearing(result.bearing_deg);
 					}
 
 					if (result.callsign_distance != "" && result.callsign_distance != 0) {
@@ -2840,10 +2882,12 @@ $("#locator").on("input focus", function () {
 				success: function (data) {
 					$('#locator_info').html(data.text).fadeIn("slow");
 					document.getElementById("distance").value = data.distance_km ?? '';
+					set_ant_az_from_bearing(data.bearing);
 				},
 				error: function () {
 					$('#locator_info').text(lang_qso_error_loading_bearing).fadeIn("slow");
 					document.getElementById("distance").value = null;
+					clear_auto_ant_az();
 				},
 			});
 		}
@@ -2854,6 +2898,7 @@ $("#locator").on("focusout", function () {
 	if ($(this).val().length == 0) {
 		$('#locator_info').text("");
 		document.getElementById("distance").value = null;
+		clear_auto_ant_az();
 	}
 });
 
@@ -2884,10 +2929,12 @@ $("#ant_path").on("change", function () {
 			success: function (data) {
 				$('#locator_info').html(data.text).fadeIn("slow");
 				$('#distance').val(data.distance_km ?? '');
+				set_ant_az_from_bearing(data.bearing);
 			},
 			error: function () {
 				$('#locator_info').text(lang_qso_error_loading_bearing).fadeIn("slow");
 				$('#distance').val("");
+				clear_auto_ant_az();
 			},
 		});
 	}
@@ -3013,6 +3060,7 @@ function resetDefaultQSOFields() {
 	$('#country').val("");
 	$('#continent').val("");
 	$("#distance").val("");
+	clear_auto_ant_az();		// keeps a sat-ticker or hand-typed azimuth for the next QSO
 	$('#email').val("");
 	$('#email_info').html("").addClass('d-none').hide();
 	$('#region').val("");


### PR DESCRIPTION
Antenna-Analytics never worked for shortwave-QSOs, even if ANT_AZ was filled.
This PR fixes it.

three parts:

1. Take care of HF-Only QSOs in controller (it passed orbit / sat even if only HF was selected)
2. Since we update distances at distance-analytics for QSOs without distance, why not update Bearing as well (if not given, if prop-mode empty)?
3. Take calculated (and displayed!) bearing if propagation_mode is empty or not overriden by user for ant_az while logging

furthermore some simplification in code. removed redundant logics for own station-grid

Testinghints:
- Run Distance-Analytics to populate bearing as well for HF-QSOs
- Run Antenna-Analytics for Shortwave and SAT
- Log QSO and see how Az is populated (check in QSO Details afterwards). test it with:
  - HF
  - SAT-QSOs (LEO/MEO) - should be autopopulated
