### PR TITLE
Fix State dropdown/dep in station edit

### DIFF
--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -123,12 +123,9 @@ if ($dxcc_list->result() > 0) {
 					</div>
 
 					<!-- State -->
-					<script>
-						var set_state = '<?php echo $my_station_profile->state; ?>';
-					</script>
 					<div class="mb-3" id="location_state">
 		    			<label for="stateInput" id="stateInputLabel"></label>
-						<select class="form-select" name="station_state" id="stateDropdown">
+						<select class="form-select" name="station_state" id="stateDropdown" data-state="<?php echo htmlspecialchars((string)($my_station_profile->state ?? '')); ?>">
 							<option value=""></option>
 						</select>
 						<small id="StateHelp" class="form-text text-muted"><?= __("Station state. Applies to certain countries only."); ?></small>

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -1098,7 +1098,6 @@ if ($('.table-responsive .dropdown-toggle').length>0) {
     });
 }
 
-var set_state;
 function statesDropdown(states, set_state = null, dropdown = '#stateDropdown') {
     var dropdown = $(dropdown);
     dropdown.empty();


### PR DESCRIPTION
Fixes a bug mentioned in #3621:

State dropdown isn't populated when editing stationlocation (with a saved State)