### PR TITLE
OnAir widget

### DIFF
--- a/application/controllers/Header_auth.php
+++ b/application/controllers/Header_auth.php
@@ -334,6 +334,7 @@ class Header_auth extends CI_Controller {
             $mapped['on_air_widget_enabled']                  ?? '',
             $mapped['on_air_widget_display_last_seen']        ?? '',
             $mapped['on_air_widget_show_only_most_recent_radio'] ?? '',
+            $mapped['on_air_widget_display_radio_name']       ?? '',
             $mapped['qso_widget_display_qso_time']            ?? '',
             $mapped['dashboard_banner']                       ?? '',
             $mapped['dashboard_solar']                        ?? '',

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -324,6 +324,7 @@ class User extends CI_Controller {
 				$this->input->post('on_air_widget_enabled'),
 				$this->input->post('on_air_widget_display_last_seen'),
 				$this->input->post('on_air_widget_show_only_most_recent_radio'),
+				$this->input->post('on_air_widget_display_radio_name'),
 				$this->input->post('qso_widget_display_qso_time'),
 				$this->input->post('user_dashboard_banner') ?? 'Y',
 				$this->input->post('user_dashboard_solar') ?? 'Y',
@@ -1004,6 +1005,7 @@ class User extends CI_Controller {
 			$data['on_air_widget_enabled'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'enabled'), $this->uri->segment(3))->row()->option_value ?? "false");
 			$data['on_air_widget_display_last_seen'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'display_last_seen'), $this->uri->segment(3))->row()->option_value ?? "false");
 			$data['on_air_widget_show_only_most_recent_radio'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'display_only_most_recent_radio'), $this->uri->segment(3))->row()->option_value ?? "true");
+			$data['on_air_widget_display_radio_name'] = ($this->user_options_model->get_options('widget', array('option_name'=>'on_air', 'option_key' => 'display_radio_name'), $this->uri->segment(3))->row()->option_value ?? "false");
 			$data['on_air_widget_url'] = site_url('widgets/on_air/' . $q->slug);
 			$data['qso_widget_display_qso_time'] = ($this->user_options_model->get_options('widget', array('option_name'=>'qso', 'option_key' => 'display_qso_time'), $this->uri->segment(3))->row()->option_value ?? "false");
 			$data['csrf_token'] = $this->paths->csrf_generate($this->router->class.'_'.$this->router->method);
@@ -1142,6 +1144,7 @@ class User extends CI_Controller {
 			$data['on_air_widget_enabled'] = $this->input->post('on_air_widget_enabled', true);
 			$data['on_air_widget_display_last_seen'] = $this->input->post('on_air_widget_display_last_seen', true);
 			$data['on_air_widget_show_only_most_recent_radio'] = $this->input->post('on_air_widget_show_only_most_recent_radio', true);
+			$data['on_air_widget_display_radio_name'] = $this->input->post('on_air_widget_display_radio_name', true);
 			$data['qso_widget_display_qso_time'] = $this->input->post('qso_widget_display_qso_time', true);
 			$data['global_oqrs_text'] = $this->input->post('global_oqrs_text', true);
 			$data['oqrs_grouped_search'] = $this->input->post('oqrs_grouped_search', true);

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -216,7 +216,7 @@ class Widgets extends CI_Controller {
 			$data['user_slug'] = $user_slug;
 			$data['nojs'] = $nojs;
 
-			$data['user_callsign'] = strtoupper($user->user_callsign);
+			$data['user_callsign'] = $this->get_active_station_callsign($user_id, $user->user_callsign);
 			$data['is_on_air'] = count($radios_online) > 0;
 			$data['radios_online'] = $radios_online;
 			$data['last_seen_text'] = $last_seen_text;
@@ -227,7 +227,7 @@ class Widgets extends CI_Controller {
 			$data['user_slug'] = $user_slug;
 			$data['nojs'] = $nojs;
 			$data['error'] = __("No CAT interfaced radios found. You need to have at least one radio interface configured.");
-			$data['user_callsign'] = strtoupper($user->user_callsign);
+			$data['user_callsign'] = $this->get_active_station_callsign($user_id, $user->user_callsign);
 			$data['is_on_air'] = false;
 			$data['radios_online'] = [];
 			$data['last_seen_text'] = null;
@@ -296,7 +296,7 @@ class Widgets extends CI_Controller {
 
 			$response = [
 				'success' => true,
-				'user_callsign' => strtoupper($user->user_callsign),
+				'user_callsign' => $this->get_active_station_callsign($user_id, $user->user_callsign),
 				'is_on_air' => count($radios_online) > 0,
 				'radios_online' => $radios_online,
 				'last_seen_text' => $last_seen_text,
@@ -307,7 +307,7 @@ class Widgets extends CI_Controller {
 		} else {
 			echo json_encode([
 				'success' => true,
-				'user_callsign' => strtoupper($user->user_callsign),
+				'user_callsign' => $this->get_active_station_callsign($user_id, $user->user_callsign),
 				'is_on_air' => false,
 				'radios_online' => [],
 				'last_seen_text' => null,
@@ -390,6 +390,19 @@ class Widgets extends CI_Controller {
 		}
 
 		return $options;
+	}
+
+	/**
+	 * Fetch the callsign of the user's active station location.
+	 * Falls back to the user's own callsign if no station is active.
+	 *
+	 * @return string
+	 */
+	private function get_active_station_callsign($user_id, $fallback_callsign) {
+		$active_station_id = $this->stations->find_active($user_id);
+		$station = $this->stations->profile($active_station_id)->row();
+
+		return strtoupper($station->station_callsign ?? $fallback_callsign);
 	}
 
 	/**

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -196,6 +196,7 @@ class Widgets extends CI_Controller {
 					$radio_obj->updated_at = $radio_data->timestamp;
 					$radio_obj->frequency_string = $this->prepare_frequency_string_for_widget($radio_data);
 					$radio_obj->mode = $radio_data->mode ?? '';
+					$radio_obj->radio_name = $widget_options->display_radio_name ? ($radio_data->radio ?? '') : null;
 					$radios_online[] = $radio_obj;
 				}
 			}
@@ -278,6 +279,7 @@ class Widgets extends CI_Controller {
 					$radio_obj->updated_at = $radio_data->timestamp;
 					$radio_obj->frequency_string = $this->prepare_frequency_string_for_widget($radio_data);
 					$radio_obj->mode = $radio_data->mode ?? '';
+					$radio_obj->radio_name = $widget_options->display_radio_name ? ($radio_data->radio ?? '') : null;
 					$radios_online[] = $radio_obj;
 				}
 			}
@@ -359,6 +361,7 @@ class Widgets extends CI_Controller {
 		$options->is_enabled = false;
 		$options->display_last_seen = false;
 		$options->display_only_most_recent_radio = true;
+		$options->display_radio_name = false;
 
 		if ($raw_widget_options === null) {
 			return $options;
@@ -380,6 +383,9 @@ class Widgets extends CI_Controller {
 			}
 			if ($key === "display_only_most_recent_radio") {
 				$options->display_only_most_recent_radio = $value === "true";
+			}
+			if ($key === "display_radio_name") {
+				$options->display_radio_name = $value === "true";
 			}
 		}
 

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -353,8 +353,11 @@ class Stations extends CI_Model {
 		}
 	}
 
-	public function find_active() {
-		$this->db->where('user_id', $this->session->userdata('user_id'));
+	public function find_active($user_id = null) {
+		if ($user_id == null) {
+			$user_id = $this->session->userdata('user_id');
+		}
+		$this->db->where('user_id', $user_id);
 		$this->db->where('station_active', 1);
 		$query = $this->db->get('station_profile');
 

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -248,7 +248,7 @@ class User_Model extends CI_Model {
 		$user_language, $user_hamsat_key, $user_hamsat_workable_only, $user_iota_to_qso_tab, $user_sota_to_qso_tab,
 		$user_wwff_to_qso_tab, $user_pota_to_qso_tab, $user_sig_to_qso_tab, $user_dok_to_qso_tab, $user_station_to_qso_tab,
 		$user_lotw_name, $user_lotw_password, $user_eqsl_name, $user_eqsl_password, $user_clublog_name, $user_clublog_password,
-		$user_winkey, $on_air_widget_enabled, $on_air_widget_display_last_seen, $on_air_widget_show_only_most_recent_radio,
+		$user_winkey, $on_air_widget_enabled, $on_air_widget_display_last_seen, $on_air_widget_show_only_most_recent_radio, $on_air_widget_display_radio_name,
 		$qso_widget_display_qso_time, $dashboard_banner, $dashboard_solar, $global_oqrs_text, $oqrs_grouped_search,
 		$oqrs_grouped_search_show_station_name, $oqrs_auto_matching, $oqrs_direct_auto_matching,$user_dxwaterfall_enable, $user_qso_show_map, $clubstation = 0, $external_account = null) {
 		// Check that the user isn't already used
@@ -339,6 +339,7 @@ class User_Model extends CI_Model {
 				['widget',     'on_air',                  'enabled',                       $on_air_widget_enabled                      ?? 'false'],
 				['widget',     'on_air',                  'display_last_seen',             $on_air_widget_display_last_seen            ?? 'false'],
 				['widget',     'on_air',                  'display_only_most_recent_radio',$on_air_widget_show_only_most_recent_radio  ?? 'true'],
+				['widget',     'on_air',                  'display_radio_name',            $on_air_widget_display_radio_name           ?? 'false'],
 				['widget',     'qso',                     'display_qso_time',              $qso_widget_display_qso_time                ?? 'false'],
 				['qso_db_search_priority', 'enable',      'boolean',                       $user_qso_db_search_priority ?? 'Y'],
 				['dxwaterfall', 'enable',                 'boolean',                       $user_dxwaterfall_enable     ?? 'N'],
@@ -422,6 +423,7 @@ class User_Model extends CI_Model {
 					['widget',     'on_air',                  'enabled',                       $fields['on_air_widget_enabled']                     ?? 'false'],
 					['widget',     'on_air',                  'display_last_seen',             $fields['on_air_widget_display_last_seen']           ?? 'false'],
 					['widget',     'on_air',                  'display_only_most_recent_radio',$fields['on_air_widget_show_only_most_recent_radio'] ?? 'true'],
+					['widget',     'on_air',                  'display_radio_name',            $fields['on_air_widget_display_radio_name']          ?? 'false'],
 					['widget',     'qso',                     'display_qso_time',              $fields['qso_widget_display_qso_time']               ?? 'false'],
 					['dashboard',  'last_qso_count',          'count',                         $dashboard_last_qso_count],
 					['dashboard',  'show_map',                'boolean',                       $fields['user_dashboard_map']    ?? 'Y'],

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -1188,6 +1188,17 @@
 											<small class="form-text text-muted"><?= __("This setting control whether the 'Last seen' time is displayed in widget or not."); ?></small>
 										</div>
 									</div>
+									<?php if(!isset($on_air_widget_display_radio_name)) { $on_air_widget_display_radio_name='false'; }?>
+									<div class="d-flex align-items-start gap-2 mb-3">
+										<input type="hidden" name="on_air_widget_display_radio_name" value="false">
+										<div class="form-check form-switch mt-1">
+											<input class="form-check-input" type="checkbox" role="switch" id="on_air_widget_display_radio_name" name="on_air_widget_display_radio_name" value="true" <?php if ($on_air_widget_display_radio_name == 'true') { echo 'checked'; } ?>>
+										</div>
+										<div>
+											<label class="d-block mb-0"><?= __("Display radio name"); ?></label>
+											<small class="form-text text-muted"><?= __("This setting controls whether the radio's name is displayed in the widget or not."); ?></small>
+										</div>
+									</div>
 									<div class="mb-3">
 										<label><?= __("Display only most recently updated radio"); ?></label>
 										<?php if(!isset($on_air_widget_show_only_most_recent_radio)) { $on_air_widget_show_only_most_recent_radio='true'; }?>

--- a/application/views/widgets/on_air.php
+++ b/application/views/widgets/on_air.php
@@ -143,13 +143,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <div>
                     <span class="status-indicator <?php echo $is_on_air ? 'on-air' : 'off-air'; ?>"></span>
                     <span class="<?= $text_size_class ?>">
-                        <?php
-                            if ($is_on_air === true) {
-                                printf("%s ON-AIR", $user_callsign);
-                            } else {
-                                printf("%s OFF-AIR", $user_callsign);
-                            }
-                        ?>
+						<?= sprintf(_pgettext("on air status test: callsign is on-air/off-air","%s is %s"), $user_callsign, $is_on_air ? 'ON-AIR' : 'OFF-AIR'); ?>
                     </span>
                 </div>
             </div>
@@ -204,13 +198,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <div>
                     <span class="status-indicator <?php echo $is_on_air ? 'on-air' : 'off-air'; ?>"></span>
                     <span class="<?= $text_size_class ?>" id="status-text">
-                        <?php
-                            if ($is_on_air === true) {
-                                printf("%s is ON-AIR", $user_callsign);
-                            } else {
-                                printf("%s is OFF-AIR", $user_callsign);
-                            }
-                        ?>
+						<?= sprintf(_pgettext("on air status test: callsign is on-air/off-air","%s is %s"), $user_callsign, $is_on_air ? 'ON-AIR' : 'OFF-AIR'); ?>
                     </span>
                 </div>
                 <div class="refresh-indicator" id="refresh-indicator">
@@ -255,6 +243,8 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
             const userSlug = '<?php echo $user_slug ?? ''; ?>';
             let updateInterval;
 
+			let statusTextTranslation = "<?= _pgettext("on air status test: callsign is on-air/off-air","%s is %s"); ?>";
+
             function updateWidget() {
                 if (!userSlug) return;
 
@@ -269,7 +259,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                     refreshIndicator.classList.add('updating');
                 }
 
-                fetch(`${window.location.origin}/index.php/widgets/on_air_ajax/${userSlug}`)
+				fetch(`<?php echo base_url(); ?>index.php/widgets/on_air_ajax/${userSlug}`)
                     .then(response => response.json())
                     .then(data => {
                         if (data.error) {
@@ -278,7 +268,8 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                         }
 
                         if (statusText) {
-                            statusText.textContent = `${data.user_callsign} is ${data.is_on_air ? 'ON-AIR' : 'OFF-AIR'}`;
+							let airStatus = data.is_on_air ? 'ON-AIR' : 'OFF-AIR'
+                            statusText.textContent = statusTextTranslation.replace("%s", data.user_callsign).replace("%s", airStatus);
                         }
 
                         if (statusIndicator) {
@@ -298,14 +289,14 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                                         </div>
                                     `;
                                 });
-                                html += '<div class="last-updated mt-2"><small id="last-updated-text">Last updated: ' +
+								html += '<div class="last-updated mt-2"><small id="last-updated-text"><?= __("Last updated:"); ?> ' +
                                        new Date().toLocaleTimeString() + '</small></div>';
                             } else if (data.last_seen_text) {
                                 html = `<p class="${window.textSizeClass || ''}" id="last-seen-text">${data.last_seen_text}</p>`;
-                                html += '<div class="last-updated mt-2"><small id="last-updated-text">Last updated: ' +
+								html += '<div class="last-updated mt-2"><small id="last-updated-text"><?= __("Last updated:"); ?> ' +
                                        new Date().toLocaleTimeString() + '</small></div>';
                             } else {
-                                html = '<div class="last-updated mt-2"><small id="last-updated-text">Last updated: ' +
+								html = '<div class="last-updated mt-2"><small id="last-updated-text"><?= __("Last updated:"); ?> ' +
                                        new Date().toLocaleTimeString() + '</small></div>';
                             }
 
@@ -313,7 +304,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                         }
 
                         if (lastUpdatedText) {
-                            lastUpdatedText.textContent = 'Last updated: ' + new Date().toLocaleTimeString();
+							lastUpdatedText.textContent = '<?= __("Last updated:"); ?> ' + new Date().toLocaleTimeString();
                         }
                     })
                     .catch(error => {

--- a/application/views/widgets/on_air.php
+++ b/application/views/widgets/on_air.php
@@ -1,5 +1,4 @@
 <!--
-
 This is a DYNAMIC On-Air widget to place in your QRZ.com Bio or somewhere else.
 
 For normal use with JavaScript:
@@ -169,7 +168,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                     </div>
                 <?php } ?>
                 <div class="last-updated mt-2">
-                    <small>Updated: <?= date('H:i:s'); ?> (auto-refreshed every 60s)</small>
+					<small><?= sprintf(__("Updated: %s (%s)"), date('H:i:s'), __("auto-refreshed every 60s")); ?></small>
                 </div>
             </div>
         </div>
@@ -186,7 +185,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                     <?= $error ?>
                 </div>
                 <div class="last-updated mt-2">
-                    <small>Updated: <?= date('H:i:s'); ?> (auto-refreshed by QRZ.com every 60s)</small>
+                    <small><?= sprintf(__("Updated: %s (%s)"), date('H:i:s'), __("auto-refreshed by QRZ.com every 60s")); ?></small>
                 </div>
             </div>
         </div>
@@ -233,7 +232,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                     </p>
                 <?php } ?>
                 <div class="last-updated mt-2">
-                    <small id="last-updated-text">Last updated: <?= date('H:i:s'); ?></small>
+					<small id="last-updated-text"><?= sprintf(__("Last updated: %s"), date('H:i:s')); ?></small>
                 </div>
             </div>
         </div>
@@ -330,9 +329,9 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
             window.textSizeClass = '<?php echo $text_size_class ?? ''; ?>';
 
             setTimeout(() => {
-                updateWidget(); 
-                updateInterval = setInterval(updateWidget, 30000); 
-            }, 2000); 
+                updateWidget();
+                updateInterval = setInterval(updateWidget, 30000);
+            }, 2000);
 
             window.addEventListener('beforeunload', () => {
                 if (updateInterval) {

--- a/application/views/widgets/on_air.php
+++ b/application/views/widgets/on_air.php
@@ -122,6 +122,19 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
             margin-left: 10px;
         }
 
+        .frequency-info {
+            display: flex;
+            align-items: center;
+        }
+
+        .radio-name-label {
+            font-size: 0.9em;
+            color: #6c757d;
+            margin-right: 10px;
+            padding-right: 10px;
+            border-right: 1px solid #6c757d;
+        }
+
         .last-updated {
             font-size: 0.8em;
             color: #6c757d;
@@ -151,6 +164,9 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <?php if ($is_on_air === true) { ?>
                     <?php foreach ($radios_online as $radio_data) { ?>
                         <div class="frequency-info mb-2">
+                            <?php if (!empty($radio_data->radio_name)) { ?>
+                            <span class="radio-name-label"><?php echo htmlspecialchars($radio_data->radio_name); ?></span>
+                            <?php } ?>
                             <span class="frequency-display <?php echo $text_size_class ?>">
                                 <?php echo htmlspecialchars($radio_data->frequency_string); ?>
                             </span>
@@ -209,6 +225,9 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <?php if ($is_on_air === true) { ?>
                     <?php foreach ($radios_online as $radio_data) { ?>
                         <div class="frequency-info mb-2">
+                            <?php if (!empty($radio_data->radio_name)) { ?>
+                            <span class="radio-name-label"><?php echo htmlspecialchars($radio_data->radio_name); ?></span>
+                            <?php } ?>
                             <span class="frequency-display <?php echo $text_size_class ?>" id="frequency-display">
                                 <?php echo htmlspecialchars($radio_data->frequency_string); ?>
                             </span>
@@ -242,6 +261,12 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
         (function() {
             const userSlug = '<?php echo $user_slug ?? ''; ?>';
             let updateInterval;
+
+            function escapeHtml(text) {
+                const div = document.createElement('div');
+                div.textContent = text;
+                return div.innerHTML;
+            }
 
 			let statusTextTranslation = "<?= _pgettext("on air status test: callsign is on-air/off-air","%s is %s"); ?>";
 
@@ -283,6 +308,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                                 data.radios_online.forEach(radio => {
                                     html += `
                                         <div class="frequency-info mb-2">
+                                            ${radio.radio_name ? `<span class="radio-name-label">${escapeHtml(radio.radio_name)}</span>` : ''}
                                             <span class="frequency-display ${window.textSizeClass || ''}">
                                                 ${radio.frequency_string}
                                             </span>

--- a/application/views/widgets/on_air.php
+++ b/application/views/widgets/on_air.php
@@ -25,7 +25,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
     <link rel="stylesheet" href="<?php echo $this->paths->cache_buster('/assets/css/' . $theme . '/overrides.css'); ?>">
     <link rel="stylesheet" href="<?php echo $this->paths->cache_buster('/assets/css/general.css'); ?>">
 
-    <title><?= "Wavelog Dynamic On-Air widget"; ?></title>
+    <title>Wavelog Dynamic On-Air widget</title>
     <style>
         .widget.container {
             max-width: none;
@@ -142,7 +142,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
             <div class="top-right">
                 <div>
                     <span class="status-indicator <?php echo $is_on_air ? 'on-air' : 'off-air'; ?>"></span>
-                    <span class="<?= $text_size_class ?>">
+                    <span class="<?php echo $text_size_class ?>">
 						<?= sprintf(_pgettext("on air status test: callsign is on-air/off-air","%s is %s"), $user_callsign, $is_on_air ? 'ON-AIR' : 'OFF-AIR'); ?>
                     </span>
                 </div>
@@ -151,14 +151,14 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <?php if ($is_on_air === true) { ?>
                     <?php foreach ($radios_online as $radio_data) { ?>
                         <div class="frequency-info mb-2">
-                            <span class="frequency-display <?= $text_size_class ?>">
-                                <?= htmlspecialchars($radio_data->frequency_string); ?>
+                            <span class="frequency-display <?php echo $text_size_class ?>">
+                                <?php echo htmlspecialchars($radio_data->frequency_string); ?>
                             </span>
                         </div>
                     <?php } ?>
                 <?php } else if ($last_seen_text !== null) { ?>
-                    <div class="<?= $text_size_class ?> text-muted">
-                        <?= htmlspecialchars($last_seen_text); ?>
+                    <div class="<?php echo $text_size_class ?> text-muted">
+                        <?php echo htmlspecialchars($last_seen_text); ?>
                     </div>
                 <?php } ?>
                 <div class="last-updated mt-2">
@@ -171,12 +171,12 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
             <div class="top-right">
                 <div>
                     <span class="status-indicator off-air"></span>
-                    <span class="<?= $text_size_class ?>"><?= __("Error") ?></span>
+                    <span class="<?php echo $text_size_class ?>"><?= __("Error") ?></span>
                 </div>
             </div>
             <div class="bottom-right mt-2">
-                <div class="<?= $text_size_class ?> text-danger">
-                    <?= $error ?>
+                <div class="<?php echo $text_size_class ?> text-danger">
+                    <?php echo $error ?>
                 </div>
                 <div class="last-updated mt-2">
                     <small><?= sprintf(__("Updated: %s (%s)"), date('H:i:s'), __("auto-refreshed by QRZ.com every 60s")); ?></small>
@@ -197,7 +197,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
             <div class="top-right d-flex justify-content-between align-items-center">
                 <div>
                     <span class="status-indicator <?php echo $is_on_air ? 'on-air' : 'off-air'; ?>"></span>
-                    <span class="<?= $text_size_class ?>" id="status-text">
+                    <span class="<?php echo $text_size_class ?>" id="status-text">
 						<?= sprintf(_pgettext("on air status test: callsign is on-air/off-air","%s is %s"), $user_callsign, $is_on_air ? 'ON-AIR' : 'OFF-AIR'); ?>
                     </span>
                 </div>
@@ -209,14 +209,14 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <?php if ($is_on_air === true) { ?>
                     <?php foreach ($radios_online as $radio_data) { ?>
                         <div class="frequency-info mb-2">
-                            <span class="frequency-display <?= $text_size_class ?>" id="frequency-display">
-                                <?= htmlspecialchars($radio_data->frequency_string); ?>
+                            <span class="frequency-display <?php echo $text_size_class ?>" id="frequency-display">
+                                <?php echo htmlspecialchars($radio_data->frequency_string); ?>
                             </span>
                         </div>
                     <?php } // end foreach ?>
                 <?php } else if ($last_seen_text !== null) { ?>
-                    <p class="<?= $text_size_class ?>" id="last-seen-text">
-                        <?= htmlspecialchars($last_seen_text); ?>
+                    <p class="<?php echo $text_size_class ?>" id="last-seen-text">
+                        <?php echo htmlspecialchars($last_seen_text); ?>
                     </p>
                 <?php } ?>
                 <div class="last-updated mt-2">
@@ -227,10 +227,10 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
      <?php } else { ?>
         <div class="right-column">
             <div class="top-right">
-                <p class="<?= $text_size_class ?>"><?= __("Error") ?></p>
+                <p class="<?php echo $text_size_class ?>"><?= __("Error") ?></p>
             </div>
             <div class="bottom-right mt-3">
-                <p class="<?= $text_size_class ?>"><?= htmlspecialchars($error) ?></p>
+                <p class="<?php echo $text_size_class ?>"><?php echo htmlspecialchars($error) ?></p>
            </div>
         </div>
      <?php } ?>


### PR DESCRIPTION
Did some maintenance on the on-air widget by @filipmelik 

- Added translations show visitors see the widget in their native language (if translations are available, otherwise english)
- matched with code conventions (<?= only at translations, otherwise <?php echo)
- Added an user option to also display the radio name as requested in https://github.com/wavelog/wavelog/discussions/3550 (opt in)
- Widget shows now station callsign instead user callsign