### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 14:09+0000\n"
-"PO-Revision-Date: 2026-08-14 10:48+0000\n"
+"PO-Revision-Date: 2026-08-14 14:58+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
@@ -5330,27 +5330,27 @@ msgstr "📻 Geplante Aktivierung aus %s"
 #: application/views/activationplanner/index.php:51
 #: application/views/activationplanner/index.php:87
 msgid "Search references…"
-msgstr ""
+msgstr "Referenzen durchsuchen…"
 
 #: application/views/activationplanner/index.php:52
 msgid "No matches"
-msgstr ""
+msgstr "Keine Treffer"
 
 #: application/views/activationplanner/index.php:53
 msgid "Loading…"
-msgstr ""
+msgstr "Laden…"
 
 #: application/views/activationplanner/index.php:54
 msgid "References"
-msgstr ""
+msgstr "Referenzen"
 
 #: application/views/activationplanner/index.php:55
 msgid "Places"
-msgstr ""
+msgstr "Orte"
 
 #: application/views/activationplanner/index.php:56
 msgid "Press Enter to search places"
-msgstr ""
+msgstr "Drücke Enter, um Orte zu suchen"
 
 #: application/views/activationplanner/index.php:66
 msgid "Plan your activity here"
@@ -5408,6 +5408,8 @@ msgid ""
 "Search WWFF / POTA / SOTA / IOTA by name or reference — Enter searches place "
 "names (OpenStreetMap)"
 msgstr ""
+"Suche WWFF / POTA / SOTA / IOTA nach Name oder Referenz — Gib Suchanfragen "
+"über Ortsnamen ein (OpenStreetMap)"
 
 #: application/views/activationplanner/index.php:92
 #: application/views/simplefle/index.php:162
@@ -17936,10 +17938,12 @@ msgstr "Grund"
 #: application/views/logbookadvanced/showUpdateResult.php:79
 msgid "The number of QSOs updated for state/province across all DXCCs is"
 msgstr ""
+"Die Anzahl der QSOs, die für Bundesstaat/Provinz über alle DXCCs hinweg "
+"aktualisiert wurden, ist"
 
 #: application/views/logbookadvanced/showUpdateResult.php:79
 msgid "DXCCs processed"
-msgstr ""
+msgstr "DXCCs bearbeitet"
 
 #: application/views/logbookadvanced/showUpdateResult.php:131
 msgid "Results for continent update:"
@@ -17995,7 +17999,7 @@ msgstr ""
 
 #: application/views/logbookadvanced/statecheckresult.php:7
 msgid "Fix all DXCCs"
-msgstr ""
+msgstr "Alle DXCCs beheben"
 
 #: application/views/logbookadvanced/statecheckresult.php:34
 msgid "Run fix"

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 13:51+0000\n"
-"PO-Revision-Date: 2026-08-14 06:33+0000\n"
+"PO-Revision-Date: 2026-08-14 14:09+0000\n"
 "Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -1082,7 +1082,7 @@ msgstr "コンテストの更新"
 #: application/controllers/Contest_admin.php:76
 #, php-format
 msgid "Contest %s updated"
-msgstr ""
+msgstr "コンテスト %s が 更新されました"
 
 #: application/controllers/Contestcalendar.php:11
 #: application/views/interface_assets/header.php:324
@@ -2627,7 +2627,7 @@ msgstr "編集モード"
 #: application/controllers/Mode.php:76
 #, php-format
 msgid "Mode %s updated"
-msgstr ""
+msgstr "モード %s が 更新されました"
 
 #: application/controllers/Notes.php:31
 #: application/views/interface_assets/header.php:158
@@ -3377,7 +3377,7 @@ msgstr "局の所在地を編集: "
 #: application/controllers/Station.php:105
 #, php-format
 msgid "Station Location %s updated"
-msgstr ""
+msgstr "シャックの位置 %s が 更新されました"
 
 #: application/controllers/Station.php:124
 msgid "Duplicate Station Location:"
@@ -4260,15 +4260,15 @@ msgstr "QSLカードの確認書を読む"
 
 #: application/libraries/api_v2/Contest_resource.php:55
 msgid "Read contest sessions"
-msgstr ""
+msgstr "コンテストセッションを読む"
 
 #: application/libraries/api_v2/Contest_resource.php:56
 msgid "Create and update contest sessions"
-msgstr ""
+msgstr "コンテストセッションの作成と更新"
 
 #: application/libraries/api_v2/Contest_resource.php:57
 msgid "Delete contest sessions"
-msgstr ""
+msgstr "コンテストセッションを削除する"
 
 #: application/libraries/api_v2/Lookup_resource.php:44
 msgid "Look up callsigns and grids"
@@ -5272,19 +5272,19 @@ msgstr "📻 アクティベーションを計画する %s"
 #: application/views/activationplanner/index.php:51
 #: application/views/activationplanner/index.php:85
 msgid "Search references…"
-msgstr ""
+msgstr "参考文献を検索…"
 
 #: application/views/activationplanner/index.php:52
 msgid "No matches"
-msgstr ""
+msgstr "一致する項目はありません"
 
 #: application/views/activationplanner/index.php:53
 msgid "Loading…"
-msgstr ""
+msgstr "読み込み中…"
 
 #: application/views/activationplanner/index.php:54
 msgid "References"
-msgstr ""
+msgstr "参考文献"
 
 #: application/views/activationplanner/index.php:64
 msgid "Plan your activity here"
@@ -5339,7 +5339,7 @@ msgstr "私を見つけてください"
 
 #: application/views/activationplanner/index.php:85
 msgid "Search WWFF / POTA / SOTA / IOTA by name or reference"
-msgstr ""
+msgstr "WWFF / POTA / SOTA / IOTA を名前または参照番号で検索"
 
 #: application/views/activationplanner/index.php:90
 #: application/views/simplefle/index.php:162
@@ -17711,11 +17711,11 @@ msgstr "理由"
 #: application/views/logbookadvanced/showUpdateResult.php:77
 #: application/views/logbookadvanced/showUpdateResult.php:79
 msgid "The number of QSOs updated for state/province across all DXCCs is"
-msgstr ""
+msgstr "すべての DXCC における州/県ごとに更新された QSO の数は"
 
 #: application/views/logbookadvanced/showUpdateResult.php:79
 msgid "DXCCs processed"
-msgstr ""
+msgstr "処理済みのDXCC"
 
 #: application/views/logbookadvanced/showUpdateResult.php:131
 msgid "Results for continent update:"
@@ -17771,7 +17771,7 @@ msgstr ""
 
 #: application/views/logbookadvanced/statecheckresult.php:7
 msgid "Fix all DXCCs"
-msgstr ""
+msgstr "すべてのDXCCを修正します"
 
 #: application/views/logbookadvanced/statecheckresult.php:34
 msgid "Run fix"


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)