### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-09 10:10+0000\n"
-"PO-Revision-Date: 2026-08-09 07:35+0000\n"
-"Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
+"PO-Revision-Date: 2026-08-09 11:28+0000\n"
+"Last-Translator: Jörg Dorgeist <wavelog@dj7nt.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -5193,11 +5193,11 @@ msgstr "Standortanfrage dauerte zu lange."
 
 #: application/views/activationplanner/index.php:31
 msgid "Create station location"
-msgstr ""
+msgstr "Erstelle Stationsstandort"
 
 #: application/views/activationplanner/index.php:32
 msgid "References in this grid"
-msgstr ""
+msgstr "Referenzen in diesem Planquadrat"
 
 #: application/views/activationplanner/index.php:34
 #: application/views/view_log/qso.php:615
@@ -5206,7 +5206,7 @@ msgstr "Teilen"
 
 #: application/views/activationplanner/index.php:35
 msgid "Share activation"
-msgstr ""
+msgstr "Teile Aktivierung"
 
 #: application/views/activationplanner/index.php:36
 #, php-format

--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -28,7 +28,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-09 10:10+0000\n"
 "PO-Revision-Date: 2026-08-09 11:28+0000\n"
-"Last-Translator: Jörg Dorgeist <wavelog@dj7nt.de>\n"
+"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -3971,7 +3971,7 @@ msgid ""
 "setup, click %shere%s."
 msgstr ""
 "Station erfolgreich erstellt! Willkommen bei Wavelog! Um die Einrichtung "
-"deiner Station abzuschliessen, klicke %shier%s."
+"deiner Station abzuschließen, klicke %shier%s."
 
 #: application/controllers/User.php:1511
 msgid "Station setup failed! Please set up your station manually."
@@ -5155,7 +5155,7 @@ msgstr "Locator-Grenzen"
 #: application/views/user/modals/more_actions_modal.php:166
 #: application/views/version_dialog/index.php:79
 msgid "Close"
-msgstr "Schliessen"
+msgstr "Schließen"
 
 #: application/views/activationplanner/index.php:22
 msgid "Tracking"
@@ -5211,7 +5211,7 @@ msgstr "Teile Aktivierung"
 #: application/views/activationplanner/index.php:36
 #, php-format
 msgid "📻 Planning an activation from %s"
-msgstr ""
+msgstr "📻 Geplante Aktivierung aus %s"
 
 #: application/views/activationplanner/index.php:46
 msgid "Plan your activity here"
@@ -20221,7 +20221,7 @@ msgstr "Weiterleitung zur QSO-Logging Seite..."
 
 #: application/views/qso/log_qso.php:75
 msgid "The data was redirected. You can close this window."
-msgstr "Die Daten wurden weitergeleitet. Du kannst dieses Fenster schliessen."
+msgstr "Die Daten wurden weitergeleitet. Du kannst dieses Fenster schließen."
 
 #: application/views/radio/edit.php:18
 msgid "CAT URL"
@@ -20234,7 +20234,7 @@ msgid ""
 "(/) and QRG is added automatically. Default is %s"
 msgstr ""
 "Aufgerufene URL, wenn ein Spot im DXCluster angeklickt wird. Hinweis: Der "
-"abschliessende Schrägstrich (/) und die QRG werden automatisch hinzugefügt. "
+"abschließende Schrägstrich (/) und die QRG werden automatisch hinzugefügt. "
 "Standardwert ist %s"
 
 #: application/views/radio/index.php:22

--- a/install/includes/gettext/locale/de_DE/LC_MESSAGES/installer.po
+++ b/install/includes/gettext/locale/de_DE/LC_MESSAGES/installer.po
@@ -13,8 +13,8 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-29 15:45+0000\n"
-"PO-Revision-Date: 2026-06-14 15:17+0000\n"
-"Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
+"PO-Revision-Date: 2026-08-09 11:28+0000\n"
+"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/"
 "installer/de/>\n"
 "Language: de_DE\n"
@@ -227,7 +227,7 @@ msgstr "Wähle eine Sprache"
 
 #: install/index.php:116 install/index.php:484
 msgid "Close"
-msgstr "Schliessen"
+msgstr "Schließen"
 
 #: install/index.php:126
 msgid "PHP Modules"


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)