### PR TITLE
Session Locks and New Redis2 Session Driver

### DIFF
--- a/application/config/config.sample.php
+++ b/application/config/config.sample.php
@@ -490,7 +490,13 @@ $config['encryption_key'] = 'flossie1234555541';
 |
 | 'sess_driver'
 |
-|	The storage driver to use: files, database, redis, memcached
+|	The storage driver to use: files, database, redis, redis2, memcached
+|
+|	'redis2' is Wavelog's own Redis driver. It behaves like 'redis' but waits
+|	for the session lock with BLPOP instead of polling, so parallel AJAX
+|	requests of the same user are no longer delayed by up to a second each.
+|	When redis is needed, use 'redis2' instead of 'redis' for better performance
+|   unless you have a really good reason to use the original 'redis' driver.
 |
 | 'sess_cookie_name'
 |

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -821,6 +821,7 @@ class Contesting extends CI_Controller {
 		}
 
 		header('Content-Type: application/json');
+		session_write_close();
 
 		try {
 			$payload = json_decode($this->input->raw_input_stream, true);
@@ -944,6 +945,7 @@ class Contesting extends CI_Controller {
 		}
 
 		header('Content-Type: application/json');
+		session_write_close();
 
 		try {
 			$payload = json_decode($this->input->raw_input_stream, true);
@@ -1480,6 +1482,8 @@ class Contesting extends CI_Controller {
 			return;
 		}
 
+		session_write_close();
+
 		try {
 			$this->load->model('user_options_model');
 			$result = $this->user_options_model->get_options('contest_logger_layout');
@@ -1528,6 +1532,8 @@ class Contesting extends CI_Controller {
 			return;
 		}
 
+		session_write_close();
+
 		try {
 			$json_input = $this->input->raw_input_stream;
 			$payload = json_decode($json_input, true);
@@ -1573,6 +1579,8 @@ class Contesting extends CI_Controller {
 			return;
 		}
 
+		session_write_close();
+
 		try {
 			$payload = json_decode($this->input->raw_input_stream, true);
 			if (!is_array($payload)) {
@@ -1616,6 +1624,8 @@ class Contesting extends CI_Controller {
 			$this->_teapot();
 			return;
 		}
+
+		session_write_close();
 
 		try {
 			$json_input = $this->input->raw_input_stream;
@@ -1664,6 +1674,8 @@ class Contesting extends CI_Controller {
 			$this->_teapot();
 			return;
 		}
+
+		session_write_close();
 
 		try {
 			$json_input = $this->input->raw_input_stream;
@@ -1717,6 +1729,8 @@ class Contesting extends CI_Controller {
 			return;
 		}
 
+		session_write_close();
+
 		try {
 			$json_input = $this->input->raw_input_stream;
 			$payload = json_decode($json_input, true);
@@ -1756,6 +1770,8 @@ class Contesting extends CI_Controller {
 	 * the callbook has more specific data. Result is cached server-side for 4 hours.
 	 */
 	public function callbook() {
+		session_write_close();
+
 		$this->load->library('callbook');
 		$call = $this->input->get('call', TRUE);
 		if (!$call || strlen($call) < 3) {

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -253,6 +253,8 @@ class Dashboard extends CI_Controller {
 	}
 
 	function radio_display_component() {
+		session_write_close();
+
 		$this->load->model('cat');
 
 		$data['radio_status'] = $this->cat->recent_status();

--- a/application/controllers/Dxcluster.php
+++ b/application/controllers/Dxcluster.php
@@ -15,6 +15,8 @@ class Dxcluster extends CI_Controller {
 
 
 	public function spots($band, $age = '', $de = '', $mode = 'All') {
+		session_write_close();
+
 		// Sanitize inputs
 		$band = $this->security->xss_clean($band);
 		$mode = $this->security->xss_clean($mode);

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -1451,6 +1451,8 @@ class Logbook extends CI_Controller {
 	function qralatlngjson() {
 		if(!$this->user_model->authorize($this->config->item('auth_mode'))) { return; }
 
+		session_write_close();
+
 		$qra = xss_clean($this->input->post('qra'));
 		if(!$this->load->is_loaded('Qra')) {
 			$this->load->library('Qra');

--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -177,6 +177,8 @@ class Lookup extends CI_Controller {
 	}
 
 	public function get_state_list() {
+		session_write_close();
+
 		$this->load->library('subdivisions');
 
 		$dxcc = xss_clean($this->input->post('dxcc'));

--- a/application/controllers/Map.php
+++ b/application/controllers/Map.php
@@ -222,6 +222,8 @@ class Map extends CI_Controller {
 
 	// Generic fonction for return Json for MAP //
 	public function map_plot_json() {
+		session_write_close();
+
 		$this->load->model('Stations');
 		$this->load->model('logbook_model');
 

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -211,6 +211,9 @@ class QSO extends CI_Controller {
 				$this->session->set_userdata('prop_mode', 'SAT');
 			}
 
+			// All session writes are done, release the lock before the expensive part
+			session_write_close();
+
 			// Add QSO
 			// $this->logbook_model->add();
 			//change to create_qso function as add and create_qso duplicate functionality
@@ -260,6 +263,8 @@ class QSO extends CI_Controller {
 			             ->set_output(json_encode(['error' => 'Forbidden']));
 			return;
 		}
+
+		session_write_close();
 
 		$this->load->model('logbook_model');
 
@@ -654,6 +659,7 @@ class QSO extends CI_Controller {
 
 
 	function band_to_freq($band, $mode) {
+		session_write_close();
 
 		if ($band != null and $band != 'null') {
 			echo $this->frequency->convert_band($band, $mode);
@@ -665,6 +671,8 @@ class QSO extends CI_Controller {
 	 * Function is used for autocompletion of SOTA in the QSO entry form
 	 */
 	public function get_sota() {
+		session_write_close();
+
 		$query = $this->input->get('query', TRUE) ?? FALSE;
 
 		$this->load->model('sota');
@@ -675,6 +683,8 @@ class QSO extends CI_Controller {
 	}
 
 	public function get_wwff() {
+		session_write_close();
+
 		$query = $this->input->get('query', TRUE) ?? FALSE;
 
 		$this->load->model('wwff');
@@ -685,6 +695,8 @@ class QSO extends CI_Controller {
 	}
 
 	public function get_pota() {
+		session_write_close();
+
 		$query = $this->input->get('query', TRUE) ?? FALSE;
 
 		$this->load->model('pota');
@@ -698,6 +710,8 @@ class QSO extends CI_Controller {
 	 * Function is used for autocompletion of DOK in the QSO entry form
 	 */
 	public function get_dok() {
+		session_write_close();
+
 		$json = [];
 
 		$query = $this->input->get('query', TRUE) ?? FALSE;
@@ -732,6 +746,8 @@ class QSO extends CI_Controller {
 	}
 
 	public function get_sota_info() {
+		session_write_close();
+
 		$this->load->library('sota');
 
 		$sota = $this->input->post('sota', TRUE);
@@ -741,6 +757,8 @@ class QSO extends CI_Controller {
 	}
 
 	public function get_wwff_info() {
+		session_write_close();
+
 		$this->load->library('wwff');
 
 		$wwff = $this->input->post('wwff', TRUE);
@@ -750,6 +768,8 @@ class QSO extends CI_Controller {
 	}
 
 	public function get_pota_info() {
+		session_write_close();
+
 		$this->load->library('pota');
 
 		$pota = $this->input->post('pota', TRUE);
@@ -759,6 +779,8 @@ class QSO extends CI_Controller {
 	}
 
 	public function get_station_power() {
+		session_write_close();
+
 		$this->load->model('stations');
 		$this->load->library('qra');
 		$stationProfile = $this->input->post('stationProfile', TRUE);

--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -157,6 +157,7 @@ class Satellite extends CI_Controller {
 	}
 
 	public function satellite_data() {
+		session_write_close();
 
 		$this->load->model('satellite_model');
 		$satellite_data = $this->satellite_model->satellite_data();

--- a/application/controllers/User_options.php
+++ b/application/controllers/User_options.php
@@ -28,6 +28,8 @@ class User_Options extends CI_Controller {
 	}
 
 	public function get_fav() {
+		session_write_close();
+
 		$result=$this->user_options_model->get_options('Favourite');
 		$jsonout=[];
 		foreach($result->result() as $options) {
@@ -126,6 +128,7 @@ class User_Options extends CI_Controller {
 	}
 
 	public function get_qrg_units() {
+		session_write_close();
 
 		$qrg_units = [];
 

--- a/application/libraries/Session/drivers/Session_redis2_driver.php
+++ b/application/libraries/Session/drivers/Session_redis2_driver.php
@@ -1,0 +1,185 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+// The session library only autoloads CI_Session_driver, so the parent has to be pulled in here.
+require_once BASEPATH.'libraries/Session/drivers/Session_redis_driver.php';
+
+/**
+ * Redis session driver with a blocking lock.
+ *
+ * Alternative to CI3's built-in 'redis' driver, selected with:
+ *
+ *     $config['sess_driver'] = 'redis2';
+ *
+ * Two differences to the built-in driver, everything else is inherited:
+ *
+ * 1. Waiting for the lock uses BLPOP instead of a poll loop. A waiting request
+ *    is woken by Redis the moment the holder releases it, instead of on the
+ *    next poll tick. The built-in driver sleeps between attempts, so every
+ *    waiting request pays that full interval even when the lock became free
+ *    right after it started waiting.
+ *
+ * 2. The lock holds a unique token and is released through a Lua script that
+ *    only deletes the key while the token still matches. The built-in driver
+ *    deletes unconditionally: a request whose lock had already expired via TTL
+ *    would delete a lock that meanwhile belongs to a different request, and
+ *    both would consider themselves the holder.
+ *
+ * A crashed holder never sends a wakeup, so BLPOP is bounded and retried. That
+ * case degrades to the same behaviour as the built-in driver and is ultimately
+ * resolved by the lock's own TTL.
+ */
+class Session_redis2_driver extends CI_Session_redis_driver {
+
+	/**
+	 * Lock TTL in seconds, safety net for holders that die without releasing.
+	 * Matches the value used by the built-in driver.
+	 */
+	const LOCK_TTL = 300;
+
+	/**
+	 * How long a single BLPOP waits before the acquire loop retries. Bounded so
+	 * a crashed holder cannot block a waiter until the total timeout.
+	 */
+	const BLOCK_TIMEOUT = 1;
+
+	/**
+	 * Total time to wait for the lock before giving up, in seconds.
+	 */
+	const MAX_WAIT = 30;
+
+	/**
+	 * Lifetime of a wakeup token in milliseconds. Releasing while nobody waits
+	 * would otherwise leave the token behind for the next unrelated request.
+	 */
+	const QUEUE_TTL = 1000;
+
+	/**
+	 * Releases the lock only if we still own it, then wakes exactly one waiter.
+	 */
+	const RELEASE_SCRIPT = <<<'LUA'
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+	redis.call('DEL', KEYS[1])
+	redis.call('LPUSH', KEYS[2], '1')
+	redis.call('PEXPIRE', KEYS[2], ARGV[2])
+	return 1
+end
+return 0
+LUA;
+
+	/**
+	 * Unique token identifying our own hold on the lock
+	 *
+	 * @var	string
+	 */
+	protected $_lock_token;
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Open
+	 *
+	 * Connects through the parent, then makes sure the socket read timeout
+	 * outlives a blocking BLPOP - otherwise phpRedis throws instead of waiting.
+	 *
+	 * @param	string	$save_path	Server path
+	 * @param	string	$name		Session cookie name, unused
+	 * @return	bool
+	 */
+	public function open($save_path, $name): bool
+	{
+		$result = parent::open($save_path, $name);
+
+		if ($result === $this->_success && isset($this->_redis))
+		{
+			$this->_redis->setOption(Redis::OPT_READ_TIMEOUT, self::BLOCK_TIMEOUT + 2);
+		}
+
+		return $result;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Get lock
+	 *
+	 * @param	string	$session_id	Session ID
+	 * @return	bool
+	 */
+	protected function _get_lock($session_id)
+	{
+		$lock_key = $this->_key_prefix.$session_id.':lock';
+
+		// PHP 7 reuses the SessionHandler object on regeneration, so the lock
+		// may already be ours - just refresh its TTL (same as the parent does).
+		if ($this->_lock_key === $lock_key)
+		{
+			return $this->_redis->{$this->_setTimeout_name}($this->_lock_key, self::LOCK_TTL);
+		}
+
+		$queue_key = $lock_key.':queue';
+		$token = bin2hex(random_bytes(16));
+		$deadline = microtime(TRUE) + self::MAX_WAIT;
+
+		do
+		{
+			if ($this->_redis->set($lock_key, $token, array('nx', 'ex' => self::LOCK_TTL)))
+			{
+				$this->_lock_key = $lock_key;
+				$this->_lock_token = $token;
+				$this->_lock = TRUE;
+				return TRUE;
+			}
+
+			// Someone else holds it. Wait to be woken by their release.
+			try
+			{
+				$this->_redis->blPop(array($queue_key), self::BLOCK_TIMEOUT);
+			}
+			catch (RedisException $e)
+			{
+				// Never let a blocking read take the whole request down.
+				log_message('error', 'Session: Got RedisException while waiting for lock '.$lock_key.': '.$e->getMessage());
+				usleep(100000);
+			}
+		}
+		while (microtime(TRUE) < $deadline);
+
+		log_message('error', 'Session: Unable to obtain lock for '.$lock_key.' within '.self::MAX_WAIT.' seconds, aborting.');
+		return FALSE;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Release lock
+	 *
+	 * @return	bool
+	 */
+	protected function _release_lock()
+	{
+		if ( ! isset($this->_redis, $this->_lock_key) OR ! $this->_lock)
+		{
+			return TRUE;
+		}
+
+		$released = $this->_redis->eval(
+			self::RELEASE_SCRIPT,
+			array($this->_lock_key, $this->_lock_key.':queue', $this->_lock_token, self::QUEUE_TTL),
+			2
+		);
+
+		if ($released !== 1)
+		{
+			// Our lock had already expired and may belong to another request by
+			// now. Deleting it would be exactly the bug this driver avoids, so
+			// only drop our own state.
+			log_message('error', 'Session: Lock for '.$this->_lock_key.' expired before it was released, session data may have been written concurrently.');
+		}
+
+		$this->_lock_key = NULL;
+		$this->_lock_token = NULL;
+		$this->_lock = FALSE;
+		return TRUE;
+	}
+
+}

--- a/application/libraries/Session/drivers/index.html
+++ b/application/libraries/Session/drivers/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/libraries/Session/index.html
+++ b/application/libraries/Session/index.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/install/config/config.php
+++ b/install/config/config.php
@@ -489,7 +489,13 @@ $config['encryption_key'] = '%encryptionkey%';
 |
 | 'sess_driver'
 |
-|	The storage driver to use: files, database, redis, memcached
+|	The storage driver to use: files, database, redis, redis2, memcached
+|
+|	'redis2' is Wavelog's own Redis driver. It behaves like 'redis' but waits
+|	for the session lock with BLPOP instead of polling, so parallel AJAX
+|	requests of the same user are no longer delayed by up to a second each.
+|	When redis is needed, use 'redis2' instead of 'redis' for better performance
+|   unless you have a really good reason to use the original 'redis' driver.
 |
 | 'sess_cookie_name'
 |

--- a/system/libraries/Session/drivers/Session_memcached_driver.php
+++ b/system/libraries/Session/drivers/Session_memcached_driver.php
@@ -336,14 +336,20 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 			return TRUE;
 		}
 
-		// 30 attempts to obtain a lock, in case another request already has it
+		// Wavelog: upstream CI3 polled with sleep(1), so every waiting request paid a full
+		// second even when the lock was released milliseconds later. With several parallel
+		// AJAX requests per page this produced a 1s/2s/3s staircase. Polling at 100ms keeps
+		// the total wait ceiling at 30s while picking up a released lock almost immediately.
+		$retry_interval = 100000; // microseconds
+		$max_attempts = 300;
+
 		$lock_key = $this->_key_prefix.$session_id.':lock';
 		$attempt = 0;
 		do
 		{
 			if ($this->_memcached->get($lock_key))
 			{
-				sleep(1);
+				usleep($retry_interval);
 				continue;
 			}
 
@@ -357,11 +363,11 @@ class CI_Session_memcached_driver extends CI_Session_driver implements SessionHa
 			$this->_lock_key = $lock_key;
 			break;
 		}
-		while (++$attempt < 30);
+		while (++$attempt < $max_attempts);
 
-		if ($attempt === 30)
+		if ($attempt === $max_attempts)
 		{
-			log_message('error', 'Session: Unable to obtain lock for '.$this->_key_prefix.$session_id.' after 30 attempts, aborting.');
+			log_message('error', 'Session: Unable to obtain lock for '.$this->_key_prefix.$session_id.' after '.$max_attempts.' attempts, aborting.');
 			return FALSE;
 		}
 

--- a/system/libraries/Session/drivers/Session_redis_driver.php
+++ b/system/libraries/Session/drivers/Session_redis_driver.php
@@ -142,7 +142,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			$save_path = array(
 				'host'    => $matches[1],
 				'port'    => empty($matches[2]) ? NULL : $matches[2],
-				'timeout' => NULL // We always pass this to Redis::connect(), so it needs to exist
+				'timeout' => 0.0 // We always pass this to Redis::connect(), so it needs to exist
 			);
 		}
 		else
@@ -216,9 +216,7 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 		}
 		else
 		{
-			$this->_redis = $redis;
-			$this->php5_validate_id();
-			return $this->_success;
+			log_message('error', 'Session: Unable to connect to Redis with the configured settings.');
 		}
 
 		return $this->_failure;
@@ -414,21 +412,27 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			return $this->_redis->{$this->_setTimeout_name}($this->_lock_key, 300);
 		}
 
-		// 30 attempts to obtain a lock, in case another request already has it
+		// Wavelog: upstream CI3 polled with sleep(1), so every waiting request paid a full
+		// second even when the lock was released milliseconds later. With several parallel
+		// AJAX requests per page this produced a 1s/2s/3s staircase. Polling at 100ms keeps
+		// the total wait ceiling at 30s while picking up a released lock almost immediately.
+		$retry_interval = 100000; // microseconds
+		$max_attempts = 300;
+
 		$lock_key = $this->_key_prefix.$session_id.':lock';
 		$attempt = 0;
 		do
 		{
 			if (($ttl = $this->_redis->ttl($lock_key)) > 0)
 			{
-				sleep(1);
+				usleep($retry_interval);
 				continue;
 			}
 
 			if ($ttl === -2 && ! $this->_redis->set($lock_key, time(), array('nx', 'ex' => 300)))
 			{
-				// Sleep for 1s to wait for lock releases.
-				sleep(1);
+				// Wait for the lock to be released.
+				usleep($retry_interval);
 				continue;
 			}
 			elseif ( ! $this->_redis->setex($lock_key, 300, time()))
@@ -440,11 +444,11 @@ class CI_Session_redis_driver extends CI_Session_driver implements SessionHandle
 			$this->_lock_key = $lock_key;
 			break;
 		}
-		while (++$attempt < 30);
+		while (++$attempt < $max_attempts);
 
-		if ($attempt === 30)
+		if ($attempt === $max_attempts)
 		{
-			log_message('error', 'Session: Unable to obtain lock for '.$this->_key_prefix.$session_id.' after 30 attempts, aborting.');
+			log_message('error', 'Session: Unable to obtain lock for '.$this->_key_prefix.$session_id.' after '.$max_attempts.' attempts, aborting.');
 			return FALSE;
 		}
 		elseif ($ttl === -1)


### PR DESCRIPTION
This adds `session_write_close()` to expensive ajax calls in QSO and Contesting to reduce blockings. 

While default session driver `files` is really fast and default (which is good), in some environments you need a shared session storage. For example in Kubernetes there is no way around that. As we use apache2 in our docker image real parallel requests are not possible here so reducing the blocking time between serialized ajax requests is crucial for a good performance. 

The legacy CI3 redis session driver uses polling against redis als sleeps for 1 second if the session lock was not released yet. In 2014 when codeigniter was designed, this probably was okay. Today it isn't as this causes a awesome (not) 1s staircase which massivle drops performance on redis session handlers in containerized environments. 

See here:
```php
# branch wavelog/dev in docker
$config['sess_driver'] = 'redis'; 
```

<img width="1266" height="436" alt="grafik" src="https://github.com/user-attachments/assets/fa7fbb0e-3402-4c95-bd4b-47cc32e0ed6e" />

So I dropped the sleep in the legacy redis and memcached session driver to `100ms` (timeout still at 30s as it was before)

<img width="629" height="236" alt="grafik" src="https://github.com/user-attachments/assets/af33fb76-3a84-4fe2-897e-a0d96eb44944" />

This causes 10 times more polling traffic between server and redis, which is nowadays not an issue. Also the 100ms polling shouldn't be a big deal against redis (if this causes issues, the infrastructure is just crap)

This reduction in sleep let's php picking up the session much much earlier instead waiting a full 1 second for the next request. 

So this is just a security net for those who stay with the legacy redis session driver and we all know polling is not that sexy. So I prepared a new session driver called `redis2` which lives in /application and not /system. This redis driver uses modern technology and doesn't poll redis to ask for the session lock. Instead it uses `BLPOP` which notifies php when the session is released from the lock. This reduces the waiting time between ajax calls to <1ms and doesn't require any polling. Unfortunately memcached doesn't support that. So we stick with polling here

```php
# this branch in docker
$config['sess_driver'] = 'redis2'; 
```

<img width="628" height="246" alt="grafik" src="https://github.com/user-attachments/assets/cfae168b-9c58-43bc-bdf0-1749c5227da4" />

With `redis2` the performance is nearly as good as with the files driver while being fully compatible with the session locking. 

Cheers
