### PR TITLE
Dashboard DXCC Panel

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -131,11 +131,11 @@ class Dashboard extends CI_Controller {
 
 		// Country stats
 		$data['total_countries'] = $stats['Countries_Worked'];
-			$data['unique_callsigns'] = $stats['Unique_Callsigns'];
+		$data['unique_callsigns'] = $stats['Unique_Callsigns'];
 		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
 		$data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
 		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
-		$current = $stats['Countries_Current'];
+		$confirmed = $stats['Countries_Worked_Confirmed'];
 
 		// QSL stats
 		$data['total_qsl_sent'] = $stats['QSL_Sent'];
@@ -216,7 +216,7 @@ class Dashboard extends CI_Controller {
 			$data['firstloginwizard'] = $this->load->view('user/modals/first_login_wizard', $viewdata, true);
 		}
 
-		$data['total_countries_needed'] = count($dxcc->result()) - $current;
+		$data['total_countries_needed'] = max(0, count($dxcc->result()) - $confirmed);
 
 		// Check user preferrence to show Solar Data on Dashboard and load data if yes
 		// Default to not show

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -110,10 +110,10 @@ class Visitor extends CI_Controller {
 				$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
 				$data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
 				$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
-				$current = $stats['Countries_Current'];
+				$confirmed = $stats['Countries_Worked_Confirmed'];
 
 				$dxcc = $this->dxcc->list_current();
-				$data['total_countries_needed'] = count($dxcc->result()) - $current;
+				$data['total_countries_needed'] = max(0, count($dxcc->result()) - $confirmed);
 
 				// QSL stats
 				$data['total_qsl_sent'] = $stats['QSL_Sent'];

--- a/application/libraries/api_v2/Statistic_resource.php
+++ b/application/libraries/api_v2/Statistic_resource.php
@@ -115,6 +115,14 @@ class Statistic_resource extends Api_v2_resource {
 	 * QSO analytics for the token owner: total, activity (today/month/year),
 	 * band/mode breakdown, confirmation and DXCC totals. Scoped to the owner's
 	 * station locations, so the numbers are the user's own, not the instance.
+	 *
+	 * DXCC semantics:
+	 * - worked: unique valid DXCC entities worked in the log
+	 * - confirmed: DXCC entities confirmed by paper QSL or LoTW only
+	 * - available: current DXCC entities in the active DXCC list
+	 *
+	 * eQSL remains visible in the dashboard/UI and in the confirmations topic,
+	 * but it is intentionally excluded from dxcc.confirmed.
 	 */
 	protected function qso_topic() {
 		$this->CI->load->model('logbook_model');
@@ -126,9 +134,9 @@ class Statistic_resource extends Api_v2_resource {
 
 		$counts = $this->CI->logbook_model->get_qso_counts($scope);
 
-		// dashboard_stats_batch() already computes confirmation (QSL/eQSL/LoTW
-		// received) and DXCC worked/confirmed totals for a given set of station
-		// locations, so we reuse it instead of duplicating those queries.
+		// dashboard_stats_batch() already computes confirmation counts and DXCC
+		// worked/confirmed totals for a given set of station locations, so we
+		// reuse it instead of duplicating those queries.
 		$batch = $this->CI->logbook_model->dashboard_stats_batch($scope);
 
 		return [

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4247,7 +4247,9 @@ class Logbook_model extends CI_Model {
 				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
 				COUNT(DISTINCT CASE WHEN t.COL_EQSL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_EQSL,
 				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
-				COUNT(DISTINCT CASE WHEN (t.COL_QSL_RCVD = 'Y' OR t.COL_EQSL_QSL_RCVD = 'Y' OR t.COL_LOTW_QSL_RCVD = 'Y') AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_Confirmed,
+				-- DXCC confirmed totals intentionally count only paper QSL + LoTW.
+				-- eQSL is tracked separately in the UI as display-only information.
+				COUNT(DISTINCT CASE WHEN (t.COL_QSL_RCVD = 'Y' OR t.COL_LOTW_QSL_RCVD = 'Y') AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_Confirmed,
 				COUNT(DISTINCT CASE WHEN d.end IS NULL AND d.adif != 0 AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Current,
 				-- QSL stats (SUM - no filtering, all QSOs)
 				SUM(CASE WHEN t.COL_QSL_SENT = 'Y' THEN 1 ELSE 0 END) as QSL_Sent,

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -491,7 +491,12 @@ function echo_table_header_col($name) {
 						<th scope="row" width="50%"><?= __("Confirmed"); ?></th>
 						<td width="50%">
 							<span title="<?= __("QSL Cards"); ?>" aria-label="<?= __("QSL Cards"); ?>: <?php echo $total_countries_confirmed_paper; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_paper; ?></span> /
-							<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $total_countries_confirmed_lotw; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_lotw; ?></span> /
+							<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $total_countries_confirmed_lotw; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_lotw; ?></span>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row" width="50%"><?= __("eQSL"); ?></th>
+						<td width="50%">
 							<span title="<?= __("eQSL"); ?>" aria-label="<?= __("eQSL"); ?>: <?php echo $total_countries_confirmed_eqsl; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_eqsl; ?></span>
 						</td>
 					</tr>

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -497,7 +497,7 @@ function echo_table_header_col($name) {
 					<tr>
 						<th scope="row" width="50%"><?= __("eQSL"); ?></th>
 						<td width="50%">
-							<span title="<?= __("eQSL"); ?>" aria-label="<?= __("eQSL"); ?>: <?php echo $total_countries_confirmed_eqsl; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_eqsl; ?></span>
+							<span aria-label="<?= __("eQSL"); ?>: <?php echo $total_countries_confirmed_eqsl; ?>"><?php echo $total_countries_confirmed_eqsl; ?></span>
 						</td>
 					</tr>
 					<tr>

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -267,14 +267,16 @@ if ($public_maps_option == 'true') { ?>
 						<td width="50%"><?php echo $total_countries; ?></td>
 					</tr>
 					<tr>
-						<td width="50%"><a href="#" onclick="return false" title="QSL Cards / eQSL / LoTW" data-bs-toggle="tooltip"><?= __("Confirmed"); ?></a></td>
+						<td width="50%"><a href="#" onclick="return false" title="QSL Cards / LoTW" data-bs-toggle="tooltip"><?= __("Confirmed"); ?></a></td>
 						<td width="50%">
 							<?php echo $total_countries_confirmed_paper; ?> /
-							<?php echo $total_countries_confirmed_eqsl; ?> /
 							<?php echo $total_countries_confirmed_lotw; ?>
 						</td>
 					</tr>
-
+					<tr>
+						<td width="50%"><?= __("eQSL"); ?></td>
+						<td width="50%"><?php echo $total_countries_confirmed_eqsl; ?></td>
+					</tr>
 					<tr>
 						<td width="50%"><?= __("Needed"); ?></td>
 						<td width="50%"><?php echo $total_countries_needed; ?></td>


### PR DESCRIPTION
Count DXCC confirmed totals from paper QSL and LoTW only.
Derive needed from current DXCC entities minus confirmed.
Keep eQSL separate in dashboard and visitor breakdowns.
Document the updated DXCC semantics in API v2.