### PR TITLE
Env disable cron

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -44,7 +44,9 @@ if [ -n "$PUID" ] || [ -n "$PGID" ]; then
 	done < /var/www/html/docker/writable-dirs
 fi
 
-# start cron daemon (runs as wavelog via /etc/cron.d/wavelog)
-cron
+# start cron daemon (runs as wavelog via /etc/cron.d/wavelog), unless DISABLE_CRON=true
+if [ "${DISABLE_CRON:-false}" != "true" ]; then
+	cron
+fi
 
 exec "$@"


### PR DESCRIPTION
In replicated environments (e.g. Kubernetes) you want the cronjob to be managed externally.

To disable the cronjob inside the container you then can use 

```
DISABLE_CRON: true
```

if this env variable is not set or set to false, the cronjob runs normally