### PR TITLE
Add QSL confirmation-source filter to US Counties award page

### DIFF
--- a/application/controllers/Awards.php
+++ b/application/controllers/Awards.php
@@ -1357,7 +1357,9 @@ class Awards extends CI_Controller {
 
     public function counties()	{
         $this->load->model('counties');
-        $data['counties_progress'] = $this->counties->get_counties_progress();
+        $qsl_sources = $this->counties_qsl_sources_from_post();
+        $data['counties_progress'] = $this->counties->get_counties_progress($qsl_sources);
+        $data['qsl_sources'] = $qsl_sources;
 		$data['user_map_custom'] = $this->optionslib->get_map_custom();
 
         // Render Page
@@ -1367,11 +1369,37 @@ class Awards extends CI_Controller {
         $this->load->view('interface_assets/footer');
     }
 
+    /*
+     * Reads which QSL confirmation sources (qsl/lotw/eqsl/qrz/clublog) are
+     * selected in the counties award filter. The filter form (and the state
+     * / list AJAX calls it drives) always posts a "qslFilterSet" marker
+     * alongside the checkboxes, so an unchecked box can be told apart from
+     * a request that never included the filter (which defaults to all
+     * sources, e.g. a fresh page load).
+     */
+    private function counties_qsl_sources_from_post() {
+        $available = array('qsl', 'lotw', 'eqsl', 'qrz', 'clublog');
+
+        if (!$this->input->post('qslFilterSet')) {
+            return $available;
+        }
+
+        $qsl_sources = array();
+        foreach ($available as $source) {
+            if ($this->input->post($source)) {
+                $qsl_sources[] = $source;
+            }
+        }
+
+        return $qsl_sources;
+    }
+
     public function counties_list_ajax() {
         $this->load->model('counties');
         $state = str_replace('"', "", $this->security->xss_clean($this->input->post("State")));
         $type  = str_replace('"', "", $this->security->xss_clean($this->input->post("Type")));
-        $data['counties_array'] = $this->counties->counties_details($state, $type);
+        $qsl_sources = $this->counties_qsl_sources_from_post();
+        $data['counties_array'] = $this->counties->counties_details($state, $type, $qsl_sources);
         $data['type'] = $type;
         $this->load->view('awards/counties/details_ajax', $data);
     }
@@ -1393,7 +1421,8 @@ class Awards extends CI_Controller {
     public function counties_state_ajax() {
         $this->load->model('counties');
         $state = str_replace('"', "", $this->security->xss_clean($this->input->post("State")));
-        $data['counties_array'] = $this->counties->get_county_counts($state);
+        $qsl_sources = $this->counties_qsl_sources_from_post();
+        $data['counties_array'] = $this->counties->get_county_counts($state, $qsl_sources);
         $data['state'] = $state;
         $this->load->view('awards/counties/state_ajax', $data);
     }

--- a/application/models/Counties.php
+++ b/application/models/Counties.php
@@ -13,7 +13,8 @@ class Counties extends CI_Model
 
     /*
      * Returns a result of worked/confirmed US Counties, grouped by STATE
-     * QSL card and EQSL is valid for award. Satellite does not count.
+     * QSL card, LoTW, EQSL, QRZ.com and Clublog are valid for award.
+     * Satellite does not count.
      * No band split, as it only count the number of counties in the award.
      */
     function get_counties_summary() {
@@ -42,7 +43,7 @@ class Counties extends CI_Model
             " and COL_DXCC in ('291', '6', '110')
                     and coalesce(COL_CNTY, '') <> ''
                     and COL_BAND != 'SAT'
-                    and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y')
+                    and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y')
                     group by COL_STATE
                     order by COL_STATE
                 ) x on thcv.COL_STATE = x.COL_STATE
@@ -107,7 +108,7 @@ class Counties extends CI_Model
         }
 
         if ($confirmationtype != 'none') {
-            $sql .= " and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y')";
+            $sql .= " and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y')";
         }
 
         $sql .= " order by thcv.COL_STATE";
@@ -141,7 +142,7 @@ class Counties extends CI_Model
 
         $sql = "select COL_CNTY,
 			count(*) as worked,
-			sum(case when (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y') then 1 else 0 end) as confirmed
+			sum(case when (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y') then 1 else 0 end) as confirmed
 		from " . $this->config->item('table_name') . " thcv
 		where station_id in (" . $location_list . ")" .
 		" and col_band in (" . $bandslots_list . ")" .

--- a/application/models/Counties.php
+++ b/application/models/Counties.php
@@ -3,6 +3,18 @@
 class Counties extends CI_Model
 {
 
+    /*
+     * Maps the selectable QSL confirmation sources to their DB columns.
+     * Used to build the "confirmed" condition based on user selection.
+     */
+    private $qsl_source_columns = array(
+        'qsl'     => 'col_qsl_rcvd',
+        'lotw'    => 'col_lotw_qsl_rcvd',
+        'eqsl'    => 'col_eqsl_qsl_rcvd',
+        'qrz'     => 'COL_QRZCOM_QSO_DOWNLOAD_STATUS',
+        'clublog' => 'COL_CLUBLOG_QSO_DOWNLOAD_STATUS',
+    );
+
     function __construct() {
         $this->load->driver('cache', [
             'adapter' => $this->config->item('cache_adapter') ?? 'file',
@@ -12,12 +24,38 @@ class Counties extends CI_Model
     }
 
     /*
-     * Returns a result of worked/confirmed US Counties, grouped by STATE
-     * QSL card, LoTW, EQSL, QRZ.com and Clublog are valid for award.
-     * Satellite does not count.
+     * Builds the SQL "confirmed" condition from a list of selected QSL
+     * sources (subset of keys of $qsl_source_columns). Defaults to all
+     * sources when null (not just empty) is given, so existing callers keep
+     * prior behaviour while an explicit empty selection ("nothing counts as
+     * confirmed") is still honoured rather than silently falling back to all.
+     */
+    function build_confirmed_condition($qsl_sources) {
+        if ($qsl_sources === null) {
+            $qsl_sources = array_keys($this->qsl_source_columns);
+        }
+
+        $conditions = array();
+        foreach ($qsl_sources as $source) {
+            if (isset($this->qsl_source_columns[$source])) {
+                $conditions[] = $this->qsl_source_columns[$source] . " = 'Y'";
+            }
+        }
+
+        if (empty($conditions)) {
+            return '1=0';
+        }
+
+        return '(' . implode(' or ', $conditions) . ')';
+    }
+
+    /*
+     * Returns a result of worked/confirmed US Counties, grouped by STATE.
+     * The QSL sources counted as "confirmed" are selectable; see
+     * build_confirmed_condition(). Satellite does not count.
      * No band split, as it only count the number of counties in the award.
      */
-    function get_counties_summary() {
+    function get_counties_summary($qsl_sources = null) {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
@@ -33,6 +71,8 @@ class Counties extends CI_Model
 
 		$bandslots_list = "'".implode("','",$bandslots)."'";
 
+		$confirmed_condition = $this->build_confirmed_condition($qsl_sources);
+
         $sql = "select count(distinct COL_CNTY) countycountworked, coalesce(x.countycountconfirmed, 0) countycountconfirmed, thcv.COL_STATE
                 from " . $this->config->item('table_name') . " thcv
                  left outer join (
@@ -43,7 +83,7 @@ class Counties extends CI_Model
             " and COL_DXCC in ('291', '6', '110')
                     and coalesce(COL_CNTY, '') <> ''
                     and COL_BAND != 'SAT'
-                    and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y')
+                    and " . $confirmed_condition . "
                     group by COL_STATE
                     order by COL_STATE
                 ) x on thcv.COL_STATE = x.COL_STATE
@@ -62,11 +102,11 @@ class Counties extends CI_Model
     /*
     * Makes a list of all counties in given state
     */
-    function counties_details($state, $type) {
+    function counties_details($state, $type, $qsl_sources = null) {
         if ($type == 'worked') {
-            $counties = $this->get_counties($state, 'none');
+            $counties = $this->get_counties($state, 'none', $qsl_sources);
         } else if ($type == 'confirmed') {
-            $counties = $this->get_counties($state, 'confirmed');
+            $counties = $this->get_counties($state, 'confirmed', $qsl_sources);
         }
         if (!isset($counties)) {
             return 0;
@@ -76,7 +116,7 @@ class Counties extends CI_Model
         }
     }
 
-    function get_counties($state, $confirmationtype) {
+    function get_counties($state, $confirmationtype, $qsl_sources = null) {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
@@ -108,7 +148,7 @@ class Counties extends CI_Model
         }
 
         if ($confirmationtype != 'none') {
-            $sql .= " and (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y')";
+            $sql .= " and " . $this->build_confirmed_condition($qsl_sources);
         }
 
         $sql .= " order by thcv.COL_STATE";
@@ -122,7 +162,7 @@ class Counties extends CI_Model
     * Uses the same band/DXCC/SAT rules as get_counties() so the counts match
     * what counts toward the USA-CA award.
     */
-    function get_county_counts($state) {
+    function get_county_counts($state, $qsl_sources = null) {
 		$this->load->model('logbooks_model');
 		$logbooks_locations_array = $this->logbooks_model->list_logbook_relationships($this->session->userdata('active_station_logbook'));
 
@@ -140,9 +180,11 @@ class Counties extends CI_Model
 
 		$binding = [];
 
+		$confirmed_condition = $this->build_confirmed_condition($qsl_sources);
+
         $sql = "select COL_CNTY,
 			count(*) as worked,
-			sum(case when (col_qsl_rcvd='Y' or col_eqsl_qsl_rcvd='Y' or col_lotw_qsl_rcvd='Y' or COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y' or COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y') then 1 else 0 end) as confirmed
+			sum(case when " . $confirmed_condition . " then 1 else 0 end) as confirmed
 		from " . $this->config->item('table_name') . " thcv
 		where station_id in (" . $location_list . ")" .
 		" and col_band in (" . $bandslots_list . ")" .
@@ -221,9 +263,9 @@ class Counties extends CI_Model
      * 2-letter state code. Every state present in US_counties.csv is included,
      * even if nothing has been worked there yet.
      */
-    function get_counties_progress() {
+    function get_counties_progress($qsl_sources = null) {
         $targets = $this->get_counties_targets();
-        $worked = $this->get_counties_summary();
+        $worked = $this->get_counties_summary($qsl_sources);
 
         $worked_map = array();
         if (isset($worked)) {

--- a/application/views/awards/counties/index.php
+++ b/application/views/awards/counties/index.php
@@ -1,3 +1,9 @@
+<style>
+    .dropdown-filters-responsive {
+        width: min(850px, 90vw);
+        min-width: 600px;
+    }
+</style>
 <div class="container px-3 px-lg-4 mt-3 mb-3">
         <!-- Award Info Box -->
         <div id="awardInfoButton">
@@ -18,6 +24,45 @@
             <?= __("Counties Progress"); ?>
         </div>
         <div class="card-body">
+    <form class="form" action="<?php echo site_url('awards/counties'); ?>" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="qslFilterSet" value="1">
+        <div class="mb-4 text-center">
+            <div class="dropdown" data-bs-auto-close="outside">
+                <button class="btn btn-sm btn-primary dropdown-toggle" type="button" id="countiesFilterDropdown" data-bs-toggle="dropdown" aria-expanded="false"><?= __("Filters") ?></button>
+                <button type="submit" name="button1id" class="btn btn-sm btn-primary"><?= __("Show"); ?></button>
+
+                <!-- Dropdown Menu with Filter Content -->
+                <div class="dropdown-menu start-50 translate-middle-x p-3 mt-5 dropdown-filters-responsive" aria-labelledby="countiesFilterDropdown">
+                    <div class="card-body filterbody">
+                        <div class="mb-3 row">
+                            <div class="col-md-3"><?= __("Count QSO as Confirmed via"); ?></div>
+                            <div class="col-md-9">
+                                <div class="form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="qsl" value="1" id="countiesQsl" <?php if (in_array('qsl', $qsl_sources)) echo ' checked="checked"'; ?>>
+                                    <label class="form-check-label" for="countiesQsl"><?= __("QSL"); ?></label>
+                                </div>
+                                <div class="form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="lotw" value="1" id="countiesLotw" <?php if (in_array('lotw', $qsl_sources)) echo ' checked="checked"'; ?>>
+                                    <label class="form-check-label" for="countiesLotw"><?= __("LoTW"); ?></label>
+                                </div>
+                                <div class="form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="eqsl" value="1" id="countiesEqsl" <?php if (in_array('eqsl', $qsl_sources)) echo ' checked="checked"'; ?>>
+                                    <label class="form-check-label" for="countiesEqsl"><?= __("eQSL"); ?></label>
+                                </div>
+                                <div class="form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="qrz" value="1" id="countiesQrz" <?php if (in_array('qrz', $qsl_sources)) echo ' checked="checked"'; ?>>
+                                    <label class="form-check-label" for="countiesQrz"><?= __("QRZ.com"); ?></label>
+                                </div>
+                                <div class="form-check-inline">
+                                    <input class="form-check-input" type="checkbox" name="clublog" value="1" id="countiesClublog" <?php if (in_array('clublog', $qsl_sources)) echo ' checked="checked"'; ?>>
+                                    <label class="form-check-label" for="countiesClublog"><?= __("Clublog"); ?></label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     <?php if ($counties_progress) {
         $progress_bar = function ($pct, $color) {
             return '<div class="progress" style="height: 20px; position: relative;">'
@@ -122,6 +167,7 @@
         echo '<div class="alert alert-danger" role="alert">' . __("Nothing found!") . '</div>';
     }
     ?>
+    </form>
         </div>
     </div>
 </div>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2846,12 +2846,25 @@ function viewEqsl(picture, callsign) {
         });
     }
 
+    function countiesQslFilterData() {
+        var sources = ['qsl', 'lotw', 'eqsl', 'qrz', 'clublog'];
+        var data = {};
+        var $qslCheckbox = $('#countiesQsl');
+        if ($qslCheckbox.length) {
+            data['qslFilterSet'] = 1;
+            sources.forEach(function(source) {
+                data[source] = $('#counties' + source.charAt(0).toUpperCase() + source.slice(1)).is(':checked') ? 1 : 0;
+            });
+        }
+        return data;
+    }
+
     function displayStateCounties(state) {
         var baseURL= "<?php echo base_url(); ?>";
         $.ajax({
             url: baseURL + 'index.php/awards/counties_state_ajax',
             type: 'post',
-            data: {'State': state },
+            data: $.extend({'State': state }, countiesQslFilterData()),
             success: function(html) {
                 BootstrapDialog.show({
                     title: "<?php echo __("US Counties for state"); ?>" + ': ' + state,
@@ -2904,7 +2917,7 @@ function viewEqsl(picture, callsign) {
         $.ajax({
             url: baseURL + 'index.php/awards/counties_list_ajax',
             type: 'post',
-            data: {'State': state, 'Type': type },
+            data: $.extend({'State': state, 'Type': type }, countiesQslFilterData()),
             success: function(html) {
                 BootstrapDialog.show({
                     title: (type === 'confirmed' ? "<?php echo __("Confirmed counties for state:"); ?>" : "<?php echo __("Worked counties for state:"); ?>") + " " +state,


### PR DESCRIPTION
## What changed and why

Implements #3634.

**Branch tested:** [`Reid-n0rc:counties-award-qsl-source-filter-v2`](https://github.com/Reid-n0rc/wavelog/tree/counties-award-qsl-source-filter-v2) — this is exactly what was run through the Docker test described below, no changes since.

**Depends on #3633** (the LoTW/QRZ.com/Clublog confirmed-count fix). This branch is built on top of that fix, so the diff currently shows both commits until #3633 merges — only the second commit ("Add QSL source filter...") is new here.

Once #3632 is fixed, "Confirmed" on **Awards > USA > US Counties** always means "confirmed via any source," with no way to narrow it down. Every other award page with a confirmation concept (DXCC, WPX, WAC, ITU, POTA, SOTA, WWFF, WAE, …) already has a "Show QSO with QSL Type" filter for this. This adds the same pattern to the US Counties page.

### Model (`application/models/Counties.php`)

- Added `$qsl_source_columns`, mapping the 5 selectable sources (`qsl`, `lotw`, `eqsl`, `qrz`, `clublog`) to their DB columns.
- Added `build_confirmed_condition($qsl_sources)`: builds the SQL `OR` condition from a caller-supplied list. `null` (not passed) means "default to all sources," so existing callers are unaffected. An **explicitly empty array** ("user unchecked every source") correctly returns `1=0` rather than silently falling back to all — this distinction matters and is covered below under Testing.
- `get_counties_summary()`, `get_counties()`, and `get_county_counts()` now accept an optional `$qsl_sources` param and use the shared helper instead of a hardcoded predicate.
- Every value that reaches the generated SQL is looked up through `isset($this->qsl_source_columns[$source])` first — user input never reaches the query string directly, only the fixed whitelisted column name does.

### Controller (`application/controllers/Awards.php`)

- `counties_qsl_sources_from_post()`: reads which checkboxes were submitted. A hidden `qslFilterSet` marker distinguishes "the filter form was actually submitted with these boxes checked/unchecked" from "no filter was submitted at all, use the default" — needed because unchecked checkboxes simply don't appear in the POST body, so presence-of-marker is the only reliable signal.
- `counties()`, `counties_list_ajax()`, and `counties_state_ajax()` all resolve and pass through `$qsl_sources`, so the main table and both drill-down views stay consistent.

### Views

- `application/views/awards/counties/index.php`: adds a "Filters" dropdown matching the DXCC page's pattern (same `dropdown-filters-responsive` CSS, same checkbox layout), defaulting to all 5 sources checked.
- `application/views/interface_assets/footer.php`: `countiesQslFilterData()` reads the current checkbox state and is merged into the existing `displayStateCounties()` / `displayStateCountiesList()` AJAX calls, so the state/county drill-downs match whatever was last submitted on the main page.

"Worked" and "Remaining" are intentionally unaffected — "Remaining" is explicitly `target - worked` (labeled "Based on current worked count" in the UI), and worked status doesn't depend on how/whether a QSO was confirmed.

## Testing

Tested end-to-end against a real running instance (Docker + MySQL 8, standard web installer), same methodology as #3633.

Seeded 6 QSOs in California, one confirmed via each of the 5 sources plus one unconfirmed:

| County | Confirmed via |
|---|---|
| Los Angeles | Paper QSL only |
| Orange | LoTW only |
| San Diego | eQSL only |
| Ventura | QRZ.com only |
| Kern | Clublog only |
| Fresno | none |

Submitted the filter form with different combinations and read back the rendered `awards/counties` page and the `counties_state_ajax` / `counties_list_ajax` drill-downs:

| Filter selection | Expected CA Confirmed | Actual |
|---|---|---|
| Default (fresh load, no filter submitted) | 5 | 5 ✅ |
| Only LoTW checked | 1 (Orange) | 1 ✅ |
| QSL + eQSL checked | 2 (Los Angeles, San Diego) | 2 ✅ |
| All 5 explicitly checked | 5 | 5 ✅ |
| **No sources checked** | **0** | 0 ✅ |

The last row caught a real bug during testing: the first version of `build_confirmed_condition()` used PHP's `empty()` to decide "no sources given → default to all," which also matched "user explicitly unchecked every box," so submitting the filter with nothing checked incorrectly showed Confirmed = 5 instead of 0. Fixed by switching the default check to `=== null` so a real (even empty) array from the controller is never re-defaulted.

Also verified the per-state and per-county drill-downs honor the filter — e.g. with only QRZ.com checked, `counties_list_ajax` (type=confirmed) correctly returns only `CA,Ventura`, and `counties_state_ajax` shows every other CA county at 0 confirmed with Ventura at 1.

## Screenshots / output

Per-county breakdown from `counties_state_ajax` with only LoTW checked:

```
#  County          QSOs Worked  QSOs Confirmed
1  CA,Fresno       1            0
2  CA,Kern         1            0
3  CA,Los Angeles  1            0
4  CA,Orange       1            1
5  CA,San Diego    1            0
6  CA,Ventura      1            0
   Total           6            1
```

