### PR TITLE
APIv2 should spit out deleted / confirmed as dashboard does

### DIFF
--- a/application/libraries/api_v2/Statistic_resource.php
+++ b/application/libraries/api_v2/Statistic_resource.php
@@ -116,10 +116,15 @@ class Statistic_resource extends Api_v2_resource {
 	 * band/mode breakdown, confirmation and DXCC totals. Scoped to the owner's
 	 * station locations, so the numbers are the user's own, not the instance.
 	 *
-	 * DXCC semantics:
+	 * DXCC semantics (mirrors the dashboard DXCC card):
 	 * - worked: unique valid DXCC entities worked in the log
-	 * - confirmed: DXCC entities confirmed by paper QSL or LoTW only
+	 * - confirmed: DXCC entities confirmed by paper QSL OR LoTW (combined,
+	 *   deduped) — the Needed numerator; the card itself shows the split below
+	 * - confirmed_paper / confirmed_lotw: the paper-QSL / LoTW split the card
+	 *   displays in its Confirmed row
 	 * - available: current DXCC entities in the active DXCC list
+	 * - deleted: DXCC entities worked but since deleted from the active list
+	 *   (worked plus the same paper/LoTW confirmation split), shown in brackets
 	 *
 	 * eQSL remains visible in the dashboard/UI and in the confirmations topic,
 	 * but it is intentionally excluded from dxcc.confirmed.
@@ -151,9 +156,16 @@ class Statistic_resource extends Api_v2_resource {
 				'by_mode' => $this->shape_counts($this->CI->logbook_model->total_modes(null, null, $scope, 12), 'mode'),
 			],
 			'dxcc' => [
-				'worked'    => (int) $batch['Countries_Worked'],
-				'confirmed' => (int) $batch['Countries_Worked_Confirmed'],
-				'available' => $this->CI->logbook_model->count_dxcc_entities(),
+				'worked'          => (int) $batch['Countries_Worked'],
+				'confirmed'       => (int) $batch['Countries_Worked_Confirmed'],
+				'confirmed_paper' => (int) $batch['Countries_Worked_QSL'],
+				'confirmed_lotw'  => (int) $batch['Countries_Worked_LOTW'],
+				'available'       => $this->CI->logbook_model->count_dxcc_entities(),
+				'deleted' => [
+					'worked'          => (int) $batch['Countries_Deleted_Worked'],
+					'confirmed_paper' => (int) $batch['Countries_Deleted_Worked_QSL'],
+					'confirmed_lotw'  => (int) $batch['Countries_Deleted_Worked_LOTW'],
+				],
 			],
 		];
 	}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -3958,14 +3958,15 @@ class Logbook_model extends CI_Model {
 	}
 
 	/**
-	 * Number of DXCC entities that exist (i.e. are theoretically workable),
-	 * excluding the "None" (deleted/invalid) placeholder entry. Used by the
-	 * statistics API as the denominator for "DXCC worked".
+	 * Number of currently active DXCC entities (not deleted, excluding the
+	 * "None" placeholder). Matches the dashboard's Needed denominator
+	 * (Dxcc::list_current()) and feeds the statistics API's "available"
+	 * DXCC count.
 	 *
 	 * @return int
 	 */
 	function count_dxcc_entities() {
-		return (int) $this->db->query('SELECT COUNT(*) AS count FROM dxcc_entities')->row()->count - 1; // Subtract 1 for the "None" entry
+		return (int) $this->db->query('SELECT COUNT(*) AS count FROM dxcc_entities WHERE end IS NULL AND adif != 0')->row()->count;
 	}
 
 	private function where_date_range($dateFrom, $dateTo) {


### PR DESCRIPTION
Changes at API should follow same logic like in #3656 and #3615 

testing (caution: api takes ALL stations of user, if not explicity station_id requested):

`curl -s "https://[WL_URL]/api/v2/statistic" -H "Authorization: Bearer [v2_key]" |jq .`

Documentation adjusted as well: https://docs.wavelog.org/developer/api-v2/statistic/#qso-default