### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 09:39+0000\n"
-"PO-Revision-Date: 2026-08-14 10:04+0000\n"
-"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
+"PO-Revision-Date: 2026-08-14 10:48+0000\n"
+"Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -24069,17 +24069,17 @@ msgstr "LoTW Nutzer. Letzter Upload vom "
 #: application/controllers/Contest_admin.php:76
 #, php-format
 msgid "Contest %s updated"
-msgstr ""
+msgstr "Contest %s aktualisiert"
 
 #: application/controllers/Mode.php:76
 #, php-format
 msgid "Mode %s updated"
-msgstr ""
+msgstr "Mode %s aktualisiert"
 
 #: application/controllers/Station.php:105
 #, php-format
 msgid "Station Location %s updated"
-msgstr ""
+msgstr "Stationsstandort %s aktualisiert"
 
 #~ msgid "Add stroked zero (Ø)"
 #~ msgstr "Füge durchgestrichene Null (Ø) hinzu"

--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 09:39+0000\n"
-"PO-Revision-Date: 2026-08-13 09:37+0000\n"
+"PO-Revision-Date: 2026-08-14 10:04+0000\n"
 "Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
@@ -4313,15 +4313,15 @@ msgstr "QSL Bestätigungen lesen"
 
 #: application/libraries/api_v2/Contest_resource.php:55
 msgid "Read contest sessions"
-msgstr ""
+msgstr "Lese Contest Sitzungen"
 
 #: application/libraries/api_v2/Contest_resource.php:56
 msgid "Create and update contest sessions"
-msgstr ""
+msgstr "Erstelle und aktualisiere Contest Sitzungen"
 
 #: application/libraries/api_v2/Contest_resource.php:57
 msgid "Delete contest sessions"
-msgstr ""
+msgstr "Lösche Contest Sitzungen"
 
 #: application/libraries/api_v2/Lookup_resource.php:44
 msgid "Look up callsigns and grids"

--- a/application/locale/it_IT/LC_MESSAGES/messages.po
+++ b/application/locale/it_IT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-13 13:59+0000\n"
-"PO-Revision-Date: 2026-08-12 14:57+0000\n"
+"PO-Revision-Date: 2026-08-14 06:33+0000\n"
 "Last-Translator: iv3cvn <ricentis@gmail.com>\n"
 "Language-Team: Italian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/it/>\n"
@@ -13251,7 +13251,7 @@ msgstr "Stato DXCC"
 #: application/views/dashboard/index.php:488
 #: application/views/visitor/index.php:267
 msgid "Deleted DXCCs"
-msgstr ""
+msgstr "DXCC eliminati"
 
 #: application/views/dashboard/index.php:498
 #: application/views/visitor/index.php:277
@@ -14958,6 +14958,8 @@ msgid ""
 "At least one of the locators is empty. Calculation not possible. Possibly "
 "missing locator in station location. Please check."
 msgstr ""
+"Almeno uno dei locatori è vuoto. Calcolo non possibile. Potrebbe mancare un "
+"locatore nella posizione della stazione. Si prega di controllare."
 
 #: application/views/interface_assets/footer.php:62
 #: application/views/user/index.php:20 application/views/user/index.php:144
@@ -20446,6 +20448,8 @@ msgstr "Visualizza una mappa con le rotte di volo dei satelliti"
 msgid ""
 "Active station location does not have a gridsquare configured. Please check"
 msgstr ""
+"La posizione della stazione attiva non ha un gridsquare configurato. Per "
+"favore controlla"
 
 #: application/views/satellite/flightpath.php:57
 msgid ""
@@ -21283,6 +21287,9 @@ msgid ""
 "distance statistics and more. Make sure to fill in the gridsquare if you "
 "want to use those features"
 msgstr ""
+"Questo è necessario per tutte le funzionalità basate sulla posizione "
+"attuale, ad esempio mappe, statistiche di distanza e altro. Assicurati di "
+"compilare il gridsquare se vuoi utilizzare queste funzionalità"
 
 #: application/views/station_profile/create.php:200
 #: application/views/station_profile/edit.php:222

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-13 13:59+0000\n"
-"PO-Revision-Date: 2026-08-12 19:17+0000\n"
+"PO-Revision-Date: 2026-08-14 06:33+0000\n"
 "Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -14814,6 +14814,8 @@ msgid ""
 "At least one of the locators is empty. Calculation not possible. Possibly "
 "missing locator in station location. Please check."
 msgstr ""
+"少なくとも1つのロケーターが空です。計算ができません。ステーションの位置情報に"
+"ロケーターが欠落している可能性があります。ご確認ください。"
 
 #: application/views/interface_assets/footer.php:62
 #: application/views/user/index.php:20 application/views/user/index.php:144
@@ -20224,6 +20226,8 @@ msgstr "衛星の飛行経路を示す地図を表示する"
 msgid ""
 "Active station location does not have a gridsquare configured. Please check"
 msgstr ""
+"アクティブなステーションの位置にグリッドスクエアが設定されていません。確認し"
+"てください"
 
 #: application/views/satellite/flightpath.php:57
 msgid ""
@@ -21039,6 +21043,8 @@ msgid ""
 "distance statistics and more. Make sure to fill in the gridsquare if you "
 "want to use those features"
 msgstr ""
+"これは、地図、距離統計など、現在位置に基づくすべての機能に必要です。これらの"
+"機能を使用する場合は、グリッドスクエアを必ず入力してください"
 
 #: application/views/station_profile/create.php:200
 #: application/views/station_profile/edit.php:222

--- a/application/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/application/locale/nl_NL/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 06:32+0000\n"
-"PO-Revision-Date: 2026-08-13 05:11+0000\n"
+"PO-Revision-Date: 2026-08-14 09:39+0000\n"
 "Last-Translator: Alexander <alexander@pa8s.nl>\n"
 "Language-Team: Dutch <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/nl/>\n"
@@ -14902,6 +14902,8 @@ msgid ""
 "At least one of the locators is empty. Calculation not possible. Possibly "
 "missing locator in station location. Please check."
 msgstr ""
+"Ten minste één van de locatorvakken is leeg. Berekening niet mogelijk. "
+"Mogelijk ontbrekend locatorvak op de stationlocatie. Controleer dit a.u.b."
 
 #: application/views/interface_assets/footer.php:62
 #: application/views/user/index.php:20 application/views/user/index.php:144
@@ -20375,6 +20377,8 @@ msgstr "Bekijk een kaart met de routes van satellieten"
 msgid ""
 "Active station location does not have a gridsquare configured. Please check"
 msgstr ""
+"Actief stationlocatie heeft geen locatorvak geconfigureerd. Gelieve dit te "
+"controleren"
 
 #: application/views/satellite/flightpath.php:57
 msgid ""
@@ -21212,6 +21216,9 @@ msgid ""
 "distance statistics and more. Make sure to fill in the gridsquare if you "
 "want to use those features"
 msgstr ""
+"Dit is nodig voor alle functies die gebaseerd zijn op de huidige locatie, "
+"bijvoorbeeld kaarten, afstandsstatistieken en meer. Zorg ervoor dat je het "
+"locatorvak invult als je die functies wilt gebruiken"
 
 #: application/views/station_profile/create.php:200
 #: application/views/station_profile/edit.php:222

--- a/application/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/application/locale/sv_SE/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-13 13:59+0000\n"
-"PO-Revision-Date: 2026-08-13 05:11+0000\n"
+"PO-Revision-Date: 2026-08-14 06:33+0000\n"
 "Last-Translator: \"Jorgen Dahl, NU1T\" <sm6srw@arrl.net>\n"
 "Language-Team: Swedish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/sv/>\n"
@@ -14830,6 +14830,8 @@ msgid ""
 "At least one of the locators is empty. Calculation not possible. Possibly "
 "missing locator in station location. Please check."
 msgstr ""
+"Minst en av lokatorerna är tom. Beräkning är inte möjlig. Möjligen saknas "
+"lokator i stationplatsen. Kontrollera, tack."
 
 #: application/views/interface_assets/footer.php:62
 #: application/views/user/index.php:20 application/views/user/index.php:144
@@ -20276,6 +20278,7 @@ msgstr "Visa en karta med satellitflygbanor"
 msgid ""
 "Active station location does not have a gridsquare configured. Please check"
 msgstr ""
+"Aktiv stationsplats har ingen lokator konfigurerad. Vänligen kontrollera"
 
 #: application/views/satellite/flightpath.php:57
 msgid ""
@@ -21100,6 +21103,9 @@ msgid ""
 "distance statistics and more. Make sure to fill in the gridsquare if you "
 "want to use those features"
 msgstr ""
+"Detta behövs för alla funktioner baserade på aktuell plats, t.ex. kartor, "
+"distansstatistik och mer. Se till att fylla i lokatorn om du vill använda "
+"dessa funktioner"
 
 #: application/views/station_profile/create.php:200
 #: application/views/station_profile/edit.php:222


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)