### PR TITLE
Catch undefined variable (if no station location exists)

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -306,7 +306,7 @@ function get_bearing($lat1, $lon1, $lat2, $lon2, $ant_path = null) {
 }
 
 function qra2latlong($strQRA) {
-	$strQRA = preg_replace('/\s+/', '', $strQRA);
+	$strQRA = preg_replace('/\s+/', '', ($strQRA ?? ''));
 	if (substr_count($strQRA, ',') > 0) {
 		$grids = explode(',', $strQRA);
 		if (count($grids) != 2 && count($grids) != 4) {


### PR DESCRIPTION
Fixes this: 

<img width="1104" height="585" alt="image" src="https://github.com/user-attachments/assets/6b7273f6-a687-41b6-a7c0-538fc60e9023" />

Occurs if no station profile is existing / selected.