### PR TITLE
[Logbook] Tighten Club Log confirmation handling

### DIFF
--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -430,6 +430,12 @@ class Logbook extends CI_Controller {
 			}
 			$extrawhere.=" COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
 		}
+		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+			if ($extrawhere!='') {
+				$extrawhere.=" OR";
+			}
+			$extrawhere.=" COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
+		}
 
 		if($type == "SAT") {
 			$this->db->where('COL_PROP_MODE', 'SAT');
@@ -519,6 +525,12 @@ class Logbook extends CI_Controller {
 					$extrawhere.=" OR";
 				}
 				$extrawhere.=" COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
+			}
+			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+				if ($extrawhere!='') {
+					$extrawhere.=" OR";
+				}
+				$extrawhere.=" COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
 			}
 
 
@@ -621,6 +633,12 @@ class Logbook extends CI_Controller {
 					$extrawhere.=" OR";
 				}
 				$extrawhere.=" COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
+			}
+			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+				if ($extrawhere!='') {
+					$extrawhere.=" OR";
+				}
+				$extrawhere.=" COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
 			}
 
 

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -2919,6 +2919,12 @@ class Logbook_model extends CI_Model {
 			}
 			$extrawhere .= " COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
 		}
+		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+			if ($extrawhere != '') {
+				$extrawhere .= " OR";
+			}
+			$extrawhere .= " COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
+		}
 
 
 		$this->db->select('COL_CALL');
@@ -3031,6 +3037,12 @@ class Logbook_model extends CI_Model {
 			}
 			$extrawhere .= " COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
 		}
+		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+			if ($extrawhere != '') {
+				$extrawhere .= " OR";
+			}
+			$extrawhere .= " COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
+		}
 		if ($extrawhere == '') {
 			$extrawhere='1=0';	// No default_confirmations set? in that case everything is false
 		}
@@ -3111,6 +3123,12 @@ class Logbook_model extends CI_Model {
 				$extrawhere .= " OR";
 			}
 			$extrawhere .= " COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
+		}
+		if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+			if ($extrawhere != '') {
+				$extrawhere .= " OR";
+			}
+			$extrawhere .= " COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
 		}
 
 
@@ -6225,6 +6243,11 @@ class Logbook_model extends CI_Model {
 			}
 			if (strpos($user_default_confirmation, 'Z') !== false) { // QRZ
 				if ($qso['COL_QRZCOM_QSO_DOWNLOAD_STATUS'] == 'Y') {
+					$confirmed = true;
+				}
+			}
+			if (strpos($user_default_confirmation, 'C') !== false) { // Clublog
+				if ($qso['COL_CLUBLOG_QSO_DOWNLOAD_STATUS'] == 'Y') {
 					$confirmed = true;
 				}
 			}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -6227,27 +6227,27 @@ class Logbook_model extends CI_Model {
 		if (isset($user_default_confirmation)) {
 			$qso = (array) $qso;
 			if (strpos($user_default_confirmation, 'Q') !== false) {        // QSL
-				if ($qso['COL_QSL_RCVD'] == 'Y') {
+				if (($qso['COL_QSL_RCVD'] ?? null) === 'Y') {
 					$confirmed = true;
 				}
 			}
 			if (strpos($user_default_confirmation, 'L') !== false) { // LoTW
-				if ($qso['COL_LOTW_QSL_RCVD'] == 'Y') {
+				if (($qso['COL_LOTW_QSL_RCVD'] ?? null) === 'Y') {
 					$confirmed = true;
 				}
 			}
 			if (strpos($user_default_confirmation, 'E') !== false) { // eQsl
-				if ($qso['COL_EQSL_QSL_RCVD'] == 'Y') {
+				if (($qso['COL_EQSL_QSL_RCVD'] ?? null) === 'Y') {
 					$confirmed = true;
 				}
 			}
 			if (strpos($user_default_confirmation, 'Z') !== false) { // QRZ
-				if ($qso['COL_QRZCOM_QSO_DOWNLOAD_STATUS'] == 'Y') {
+				if (($qso['COL_QRZCOM_QSO_DOWNLOAD_STATUS'] ?? null) === 'Y') {
 					$confirmed = true;
 				}
 			}
 			if (strpos($user_default_confirmation, 'C') !== false) { // Clublog
-				if ($qso['COL_CLUBLOG_QSO_DOWNLOAD_STATUS'] == 'Y') {
+				if (($qso['COL_CLUBLOG_QSO_DOWNLOAD_STATUS'] ?? null) === 'Y') {
 					$confirmed = true;
 				}
 			}

--- a/application/models/Lookup_model.php
+++ b/application/models/Lookup_model.php
@@ -243,6 +243,12 @@ class Lookup_model extends CI_Model{
 				}
 				$extrawhere.=" COL_QRZCOM_QSO_DOWNLOAD_STATUS='Y'";
 			}
+			if (isset($user_default_confirmation) && strpos($user_default_confirmation, 'C') !== false) {
+				if ($extrawhere!='') {
+					$extrawhere.=" OR";
+				}
+				$extrawhere.=" COL_CLUBLOG_QSO_DOWNLOAD_STATUS='Y'";
+			}
 
 			if (($confirmedtype == 'confirmed') && ($extrawhere != '')){
 				$sqlqueryconfirmationstring = " and (".$extrawhere.")";

--- a/application/models/Qsl_model.php
+++ b/application/models/Qsl_model.php
@@ -155,6 +155,10 @@ class Qsl_model extends CI_Model {
 			return null;
 		}
 
+		if (!is_array($confirmationtype)) {
+			$confirmationtype = ($confirmationtype === null || $confirmationtype === '') ? [] : [$confirmationtype];
+		}
+
 		$location_list = "'".implode("','",$logbooks_locations_array)."'";
 		$table = $this->config->item('table_name');
 		$sql_parts = array();

--- a/application/models/Visitor_model.php
+++ b/application/models/Visitor_model.php
@@ -94,21 +94,24 @@ class Visitor_model extends CI_Model {
 
 	function qso_is_confirmed($qso, $user_default_confirmation) {
 		$confirmed = false;
+		if (!is_string($user_default_confirmation) || $user_default_confirmation === '') {
+			return false;
+		}
 		$qso = (array) $qso;
 		if (strpos($user_default_confirmation, 'Q') !== false) { // QSL
-			if ($qso['COL_QSL_RCVD']=='Y') { $confirmed = true; }
+			if (($qso['COL_QSL_RCVD'] ?? null) === 'Y') { $confirmed = true; }
 		}
 		if (strpos($user_default_confirmation, 'L') !== false) { // LoTW
-			if ($qso['COL_LOTW_QSL_RCVD']=='Y') { $confirmed = true; }
+			if (($qso['COL_LOTW_QSL_RCVD'] ?? null) === 'Y') { $confirmed = true; }
 		}
 		if (strpos($user_default_confirmation, 'E') !== false) { // eQsl
-			if ($qso['COL_EQSL_QSL_RCVD']=='Y') { $confirmed = true; }
+			if (($qso['COL_EQSL_QSL_RCVD'] ?? null) === 'Y') { $confirmed = true; }
 		}
 		if (strpos($user_default_confirmation, 'Z') !== false) { // QRZ
-			if ($qso['COL_QRZCOM_QSO_DOWNLOAD_STATUS']=='Y') { $confirmed = true; }
+			if (($qso['COL_QRZCOM_QSO_DOWNLOAD_STATUS'] ?? null) === 'Y') { $confirmed = true; }
 		}
 		if (strpos($user_default_confirmation, 'C') !== false) { // Clublog
-			if ($qso['COL_CLUBLOG_QSO_DOWNLOAD_STATUS']=='Y') { $confirmed = true; }
+			if (($qso['COL_CLUBLOG_QSO_DOWNLOAD_STATUS'] ?? null) === 'Y') { $confirmed = true; }
 		}
 		return $confirmed;
 	}

--- a/application/views/view_log/partial/log_ajax.php
+++ b/application/views/view_log/partial/log_ajax.php
@@ -152,7 +152,7 @@ function getDistance($distance) {
     		    <?php if ( strpos($this->session->userdata('user_default_confirmation'),'Z') !== false && ($this->session->userdata('hasQrzKey') != "") ) { ?>
                         <th scope="col">QRZ</th>
                     <?php } ?>
-    		    <?php if ( strpos($this->session->userdata('user_default_confirmation'),'C') !== false  ) { ?>
+		    <?php if ( strpos($this->session->userdata('user_default_confirmation'),'C') !== false && ($this->session->userdata('user_clublog_name') != "") ) { ?>
                         <th scope="col"><?= __("Clublog"); ?></th>
                     <?php } ?>
     		    <?php if ( strpos($this->session->userdata('user_default_confirmation'),'D') !== false  ) { ?>
@@ -474,7 +474,7 @@ function getDistance($distance) {
                     </td>
                 <?php } ?>
 
-                <?php if ( strpos($this->session->userdata('user_default_confirmation'),'C') !== false ) { ?>
+                <?php if ( strpos($this->session->userdata('user_default_confirmation'),'C') !== false && ($this->session->userdata('user_clublog_name') != "") ) { ?>
                     <td class="clublog">
                     <span <?php
                         $timestamp = '';


### PR DESCRIPTION
This is a low-impact hardening pass around the existing Club Log
confirmation flow. It does not add new feature surface or change the
DXCC breakdown.

The main goal is to make the existing confirmation handlers use the
right data flags consistently:

  - `dxcc_confirmed`
  - `dxcc_confirmed_on_band`
  - `dxcc_confirmed_on_band_mode`
  - `confirmed` in the logbook / lookup / QSO UI paths

It also includes a small UI consistency fix so the Club Log column is
only shown when the user has Club Log configured.

Changes:
  - normalize confirmation input before building confirmation queries
  - guard missing QSO fields in confirmation checks
  - include Club Log in the shared confirmation filters
  - gate the Club Log column by user setup

This keeps Club Log aligned with the other confirmation sources and
fixes the existing handlers rather than adding new behavior.