### PR TITLE
decouple maintenance mode from CI_ENV

### DIFF
--- a/application/controllers/Clublog.php
+++ b/application/controllers/Clublog.php
@@ -11,7 +11,7 @@ class Clublog extends CI_Controller
 	{
 		parent::__construct();
 
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('dashboard');
 		}

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -8,7 +8,7 @@ class cron extends CI_Controller {
 
 		parent::__construct();
 
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/Dcl.php
+++ b/application/controllers/Dcl.php
@@ -8,7 +8,7 @@ class Dcl extends CI_Controller {
 		$this->load->helper(array('form', 'url'));
 
 		if (!($this->config->item('enable_dcl_interface') ?? false)) { $this->session->set_flashdata('error', __("You're not allowed to do that!")); redirect('dashboard'); exit; }
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/Eqsl.php
+++ b/application/controllers/Eqsl.php
@@ -9,7 +9,7 @@ class eqsl extends CI_Controller {
 
 		$this->load->helper(array('form', 'url'));
 
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/Header_auth.php
+++ b/application/controllers/Header_auth.php
@@ -84,7 +84,7 @@ class Header_auth extends CI_Controller {
         $isNewUser = false;
 
         if (!$query || $query->num_rows() !== 1) {
-            if (ENVIRONMENT == 'maintenance') {
+            if (MAINTENANCE_MODE) {
                 $this->_sso_error(__("Sorry. This instance is currently in maintenance mode."));
                 return;
             } elseif ($this->config->item('auth_header_create', 'sso')) {
@@ -111,19 +111,19 @@ class Header_auth extends CI_Controller {
         }
 
         // Maintenance mode check (admin only allowed)  
-        if (ENVIRONMENT === 'maintenance' && (int)$user->user_type !== 99) {
+        if (MAINTENANCE_MODE && (int)$user->user_type !== 99) {
             $this->_sso_error(__("Sorry. This instance is currently in maintenance mode. Only administrators are currently allowed to log in."));
         }
 
         // Check if club station before update
         // Don't update fields in maintenance mode
-        if (ENVIRONMENT !== 'maintenance') {
+        if (!MAINTENANCE_MODE) {
             // Update fields from JWT claims where override_on_update is enabled
             $this->_update_user_from_claims($user->user_id, $mapped);
         }
 
         // Clubstation
-        if (!empty($claim_groups_key) && ENVIRONMENT !== 'maintenance') {
+        if (!empty($claim_groups_key) && !MAINTENANCE_MODE) {
             $groups = $claims[$claim_groups_key] ?? [];
             $this -> _update_club_membership($user->user_id, $groups, $isNewUser);
         }

--- a/application/controllers/Hrdlog.php
+++ b/application/controllers/Hrdlog.php
@@ -15,7 +15,7 @@ class Hrdlog extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -23,7 +23,7 @@ class Lotw extends CI_Controller {
 		parent::__construct();
 		$this->load->helper(array('form', 'url'));
 
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -10,7 +10,7 @@ class Qrz extends CI_Controller {
 	{
 		parent::__construct();
 		
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
             echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -11,7 +11,7 @@ class Update extends CI_Controller {
 	function __construct() {
 		parent::__construct();
 
-		if (ENVIRONMENT == 'maintenance' && $this->session->userdata('user_id') == '') {
+		if (MAINTENANCE_MODE && $this->session->userdata('user_id') == '') {
 			echo __("Maintenance Mode is active. Try again later.")."\n";
 			redirect('user/login');
 		}

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -1357,7 +1357,7 @@ class User extends CI_Controller {
 				if ($this->user_model->check_keep_hash($a, $b)) {
 
 					// check if maintenance mode is active or the user is an admin
-					if (ENVIRONMENT != 'maintenance' || $user_type == 99) {
+					if (!MAINTENANCE_MODE || $user_type == 99) {
 
 						// if everything is fine we can log in the user
 						$this->user_model->update_session($uid);
@@ -1458,7 +1458,7 @@ class User extends CI_Controller {
 				$this->session->set_flashdata('warning', __("Your account is locked, due to too many failed login-attempts. Please reset your password."));
 				redirect('user/login');
 			} else {
-				if(ENVIRONMENT == 'maintenance') {
+				if(MAINTENANCE_MODE) {
 					$this->session->set_flashdata('notice', __("Sorry. This instance is currently in maintenance mode. If this message appears unexpectedly or keeps showing up, please contact an administrator. Only administrators are currently allowed to log in."));
 					redirect('user/login');
 				} else {

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -726,7 +726,7 @@ class User_Model extends CI_Model {
 			$user_hash = $this->session->userdata('user_hash');
 			$impersonate = $this->session->userdata('impersonate');
 
-			if(ENVIRONMENT != 'maintenance') {
+			if(!MAINTENANCE_MODE) {
 				$session_token = $this->session->userdata('session_token');
 				if($session_token && $this->_auth($user_id . $user_type . $session_token, $user_hash)) {
 					// Freshen the session
@@ -782,7 +782,7 @@ class User_Model extends CI_Model {
 
 			if($this->_auth($password, $u->row()->user_password)) {
 				$this->db->query("UPDATE users SET login_attempts = 0 WHERE user_id = ?", [$u->row()->user_id]);	// Reset failurecount
-				if (ENVIRONMENT != "maintenance") {
+				if (!MAINTENANCE_MODE) {
 					return 1;
 				} else {
 					if($u->row()->user_type != 99){

--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -101,7 +101,7 @@
 			<?php if (ENVIRONMENT == "development" || (ENVIRONMENT == "docker" && filter_var($_ENV['DOCKER_DEVELOPMENT'] ?? false, FILTER_VALIDATE_BOOLEAN))) { ?>
 				<span class="badge text-bg-danger me-1"><?= __("Developer Mode"); ?></span>
 			<?php } ?>
-			<?php if (ENVIRONMENT == "maintenance") { ?>
+			<?php if (MAINTENANCE_MODE) { ?>
 				<span class="badge text-bg-info me-1"><?= __("Maintenance Mode"); ?></span>
 			<?php } ?>
 			<?php if ($this->session->userdata('clubstation') == '1' && $this->session->userdata('impersonate') == '1') { ?>

--- a/application/views/user/login.php
+++ b/application/views/user/login.php
@@ -20,7 +20,7 @@
 </style>
 <main class="form-signin">
     <a href="<?php echo base_url() ?>"><img src="<?php echo $this->paths->cache_buster('/assets/logo/' . $this->optionslib->get_logo('main_logo') . '.png'); ?>" class="mx-auto d-block mainLogo" alt=""></a>
-    <?php if (ENVIRONMENT == 'maintenance') { ?>
+    <?php if (MAINTENANCE_MODE) { ?>
         <div class="d-flex justify-content-center align-items-center">
             <span class="badge text-bg-warning mb-4 pt-2 pb-2"><?= __("MAINTENANCE MODE"); ?></span>
         </div>

--- a/index.php
+++ b/index.php
@@ -48,21 +48,27 @@
  * This can be set to anything, but default usage is:
  *
  *     development			Developer Mode - Shows for example PHP errors in frontend
- *     maintenance			Maintenance Mode - Only Admin's are allowed to login
  *     production			Production Mode - Regular Mode
  *
  * NOTE: If you change these, also change the error_reporting() code below
  */
-	#define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
-	if (isset($_ENV['CI_ENV'])) {
-		define('ENVIRONMENT', $_ENV['CI_ENV']);
-	} else if (file_exists('.debug')) {
-		define('ENVIRONMENT', 'development');
-	} else if (file_exists('.maintenance')) {
-		define('ENVIRONMENT', 'maintenance');
-	} else {
-		define('ENVIRONMENT', 'production');
-	}
+#define('ENVIRONMENT', isset($_SERVER['CI_ENV']) ? $_SERVER['CI_ENV'] : 'development');
+if (isset($_ENV['CI_ENV'])) {
+	define('ENVIRONMENT', $_ENV['CI_ENV']);
+} else if (file_exists('.debug')) {
+	define('ENVIRONMENT', 'development');
+} else {
+	define('ENVIRONMENT', 'production');
+}
+
+/*
+ *---------------------------------------------------------------
+ * MAINTENANCE MODE
+ *---------------------------------------------------------------
+ *
+ * Only Admin's are allowed to login while this is active.
+ */
+define('MAINTENANCE_MODE', file_exists(__DIR__.'/.maintenance'));
 
 /*
  *---------------------------------------------------------------
@@ -75,11 +81,6 @@
 switch (ENVIRONMENT)
 {
 	case 'development':
-		error_reporting(-1);
-		ini_set('display_errors', 1);
-		break;
-
-	case 'maintenance':
 		error_reporting(-1);
 		ini_set('display_errors', 1);
 		break;


### PR DESCRIPTION
the maintenance mode which was implemented in #173 should not be handled by the defined CI_ENV but with a dedicated constant. This way it will be possible to enable the maintenance mode in docker environments which is not possible at the moment. Behaviour itself did not change. Create `.maintenance` in webroot. 

