### PR TITLE
Docker development

### DIFF
--- a/application/libraries/Worker.php
+++ b/application/libraries/Worker.php
@@ -112,7 +112,6 @@ class Worker {
 		curl_exec($ch);
 		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		$curl_err  = curl_error($ch);
-		curl_close($ch);
 
 		if ($curl_err !== '') {
 			log_message('error', 'Worker: publish(' . $topic . ') failed: ' . $curl_err);
@@ -255,7 +254,6 @@ class Worker {
 		]);
 		$raw       = curl_exec($ch);
 		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 
 		$stats = ($http_code === 200 && $raw) ? json_decode($raw, true) : null;
 
@@ -297,7 +295,6 @@ class Worker {
 		curl_exec($ch);
 		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		$curl_err  = curl_error($ch);
-		curl_close($ch);
 
 		if ($curl_err !== '') {
 			log_message('error', 'Worker: POST ' . $path . ' failed: ' . $curl_err);

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -599,7 +599,6 @@ class Update_model extends CI_Model {
 		$response = curl_exec($curl);
 		$err  = curl_error($curl);
 		$http = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-		curl_close($curl);
 
 		if ($response === false || $http !== 200) {
 			log_message('error', 'CelesTrak OMM fetch failed (HTTP ' . $http . '): ' . $err);

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -98,7 +98,7 @@
 	<nav class="navbar navbar-expand-lg navbar-light bg-light main-nav" id="header-menu">
 		<div class="container">
 			<a class="navbar-brand" href="<?php echo site_url(); ?>"><img class="headerLogo" src="<?php echo $this->paths->cache_buster('/assets/logo/'. $this->optionslib->get_logo('header_logo').'.png'); ?>" alt="<?= __("Wavelog home"); ?>" /></a>
-			<?php if (ENVIRONMENT == "development") { ?>
+			<?php if (ENVIRONMENT == "development" || (ENVIRONMENT == "docker" && ($_ENV['DOCKER_DEVELOPMENT'] ?? false) == true)) { ?>
 				<span class="badge text-bg-danger me-1"><?= __("Developer Mode"); ?></span>
 			<?php } ?>
 			<?php if (ENVIRONMENT == "maintenance") { ?>

--- a/index.php
+++ b/index.php
@@ -86,11 +86,7 @@ switch (ENVIRONMENT)
 
 	case 'docker':
 		ini_set('display_errors', 0);
-		if (version_compare(PHP_VERSION, '5.3', '>=')) {
-			error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
-		} else {
-			error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_USER_NOTICE);
-		}
+		error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 		if (($_ENV['DOCKER_DEVELOPMENT'] ?? false) == true) {
 			error_reporting(-1);
 			ini_set('display_errors', 1);
@@ -99,11 +95,7 @@ switch (ENVIRONMENT)
 
 	case 'production':
 		ini_set('display_errors', 0);
-		if (version_compare(PHP_VERSION, '5.3', '>=')) {
-			error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
-		} else {
-			error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_USER_NOTICE);
-		}
+		error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_USER_NOTICE & ~E_USER_DEPRECATED);
 		break;
 
 	default:

--- a/index.php
+++ b/index.php
@@ -77,12 +77,12 @@ switch (ENVIRONMENT)
 	case 'development':
 		error_reporting(-1);
 		ini_set('display_errors', 1);
-	break;
+		break;
 
 	case 'maintenance':
 		error_reporting(-1);
 		ini_set('display_errors', 1);
-	break;
+		break;
 
 	case 'docker':
 		ini_set('display_errors', 0);
@@ -91,6 +91,11 @@ switch (ENVIRONMENT)
 		} else {
 			error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_USER_NOTICE);
 		}
+		if (($_ENV['DOCKER_DEVELOPMENT'] ?? false) == true) {
+			error_reporting(-1);
+			ini_set('display_errors', 1);
+		}
+		break;
 
 	case 'production':
 		ini_set('display_errors', 0);
@@ -99,7 +104,7 @@ switch (ENVIRONMENT)
 		} else {
 			error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_USER_NOTICE);
 		}
-	break;
+		break;
 
 	default:
 		header('HTTP/1.1 503 Service Unavailable.', TRUE, 503);


### PR DESCRIPTION
it was not possible to enable debug mode in docker containers. creating `.debug` in a container is kinda cumbersome so for docker there is a new option to set `DOCKER_DEVELOPMENT` as env in docker or somewhere else so you can enable the developer mode also in docker container without handling any files. dev mode in normal installations is untouched. Since I now saw some issue i removed some deprecated stuff. 