### PR TITLE
Refactor DXCC stats on dashboards

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -133,7 +133,6 @@ class Dashboard extends CI_Controller {
 		$data['total_countries'] = $stats['Countries_Worked'];
 		$data['unique_callsigns'] = $stats['Unique_Callsigns'];
 		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
-		$data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
 		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
 		$confirmed = $stats['Countries_Worked_Confirmed'];
 

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -108,7 +108,6 @@ class Visitor extends CI_Controller {
 				// Country stats
 				$data['total_countries'] = $stats['Countries_Worked'];
 				$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
-				$data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
 				$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
 				$confirmed = $stats['Countries_Worked_Confirmed'];
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4284,7 +4284,7 @@ class Logbook_model extends CI_Model {
 				$row = $query->row();
 				return [
 					// Country stats
-				'Unique_Callsigns' => $row->Unique_Callsigns,
+					'Unique_Callsigns' => $row->Unique_Callsigns,
 					'Countries_Worked' => $row->Countries_Worked,
 					'Countries_Worked_QSL' => $row->Countries_Worked_QSL,
 					'Countries_Worked_LOTW' => $row->Countries_Worked_LOTW,

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4322,7 +4322,6 @@ class Logbook_model extends CI_Model {
 		return [
 			'Countries_Worked' => 0,
 			'Countries_Worked_QSL' => 0,
-			'Countries_Worked_EQSL' => 0,
 			'Countries_Worked_LOTW' => 0,
 			'Countries_Worked_Confirmed' => 0,
 			'Countries_Current' => 0,

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4245,7 +4245,6 @@ class Logbook_model extends CI_Model {
 				COUNT(DISTINCT t.COL_CALL) as Unique_Callsigns,
 				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked,
 				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
-				COUNT(DISTINCT CASE WHEN t.COL_EQSL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_EQSL,
 				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
 				-- DXCC confirmed totals intentionally count only paper QSL + LoTW.
 				-- eQSL is tracked separately in the UI as display-only information.
@@ -4288,7 +4287,6 @@ class Logbook_model extends CI_Model {
 				'Unique_Callsigns' => $row->Unique_Callsigns,
 					'Countries_Worked' => $row->Countries_Worked,
 					'Countries_Worked_QSL' => $row->Countries_Worked_QSL,
-					'Countries_Worked_EQSL' => $row->Countries_Worked_EQSL,
 					'Countries_Worked_LOTW' => $row->Countries_Worked_LOTW,
 					'Countries_Worked_Confirmed' => $row->Countries_Worked_Confirmed,
 					'Countries_Current' => $row->Countries_Current,

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -495,12 +495,6 @@ function echo_table_header_col($name) {
 						</td>
 					</tr>
 					<tr>
-						<th scope="row" width="50%"><?= __("eQSL"); ?></th>
-						<td width="50%">
-							<span aria-label="<?= __("eQSL"); ?>: <?php echo $total_countries_confirmed_eqsl; ?>"><?php echo $total_countries_confirmed_eqsl; ?></span>
-						</td>
-					</tr>
-					<tr>
 						<th scope="row" width="50%"><?= __("Needed"); ?></th>
 						<td width="50%"><?php echo $total_countries_needed; ?></td>
 					</tr>

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -267,10 +267,10 @@ if ($public_maps_option == 'true') { ?>
 						<td width="50%"><?php echo $total_countries; ?></td>
 					</tr>
 					<tr>
-						<td width="50%"><a href="#" onclick="return false" title="QSL Cards / LoTW" data-bs-toggle="tooltip"><?= __("Confirmed"); ?></a></td>
+						<td width="50%"><?= __("Confirmed"); ?></td>
 						<td width="50%">
-							<?php echo $total_countries_confirmed_paper; ?> /
-							<?php echo $total_countries_confirmed_lotw; ?>
+							<span title="<?= __("QSL Cards"); ?>" aria-label="<?= __("QSL Cards"); ?>: <?php echo $total_countries_confirmed_paper; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_paper; ?></span> /
+							<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $total_countries_confirmed_lotw; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_lotw; ?></span>
 						</td>
 					</tr>
 					<tr>

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -274,10 +274,6 @@ if ($public_maps_option == 'true') { ?>
 						</td>
 					</tr>
 					<tr>
-						<td width="50%"><?= __("eQSL"); ?></td>
-						<td width="50%"><?php echo $total_countries_confirmed_eqsl; ?></td>
-					</tr>
-					<tr>
 						<td width="50%"><?= __("Needed"); ?></td>
 						<td width="50%"><?php echo $total_countries_needed; ?></td>
 					</tr>


### PR DESCRIPTION
This PR implements minor changes in the dashbaords:

- Removed eQSL from countings (as this is not valid for the official DXCC award anyway)
- Aligned the layout of the visitor dashboard with the logged-in user dashboard (removed empty link on "Confirmed" and add tooltips to numbers)