### PR TITLE
[Activation Planner] Name fix

### DIFF
--- a/assets/js/sections/activationplanner.js
+++ b/assets/js/sections/activationplanner.js
@@ -1,7 +1,7 @@
 (function () {
 	'use strict';
 
-	let cfg           = window.gridlookupConfig || {};
+	let cfg           = window.activationplannerConfig || {};
 	let tileUrl       = cfg.tileUrl    || 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 	let tileAttr      = cfg.tileAttr   || '&copy; OpenStreetMap contributors';
 	let glOverlays    = cfg.overlays    || [];


### PR DESCRIPTION
Not everything was renamed, so overlays and user set units would fail.
Here is the fix.