### PR TITLE
OptionsLib Refactoring

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 294;
+$config['migration_version'] = 295;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -157,7 +157,7 @@ class cron extends CI_Controller {
 
 			$datetime = new DateTime("now", new DateTimeZone('UTC'));
 			$datetime = $datetime->format('Y-m-d H:i:s');
-			$this->optionslib->update('mastercron_last_run', $datetime , 'no');
+			$this->optionslib->update('mastercron_last_run', $datetime);
 		} else {
 			log_message('error', 'CRON: PHP Version '. PHP_VERSION . ' not supported. Minimum Version is: ' . $this->min_php_version);
 			echo 'CRON: PHP Version '. PHP_VERSION . ' not supported. Minimum Version is: ' . $this->min_php_version . "\n";

--- a/application/controllers/Options.php
+++ b/application/controllers/Options.php
@@ -54,7 +54,7 @@ class Options extends CI_Controller {
 			$this->load->view('interface_assets/footer');
 		} else {
 			// Update theme choice within the options system
-			$theme_update_status = $this->optionslib->update('theme', $this->input->post('theme'), 'yes');
+			$theme_update_status = $this->optionslib->update('theme', $this->input->post('theme', true));
 
 			// If theme update is complete set a flashsession with a success note
 			if($theme_update_status == TRUE) {
@@ -62,7 +62,7 @@ class Options extends CI_Controller {
 			}
 
 			// Update logbook map within the options system
-			$logbook_map_update_status = $this->optionslib->update('logbook_map', $this->input->post('logbookMap'), 'yes');
+			$logbook_map_update_status = $this->optionslib->update('logbook_map', $this->input->post('logbookMap', true));
 
 			// If logbook map update is complete set a flashsession with a success note
 			if($logbook_map_update_status == TRUE) {
@@ -70,7 +70,7 @@ class Options extends CI_Controller {
 			}
 
 			// Update public maps within the options system
-			$public_maps_update_status = $this->optionslib->update('public_maps', $this->input->post('publicMaps'), 'yes');
+			$public_maps_update_status = $this->optionslib->update('public_maps', $this->input->post('publicMaps', true));
 
 			// If the option was saved successfully set a flashsession with success note
 			if($public_maps_update_status == TRUE) {
@@ -78,7 +78,7 @@ class Options extends CI_Controller {
 			}
 
 			// Update public github button within the options system
-			$public_github_button_update_status = $this->optionslib->update('public_github_button', $this->input->post('publicGithubButton'), 'yes');
+			$public_github_button_update_status = $this->optionslib->update('public_github_button', $this->input->post('publicGithubButton', true));
 
 			// If the option was saved successfully set a flashsession with success note
 			if($public_github_button_update_status == TRUE) {
@@ -86,7 +86,7 @@ class Options extends CI_Controller {
 			}
 
 			// Update public login button within the options system
-			$public_login_button_update_status = $this->optionslib->update('public_login_button', $this->input->post('publicLoginButton'), 'yes');
+			$public_login_button_update_status = $this->optionslib->update('public_login_button', $this->input->post('publicLoginButton', true));
 
 			// If the option was saved successfully set a flashsession with success note
 			if($public_login_button_update_status == TRUE) {
@@ -127,7 +127,7 @@ class Options extends CI_Controller {
 			$this->load->view('options/hon');
 			$this->load->view('interface_assets/footer');
 		} else {
-			$hon_url_update = $this->optionslib->update('hon_url', $this->input->post('hon_url'), 'yes');
+			$hon_url_update = $this->optionslib->update('hon_url', $this->input->post('hon_url', false)); // no xss cleaning of urls
 			if($hon_url_update == TRUE) {
 				$this->session->set_flashdata('success', __("Hams-Of-Note URL changed to ").$this->input->post('hon_url',true));
 			}
@@ -165,17 +165,17 @@ class Options extends CI_Controller {
 			$this->load->view('options/dxcluster');
 			$this->load->view('interface_assets/footer');
 		} else {
-			$dxcluster_decont_update = $this->optionslib->update('dxcluster_decont', $this->input->post('dxcluster_decont'), 'yes');
+			$dxcluster_decont_update = $this->optionslib->update('dxcluster_decont', $this->input->post('dxcluster_decont', true));
 			if($dxcluster_decont_update == TRUE) {
 				$this->session->set_flashdata('success', __("de continent changed to ").$this->input->post('dxcluster_decont'));
 			}
 
-			$dxcluster_maxage_update = $this->optionslib->update('dxcluster_maxage', $this->input->post('dxcluster_maxage'), 'yes');
+			$dxcluster_maxage_update = $this->optionslib->update('dxcluster_maxage', $this->input->post('dxcluster_maxage', true));
 			if($dxcluster_maxage_update == TRUE) {
 				$this->session->set_flashdata('success', __("Maximum age of spots changed to ").$this->input->post('dxcluster_maxage'));
 			}
 
-			$dxcache_url_update = $this->optionslib->update('dxcache_url', $this->input->post('dxcache_url'), 'yes');
+			$dxcache_url_update = $this->optionslib->update('dxcache_url', $this->input->post('dxcache_url', false)); // no xss cleaning of urls
 			if($dxcache_url_update == TRUE) {
 				$this->session->set_flashdata('success', __("DXCluster Cache URL changed to ").$this->input->post('dxcache_url'));
 			}
@@ -217,7 +217,7 @@ class Options extends CI_Controller {
 		else
 		{
 			// Update theme choice within the options system
-			$radioTimeout_update = $this->optionslib->update('cat_timeout_interval', $this->input->post('radioTimeout'), 'yes');
+			$radioTimeout_update = $this->optionslib->update('cat_timeout_interval', $this->input->post('radioTimeout', true));
 
 			// If theme update is complete set a flashsession with a success note
 			if($radioTimeout_update == TRUE) {
@@ -264,32 +264,32 @@ class Options extends CI_Controller {
 		{
 
 			// Update emailProtocol choice within the options system
-			$emailProtocolupdate = $this->optionslib->update('emailProtocol', $this->input->post('emailProtocol'), 'yes');
+			$emailProtocolupdate = $this->optionslib->update('emailProtocol', $this->input->post('emailProtocol', true));
 
 			// Update smtpEncryption choice within the options system
-			$smtpEncryptionupdate = $this->optionslib->update('smtpEncryption', $this->input->post('smtpEncryption'), 'yes');
+			$smtpEncryptionupdate = $this->optionslib->update('smtpEncryption', $this->input->post('smtpEncryption', true));
 
 			// Update email sender name within the options system
 			$emailSenderName_value = $this->input->post('emailSenderName');
 			if (empty($emailSenderName_value)) {
 				$emailSenderName_value = 'Wavelog';
 			}
-			$emailSenderNameupdate = $this->optionslib->update('emailSenderName', $emailSenderName_value, 'yes');
+			$emailSenderNameupdate = $this->optionslib->update('emailSenderName', $emailSenderName_value);
 
 			// Update email address choice within the options system
-			$emailAddressupdate = $this->optionslib->update('emailAddress', $this->input->post('emailAddress'), 'yes');
+			$emailAddressupdate = $this->optionslib->update('emailAddress', $this->input->post('emailAddress', false));
 
 			// Update smtpHost choice within the options system
-			$smtpHostupdate = $this->optionslib->update('smtpHost', $this->input->post('smtpHost'), 'yes');
+			$smtpHostupdate = $this->optionslib->update('smtpHost', $this->input->post('smtpHost', false));
 
 			// Update smtpPort choice within the options system
-			$smtpPortupdate = $this->optionslib->update('smtpPort', $this->input->post('smtpPort'), 'yes');
+			$smtpPortupdate = $this->optionslib->update('smtpPort', $this->input->post('smtpPort', true));
 
 			// Update smtpUsername choice within the options system
-			$smtpUsernameupdate = $this->optionslib->update('smtpUsername', $this->input->post('smtpUsername'), 'yes');
+			$smtpUsernameupdate = $this->optionslib->update('smtpUsername', $this->input->post('smtpUsername', false));
 
 			// Update smtpPassword choice within the options system
-			$smtpPasswordupdate = $this->optionslib->update('smtpPassword', $this->input->post('smtpPassword'), 'yes');
+			$smtpPasswordupdate = $this->optionslib->update('smtpPassword', $this->input->post('smtpPassword', false));
 
 			// Check if all updates are successful
 			$updateSuccessful = $emailProtocolupdate &&
@@ -399,16 +399,16 @@ class Options extends CI_Controller {
 			$saved = false;
 			if ($this->input->post('reset_defaults') == '1') {
 				$map_tile_server_copyright = 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a>';
-				$saved = $this->optionslib->update('map_tile_server', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', 'yes');
-				$saved = $this->optionslib->update('map_tile_server_dark', 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', 'yes');
-				$saved = $this->optionslib->update('map_tile_subdomains', 'abc', 'yes');
+				$saved = $this->optionslib->update('map_tile_server', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+				$saved = $this->optionslib->update('map_tile_server_dark', 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png');
+				$saved = $this->optionslib->update('map_tile_subdomains', 'abc');
 			} else {
 				$map_tile_server_copyright = 'Map data &copy; <a href="' . $this->input->post('copyright_url', true) . '">' . $this->input->post('copyright_text', true) . '</a>';
-				$saved = $this->optionslib->update('map_tile_server', $this->input->post('maptile_server_url', true), 'yes');
-				$saved = $this->optionslib->update('map_tile_server_dark', $this->input->post('maptile_server_url_dark', true), 'yes');
-				$saved = $this->optionslib->update('map_tile_subdomains', $this->input->post('subdomain_system', true), 'yes');
+				$saved = $this->optionslib->update('map_tile_server', $this->input->post('maptile_server_url', false));
+				$saved = $this->optionslib->update('map_tile_server_dark', $this->input->post('maptile_server_url_dark', false));
+				$saved = $this->optionslib->update('map_tile_subdomains', $this->input->post('subdomain_system', false));
 			}
-			$saved = $this->optionslib->update('map_tile_server_copyright', $map_tile_server_copyright, 'yes');
+			$saved = $this->optionslib->update('map_tile_server_copyright', $map_tile_server_copyright);
 
 			// Also clean up static map images
 			if (!$this->load->is_loaded('staticmap_model')) {
@@ -470,16 +470,16 @@ class Options extends CI_Controller {
 
 		$this->load->helper(array('form', 'url'));
 
-		$version_dialog_header_update = $this->optionslib->update('version_dialog_header', $this->input->post('version_dialog_header'), 'yes');
+		$version_dialog_header_update = $this->optionslib->update('version_dialog_header', $this->input->post('version_dialog_header', true));
 		if($version_dialog_header_update == TRUE) {
 			$this->session->set_flashdata('success0', __("Version Info Header changed to")." "."'".$this->input->post('version_dialog_header')."'");
 		}
-		$version_dialog_mode_update = $this->optionslib->update('version_dialog', $this->input->post('version_dialog_mode'), 'yes');
+		$version_dialog_mode_update = $this->optionslib->update('version_dialog', $this->input->post('version_dialog_mode', true));
 		if($version_dialog_mode_update == TRUE) {
 			$this->session->set_flashdata('success1', __("Version Info Mode changed to")." "."'".$this->input->post('version_dialog_mode')."'");
 		}
 		if ($this->input->post('version_dialog_mode') == "both" || $this->input->post('version_dialog_mode') == "custom_text" ) {
-			$version_dialog_custom_text_update = $this->optionslib->update('version_dialog_text', $this->input->post('version_dialog_custom_text'), 'yes');
+			$version_dialog_custom_text_update = $this->optionslib->update('version_dialog_text', $this->input->post('version_dialog_custom_text', true));
 			if($version_dialog_custom_text_update == TRUE) {
 				$this->session->set_flashdata('success2', __("Version Info Custom Text saved!"));
 			}

--- a/application/controllers/Widgets.php
+++ b/application/controllers/Widgets.php
@@ -28,7 +28,7 @@ class Widgets extends CI_Controller {
 			if (($this->themes_model->get_theme_mode($theme) ?? '') != '') {
 				$data['theme'] = $theme;
 			} else {
-				$data['theme'] = $this->config->item('option_theme');
+				$data['theme'] = $this->optionslib->get_option('theme');
 			}
 		} else {
 			$data['theme'] = "default";
@@ -100,10 +100,10 @@ class Widgets extends CI_Controller {
 			if (($this->themes_model->get_theme_mode($theme) ?? '') != '') {
 				$data['theme'] = $theme;
 			} else {
-				$data['theme'] = $this->config->item('option_theme');
+				$data['theme'] = $this->optionslib->get_option('theme');
 			}
 		} else {
-			$data['theme'] = $this->config->item('option_theme');
+			$data['theme'] = $this->optionslib->get_option('theme');
 		}
 
 		$user = $this->user_model->get_by_id($data['userid'])->row();
@@ -133,10 +133,10 @@ class Widgets extends CI_Controller {
 			if (($this->themes_model->get_theme_mode($theme) ?? '') != '') {
 				$data['theme'] = $theme;
 			} else {
-				$data['theme'] = $this->config->item('option_theme');
+				$data['theme'] = $this->optionslib->get_option('theme');
 			}
 		} else {
-			$data['theme'] = $this->config->item('option_theme');
+			$data['theme'] = $this->optionslib->get_option('theme');
 		}
 
 		$text_size = $this->input->get('text_size', true) ?? 1;
@@ -248,10 +248,10 @@ class Widgets extends CI_Controller {
 			if (($this->themes_model->get_theme_mode($theme) ?? '') != '') {
 				$data['theme'] = $theme;
 			} else {
-				$data['theme'] = $this->config->item('option_theme');
+				$data['theme'] = $this->optionslib->get_option('theme');
 			}
 		} else {
-			$data['theme'] = $this->config->item('option_theme');
+			$data['theme'] = $this->optionslib->get_option('theme');
 		}
 
 		$text_size = $this->input->get('text_size', true) ?? 1;

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -4,6 +4,11 @@ class OptionsLib {
 
     private $CI;
 
+    // Per-request cache: get_option() is called many times per page load
+    // (footer alone reads some options 10+ times), so each option is only
+    // fetched from the database once per request.
+    private array $cache = [];
+
     function __construct() {
 
         // Make Codeigniter functions available to library
@@ -29,7 +34,11 @@ class OptionsLib {
             $option_name = substr($option_name, 7);
         }
 
-        return $this->CI->options_model->item($option_name);
+        if (!array_key_exists($option_name, $this->cache)) {
+            $this->cache[$option_name] = $this->CI->options_model->item($option_name);
+        }
+
+        return $this->cache[$option_name];
     }
 
     /**
@@ -40,6 +49,8 @@ class OptionsLib {
      * @return bool True if the option was updated successfully, false otherwise
      */
     function update($option_name, $option_value) {
+        unset($this->cache[$option_name]);
+
         return $this->CI->options_model->update($option_name, $option_value);
     }
 

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -25,9 +25,11 @@ class OptionsLib {
      */
     function get_option($option_name) {
         // We remove the legacy "option_" prefix to maintain backwards compatibility with older code that may still use it
-        $removed_options_tag = trim($option_name, 'option_');
+        if (str_starts_with($option_name, 'option_')) {
+            $option_name = substr($option_name, 7);
+        }
 
-        return $this->CI->options_model->item($removed_options_tag);
+        return $this->CI->options_model->item($option_name);
     }
 
     /**
@@ -35,11 +37,10 @@ class OptionsLib {
      * 
      * @param string $option_name The name of the option to update
      * @param mixed $option_value The new value of the option
-     * @param string|null $auto_load Whether the option should be autoloaded ('yes' or 'no'), or null to leave unchanged
      * @return bool True if the option was updated successfully, false otherwise
      */
-    function update($option_name, $option_value, $auto_load = NULL) {
-        return $this->CI->options_model->update($option_name, $option_value, $auto_load);
+    function update($option_name, $option_value) {
+        return $this->CI->options_model->update($option_name, $option_value);
     }
 
 

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -1,160 +1,117 @@
-<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
-
-/*
-	Controls the interaction with the QRZ.com Subscription based XML API.
-*/
-
+<?php if (! defined('BASEPATH')) exit('No direct script access allowed');
 
 class OptionsLib {
 
-    function __construct()
-	{
-        // Make Codeigniter functions available to library
-        $CI =& get_instance();
+    private $CI;
 
-	// Force Migration to run on every page load
-    	$CI->load->library('Migration');
-	    $CI->migration->current();
+    function __construct() {
+
+        // Make Codeigniter functions available to library
+        $this->CI = &get_instance();
+
+        // Force Migration to run on every page load
+        $this->CI->load->library('Migration');
+        $this->CI->migration->current();
 
         //Load the options model
-        $CI->load->model('options_model');
-
-        // Store returned array of autoload options
-        $options_result = $CI->options_model->get_autoloads();
-
-        // If results are greater than one
-        if($options_result->num_rows() > 0) {
-            // Loop through the array
-            foreach ($options_result->result() as $item)
-            {
-                /*
-                * Add option to the config system dynamicly option_name is prefixed by option_
-                * you can then call $this->config->item('option_<option_name>') to get the item.
-                */
-                if($item->option_name == "language") {
-                    // language is a global internal config item there for we dont want to prefix it as an option
-                    //$CI->config->set_item($item->option_name, $item->option_value);
-                } else {
-                    $CI->config->set_item('option_'.$item->option_name, $item->option_value);
-                }
-            }
-        }
+        $this->CI->load->model('options_model');
     }
 
-    // This returns a options value based on its name
+    /**
+     * Get an option from the options table
+     * 
+     * @param string $option_name The name of the option to retrieve
+     * @return mixed The value of the option, or null if not found
+     */
     function get_option($option_name) {
-        // Make Codeigniter functions available to library
-        $CI =& get_instance();
-        if (strpos($option_name, 'option_') !== false) {
-            if(!$CI->config->item($option_name)) {
-                 //Load the options model
-                $CI->load->model('options_model');
-                $removed_options_tag = trim($option_name, 'option_');
-                // call library function to get options value
-                $options_result = $CI->options_model->item($removed_options_tag);
+        // We remove the legacy "option_" prefix to maintain backwards compatibility with older code that may still use it
+        $removed_options_tag = trim($option_name, 'option_');
 
-                // return option_value as a string
-                return $options_result;
-            } else {
-                return $CI->config->item($option_name);
-            }
-        } else {
-            if(!$CI->config->item($option_name)) {
-                //Load the options model
-               $CI->load->model('options_model');
-               // call library function to get options value
-               $options_result = $CI->options_model->item($option_name);
-
-               // return option_value as a string
-               return $options_result;
-           } else {
-                return $CI->config->item($option_name);
-           }
-        }
+        return $this->CI->options_model->item($removed_options_tag);
     }
 
-    // Function to save new option to options table
+    /**
+     * Save an option to the options table
+     * 
+     * @param string $option_name The name of the option to save
+     * @param mixed $option_value The value of the option to save
+     * @param string $autoload Whether the option should be autoloaded ('yes' or 'no')
+     * @return bool True if the option was saved successfully, false otherwise
+     */
     function save($option_name, $option_value, $autoload) {
-        // Make Codeigniter functions available to library
-        $CI =& get_instance();
-
-        //Load the options model
-        $CI->load->model('options_model');
-
-        // call library function to save update
-        $result = $CI->options_model->save($option_name, $option_value, $autoload);
-
-        // return True or False on whether its completed.
-        return $result;
+        return $this->CI->options_model->save($option_name, $option_value, $autoload);
     }
 
-    // Function to update options within the options table
+    /**
+     * Update an option in the options table
+     * 
+     * @param string $option_name The name of the option to update
+     * @param mixed $option_value The new value of the option
+     * @param string|null $auto_load Whether the option should be autoloaded ('yes' or 'no'), or null to leave unchanged
+     * @return bool True if the option was updated successfully, false otherwise
+     */
     function update($option_name, $option_value, $auto_load = NULL) {
-        // Make Codeigniter functions available to library
-        $CI =& get_instance();
-
-        //Load the options model
-        $CI->load->model('options_model');
-
-        // call library function to save update
-        $result = $CI->options_model->update($option_name, $option_value, $auto_load);
-
-        // return True or False on whether its completed.
-        return $result;
+        return $this->CI->options_model->update($option_name, $option_value, $auto_load);
     }
 
 
-    // This returns the global theme or the theme stored in the logged in users session data.
+    /**
+     * Get the current theme for the user, either from session data or from the global configuration
+     * 
+     * @return string The name of the current theme
+     */
     function get_theme() {
-        // Make Codeigniter functions available to library
-        $CI =& get_instance();
-
-        // If session data for stylesheet is set return choice
-        if($CI->session->userdata('user_stylesheet')) {
-            return $CI->session->userdata('user_stylesheet');
+        if ($this->CI->session->userdata('user_stylesheet')) {
+            return $this->CI->session->userdata('user_stylesheet');
         } else {
-            // Return the global choice.
-            return $CI->config->item('option_theme');
+            return $this->get_option('theme');
         }
-
     }
 
+    /**
+     * Get the logo for the current theme, or a specific theme if provided
+     * 
+     * @param string $logo_location The location of the logo to retrieve (e.g. 'header_logo', 'main_logo')
+     * @param string|null $theme The name of the theme to retrieve the logo for, or null to use the current theme
+     * @return string The name of the logo file, or 'no_logo_found' if the logo is not found
+     */
     function get_logo($logo_location, $theme = null) {
-
-        $CI =& get_instance();
-
-        // get the theme with the get_theme() function above
         if ($theme == null) {
             $theme = $this->get_theme();
         }
 
         // load the themes model and fetch the logo name from it
-        $CI->load->model('Themes_model');
+        $this->CI->load->model('Themes_model');
 
-        $logo = $CI->Themes_model->get_logo_from_theme($theme, $logo_location);
+        $logo = $this->CI->Themes_model->get_logo_from_theme($theme, $logo_location);
 
         if ($logo != null) {
             return $logo;
         } else {
+            // uses assets/logo/no_logo_found.png; don't change this string
             return 'no_logo_found';
         }
     }
 
+    /**
+     * Get the custom map options for the user, either from the database or from default values
+     * 
+     * @param bool $visitor Whether the user is a visitor (true) or a logged-in user (false)
+     * @param string|null $slug The slug of the user to retrieve options for, or null to use the current user
+     * @return string A JSON-encoded string of the custom map options
+     */
     function get_map_custom($visitor = false, $slug = null) {
-
-        $CI =& get_instance();
-
         $jsonout = [];
 
         if ($visitor == false) {
 
-            $result = $CI->user_options_model->get_options('map_custom');
+            $result = $this->CI->user_options_model->get_options('map_custom');
 
-            foreach($result->result() as $options) {
+            foreach ($result->result() as $options) {
                 if ($options->option_name == 'icon') {
-                    $jsonout[$options->option_key] = json_decode($options->option_value,true);
+                    $jsonout[$options->option_key] = json_decode($options->option_value, true);
                 } else {
-                    $jsonout[$options->option_name.'_'.$options->option_key]=$options->option_value;
+                    $jsonout[$options->option_name . '_' . $options->option_key] = $options->option_value;
                 }
             }
 
@@ -172,21 +129,20 @@ class OptionsLib {
                     "color" => "#0000ff"
                 );
             }
-
         } else {
 
-            $CI->load->model('stationsetup_model');
+            $this->CI->load->model('stationsetup_model');
 
-            $slug = $CI->security->xss_clean($slug);
-            $userid = $CI->stationsetup_model->public_slug_exists_userid($slug);
+            $slug = $this->CI->security->xss_clean($slug);
+            $userid = $this->CI->stationsetup_model->public_slug_exists_userid($slug);
 
-            $result = $CI->user_options_model->get_options('map_custom', null, $userid);
+            $result = $this->CI->user_options_model->get_options('map_custom', null, $userid);
 
-            foreach($result->result() as $options) {
-                if ($options->option_name=='icon') {
-                    $jsonout[$options->option_key] = json_decode($options->option_value,true);
+            foreach ($result->result() as $options) {
+                if ($options->option_name == 'icon') {
+                    $jsonout[$options->option_key] = json_decode($options->option_value, true);
                 } else {
-                    $jsonout[$options->option_name.'_'.$options->option_key] = $options->option_value;
+                    $jsonout[$options->option_name . '_' . $options->option_key] = $options->option_value;
                 }
             }
 
@@ -205,15 +161,14 @@ class OptionsLib {
                 );
             }
 
-            $jsonout['gridsquare_layer']    = $CI->user_options_model->get_options('ExportMapOptions',array('option_name'=>'gridsquare_layer','option_key'=>$slug), $userid)->row()->option_value ?? true;
-            $jsonout['path_lines']          = $CI->user_options_model->get_options('ExportMapOptions',array('option_name'=>'path_lines','option_key'=>$slug), $userid)->row()->option_value ?? true;
-            $jsonout['cqzone_layer']        = $CI->user_options_model->get_options('ExportMapOptions',array('option_name'=>'cqzone_layer','option_key'=>$slug), $userid)->row()->option_value ?? true;
-            $jsonout['qsocount']            = $CI->user_options_model->get_options('ExportMapOptions',array('option_name'=>'qsocount','option_key'=>$slug), $userid)->row()->option_value ?? 250;
-            $jsonout['nightshadow_layer']   = $CI->user_options_model->get_options('ExportMapOptions',array('option_name'=>'nightshadow_layer','option_key'=>$slug), $userid)->row()->option_value ?? true;
-            $jsonout['band']                = $CI->user_options_model->get_options('ExportMapOptions',array('option_name'=>'band','option_key'=>$slug), $userid)->row()->option_value ?? '';
+            $jsonout['gridsquare_layer']    = $this->CI->user_options_model->get_options('ExportMapOptions', array('option_name' => 'gridsquare_layer', 'option_key' => $slug), $userid)->row()->option_value ?? true;
+            $jsonout['path_lines']          = $this->CI->user_options_model->get_options('ExportMapOptions', array('option_name' => 'path_lines', 'option_key' => $slug), $userid)->row()->option_value ?? true;
+            $jsonout['cqzone_layer']        = $this->CI->user_options_model->get_options('ExportMapOptions', array('option_name' => 'cqzone_layer', 'option_key' => $slug), $userid)->row()->option_value ?? true;
+            $jsonout['qsocount']            = $this->CI->user_options_model->get_options('ExportMapOptions', array('option_name' => 'qsocount', 'option_key' => $slug), $userid)->row()->option_value ?? 250;
+            $jsonout['nightshadow_layer']   = $this->CI->user_options_model->get_options('ExportMapOptions', array('option_name' => 'nightshadow_layer', 'option_key' => $slug), $userid)->row()->option_value ?? true;
+            $jsonout['band']                = $this->CI->user_options_model->get_options('ExportMapOptions', array('option_name' => 'band', 'option_key' => $slug), $userid)->row()->option_value ?? '';
         }
 
         return json_encode($jsonout, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
     }
-
 }

--- a/application/libraries/OptionsLib.php
+++ b/application/libraries/OptionsLib.php
@@ -31,18 +31,6 @@ class OptionsLib {
     }
 
     /**
-     * Save an option to the options table
-     * 
-     * @param string $option_name The name of the option to save
-     * @param mixed $option_value The value of the option to save
-     * @param string $autoload Whether the option should be autoloaded ('yes' or 'no')
-     * @return bool True if the option was saved successfully, false otherwise
-     */
-    function save($option_name, $option_value, $autoload) {
-        return $this->CI->options_model->save($option_name, $option_value, $autoload);
-    }
-
-    /**
      * Update an option in the options table
      * 
      * @param string $option_name The name of the option to update

--- a/application/migrations/295_drop_options_autoload.php
+++ b/application/migrations/295_drop_options_autoload.php
@@ -1,0 +1,31 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+* The autoload column of the options table was never used to actually preload options.
+* Every option is fetched on demand, so the column is dropped.
+*/
+
+class Migration_drop_options_autoload extends CI_Migration {
+
+	public function up()
+	{
+		if ($this->db->field_exists('autoload', 'options')) {
+			$this->dbforge->drop_column('options', 'autoload');
+		}
+	}
+
+	public function down()
+	{
+		if (!$this->db->field_exists('autoload', 'options')) {
+			$this->dbforge->add_column('options', array(
+				"autoload varchar(20) DEFAULT NULL",
+			));
+
+			// mastercron_last_run was the only option that was never autoloaded
+			$this->db->where('option_name !=', 'mastercron_last_run');
+			$this->db->update('options', array('autoload' => 'yes'));
+		}
+	}
+}

--- a/application/models/Options_model.php
+++ b/application/models/Options_model.php
@@ -23,34 +23,6 @@ class Options_model extends CI_Model {
 
 	/*
 	*
-	* Saves an option to the database
-	*
-	* Parameters
-	* - option_name: name of the option with no spaces
-	* - option_value: the value of the option name
-	*/
-	function save($option_name, $option_value) {
-		$this->db->where('option_name', $option_name);
-		$query = $this->db->get('options');
-
-		if($query->num_rows() > 0) {
-			// Update the Entry
-			return FALSE;
-		} else {
-			$data = array(
-				'option_name' => $option_name,
-				'option_value' => $option_value,
-			);
-
-			// Save to database
-			$this->db->insert('options', $data);
-
-			return TRUE;
-		}
-	}
-
-	/*
-	*
 	* Saves an update to option
 	*
 	* Parameters

--- a/application/models/Options_model.php
+++ b/application/models/Options_model.php
@@ -8,12 +8,6 @@
 
 class Options_model extends CI_Model {
 
-    // Returns all options that are autoload yes
-	function get_autoloads() {
-		$this->db->where('autoload', "yes");
-		return $this->db->get('options');
-	}
-
 	// Return option value for an option
 	function item($option_name) {
 		$this->db->where('option_name', $option_name);
@@ -34,9 +28,8 @@ class Options_model extends CI_Model {
 	* Parameters
 	* - option_name: name of the option with no spaces
 	* - option_value: the value of the option name
-	* - autoload: this is whether it needs to be loaded every page load set to yes or no
 	*/
-	function save($option_name, $option_value, $autoload) {
+	function save($option_name, $option_value) {
 		$this->db->where('option_name', $option_name);
 		$query = $this->db->get('options');
 
@@ -47,7 +40,6 @@ class Options_model extends CI_Model {
 			$data = array(
 				'option_name' => $option_name,
 				'option_value' => $option_value,
-				'autoload' => $autoload,
 			);
 
 			// Save to database
@@ -65,14 +57,13 @@ class Options_model extends CI_Model {
 	* - option_name: name of the option with no spaces
 	* - option_value: the value of the option name
 	*/
-	function update($option_name, $option_value, $auto_load = NULL) {
+	function update($option_name, $option_value) {
 		$this->db->where('option_name', $option_name);
 		$query = $this->db->get('options');
 
 		$data = array(
 			'option_name' => $option_name,
 			'option_value' => $option_value,
-			'autoload' => $auto_load,
 		);
 
 		if($query->num_rows() > 0) {

--- a/application/models/Staticmap_model.php
+++ b/application/models/Staticmap_model.php
@@ -167,14 +167,14 @@ class Staticmap_model extends CI_Model {
                 $server_url = $this->optionslib->get_option('option_map_tile_server') ?? '';
                 if ($server_url == '') {
                     $server_url = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-                    $this->optionslib->update('map_tile_server', $server_url, 'yes');
+                    $this->optionslib->update('map_tile_server', $server_url);
                 }
                 $tileLayer = new \Wavelog\StaticMapImage\TileLayer($server_url, $attribution, $thememode, $subdomains);
             } elseif ($thememode == 'dark') {
                 $server_url = $this->optionslib->get_option('option_map_tile_server_dark') ?? '';
                 if ($server_url == '') {
                     $server_url = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
-                    $this->optionslib->update('map_tile_server_dark', $server_url, 'yes');
+                    $this->optionslib->update('map_tile_server_dark', $server_url);
                 }
                 $tileLayer = new \Wavelog\StaticMapImage\TileLayer($server_url, $attribution, $thememode, $subdomains);
             } else {

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -683,26 +683,11 @@ class Update_model extends CI_Model {
         return $latest_tag;
     }
 
-    function set_latest_release($release) {
-        $this->db->select('option_value');
-        $this->db->where('option_name', 'latest_release');
-        $query = $this->db->get('options');
-        if ($query->num_rows() > 0) {
-            $this->db->where('option_name', 'latest_release');
-            $this->db->update('options', array('option_value' => $release));
-        } else {
-            $data = array(
-                array('option_name' => "latest_release", 'option_value' => $release),
-            );
-            $this->db->insert_batch('options', $data);
-        }
-    }
-
     function update_check($silent = false) {
         if (!$this->config->item('disable_version_check') ?? false) {
             $running_version = $this->optionslib->get_option('version');
             $latest_release = $this->wavelog_latest_release();
-            $this->set_latest_release($latest_release);
+            $this->optionslib->update('latest_release', $latest_release);
             if (version_compare($latest_release, $running_version, '>')) {
                 if (!$silent) {
                    print __("Newer release available:")." ".$latest_release;

--- a/application/models/Update_model.php
+++ b/application/models/Update_model.php
@@ -692,7 +692,7 @@ class Update_model extends CI_Model {
             $this->db->update('options', array('option_value' => $release));
         } else {
             $data = array(
-                array('option_name' => "latest_release", 'option_value' => $release, 'autoload' => "yes"),
+                array('option_name' => "latest_release", 'option_value' => $release),
             );
             $this->db->insert_batch('options', $data);
         }

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -216,11 +216,11 @@ if ($lang_code !== 'en' && file_exists(FCPATH . "assets/json/datatables_language
 if($this->session->userdata('user_id') != null) {
     $versionDialog = $this->optionslib->get_option('version_dialog');
     if (empty($versionDialog)) {
-        $this->optionslib->update('version_dialog', 'release_notes', 'yes');
+        $this->optionslib->update('version_dialog', 'release_notes');
     }
     $versionDialogHeader = $this->optionslib->get_option('version_dialog_header');
     if (empty($versionDialogHeader)) {
-        $this->optionslib->update('version_dialog_header', __("Version Info"), 'yes');
+        $this->optionslib->update('version_dialog_header', __("Version Info"));
     }
     if($versionDialog != "disabled" && !($is_first_login ?? false)) {
         $confirmed = $this->user_options_model->get_options('version_dialog', array('option_name'=>'confirmed'))->result();

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -688,7 +688,7 @@
 						// The menu items will be displayed to the top right under extras.
 						//
 						// Example:
-						// INSERT INTO options (option_name,option_value,autoload) VALUES
+						// INSERT INTO options (option_name,option_value) VALUES
 						// 	('menuitems','[
 						// {
 						// 		"url":"gridmap",
@@ -700,7 +700,7 @@
 						// 		"text":"Gallery",
 						// 		"icon":"fa-globe-europe"
 						// }
-						// ]','yes');
+						// ]');
 						$menuitems = $this->optionslib->get_option('menuitems');
 
 						if ($menuitems) { ?>


### PR DESCRIPTION
This PR brings a major refactoring of the `OptionsLib` which was implemented many years ago and barely touched since then. Issue here was that the optionslib loaded every option from the database in memory even they don't are used. Back then this may was a cool idea but today this just eats ressources. 

Therefore I dropped the whole config option autoload thingy and dropped the autoload column from database as it's not needed anymore. The OptionsLib itself is still autoloaded by PHP on each request since this manages the auto migrate. 

Result is a more efficient way of loading options and reducing overhead (on my mac locally in docker each pageload is now 10ms faster)