### PR TITLE
Fix COL_CONTEST_ID

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 293;
+$config['migration_version'] = 294;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/migrations/294_fix_contest_id.php
+++ b/application/migrations/294_fix_contest_id.php
@@ -15,11 +15,13 @@ class Migration_fix_contest_id extends CI_Migration
 	{
 		$table_name = $this->config->item('table_name');
 		$ix_name = 'HRD_IDX_COL_CONTEST_ID';
+		$ix_created = false;
 
 		$ix_exist = $this->db->query("SHOW INDEX FROM {$table_name} WHERE Column_name = 'COL_CONTEST_ID' AND Seq_in_index = 1")->num_rows();
 
 		if ($ix_exist == 0) {
 			$this->dbtry("ALTER TABLE {$table_name} ADD INDEX `{$ix_name}` (COL_CONTEST_ID)");
+			$ix_created = true;
 		}
 
 		$this->dbtry("UPDATE {$table_name} t
@@ -33,6 +35,10 @@ class Migration_fix_contest_id extends CI_Migration
 							HAVING COUNT(*) = 1
 						) c ON t.COL_CONTEST_ID = c.name
 						SET t.COL_CONTEST_ID = c.adifname");
+		
+		if ($ix_created) {
+			$this->dbtry("ALTER TABLE {$table_name} DROP INDEX `{$ix_name}`");
+		}
 	}
 
 	public function down()

--- a/application/migrations/294_fix_contest_id.php
+++ b/application/migrations/294_fix_contest_id.php
@@ -1,0 +1,50 @@
+<?php
+defined('BASEPATH') or exit('No direct script access allowed');
+
+/**
+ * PR #3063 (new contesting) introduced a bug where the COL_CONTEST_ID was set to the display
+ * name of the contest instead of the ADIF name. This migration fixes that by updating all
+ * QSOs with the correct ADIF name.
+ *
+ * Since this is a heavy query we create an index on COL_CONTEST_ID to speed up the update.
+ */
+
+class Migration_fix_contest_id extends CI_Migration
+{
+	public function up()
+	{
+		$table_name = $this->config->item('table_name');
+		$ix_name = 'HRD_IDX_COL_CONTEST_ID';
+
+		$ix_exist = $this->db->query("SHOW INDEX FROM {$table_name} WHERE Column_name = 'COL_CONTEST_ID' AND Seq_in_index = 1")->num_rows();
+
+		if ($ix_exist == 0) {
+			$this->dbtry("ALTER TABLE {$table_name} ADD INDEX `{$ix_name}` (COL_CONTEST_ID)");
+		}
+
+		$this->dbtry("UPDATE {$table_name} t
+						JOIN (
+							SELECT c1.name, MIN(c1.adifname) AS adifname
+							FROM contest c1
+							WHERE NOT EXISTS (
+								SELECT 1 FROM contest x WHERE x.adifname = c1.name
+							)
+							GROUP BY c1.name
+							HAVING COUNT(*) = 1
+						) c ON t.COL_CONTEST_ID = c.name
+						SET t.COL_CONTEST_ID = c.adifname");
+	}
+
+	public function down()
+	{
+		// Not possible - the contest id should be the adif name, not the display name.
+	}
+
+	function dbtry($what) {
+		try {
+			$this->db->query($what);
+		} catch (Exception $e) {
+			log_message("error", "Mig 294: Something gone wrong while fixing the COL_CONTEST_ID: ".$e." // Executing: ".$this->db->last_query());
+		}
+	}
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -5918,34 +5918,25 @@ class Logbook_model extends CI_Model {
 	}
 
 	/**
-	 * Sets the display contest name (contest_name) in logbook
+	 * Sets the ADIF contest name (COL_CONTEST_ID) in logbook
 	 *
 	 * @param int $qso_id The ID of the QSO.
 	 * @param int $contest_adif_id The contest adif id, if 0 empty
-	 * @return bool True on success, false on failure.
 	 */
-	function set_contest($qso_id, $contest_adif_id) {
-
+	function set_contest($qso_id, $contest_adif_id = 0) {
 
 		if ($contest_adif_id != 0) {
-
-			$getName = "SELECT id, name FROM contest WHERE active = 1 AND id = ?;";
-			$nameQuery = $this->db->query($getName, $contest_adif_id);
-
-			$nameRow = $nameQuery->row() ? $nameQuery->row()->name : '';
-
+			$sql = "SELECT id, adifname FROM contest WHERE active = 1 AND id = ?;";
+			$nameQuery = $this->db->query($sql, [$contest_adif_id]);
+			$adifname = $nameQuery->row() ? $nameQuery->row()->adifname : '';
 		} else {
-			$nameRow = '';
+			$adifname = '';
 		}
 
-			$data = array(
-				'COL_CONTEST_ID' => xss_clean($nameRow),
-			);
-
-		$this->db->where(array('COL_PRIMARY_KEY' => $qso_id));
-		$this->db->update($this->config->item('table_name'), $data);
-
-		return true;
+		$table_name = $this->config->item('table_name');
+		$sql = "UPDATE {$table_name} SET COL_CONTEST_ID = ? WHERE COL_PRIMARY_KEY = ?;";
+		$this->db->query($sql, [$adifname, $qso_id]);
+		return;
 	}
 
 	function mark_dcl_rcvd($key) {


### PR DESCRIPTION
PR #3063 introduced a bug in set_contest() which set the COL_CONTEST_ID to the display name instead the ADIF name. This is wrong and this PR fixes this. To also fix existing QSOs it needs a migration. Since this is a heavy migration it set's an index before which helps a lot in this case and for later contest stuff performance. 

This popped up while reviewing #3613