### PR TITLE
Various fixes concerning grids

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -803,7 +803,9 @@ class QSO extends CI_Controller {
 		switch ($type) {
 		case 'grid':
 			$grid = $this->input->post('locator', TRUE);
-			$this->load->library('Qra');
+			if (!$this->load->is_loaded('Qra')) {
+				$this->load->library('Qra');
+			}
 			if ($this->qra->validate_grid($grid, 'grid')) {
 				return true;
 			} else {
@@ -813,7 +815,9 @@ class QSO extends CI_Controller {
 			break;
 		case 'vucc':
 			$grid = $this->input->post('vucc_grids', TRUE);
-			$this->load->library('Qra');
+			if (!$this->load->is_loaded('Qra')) {
+				$this->load->library('Qra');
+			}
 			if ($this->qra->validate_grid($grid, 'vucc')) {
 				return true;
 			} else {
@@ -822,7 +826,9 @@ class QSO extends CI_Controller {
 			}
 			break;
 		default:
-			$this->load->library('Qra');
+			if (!$this->load->is_loaded('Qra')) {
+				$this->load->library('Qra');
+			}
 			if ($this->qra->validate_grid($grid, 'any')) {
 				return true;
 			} else {

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -152,7 +152,9 @@ class QSO extends CI_Controller {
 		$this->form_validation->set_rules('callsign', 'Callsign', 'required');
 		$this->form_validation->set_rules('band', 'Band', 'required');
 		$this->form_validation->set_rules('mode', 'Mode', 'required');
-		$this->form_validation->set_rules('locator', 'Locator', 'callback_check_locator[any]');
+		if (($this->input->post('locator') ?? '') != '') {
+			$this->form_validation->set_rules('locator', 'Locator', 'callback_check_locator[any]');
+		}
 
 		// [eQSL default msg] GET user options (option_type='eqsl_default_qslmsg'; option_name='key_station_id'; option_key=station_id) //
 		$options_object = $this->user_options_model->get_options('eqsl_default_qslmsg',array('option_name'=>'key_station_id','option_key'=>$data['active_station_profile']))->result();

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -494,6 +494,9 @@ class QSO extends CI_Controller {
 		$this->form_validation->set_rules('time_on', 'Start Date', 'required');
 		$this->form_validation->set_rules('time_off', 'End Date', 'required');
 		$this->form_validation->set_rules('id', 'qso ID', 'required');
+		if (strtoupper(trim($this->input->post('locator')) ?? '') != '') {
+			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator');
+		}
 
 		$edit_result=array();
 		$edit_result['success']=false;
@@ -793,24 +796,11 @@ class QSO extends CI_Controller {
 
 	function check_locator($grid) {
 		$grid = $this->input->post('locator', TRUE);
-		// Allow empty locator
-		if (preg_match('/^$/', $grid)) return true;
-		// Allow 6-digit locator
-		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Xa-x]{2}$/', $grid)) return true;
-		// Allow 4-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
-		// Allow 4-digit grid line
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
-		// Allow 4-digit grid corner
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
-		// Allow 2-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}$/', $grid)) return true;
-		// Allow 8-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Xa-x]{2}[0-9]{2}$/', $grid)) return true;
-		// Allow 10-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Xa-x]{2}[0-9]{2}[A-Xa-x]{2}$/', $grid)) return true;
-		else {
-			$this->form_validation->set_message('check_locator', 'Please check value for grid locator ('.strtoupper($grid).').');
+		$this->load->library('Qra');
+		if ($this->qra->validate_grid($grid, 'grid')) {
+			return true;
+		} else {
+			$this->form_validation->set_message('check_locator', sprintf(__("Please check value for grid locator (%s)"), strtoupper($grid)));
 			return false;
 		}
 	}

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -497,6 +497,9 @@ class QSO extends CI_Controller {
 		if (strtoupper(trim($this->input->post('locator')) ?? '') != '') {
 			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator');
 		}
+		if (strtoupper(trim($this->input->post('vucc_grids')) ?? '') != '') {
+			$this->form_validation->set_rules('vucc_grids', 'VUCC Grids', 'callback_check_grids');
+		}
 
 		$edit_result=array();
 		$edit_result['success']=false;
@@ -800,7 +803,18 @@ class QSO extends CI_Controller {
 		if ($this->qra->validate_grid($grid, 'grid')) {
 			return true;
 		} else {
-			$this->form_validation->set_message('check_locator', sprintf(__("Please check value for grid locator (%s)"), strtoupper($grid)));
+			$this->form_validation->set_message('check_locator', sprintf(__("Please check value for gridsquare (%s)"), strtoupper($grid)));
+			return false;
+		}
+	}
+
+	function check_grids($grid) {
+		$grid = $this->input->post('vucc_grids', TRUE);
+		$this->load->library('Qra');
+		if ($this->qra->validate_grid($grid, 'vucc')) {
+			return true;
+		} else {
+			$this->form_validation->set_message('check_grids', sprintf(__("Please check value for VUCC gridsquare (%s)"), strtoupper($grid)));
 			return false;
 		}
 	}

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -152,7 +152,7 @@ class QSO extends CI_Controller {
 		$this->form_validation->set_rules('callsign', 'Callsign', 'required');
 		$this->form_validation->set_rules('band', 'Band', 'required');
 		$this->form_validation->set_rules('mode', 'Mode', 'required');
-		$this->form_validation->set_rules('locator', 'Locator', 'callback_check_locator');
+		$this->form_validation->set_rules('locator', 'Locator', 'callback_check_locator[any]');
 
 		// [eQSL default msg] GET user options (option_type='eqsl_default_qslmsg'; option_name='key_station_id'; option_key=station_id) //
 		$options_object = $this->user_options_model->get_options('eqsl_default_qslmsg',array('option_name'=>'key_station_id','option_key'=>$data['active_station_profile']))->result();
@@ -495,10 +495,10 @@ class QSO extends CI_Controller {
 		$this->form_validation->set_rules('time_off', 'End Date', 'required');
 		$this->form_validation->set_rules('id', 'qso ID', 'required');
 		if (strtoupper(trim($this->input->post('locator')) ?? '') != '') {
-			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator');
+			$this->form_validation->set_rules('gridsquare', 'Locator', 'callback_check_locator[grid]');
 		}
 		if (strtoupper(trim($this->input->post('vucc_grids')) ?? '') != '') {
-			$this->form_validation->set_rules('vucc_grids', 'VUCC Grids', 'callback_check_grids');
+			$this->form_validation->set_rules('vucc_grids', 'VUCC Grids', 'callback_check_locator[vucc]');
 		}
 
 		$edit_result=array();
@@ -797,25 +797,37 @@ class QSO extends CI_Controller {
 		echo json_encode($this->config->item('lotw_unsupported_prop_modes'));
 	}
 
-	function check_locator($grid) {
-		$grid = $this->input->post('locator', TRUE);
-		$this->load->library('Qra');
-		if ($this->qra->validate_grid($grid, 'grid')) {
-			return true;
-		} else {
-			$this->form_validation->set_message('check_locator', sprintf(__("Please check value for gridsquare (%s)"), strtoupper($grid)));
-			return false;
-		}
-	}
-
-	function check_grids($grid) {
-		$grid = $this->input->post('vucc_grids', TRUE);
-		$this->load->library('Qra');
-		if ($this->qra->validate_grid($grid, 'vucc')) {
-			return true;
-		} else {
-			$this->form_validation->set_message('check_grids', sprintf(__("Please check value for VUCC gridsquare (%s)"), strtoupper($grid)));
-			return false;
+	function check_locator($grid, $type) {
+		switch ($type) {
+		case 'grid':
+			$grid = $this->input->post('locator', TRUE);
+			$this->load->library('Qra');
+			if ($this->qra->validate_grid($grid, 'grid')) {
+				return true;
+			} else {
+				$this->form_validation->set_message('check_locator', sprintf(__("Please check value for gridsquare (%s)"), strtoupper($grid)));
+				return false;
+			}
+			break;
+		case 'vucc':
+			$grid = $this->input->post('vucc_grids', TRUE);
+			$this->load->library('Qra');
+			if ($this->qra->validate_grid($grid, 'vucc')) {
+				return true;
+			} else {
+				$this->form_validation->set_message('check_locator', sprintf(__("Please check value for VUCC gridsquare (%s)"), strtoupper($grid)));
+				return false;
+			}
+			break;
+		default:
+			$this->load->library('Qra');
+			if ($this->qra->validate_grid($grid, 'any')) {
+				return true;
+			} else {
+				$this->form_validation->set_message('check_locator', sprintf(__("Please check value for gridsquare (%s)"), strtoupper($grid)));
+				return false;
+			}
+			break;
 		}
 	}
 

--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -203,7 +203,7 @@ class Qra {
 		return [atan2(($z / $n), sqrt($x * $x + $y * $y)) * 180 / pi(), atan2($y, $x) * 180 / pi()];
 	}
 
-	function validate_grid($grid) {
+	function validate_grid($grid, $type='any') {
 		// (Try to) Detect placeholders like AA00aa (returned from qrz.com for example)
 		if (strlen($grid) == 6 && strtoupper($grid) == 'AA00AA') {
 			return false;
@@ -211,21 +211,25 @@ class Qra {
 		// Allow 6-digit locator
 		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
 		// Allow 4-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
-		// Allow 4-digit grid line
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
-		// Allow 4-digit grid corner
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
 		// Allow 2-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}$/', $grid)) return true;
+		if (preg_match('/^[A-Ra-r]{2}$/', $grid)) return true;
 		// Allow 8-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}$/', $grid)) return true;
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}$/', $grid)) return true;
 		// Allow 10-digit locator
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		if ($type == 'grid') return false;
+
+		// Allow 4-digit grid line
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
 		// Allow 6-digit grid line
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		if ($type == 'line') return false;
+
+		// Allow 4-digit grid corner
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
 		// Allow 6-digit grid corner
-		else if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
+		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
 		return false;
 	}
 }

--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -50,14 +50,14 @@ class Qra {
 			try {
 				$total_distance = calc_distance($my[0], $my[1], $stn[0], $stn[1], $unit, $ant_path);
 			} catch (Exception $e) {
-				$total_distance = 0;
+				$total_distance = false;
 			}
 
 			// Return the distance
 			return $total_distance;
 		} else {
 			// Handle the case where qra2latlong did not return valid values
-			return 0;
+			return false;
 		}
 	}
 

--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -208,6 +208,7 @@ class Qra {
 		if (strlen($grid) == 6 && strtoupper($grid) == 'AA00AA') {
 			return false;
 		}
+		if ($type == 'vucc') goto vucc;
 		// Allow 6-digit locator
 		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
 		// Allow 4-digit locator
@@ -220,11 +221,11 @@ class Qra {
 		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
 		if ($type == 'grid') return false;
 
+		vucc:
 		// Allow 4-digit grid line
 		if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;
 		// Allow 6-digit grid line
 		if (preg_match('/^[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2},[A-Ra-r]{2}[0-9]{2}[A-Za-z]{2}$/', $grid)) return true;
-		if ($type == 'line') return false;
 
 		// Allow 4-digit grid corner
 		if (preg_match('/^[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2},[A-Ra-r]{2}[0-9]{2}$/', $grid)) return true;

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -125,7 +125,43 @@
                         <td><?php echo $row->COL_RST_RCVD; ?> <?php if ($row->COL_SRX) { ?>(<?php printf("%03d", $row->COL_SRX);?>)<?php } ?> <?php if ($row->COL_SRX_STRING) { ?>(<?php echo $row->COL_SRX_STRING;?>)<?php } ?></td>
                     </tr>
 
-                    <?php if($row->COL_GRIDSQUARE != null) { ?>
+                    <?php $ant_path = $row->COL_ANT_PATH ?? null; ?>
+                    <?php if($row->COL_VUCC_GRIDS != null) { ?>
+                    <tr>
+                        <th scope="row"><?= __("Gridsquare"); ?> (Multi):</th>
+                        <td>
+                        <?php
+                           if (!str_contains($row->COL_VUCC_GRIDS, ',')) {
+                              echo "<span class='fw-bolder text-warning'>";
+                           }
+                           echo $row->COL_VUCC_GRIDS;
+                           if (!str_contains($row->COL_VUCC_GRIDS, ',')) {
+                              echo " <i class='fa fa-question-circle' aria-hidden='true' data-bs-toggle='tooltip' title='".__("A single gridsquare was entered into the VUCC gridsquares field which should contain two or four gridsquares instead of a single grid.")."'></i>";
+                              echo "</span>";
+                           }
+                           echo " <button type='button' class='btn btn-link text-decoration-none p-0 align-baseline' onclick='spawnQrbCalculator('".$row->station_gridsquare."\',\'".$row->COL_VUCC_GRIDS.")' aria-label='".__("Calculate distance/bearing")."'><i class='fas fa-globe' aria-hidden='true'></i></button>";
+                        ?>
+                        </td>
+                            <?php
+                                // Cacluate Distance
+                                $distance = $this->qra->distance($row->station_gridsquare, $row->COL_VUCC_GRIDS, $measurement_base, $row->COL_ANT_PATH ?? null);
+
+                                switch ($measurement_base) {
+                                    case 'M':
+                                        $distance .= " mi";
+                                        break;
+                                    case 'K':
+                                        $distance .= " km";
+                                        break;
+                                    case 'N':
+                                        $distance .= " nmi";
+                                        break;
+                                }
+                                echo $distance;
+                            ?>
+                    </tr>
+
+                    <?php } else if($row->COL_GRIDSQUARE != null) { ?>
                     <tr>
                         <th scope="row"><?= __("Gridsquare"); ?>:</th>
                         <td><?php echo $row->COL_GRIDSQUARE; ?> <button type="button" class="btn btn-link text-decoration-none p-0 align-baseline" onclick="spawnQrbCalculator('<?php echo $row->station_gridsquare . '\',\'' . $row->COL_GRIDSQUARE; ?>')" aria-label="<?= __("Calculate distance/bearing"); ?>"><i class="fas fa-globe" aria-hidden="true"></i></button></td>
@@ -135,7 +171,6 @@
                     <!-- Total Distance Between the Station Profile Gridsquare and Logged Square -->
                     <?php
                         if($row->COL_GRIDSQUARE != null && strlen($row->COL_GRIDSQUARE) >= 4) {
-                            $ant_path = $row->COL_ANT_PATH ?? null;
                             $distance = $this->qra->distance($row->station_gridsquare, $row->COL_GRIDSQUARE, $measurement_base, $ant_path);
                             if ($distance != false) { ?>
                                 <tr>
@@ -176,42 +211,6 @@
                                     </td>
                                 </tr>
                         <?php } ?>
-                    <?php } ?>
-
-                    <?php if($row->COL_VUCC_GRIDS != null) { ?>
-                    <tr>
-                        <th scope="row"><?= __("Gridsquare"); ?> (Multi):</th>
-                        <td>
-                        <?php
-                           if (!str_contains($row->COL_VUCC_GRIDS, ',')) {
-                              echo "<span class='fw-bolder text-warning'>";
-                           }
-                           echo $row->COL_VUCC_GRIDS;
-                           if (!str_contains($row->COL_VUCC_GRIDS, ',')) {
-                              echo " <i class='fa fa-question-circle' aria-hidden='true' data-bs-toggle='tooltip' title='".__("A single gridsquare was entered into the VUCC gridsquares field which should contain two or four gridsquares instead of a single grid.")."'></i>";
-                              echo "</span>";
-                           }
-                           echo " <button type='button' class='btn btn-link text-decoration-none p-0 align-baseline' onclick='spawnQrbCalculator('".$row->station_gridsquare."\',\'".$row->COL_VUCC_GRIDS.")' aria-label='".__("Calculate distance/bearing")."'><i class='fas fa-globe' aria-hidden='true'></i></button>";
-                        ?>
-                        </td>
-                            <?php
-                                // Cacluate Distance
-                                $distance = $this->qra->distance($row->station_gridsquare, $row->COL_VUCC_GRIDS, $measurement_base, $row->COL_ANT_PATH ?? null);
-
-                                switch ($measurement_base) {
-                                    case 'M':
-                                        $distance .= " mi";
-                                        break;
-                                    case 'K':
-                                        $distance .= " km";
-                                        break;
-                                    case 'N':
-                                        $distance .= " nmi";
-                                        break;
-                                }
-                                echo $distance;
-                            ?>
-                    </tr>
                     <?php } ?>
 
                     <?php if($row->COL_STATE != null) { ?>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -132,49 +132,50 @@
                     </tr>
                     <?php } ?>
 
-                    <?php if($row->COL_GRIDSQUARE != null && strlen($row->COL_GRIDSQUARE) >= 4) { ?>
                     <!-- Total Distance Between the Station Profile Gridsquare and Logged Square -->
-                    <tr>
-                        <th scope="row"><?= __("Total Distance"); //Total distance ?></th>
-                        <td>
-                            <?php
-                                // Cacluate Distance if COL_DISTANCE is not set
-                                $ant_path = $row->COL_ANT_PATH ?? null;
-                                $distance = $this->qra->distance($row->station_gridsquare, $row->COL_GRIDSQUARE, $measurement_base, $ant_path);
-                                switch ($measurement_base) {
-                                    case 'M':
-                                        $distance .= " mi";
-                                        break;
-                                    case 'K':
-                                        $distance .= " km";
-                                        break;
-                                    case 'N':
-                                        $distance .= " nmi";
-                                        break;
-                                }
-
-                                if ($ant_path != null) {
-                                    switch ($row->COL_ANT_PATH) {
-                                        case "S":
-                                            $distance .= ' <span class="badge bg-secondary">' . __("Short Path") . "</span>";
-                                            break;
-                                        case "L":
-                                            $distance .= ' <span class="badge bg-secondary">' . __("Long Path") . "</span>";
-                                            break;
-                                        case "O":
-                                            $distance .= ' <span class="badge bg-secondary">' . __("Other Path") . "</span>";
-                                            break;
-                                        case "G":
-                                            $distance .= ' <span class="badge bg-secondary">' . __("Greyline") . "</span>";
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                }
-                                echo $distance;
-                            ?>
-                        </td>
-                    </tr>
+                    <?php
+                        if($row->COL_GRIDSQUARE != null && strlen($row->COL_GRIDSQUARE) >= 4) {
+                            $ant_path = $row->COL_ANT_PATH ?? null;
+                            $distance = $this->qra->distance($row->station_gridsquare, $row->COL_GRIDSQUARE, $measurement_base, $ant_path);
+                            if ($distance != false) { ?>
+                                <tr>
+                                    <th scope="row"><?= __("Total Distance"); //Total distance ?></th>
+                                    <td>
+                                        <?php
+                                            switch ($measurement_base) {
+                                                case 'M':
+                                                    $distance .= " mi";
+                                                    break;
+                                                case 'K':
+                                                    $distance .= " km";
+                                                    break;
+                                                case 'N':
+                                                    $distance .= " nmi";
+                                                    break;
+                                            }
+                                            if ($ant_path != null) {
+                                                switch ($row->COL_ANT_PATH) {
+                                                    case "S":
+                                                        $distance .= ' <span class="badge bg-secondary">' . __("Short Path") . "</span>";
+                                                        break;
+                                                    case "L":
+                                                        $distance .= ' <span class="badge bg-secondary">' . __("Long Path") . "</span>";
+                                                        break;
+                                                    case "O":
+                                                        $distance .= ' <span class="badge bg-secondary">' . __("Other Path") . "</span>";
+                                                        break;
+                                                    case "G":
+                                                        $distance .= ' <span class="badge bg-secondary">' . __("Greyline") . "</span>";
+                                                        break;
+                                                    default:
+                                                        break;
+                                                }
+                                            }
+                                            echo $distance;
+                                        ?>
+                                    </td>
+                                </tr>
+                        <?php } ?>
                     <?php } ?>
 
                     <?php if($row->COL_VUCC_GRIDS != null) { ?>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -814,9 +814,22 @@
 <?php
    if($row->COL_GRIDSQUARE != null && strlen($row->COL_GRIDSQUARE) >= 4) {
       $stn_loc = $this->qra->qra2latlong(trim($row->COL_GRIDSQUARE));
-      if($stn_loc[0] != 0) {
-         $lat = $stn_loc[0];
-         $lng = $stn_loc[1];
+      if ($stn_loc != false) {
+         if($stn_loc[0] != 0) {
+            $lat = $stn_loc[0];
+            $lng = $stn_loc[1];
+         }
+      } else {
+         if (isset($row->lat)) {
+            $lat = $row->lat;
+         } else {
+            $lat = 0;
+         }
+         if (isset($row->long)) {
+            $lng = $row->long;
+         } else {
+            $lng = 0;
+         }
       }
    } else if ($row->COL_VUCC_GRIDS != null) {
       $midpoint = $this->qra->qra2latlong($row->COL_VUCC_GRIDS);

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -145,19 +145,6 @@
                             <?php
                                 // Cacluate Distance
                                 $distance = $this->qra->distance($row->station_gridsquare, $row->COL_VUCC_GRIDS, $measurement_base, $row->COL_ANT_PATH ?? null);
-
-                                switch ($measurement_base) {
-                                    case 'M':
-                                        $distance .= " mi";
-                                        break;
-                                    case 'K':
-                                        $distance .= " km";
-                                        break;
-                                    case 'N':
-                                        $distance .= " nmi";
-                                        break;
-                                }
-                                echo $distance;
                             ?>
                     </tr>
 
@@ -165,52 +152,50 @@
                     <tr>
                         <th scope="row"><?= __("Gridsquare"); ?>:</th>
                         <td><?php echo $row->COL_GRIDSQUARE; ?> <button type="button" class="btn btn-link text-decoration-none p-0 align-baseline" onclick="spawnQrbCalculator('<?php echo $row->station_gridsquare . '\',\'' . $row->COL_GRIDSQUARE; ?>')" aria-label="<?= __("Calculate distance/bearing"); ?>"><i class="fas fa-globe" aria-hidden="true"></i></button></td>
+                        <!-- Total Distance Between the Station Profile Gridsquare and Logged Square -->
+                        <?php $distance = $this->qra->distance($row->station_gridsquare, $row->COL_VUCC_GRIDS, $measurement_base, $row->COL_ANT_PATH ?? null); ?>
                     </tr>
                     <?php } ?>
 
-                    <!-- Total Distance Between the Station Profile Gridsquare and Logged Square -->
                     <?php
-                        if($row->COL_GRIDSQUARE != null && strlen($row->COL_GRIDSQUARE) >= 4) {
-                            $distance = $this->qra->distance($row->station_gridsquare, $row->COL_GRIDSQUARE, $measurement_base, $ant_path);
-                            if ($distance != false) { ?>
-                                <tr>
-                                    <th scope="row"><?= __("Total Distance"); //Total distance ?></th>
-                                    <td>
-                                        <?php
-                                            switch ($measurement_base) {
-                                                case 'M':
-                                                    $distance .= " mi";
+                        if ($distance != false) { ?>
+                            <tr>
+                                <th scope="row"><?= __("Total Distance"); //Total distance ?></th>
+                                <td>
+                                    <?php
+                                        switch ($measurement_base) {
+                                            case 'M':
+                                                $distance .= " mi";
+                                                break;
+                                            case 'K':
+                                                $distance .= " km";
+                                                break;
+                                            case 'N':
+                                                $distance .= " nmi";
+                                                break;
+                                        }
+                                        if ($ant_path != null) {
+                                            switch ($row->COL_ANT_PATH) {
+                                                case "S":
+                                                    $distance .= ' <span class="badge bg-secondary">' . __("Short Path") . "</span>";
                                                     break;
-                                                case 'K':
-                                                    $distance .= " km";
+                                                case "L":
+                                                    $distance .= ' <span class="badge bg-secondary">' . __("Long Path") . "</span>";
                                                     break;
-                                                case 'N':
-                                                    $distance .= " nmi";
+                                                case "O":
+                                                    $distance .= ' <span class="badge bg-secondary">' . __("Other Path") . "</span>";
+                                                    break;
+                                                case "G":
+                                                    $distance .= ' <span class="badge bg-secondary">' . __("Greyline") . "</span>";
+                                                    break;
+                                                default:
                                                     break;
                                             }
-                                            if ($ant_path != null) {
-                                                switch ($row->COL_ANT_PATH) {
-                                                    case "S":
-                                                        $distance .= ' <span class="badge bg-secondary">' . __("Short Path") . "</span>";
-                                                        break;
-                                                    case "L":
-                                                        $distance .= ' <span class="badge bg-secondary">' . __("Long Path") . "</span>";
-                                                        break;
-                                                    case "O":
-                                                        $distance .= ' <span class="badge bg-secondary">' . __("Other Path") . "</span>";
-                                                        break;
-                                                    case "G":
-                                                        $distance .= ' <span class="badge bg-secondary">' . __("Greyline") . "</span>";
-                                                        break;
-                                                    default:
-                                                        break;
-                                                }
-                                            }
-                                            echo $distance;
-                                        ?>
-                                    </td>
-                                </tr>
-                        <?php } ?>
+                                        }
+                                        echo $distance;
+                                    ?>
+                                </td>
+                            </tr>
                     <?php } ?>
 
                     <?php if($row->COL_STATE != null) { ?>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -153,7 +153,7 @@
                         <th scope="row"><?= __("Gridsquare"); ?>:</th>
                         <td><?php echo $row->COL_GRIDSQUARE; ?> <button type="button" class="btn btn-link text-decoration-none p-0 align-baseline" onclick="spawnQrbCalculator('<?php echo $row->station_gridsquare . '\',\'' . $row->COL_GRIDSQUARE; ?>')" aria-label="<?= __("Calculate distance/bearing"); ?>"><i class="fas fa-globe" aria-hidden="true"></i></button></td>
                         <!-- Total Distance Between the Station Profile Gridsquare and Logged Square -->
-                        <?php $distance = $this->qra->distance($row->station_gridsquare, $row->COL_VUCC_GRIDS, $measurement_base, $row->COL_ANT_PATH ?? null); ?>
+                        <?php $distance = $this->qra->distance($row->station_gridsquare, $row->COL_GRIDSQUARE, $measurement_base, $row->COL_ANT_PATH ?? null); ?>
                     </tr>
                     <?php } ?>
 

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -158,7 +158,7 @@
                     <?php } ?>
 
                     <?php
-                        if ($distance != false) { ?>
+                        if (isset($distance) && $distance != false) { ?>
                             <tr>
                                 <th scope="row"><?= __("Total Distance"); //Total distance ?></th>
                                 <td>


### PR DESCRIPTION
This PR aims to fix various issues:

Editing QSO allows to store bogus grid in gridsquare field resulting in errors on QSO view and shows distance to be 0km (default value on errors in distance calculation):

<img width="614" height="519" alt="image" src="https://github.com/user-attachments/assets/fecdbf5a-c339-4983-b7fd-30984540075f" />

Filling grid and vucc grid in QSO edit results in bogus display of grids:

<img width="614" height="519" alt="image" src="https://github.com/user-attachments/assets/d096b924-c4ce-43ce-823e-d926163c623c" />

Storing more than 12 chars in gridsquare field on QSO edit resulted in bogus error message popup:

<img width="1027" height="724" alt="image" src="https://github.com/user-attachments/assets/75af074c-4e53-448d-9f7f-72a2450088ee" />


We changed:

- Return value of distance calculation in case of errors to false (was 0)
- Prefer display of VUCC_GRIDS over GRIDSQUARE and only show one of them
- Hide Distance row in case of errors on calculation
- Added separate checks for GRIDSQUARE and VUCC_GRIDS in QSO edit
- Fixed bogus error message in case of erroneous date in gridsquare or vucc_grids