### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/application/locale/nl_NL/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 15:34+0000\n"
-"PO-Revision-Date: 2026-08-14 09:39+0000\n"
+"PO-Revision-Date: 2026-08-16 05:44+0000\n"
 "Last-Translator: Alexander <alexander@pa8s.nl>\n"
 "Language-Team: Dutch <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/nl/>\n"
@@ -1082,7 +1082,7 @@ msgstr "Bijwerken wedstrijd"
 #: application/controllers/Contest_admin.php:76
 #, php-format
 msgid "Contest %s updated"
-msgstr ""
+msgstr "Contest %s bijgewerkt"
 
 #: application/controllers/Contestcalendar.php:11
 #: application/views/interface_assets/header.php:320
@@ -2631,7 +2631,7 @@ msgstr "Modus bewerken"
 #: application/controllers/Mode.php:76
 #, php-format
 msgid "Mode %s updated"
-msgstr ""
+msgstr "Modus %s bijgewerkt"
 
 #: application/controllers/Notes.php:31
 #: application/views/interface_assets/header.php:154
@@ -3367,7 +3367,7 @@ msgstr "Bewerk stationslocatie: "
 #: application/controllers/Station.php:105
 #, php-format
 msgid "Station Location %s updated"
-msgstr ""
+msgstr "Stations locatie %s bijgewerkt"
 
 #: application/controllers/Station.php:124
 msgid "Duplicate Station Location:"
@@ -4251,15 +4251,15 @@ msgstr "Lees QSL-bevestigingen"
 
 #: application/libraries/api_v2/Contest_resource.php:55
 msgid "Read contest sessions"
-msgstr ""
+msgstr "Lees contest-sessies"
 
 #: application/libraries/api_v2/Contest_resource.php:56
 msgid "Create and update contest sessions"
-msgstr ""
+msgstr "Maak en update contest-sessies"
 
 #: application/libraries/api_v2/Contest_resource.php:57
 msgid "Delete contest sessions"
-msgstr ""
+msgstr "Contest-sessie verwijderen"
 
 #: application/libraries/api_v2/Lookup_resource.php:44
 msgid "Look up callsigns and grids"
@@ -5265,27 +5265,27 @@ msgstr "📻 Een activatie plannen vanuit %s"
 #: application/views/activationplanner/index.php:51
 #: application/views/activationplanner/index.php:87
 msgid "Search references…"
-msgstr ""
+msgstr "Referenties zoeken…"
 
 #: application/views/activationplanner/index.php:52
 msgid "No matches"
-msgstr ""
+msgstr "Geen overeenkomsten"
 
 #: application/views/activationplanner/index.php:53
 msgid "Loading…"
-msgstr ""
+msgstr "Bezig met laden…"
 
 #: application/views/activationplanner/index.php:54
 msgid "References"
-msgstr ""
+msgstr "Referenties"
 
 #: application/views/activationplanner/index.php:55
 msgid "Places"
-msgstr ""
+msgstr "Plaatsen"
 
 #: application/views/activationplanner/index.php:56
 msgid "Press Enter to search places"
-msgstr ""
+msgstr "Druk op Enter om naar plaatsen te zoeken"
 
 #: application/views/activationplanner/index.php:66
 msgid "Plan your activity here"
@@ -5343,6 +5343,8 @@ msgid ""
 "Search WWFF / POTA / SOTA / IOTA by name or reference — Enter searches place "
 "names (OpenStreetMap)"
 msgstr ""
+"Zoek WWFF / POTA / SOTA / IOTA op naam of referentie — Druk op Enter om "
+"plaatsnamen te zoeken (OpenStreetMap)"
 
 #: application/views/activationplanner/index.php:92
 #: application/views/simplefle/index.php:162
@@ -17808,10 +17810,11 @@ msgstr "Reden"
 #: application/views/logbookadvanced/showUpdateResult.php:79
 msgid "The number of QSOs updated for state/province across all DXCCs is"
 msgstr ""
+"Het aantal QSO's dat is bijgewerkt voor staat/provincie over alle DXCC's is"
 
 #: application/views/logbookadvanced/showUpdateResult.php:79
 msgid "DXCCs processed"
-msgstr ""
+msgstr "DXCC's verwerkt"
 
 #: application/views/logbookadvanced/showUpdateResult.php:131
 msgid "Results for continent update:"
@@ -17867,7 +17870,7 @@ msgstr ""
 
 #: application/views/logbookadvanced/statecheckresult.php:7
 msgid "Fix all DXCCs"
-msgstr ""
+msgstr "Repareer alle DXCC's"
 
 #: application/views/logbookadvanced/statecheckresult.php:34
 msgid "Run fix"

--- a/application/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/application/locale/zh_CN/LC_MESSAGES/messages.po
@@ -37,10 +37,10 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-14 15:34+0000\n"
-"PO-Revision-Date: 2026-08-12 09:36+0000\n"
-"Last-Translator: \"Shen RuiQin(BH4FJN)\" <jerry19980425@gmail.com>\n"
-"Language-Team: Chinese (Simplified Han script) <https://translate.wavelog."
-"org/projects/wavelog/main-translation/zh_Hans/>\n"
+"PO-Revision-Date: 2026-08-16 05:44+0000\n"
+"Last-Translator: MCyiqiehuanying <me@sharedow.cn>\n"
+"Language-Team: Chinese (Simplified Han script) <https://"
+"translate.wavelog.org/projects/wavelog/main-translation/zh_Hans/>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1101,7 +1101,7 @@ msgstr "更新比赛"
 #: application/controllers/Contest_admin.php:76
 #, php-format
 msgid "Contest %s updated"
-msgstr ""
+msgstr "比赛 %s 已更新"
 
 #: application/controllers/Contestcalendar.php:11
 #: application/views/interface_assets/header.php:320
@@ -2622,7 +2622,7 @@ msgstr "编辑模式"
 #: application/controllers/Mode.php:76
 #, php-format
 msgid "Mode %s updated"
-msgstr ""
+msgstr "模式 %s 已更新"
 
 #: application/controllers/Notes.php:31
 #: application/views/interface_assets/header.php:154
@@ -3066,12 +3066,12 @@ msgstr "QSO无法保存"
 #: application/controllers/Qso.php:834 application/controllers/Qso.php:857
 #, php-format
 msgid "Please check value for gridsquare (%s)"
-msgstr ""
+msgstr "请检查网格坐标的值 (%s)"
 
 #: application/controllers/Qso.php:846
 #, php-format
 msgid "Please check value for VUCC gridsquare (%s)"
-msgstr ""
+msgstr "请检查 VUCC 网格 的值 (%s)"
 
 #: application/controllers/Qso.php:875
 msgid "You have to be logged in to access this URL."
@@ -3338,7 +3338,7 @@ msgstr "修改台站地址： "
 #: application/controllers/Station.php:105
 #, php-format
 msgid "Station Location %s updated"
-msgstr ""
+msgstr "台站地址 %s 已保存"
 
 #: application/controllers/Station.php:124
 msgid "Duplicate Station Location:"
@@ -4194,15 +4194,15 @@ msgstr "读取QSL确认信息"
 
 #: application/libraries/api_v2/Contest_resource.php:55
 msgid "Read contest sessions"
-msgstr ""
+msgstr "读取比赛记录"
 
 #: application/libraries/api_v2/Contest_resource.php:56
 msgid "Create and update contest sessions"
-msgstr ""
+msgstr "创建并更新比赛记录"
 
 #: application/libraries/api_v2/Contest_resource.php:57
 msgid "Delete contest sessions"
-msgstr ""
+msgstr "删除比赛记录"
 
 #: application/libraries/api_v2/Lookup_resource.php:44
 msgid "Look up callsigns and grids"
@@ -5188,27 +5188,27 @@ msgstr "📻从%s开始规划"
 #: application/views/activationplanner/index.php:51
 #: application/views/activationplanner/index.php:87
 msgid "Search references…"
-msgstr ""
+msgstr "搜索编号…"
 
 #: application/views/activationplanner/index.php:52
 msgid "No matches"
-msgstr ""
+msgstr "无匹配条目"
 
 #: application/views/activationplanner/index.php:53
 msgid "Loading…"
-msgstr ""
+msgstr "加载中…"
 
 #: application/views/activationplanner/index.php:54
 msgid "References"
-msgstr ""
+msgstr "编号"
 
 #: application/views/activationplanner/index.php:55
 msgid "Places"
-msgstr ""
+msgstr "地点"
 
 #: application/views/activationplanner/index.php:56
 msgid "Press Enter to search places"
-msgstr ""
+msgstr "按下回车键搜索地点"
 
 #: application/views/activationplanner/index.php:66
 msgid "Plan your activity here"
@@ -5262,10 +5262,11 @@ msgid "Locate me"
 msgstr "我的位置"
 
 #: application/views/activationplanner/index.php:87
+#, fuzzy
 msgid ""
 "Search WWFF / POTA / SOTA / IOTA by name or reference — Enter searches place "
 "names (OpenStreetMap)"
-msgstr ""
+msgstr "通过名称或编号搜索 WWFF / POTA / SOTA / IOTA 地点 (OpenStreetMap)"
 
 #: application/views/activationplanner/index.php:92
 #: application/views/simplefle/index.php:162
@@ -12857,7 +12858,7 @@ msgstr "DXCC 分析"
 #: application/views/dashboard/index.php:488
 #: application/views/visitor/index.php:267
 msgid "Deleted DXCCs"
-msgstr ""
+msgstr "删除 DXCC"
 
 #: application/views/dashboard/index.php:498
 #: application/views/visitor/index.php:277
@@ -14498,6 +14499,8 @@ msgid ""
 "At least one of the locators is empty. Calculation not possible. Possibly "
 "missing locator in station location. Please check."
 msgstr ""
+"有至少一个的坐标为空值。无法进行计算。这可能是因为您未在台站地址中配置坐标信"
+"息。请检查。"
 
 #: application/views/interface_assets/footer.php:62
 #: application/views/user/index.php:20 application/views/user/index.php:144
@@ -17345,7 +17348,7 @@ msgstr "已找到以下 DXCC 的 QSO，但缺少州名和包含 6 个或更多�
 
 #: application/views/logbookadvanced/statecheckresult.php:7
 msgid "Fix all DXCCs"
-msgstr ""
+msgstr "修复所有 DXCC"
 
 #: application/views/logbookadvanced/statecheckresult.php:34
 msgid "Run fix"
@@ -19787,7 +19790,7 @@ msgstr "查看卫星飞行路径地图"
 #: application/views/satellite/pass.php:28
 msgid ""
 "Active station location does not have a gridsquare configured. Please check"
-msgstr ""
+msgstr "正激活的台站地址没有配置网格坐标，请检查"
 
 #: application/views/satellite/flightpath.php:57
 msgid ""
@@ -20558,7 +20561,7 @@ msgid ""
 "This is needed for all features based on current location, e.g. maps, "
 "distance statistics and more. Make sure to fill in the gridsquare if you "
 "want to use those features"
-msgstr ""
+msgstr "如需实现地图、距离计算等基于台站位置的功能，请确保你已完成配置网格坐标配置"
 
 #: application/views/station_profile/create.php:200
 #: application/views/station_profile/edit.php:222


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)