### PR TITLE
Count needed DXCC based on status and show deleted DXCCs separately

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -131,6 +131,7 @@ class Dashboard extends CI_Controller {
 
 		// Country stats
 		$data['total_countries'] = $stats['Countries_Worked'];
+		$data['total_deleted_countries'] = $stats['Countries_Deleted_Worked'];
 		$data['unique_callsigns'] = $stats['Unique_Callsigns'];
 		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
 		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -134,7 +134,9 @@ class Dashboard extends CI_Controller {
 		$data['total_deleted_countries'] = $stats['Countries_Deleted_Worked'];
 		$data['unique_callsigns'] = $stats['Unique_Callsigns'];
 		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
+		$data['total_deleted_countries_confirmed_paper'] = $stats['Countries_Deleted_Worked_QSL'];
 		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
+		$data['total_deleted_countries_confirmed_lotw'] = $stats['Countries_Deleted_Worked_LOTW'];
 		$confirmed = $stats['Countries_Worked_Confirmed'];
 
 		// QSL stats

--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -107,6 +107,7 @@ class Visitor extends CI_Controller {
 
 				// Country stats
 				$data['total_countries'] = $stats['Countries_Worked'];
+				$data['total_deleted_countries'] = $stats['Countries_Deleted_Worked'];
 				$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
 				$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
 				$confirmed = $stats['Countries_Worked_Confirmed'];

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4267,7 +4267,7 @@ class Logbook_model extends CI_Model {
 				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
 				-- DXCC confirmed totals intentionally count only paper QSL + LoTW.
 				-- eQSL is tracked separately in the UI as display-only information.
-				COUNT(DISTINCT CASE WHEN (t.COL_QSL_RCVD = 'Y' OR t.COL_LOTW_QSL_RCVD = 'Y') AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_Confirmed,
+				COUNT(DISTINCT CASE WHEN (t.COL_QSL_RCVD = 'Y' OR t.COL_LOTW_QSL_RCVD = 'Y') AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_Confirmed,
 				COUNT(DISTINCT CASE WHEN d.end IS NULL AND d.adif != 0 AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Current,
 				-- QSL stats (SUM - no filtering, all QSOs)
 				SUM(CASE WHEN t.COL_QSL_SENT = 'Y' THEN 1 ELSE 0 END) as QSL_Sent,

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4261,7 +4261,8 @@ class Logbook_model extends CI_Model {
 				-- Country stats (COUNT DISTINCT - filtered to valid DXCC only)
 				-- Callsign stats
 				COUNT(DISTINCT t.COL_CALL) as Unique_Callsigns,
-				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked,
+				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked,
+				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Deleted_Worked,
 				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
 				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
 				-- DXCC confirmed totals intentionally count only paper QSL + LoTW.
@@ -4304,6 +4305,7 @@ class Logbook_model extends CI_Model {
 					// Country stats
 					'Unique_Callsigns' => $row->Unique_Callsigns,
 					'Countries_Worked' => $row->Countries_Worked,
+					'Countries_Deleted_Worked' => $row->Countries_Deleted_Worked,
 					'Countries_Worked_QSL' => $row->Countries_Worked_QSL,
 					'Countries_Worked_LOTW' => $row->Countries_Worked_LOTW,
 					'Countries_Worked_Confirmed' => $row->Countries_Worked_Confirmed,

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4263,8 +4263,10 @@ class Logbook_model extends CI_Model {
 				COUNT(DISTINCT t.COL_CALL) as Unique_Callsigns,
 				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked,
 				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Deleted_Worked,
-				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
-				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
+				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
+				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Deleted_Worked_QSL,
+				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_LOTW,
+				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Deleted_Worked_LOTW,
 				-- DXCC confirmed totals intentionally count only paper QSL + LoTW.
 				-- eQSL is tracked separately in the UI as display-only information.
 				COUNT(DISTINCT CASE WHEN (t.COL_QSL_RCVD = 'Y' OR t.COL_LOTW_QSL_RCVD = 'Y') AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_Confirmed,
@@ -4307,7 +4309,9 @@ class Logbook_model extends CI_Model {
 					'Countries_Worked' => $row->Countries_Worked,
 					'Countries_Deleted_Worked' => $row->Countries_Deleted_Worked,
 					'Countries_Worked_QSL' => $row->Countries_Worked_QSL,
+					'Countries_Deleted_Worked_QSL' => $row->Countries_Deleted_Worked_QSL,
 					'Countries_Worked_LOTW' => $row->Countries_Worked_LOTW,
+					'Countries_Deleted_Worked_LOTW' => $row->Countries_Deleted_Worked_LOTW,
 					'Countries_Worked_Confirmed' => $row->Countries_Worked_Confirmed,
 					'Countries_Current' => $row->Countries_Current,
 					// QSL stats
@@ -4341,8 +4345,11 @@ class Logbook_model extends CI_Model {
 		// Return zero values if no data
 		return [
 			'Countries_Worked' => 0,
+			'Countries_Deleted_Worked' => 0,
 			'Countries_Worked_QSL' => 0,
+			'Countries_Deleted_Worked_QSL' => 0,
 			'Countries_Worked_LOTW' => 0,
+			'Countries_Deleted_Worked_LOTW' => 0,
 			'Countries_Worked_Confirmed' => 0,
 			'Countries_Current' => 0,
 			'QSL_Sent' => 0,

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -490,8 +490,8 @@ function echo_table_header_col($name) {
 					<tr>
 						<th scope="row" width="50%"><?= __("Confirmed"); ?></th>
 						<td width="50%">
-							<span title="<?= __("QSL Cards"); ?>" aria-label="<?= __("QSL Cards"); ?>: <?php echo $total_countries_confirmed_paper; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_paper; ?></span> /
-							<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $total_countries_confirmed_lotw; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_lotw; ?></span>
+						<span title="<?= __("QSL Cards"); ?>" aria-label="<?= __("QSL Cards"); ?>: <?php echo $total_countries_confirmed_paper; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_paper; ?> <?php echo (isset($total_deleted_countries_confirmed_paper) && $total_deleted_countries_confirmed_paper > 0) ? "(".$total_deleted_countries_confirmed_paper.")" : ""; ?></span> /
+						<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $total_countries_confirmed_lotw; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_lotw; ?> <?php echo (isset($total_deleted_countries_confirmed_lotw) && $total_deleted_countries_confirmed_lotw > 0) ? "(".$total_deleted_countries_confirmed_lotw.")" : ""; ?></span>
 						</td>
 					</tr>
 					<tr>

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -485,7 +485,7 @@ function echo_table_header_col($name) {
 				<table class="table table-striped mb-0" aria-label="<?= __("DXCCs Breakdown"); ?>">
 					<tr>
 						<th scope="row" width="50%"><?= __("Worked"); ?></th>
-						<td width="50%"><?php echo $total_countries; ?></td>
+						<td width="50%"><?php echo $total_countries; ?> <?php echo (isset($total_deleted_countries) && $total_deleted_countries > 0) ? "<span title=\"". __("Deleted DXCCs") ."\" aria-label=\"i". __("Deleted DXCCs") .": ".$total_deleted_countries."\" data-bs-toggle=\"tooltip\">(".$total_deleted_countries.")</span>" : ''; ?></td>
 					</tr>
 					<tr>
 						<th scope="row" width="50%"><?= __("Confirmed"); ?></th>

--- a/application/views/visitor/index.php
+++ b/application/views/visitor/index.php
@@ -264,7 +264,7 @@ if ($public_maps_option == 'true') { ?>
 
 					<tr>
 						<td width="50%"><?= __("Worked"); ?></td>
-						<td width="50%"><?php echo $total_countries; ?></td>
+                  <td width="50%"><?php echo $total_countries; ?> <?php echo (isset($total_deleted_countries) && $total_deleted_countries > 0) ? "<span title=\"". __("Deleted DXCCs") ."\" aria-label=\"i". __("Deleted DXCCs") .": ".$total_deleted_countries."\" data-bs-toggle=\"tooltip\">(".$total_deleted_countries.")</span>" : ''; ?></td>
 					</tr>
 					<tr>
 						<td width="50%"><?= __("Confirmed"); ?></td>


### PR DESCRIPTION
The current DXCC query for dashboard counts worked DXCCs regardless of whether the DXCCs are (still) valid or not. So we add a criteria for the worked DXCCs to only count the not-deleted ones. Deleted ones are to be counted separately and shown in brackets on the dashboard.

<img width="663" height="263" alt="Screenshot from 2026-08-12 14-52-23" src="https://github.com/user-attachments/assets/b4846b87-241c-4cb8-9f42-60cb0401e8a9" />
