### PR TITLE
db debug shouldn't be enabled by default

### DIFF
--- a/application/config/database.sample.php
+++ b/application/config/database.sample.php
@@ -84,7 +84,7 @@ $db['default'] = array(
 	'dbdriver' => 'mysqli',
 	'dbprefix' => '',
 	'pconnect' => TRUE,
-	'db_debug' => (ENVIRONMENT !== 'production'),
+	'db_debug' => FALSE,
 	'cache_on' => FALSE,
 	'cachedir' => '',
 	'char_set' => 'utf8mb4',

--- a/install/config/database.php
+++ b/install/config/database.php
@@ -84,7 +84,7 @@ $db['default'] = array(
 	'dbdriver' => 'mysqli',
 	'dbprefix' => '',
 	'pconnect' => TRUE,
-	'db_debug' => (ENVIRONMENT !== 'production'),
+	'db_debug' => FALSE,
 	'cache_on' => FALSE,
 	'cachedir' => '',
 	'char_set' => 'utf8mb4',


### PR DESCRIPTION
while this logic works for normal installations, in docker new installations will run db_debug by default which is bullshit and costs performance. only affects new installations