### PR TITLE
[Activation Planner] Disable tooltip for WWFF, POTA and SOTA

### DIFF
--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1100,6 +1100,24 @@ label {
 	margin: 0 8px 0 0;
 }
 
+/* Permanent region labels on the activation planner zone/state overlays */
+.leaflet-tooltip.overlay-region-label {
+	background: rgba(0, 0, 0, 0.55);
+	border: none;
+	box-shadow: none;
+	color: #fff;
+	font-weight: 600;
+	font-size: 11px;
+	padding: 1px 5px;
+	border-radius: 3px;
+	max-width: 140px;
+	white-space: normal;
+	text-align: center;
+}
+.leaflet-tooltip.overlay-region-label::before {
+	display: none;
+}
+
 .info.leaflet-control {
     padding: 6px 8px;
     font: 14px/16px Arial, Helvetica, sans-serif;

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1118,6 +1118,18 @@ label {
 	display: none;
 }
 
+/* Dropdown toggle "active" state — any checkbox in the menu checked.
+ * Mirrors the advanced logbook filter button (.btn-filter-active). */
+.btn-filter-active {
+	background-color: #ffc107 !important;
+	border-color: #ffc107 !important;
+	color: #000 !important;
+}
+.btn-filter-active:hover {
+	background-color: #e0a800 !important;
+	border-color: #e0a800 !important;
+}
+
 .info.leaflet-control {
     padding: 6px 8px;
     font: 14px/16px Arial, Helvetica, sans-serif;

--- a/assets/js/sections/activationplanner.js
+++ b/assets/js/sections/activationplanner.js
@@ -455,6 +455,13 @@
 		}
 		return esc(props[cfg.numKey] != null ? props[cfg.numKey] : '');
 	}
+	/* Highlight a dropdown toggle (btn-filter-active) when any checkbox in its
+	 * menu is checked — mirrors the advanced logbook filter button. */
+	function syncToggleActive(menu, btn) {
+		if (!menu || !btn) return;
+		btn.classList.toggle('btn-filter-active', !!menu.querySelector('input[type="checkbox"]:checked'));
+	}
+
 	// Build the Overlays dropdown from the server-provided config (glOverlays).
 	function buildOverlays(host) {
 		if (!host || !glOverlays.length) return;
@@ -503,11 +510,13 @@
 			let id = e.target.getAttribute('data-oid');
 			if (!id) return;
 			if (e.target.checked) { addOverlay(id, e.target); } else { removeOverlay(id); }
+			syncToggleActive(menu, btn);
 		});
 
 		drop.appendChild(btn);
 		drop.appendChild(menu);
 		host.appendChild(drop);
+		syncToggleActive(menu, btn);   // initial state (none checked -> normal)
 	}
 	// Fetch (once, cached) and add a GeoJSON overlay layer to the map.
 	function addOverlay(id, cb) {
@@ -842,6 +851,17 @@
 			sotaCb.addEventListener('change', function () {
 				if (this.checked) { enableSota(); } else { disableSota(); }
 			});
+		}
+
+		// Reflect Refs/Overlays dropdown state on their toggle buttons.
+		let refsDrop = document.querySelector('.gl-refs');
+		if (refsDrop) {
+			let refsBtn = refsDrop.querySelector('.dropdown-toggle');
+			let refsMenu = refsDrop.querySelector('.dropdown-menu');
+			if (refsBtn && refsMenu) {
+				refsMenu.addEventListener('change', function () { syncToggleActive(refsMenu, refsBtn); });
+				syncToggleActive(refsMenu, refsBtn);   // gridsquare is on by default -> active
+			}
 		}
 
 		// Build the Overlays (GeoJSON) dropdown — zones + per-country states.

--- a/assets/js/sections/activationplanner.js
+++ b/assets/js/sections/activationplanner.js
@@ -566,7 +566,6 @@
 						fillColor: '#2b8cbe',
 						fillOpacity: 0.9
 					});
-					dot.bindTooltip(D.reference + (D.name ? ' - ' + D.name : ''));
 					dot.bindPopup('<strong>' + esc(D.reference) + '</strong>' +
 						(D.name ? '<br>' + esc(D.name) : '') +
 						'<br>' + fmtLat(D.lat) + ', ' + fmtLng(D.lon));
@@ -602,7 +601,6 @@
 						fillColor: '#238b45',
 						fillOpacity: 0.9
 					});
-					dot.bindTooltip(D.reference + (D.name ? ' - ' + D.name : ''));
 					dot.bindPopup('<strong>' + esc(D.reference) + '</strong>' +
 						(D.name ? '<br>' + esc(D.name) : '') +
 						'<br>' + fmtLat(D.lat) + ', ' + fmtLng(D.lon));
@@ -638,7 +636,6 @@
 						fillColor: '#d95f0e',
 						fillOpacity: 0.9
 					});
-					dot.bindTooltip(D.reference + (D.name ? ' - ' + D.name : ''));
 					dot.bindPopup('<strong>' + esc(D.reference) + '</strong>' +
 						(D.name ? '<br>' + esc(D.name) : '') +
 						'<br>' + fmtLat(D.lat) + ', ' + fmtLng(D.lon));

--- a/assets/js/sections/activationplanner.js
+++ b/assets/js/sections/activationplanner.js
@@ -446,14 +446,14 @@
 	function styleFor(color) {
 		return { color: color, weight: 1, opacity: 0.85, fillColor: color, fillOpacity: 0.12 };
 	}
-	function overlayPopup(props, cfg) {
+	/* Permanent label shown on each overlay region. Zones (CQ/ITU) use their
+	 * number; state/province overlays use their full name. */
+	function overlayLabel(props, cfg) {
 		props = props || {};
 		if (cfg.type === 'state') {
-			return '<strong>' + esc(props[cfg.nameKey]) + '</strong>' +
-				(props[cfg.codeKey] ? ' <span class="text-muted">(' + esc(props[cfg.codeKey]) + ')</span>' : '');
+			return esc(props[cfg.nameKey] != null ? props[cfg.nameKey] : '');
 		}
-		let prefix = cfg.type === 'cq' ? 'CQ Zone' : 'ITU Zone';
-		return '<strong>' + prefix + ' ' + esc(props[cfg.numKey]) + '</strong><br>' + esc(props[cfg.nameKey]);
+		return esc(props[cfg.numKey] != null ? props[cfg.numKey] : '');
 	}
 	// Build the Overlays dropdown from the server-provided config (glOverlays).
 	function buildOverlays(host) {
@@ -513,21 +513,31 @@
 	function addOverlay(id, cb) {
 		let cfg = overlayCfg[id];
 		if (!cfg) return;
-		if (overlayLayers[id]) { map.addLayer(overlayLayers[id]); return; }
+		if (overlayLayers[id]) {
+			let cached = overlayLayers[id];
+			map.addLayer(cached);
+			map.fitBounds(cached.getBounds(), { padding: [20, 20] });
+			return;
+		}
 		if (cb) { cb.disabled = true; }
 		fetch(glGeojsonBase + cfg.file)
 			.then(function (r) { return r.json(); })
 			.then(function (data) {
 				let layer = L.geoJSON(data, {
-					style: function () { return styleFor(cfg.color); },
+					style: function () { return Object.assign(styleFor(cfg.color), { interactive: false }); },
 					onEachFeature: function (feature, lyr) {
-						lyr.bindPopup(overlayPopup(feature.properties, cfg));
-						lyr.on('mouseover', function (ev) { ev.target.setStyle({ weight: 3, fillOpacity: 0.32 }); });
-						lyr.on('mouseout',  function (ev) { ev.target.setStyle(styleFor(cfg.color)); });
+						lyr.bindTooltip(overlayLabel(feature.properties, cfg), {
+							permanent: true,
+							direction: 'center',
+							className: 'overlay-region-label'
+						});
 					}
 				});
 				overlayLayers[id] = layer;            // cache so re-toggle is instant
-				if (!cb || cb.checked) { layer.addTo(map); }
+				if (!cb || cb.checked) {
+					layer.addTo(map);
+					map.fitBounds(layer.getBounds(), { padding: [20, 20] });
+				}
 			})
 			.catch(function (err) { console.error('Overlay load failed:', cfg.file, err); })
 			.finally(function () { if (cb) { cb.disabled = false; } });


### PR DESCRIPTION
- [x] Disable tooltip for WWFF, POTA and SOTA, as information is shown on click
- [x] Shows labels for overlays, doesn't catch click, as we want to focus on catching gridsquare click
- [x] Change button for refs and overlays if anything is active (same behavior as LBA)