### PR TITLE
Fix US Counties award undercounting confirmed QSOs (LoTW/QRZ.com/Clublog ignored)

### DIFF
--- a/application/models/Counties.php
+++ b/application/models/Counties.php
@@ -13,7 +13,8 @@ class Counties extends CI_Model
 
     /*
      * Returns a result of worked/confirmed US Counties, grouped by STATE
-     * QSL card and EQSL is valid for award. Satellite does not count.
+     * QSL card, LoTW, EQSL, QRZ.com and Clublog are valid for award.
+     * Satellite does not count.
      * No band split, as it only count the number of counties in the award.
      */
     function get_counties_summary() {
@@ -42,7 +43,7 @@ class Counties extends CI_Model
             " and COL_DXCC in ('291', '6', '110')
                     and coalesce(COL_CNTY, '') <> ''
                     and COL_BAND != 'SAT'
-                    and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y')
+                    and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y')
                     group by COL_STATE
                     order by COL_STATE
                 ) x on thcv.COL_STATE = x.COL_STATE
@@ -107,7 +108,7 @@ class Counties extends CI_Model
         }
 
         if ($confirmationtype != 'none') {
-            $sql .= " and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y')";
+            $sql .= " and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y')";
         }
 
         $sql .= " order by thcv.COL_STATE";
@@ -141,7 +142,7 @@ class Counties extends CI_Model
 
         $sql = "select COL_CNTY,
 			count(*) as worked,
-			sum(case when (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y') then 1 else 0 end) as confirmed
+			sum(case when (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y') then 1 else 0 end) as confirmed
 		from " . $this->config->item('table_name') . " thcv
 		where station_id in (" . $location_list . ")" .
 		" and col_band in (" . $bandslots_list . ")" .


### PR DESCRIPTION
## What changed and why

Fixes #3632.

**Branch tested:** [`Reid-n0rc:counties-lotw-qrz-clublog-confirmation-fix`](https://github.com/Reid-n0rc/wavelog/tree/counties-lotw-qrz-clublog-confirmation-fix) — this is exactly what was run through the Docker test described below, no changes since.

The "QSOs Confirmed" / "Confirmed Counties" numbers on **Awards > USA > US Counties** only counted a QSO as confirmed if it had `COL_QSL_RCVD='Y'` (paper QSL) or `COL_EQSL_QSL_RCVD='Y'` (eQSL). Confirmations received exclusively via LoTW, QRZ.com, or Clublog were ignored, so counties confirmed only through those (very common) methods showed up as worked but not confirmed.

This adds the three missing confirmation sources to the existing `(col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y')` predicate in all three places `application/models/Counties.php` checks it (`get_counties_summary()`, `get_counties()`, `get_county_counts()`):

- `col_lotw_qsl_rcvd`
- `COL_QRZCOM_QSO_DOWNLOAD_STATUS`
- `COL_CLUBLOG_QSO_DOWNLOAD_STATUS`

This brings the US Counties award in line with how every other award in the codebase (DXCC, WPX, WAC, ITU, POTA, SOTA, WWFF, WAE, …) already determines "confirmed" — those all check LoTW, QRZ.com, and Clublog alongside paper QSL/eQSL.

Single-purpose fix, no schema changes, no behavior change for anything outside this award.

## Testing

Ran the branch end-to-end against a real instance (not just reading the query):

1. Built a throwaway Docker stack from this repo's own `Dockerfile` + a MySQL 8 container, ran the standard web installer against it (`install/assets/install.sql`), and created a test user/station.
2. Seeded 5 QSOs in California, one per county, each with a **different single confirmation source** and nothing else set:

   | County | Confirmed via | Worked | Confirmed (before fix) | Confirmed (after fix) |
   |---|---|---|---|---|
   | Los Angeles | LoTW only | 1 | 0 | **1** |
   | Orange | QRZ.com only | 1 | 0 | **1** |
   | San Diego | Clublog only | 1 | 0 | **1** |
   | Ventura | Paper QSL only | 1 | 1 | 1 |
   | Kern | none | 1 | 0 | 0 |

3. Loaded `awards/counties` and `awards/counties_state_ajax` (the actual endpoints these queries feed) as a logged-in user and confirmed the rendered page:
   - Before the fix: CA showed Worked 5 / Confirmed 1 (only the paper-QSL county counted).
   - After the fix: CA shows **Worked 5 / Confirmed 4** — Los Angeles, Orange, San Diego, and Ventura all correctly count; Kern (genuinely unconfirmed) correctly does not.
4. Confirmed the unconfirmed county (Kern) is still correctly excluded, so the fix doesn't over-count.
5. Diffed the old vs. new confirmation predicate directly against the seeded rows to isolate the query-level behavior change shown in the table above.

## Screenshots / output

Per-county breakdown from `awards/counties_state_ajax` after the fix:

```
#  County          QSOs Worked  QSOs Confirmed
1  CA,Kern         1            0
2  CA,Los Angeles  1            1
3  CA,Orange       1            1
4  CA,San Diego    1            1
5  CA,Ventura      1            1
   Total           5            4
```

