### PR TITLE
replaced star history with a gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,7 @@ When submitting PRs please make sure code is commented and includes one feature 
 
 Support Wavelog by starring the repository on GitHub!
 
-<a href="https://www.star-history.com/?repos=wavelog%2Fwavelog&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=wavelog/wavelog&type=date&theme=dark&legend=top-left&sealed_token=iL83440cfP1r51cWS7LaQp9k39fQvc8LQSp-CNzW_xZ_tPn7OWTCtPdVm19udzG44Hwzb1wdaLgUVi3T2dxq9tereqmhIUdKi4IEEPHSbTMWxHYIqOEcz6ToZIZaU1R8o-psEVQEaT1V2zcQkgul4Khc9SVIoifhfvxCWKhhMj0oGkOfhc2yimF5RV7a" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=wavelog/wavelog&type=date&legend=top-left&sealed_token=iL83440cfP1r51cWS7LaQp9k39fQvc8LQSp-CNzW_xZ_tPn7OWTCtPdVm19udzG44Hwzb1wdaLgUVi3T2dxq9tereqmhIUdKi4IEEPHSbTMWxHYIqOEcz6ToZIZaU1R8o-psEVQEaT1V2zcQkgul4Khc9SVIoifhfvxCWKhhMj0oGkOfhc2yimF5RV7a" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=wavelog/wavelog&type=date&legend=top-left&sealed_token=iL83440cfP1r51cWS7LaQp9k39fQvc8LQSp-CNzW_xZ_tPn7OWTCtPdVm19udzG44Hwzb1wdaLgUVi3T2dxq9tereqmhIUdKi4IEEPHSbTMWxHYIqOEcz6ToZIZaU1R8o-psEVQEaT1V2zcQkgul4Khc9SVIoifhfvxCWKhhMj0oGkOfhc2yimF5RV7a" />
- </picture>
-</a>
+<img width="1600" height="441" alt="star_wavelog" src="https://github.com/user-attachments/assets/6ae874c2-6ca2-4ebe-a8b1-fbd1e1093341" />
 
 ---
 


### PR DESCRIPTION
I removed the Start History from the README. I really really liked it... But Star History is struggling. It's not their fault. 

https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/

By the end of June this year github restricted their API for metadata and stargazer data. It now requires a read token for metadata (which would not be that bad) but also the scope contents:write, which is potentially a big issue. If there appears any vulnerability there would be a token which full write access to the repo. This is not okay - and the Star History project suffers from that. 

I replaced it with a GIF for now. Maybe I find another solution but at the moment I think its a bad idea to use such a open scoped token for such a graph. 

This is the GIF: 

<img width="1600" height="441" alt="star_wavelog" src="https://github.com/user-attachments/assets/6ae874c2-6ca2-4ebe-a8b1-fbd1e1093341" />
