### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-13 09:11+0000\n"
-"PO-Revision-Date: 2026-08-13 05:11+0000\n"
-"Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
+"PO-Revision-Date: 2026-08-13 09:37+0000\n"
+"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -14981,6 +14981,8 @@ msgid ""
 "At least one of the locators is empty. Calculation not possible. Possibly "
 "missing locator in station location. Please check."
 msgstr ""
+"Mindestens einer der Locator is leer. Berechnung nicht möglich. "
+"Möglicherweise fehlender Locator im Stationsprofil. Bitte prüfen."
 
 #: application/views/interface_assets/footer.php:62
 #: application/views/user/index.php:20 application/views/user/index.php:144
@@ -20481,7 +20483,7 @@ msgstr "Zeige eine Karte der Satellitenflugbahnen"
 #: application/views/satellite/pass.php:28
 msgid ""
 "Active station location does not have a gridsquare configured. Please check"
-msgstr ""
+msgstr "Das aktive Stationsprofil enthält keinen Locator. Bitte prüfen"
 
 #: application/views/satellite/flightpath.php:57
 msgid ""
@@ -21324,6 +21326,9 @@ msgid ""
 "distance statistics and more. Make sure to fill in the gridsquare if you "
 "want to use those features"
 msgstr ""
+"Dies wird für alle Features benötigt, die auf der derzeitigen Position "
+"beruhen wie z.B. Karten, Entfernungsstatistiken und mehr. Stelle sicher, "
+"dass ein Locator eingetragen ist, wenn du diese Features nutzen möchtest"
 
 #: application/views/station_profile/create.php:200
 #: application/views/station_profile/edit.php:222

--- a/application/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/application/locale/ru_RU/LC_MESSAGES/messages.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-13 05:57+0000\n"
-"PO-Revision-Date: 2026-08-11 16:14+0000\n"
+"PO-Revision-Date: 2026-08-13 07:51+0000\n"
 "Last-Translator: Michael Skolsky <r1blh@yandex.ru>\n"
 "Language-Team: Russian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ru/>\n"
@@ -3090,12 +3090,12 @@ msgstr "QSO не может быть сохранено"
 #: application/controllers/Qso.php:834 application/controllers/Qso.php:857
 #, php-format
 msgid "Please check value for gridsquare (%s)"
-msgstr ""
+msgstr "Пожалуйста, проверьте значение квадрата QTH локатора (%s)"
 
 #: application/controllers/Qso.php:846
 #, php-format
 msgid "Please check value for VUCC gridsquare (%s)"
-msgstr ""
+msgstr "Пожалуйста, проверьте значение квадрата QTH локатора VUCC (%s)"
 
 #: application/controllers/Qso.php:875
 msgid "You have to be logged in to access this URL."
@@ -5144,12 +5144,12 @@ msgstr "Границы квадрата QTH локатора"
 #: application/views/activationplanner/index.php:24
 #: application/views/activationplanner/index.php:76
 msgid "Nearby refs"
-msgstr ""
+msgstr "Ближайшие референции"
 
 #: application/views/activationplanner/index.php:25
 #, php-format
 msgid "References within %s of the gridsquare"
-msgstr ""
+msgstr "Ссылки в пределах %s квадрата QTH локатора"
 
 #: application/views/activationplanner/index.php:26
 #: application/views/qslcard/confirmationresult.php:21
@@ -13252,7 +13252,7 @@ msgstr "Статистика по DXCC"
 #: application/views/dashboard/index.php:488
 #: application/views/visitor/index.php:267
 msgid "Deleted DXCCs"
-msgstr ""
+msgstr "Удалённые DXCC"
 
 #: application/views/dashboard/index.php:498
 #: application/views/visitor/index.php:277
@@ -20659,7 +20659,7 @@ msgstr "Результат поиска"
 #: application/views/search/lotw_unconfirmed.php:5
 #: application/views/search/main.php:5
 msgid "Ready to find a QSO?"
-msgstr "Готовы провести QSO?"
+msgstr "QSO"
 
 #: application/views/search/lotw_unconfirmed.php:23
 msgid ""


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)