### PR TITLE
PHP fixes

### DIFF
--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -507,10 +507,6 @@ class eqsl extends CI_Controller {
 
 		// Output
 		imagejpeg($thumbnail, null, 90); // 90% quality
-
-		// Clean up
-		imagedestroy($original_image);
-		imagedestroy($thumbnail);
 	}
 
 	function bulk_download_image($id) {

--- a/application/libraries/Genfunctions.php
+++ b/application/libraries/Genfunctions.php
@@ -251,9 +251,6 @@ class Genfunctions
 			// Sleep to make sure the file is available in the next run.
 			usleep(100000); // 100ms
 
-			// Clean up
-			imagedestroy($im);
-
 			return $icon;
 
 		} catch (Exception $e) {

--- a/application/models/Staticmap_model.php
+++ b/application/models/Staticmap_model.php
@@ -54,7 +54,7 @@ class Staticmap_model extends CI_Model {
             require_once($class);
         }
 
-        $fontPath = 'src/StaticMap/src/resources/font.ttf';
+        $fontPath = FCPATH . 'src/StaticMap/src/resources/font.ttf';
 
         //===============================================================================================================================
         //===================================================== CONFIGURE GRAPHICS ======================================================
@@ -579,7 +579,7 @@ class Staticmap_model extends CI_Model {
 
         // Add continent text
         if ($continentEnabled) {
-            $fontPath = 'src/StaticMap/src/resources/font.ttf';
+            $fontPath = FCPATH . 'src/StaticMap/src/resources/font.ttf';
             $color = 'ff0000'; // Red
             $image->writeText($continentText, $fontPath, $fontSize, $color, $contFontPosX, $contFontPosY);
         }

--- a/src/Label/tfpdf.php
+++ b/src/Label/tfpdf.php
@@ -1620,7 +1620,6 @@ protected function _parsegif($file)
 	ob_start();
 	imagepng($im);
 	$data = ob_get_clean();
-	imagedestroy($im);
 	$f = fopen('php://temp','rb+');
 	if(!$f)
 		$this->Error('Unable to create memory stream');

--- a/src/StaticMap/src/Image.php
+++ b/src/StaticMap/src/Image.php
@@ -320,9 +320,6 @@ class Image {
      * @return $this Fluent interface
      */
     public function destroy(): Image {
-        if ($this->isImageDefined()) {
-            \imagedestroy($this->image);
-        }
         $this->resetFields();
         return $this;
     }
@@ -724,7 +721,6 @@ class Image {
             }
         }
 
-        \imagedestroy($this->image);
         $this->image = $newImage;
 
         return $this;
@@ -832,7 +828,6 @@ class Image {
             ) {
                 return [];
             }
-            \imagedestroy($newImg);
 
             $xMin = 0;
             $xMax = 0;

--- a/system/helpers/captcha_helper.php
+++ b/system/helpers/captcha_helper.php
@@ -377,7 +377,6 @@ if ( ! function_exists('create_captcha'))
 		$img_class = (bool) strlen($img_class) ? 'class="'.$img_class.'" ' : '';
 
 		$img = '<img '.($img_id === '' ? '' : 'id="'.$img_id.'"').' src="'.$img_src.'" style="width: '.$img_width.'px; height: '.$img_height .'px; border: 0;" '.$img_class.'alt="'.$img_alt.'" />';
-		ImageDestroy($im);
 
 		return array('word' => $word, 'time' => $now, 'image' => $img, 'filename' => $img_filename);
 	}

--- a/system/libraries/Image_lib.php
+++ b/system/libraries/Image_lib.php
@@ -831,10 +831,6 @@ class CI_Image_lib {
 			return FALSE;
 		}
 
-		// Kill the file handles
-		imagedestroy($dst_img);
-		imagedestroy($src_img);
-
 		if ($this->dynamic_output !== TRUE)
 		{
 			chmod($this->full_dst_path, $this->file_permissions);
@@ -1040,10 +1036,6 @@ class CI_Image_lib {
 			return FALSE;
 		}
 
-		// Kill the file handles
-		imagedestroy($dst_img);
-		imagedestroy($src_img);
-
 		chmod($this->full_dst_path, $this->file_permissions);
 
 		return TRUE;
@@ -1118,9 +1110,6 @@ class CI_Image_lib {
 		{
 			return FALSE;
 		}
-
-		// Kill the file handles
-		imagedestroy($src_img);
 
 		chmod($this->full_dst_path, $this->file_permissions);
 
@@ -1249,9 +1238,6 @@ class CI_Image_lib {
 		{
 			return FALSE;
 		}
-
-		imagedestroy($src_img);
-		imagedestroy($wm_img);
 
 		return TRUE;
 	}
@@ -1420,8 +1406,6 @@ class CI_Image_lib {
 		{
 			$this->image_save_gd($src_img);
 		}
-
-		imagedestroy($src_img);
 
 		return TRUE;
 	}


### PR DESCRIPTION
imagedestroy has no function since php 8.0. So we can get rid of it and of the deprecation warning aswell. 

additionally the imagettftext complained about missing font since there was an FCPATH missing. (Was just a warning, worked anyway, so basically removed the warning).