### PR TITLE
Decode HTML entities in widgets

### DIFF
--- a/application/views/widgets/lotw_upload.php
+++ b/application/views/widgets/lotw_upload.php
@@ -123,7 +123,7 @@ This is a widget to show the last LoTW upload in your QRZ.com Bio or somewhere e
                 <p class="<?= $text_size_class ?>"><?= __("Error") ?></p>
             </div>
             <div class="bottom-right mt-3">
-                <p class="<?= $text_size_class ?>"><?= htmlspecialchars_decode($error) ?></p>
+                <p class="<?= $text_size_class ?>"><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8', false) ?></p>
            </div>
         </div>
      <?php } ?>

--- a/application/views/widgets/lotw_upload.php
+++ b/application/views/widgets/lotw_upload.php
@@ -123,7 +123,7 @@ This is a widget to show the last LoTW upload in your QRZ.com Bio or somewhere e
                 <p class="<?= $text_size_class ?>"><?= __("Error") ?></p>
             </div>
             <div class="bottom-right mt-3">
-                <p class="<?= $text_size_class ?>"><?= htmlspecialchars($error) ?></p>
+                <p class="<?= $text_size_class ?>"><?= htmlspecialchars_decode($error) ?></p>
            </div>
         </div>
      <?php } ?>

--- a/application/views/widgets/on_air.php
+++ b/application/views/widgets/on_air.php
@@ -249,7 +249,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <p class="<?php echo $text_size_class ?>"><?= __("Error") ?></p>
             </div>
             <div class="bottom-right mt-3">
-                <p class="<?php echo $text_size_class ?>"><?php echo htmlspecialchars($error) ?></p>
+                <p class="<?php echo $text_size_class ?>"><?php echo htmlspecialchars_decode($error) ?></p>
            </div>
         </div>
      <?php } ?>

--- a/application/views/widgets/on_air.php
+++ b/application/views/widgets/on_air.php
@@ -249,7 +249,7 @@ The widget automatically detects the nojs=1 parameter and serves a JavaScript-fr
                 <p class="<?php echo $text_size_class ?>"><?= __("Error") ?></p>
             </div>
             <div class="bottom-right mt-3">
-                <p class="<?php echo $text_size_class ?>"><?php echo htmlspecialchars_decode($error) ?></p>
+                <p class="<?php echo $text_size_class ?>"><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8', false) ?></p>
            </div>
         </div>
      <?php } ?>


### PR DESCRIPTION
Fixes this:

<img width="595" height="232" alt="image" src="https://github.com/user-attachments/assets/1c72c256-f187-46bd-bd9e-ff1a233d58d5" />
