### PR TITLE
Catch at least length/type for api

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -1099,7 +1099,7 @@ class API extends CI_Controller {
 			die();
 		}
 
-		$invalid_fields = $this->validate_radio_payload($obj);
+		$invalid_fields = $this->cat->validate_radio_payload($obj);
 		if (!empty($invalid_fields)) {
 			http_response_code(400);
 			echo json_encode(['status' => 'failed', 'reason' => "invalid field(s): " . implode(', ', $invalid_fields)]);
@@ -1132,42 +1132,6 @@ class API extends CI_Controller {
 
 		echo json_encode($arr);
 
-	}
-
-	private function validate_radio_payload(&$obj) {
-		$invalid = [];
-
-		if (!isset($obj['radio']) || !is_string($obj['radio']) || trim($obj['radio']) == '' || strlen($obj['radio']) > 250) {
-			$invalid[] = 'radio';
-		}
-
-		$numeric_fields = ['frequency', 'frequency_rx', 'uplink_freq', 'downlink_freq', 'power'];
-		foreach ($numeric_fields as $field) {
-			if (isset($obj[$field]) && $obj[$field] !== null && $obj[$field] !== '' && $obj[$field] !== 'NULL') {
-				if (!is_numeric($obj[$field]) || (int) $obj[$field] != $obj[$field]) {
-					$invalid[] = $field;
-				} else {
-					$obj[$field] = (int) $obj[$field];
-				}
-			}
-		}
-
-		$string_limits = ['mode' => 10, 'mode_rx' => 10, 'uplink_mode' => 10, 'downlink_mode' => 10, 'prop_mode' => 10, 'sat_name' => 255];
-		foreach ($string_limits as $field => $limit) {
-			if (isset($obj[$field]) && $obj[$field] !== null && $obj[$field] !== '' && $obj[$field] !== 'NULL') {
-				if (!is_string($obj[$field]) || strlen($obj[$field]) > $limit) {
-					$invalid[] = $field;
-				}
-			}
-		}
-
-		if (isset($obj['cat_url']) && $obj['cat_url'] !== null && $obj['cat_url'] !== '' && $obj['cat_url'] !== 'NULL') {
-			if (!is_string($obj['cat_url']) || $this->sanitize_cat_url($obj['cat_url']) === false) {
-				$invalid[] = 'cat_url';
-			}
-		}
-
-		return $invalid;
 	}
 
 	/*

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -1071,6 +1071,11 @@ class API extends CI_Controller {
 
 		// Decode JSON and store
 		$obj = json_decode(file_get_contents("php://input"), true);
+		if (!is_array($obj)) {
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "wrong JSON"]);
+			die();
+		}
 
 		// Check rate limit
 		$identifier = isset($obj['key']) ? $obj['key'] : null;
@@ -1094,6 +1099,13 @@ class API extends CI_Controller {
 			die();
 		}
 
+		$invalid_fields = $this->validate_radio_payload($obj);
+		if (!empty($invalid_fields)) {
+			http_response_code(400);
+			echo json_encode(['status' => 'failed', 'reason' => "invalid field(s): " . implode(', ', $invalid_fields)]);
+			die();
+		}
+
 		$this->api_model->update_last_used($obj['key']);
 
 		$user_id = $this->api_model->key_userid($obj['key']);
@@ -1108,10 +1120,7 @@ class API extends CI_Controller {
 
 		// Handle optional cat_url
 		if (isset($obj['cat_url']) && !empty($obj['cat_url'])) {
-			$cat_url = $this->sanitize_cat_url($obj['cat_url']);
-			if ($cat_url !== false) {
-				$obj['cat_url'] = $cat_url;
-			}
+			$obj['cat_url'] = $this->sanitize_cat_url($obj['cat_url']);
 		}
 
 		// Store Result to Database
@@ -1123,6 +1132,42 @@ class API extends CI_Controller {
 
 		echo json_encode($arr);
 
+	}
+
+	private function validate_radio_payload(&$obj) {
+		$invalid = [];
+
+		if (!isset($obj['radio']) || !is_string($obj['radio']) || trim($obj['radio']) == '' || strlen($obj['radio']) > 250) {
+			$invalid[] = 'radio';
+		}
+
+		$numeric_fields = ['frequency', 'frequency_rx', 'uplink_freq', 'downlink_freq', 'power'];
+		foreach ($numeric_fields as $field) {
+			if (isset($obj[$field]) && $obj[$field] !== null && $obj[$field] !== '' && $obj[$field] !== 'NULL') {
+				if (!is_numeric($obj[$field]) || (int) $obj[$field] != $obj[$field]) {
+					$invalid[] = $field;
+				} else {
+					$obj[$field] = (int) $obj[$field];
+				}
+			}
+		}
+
+		$string_limits = ['mode' => 10, 'mode_rx' => 10, 'uplink_mode' => 10, 'downlink_mode' => 10, 'prop_mode' => 10, 'sat_name' => 255];
+		foreach ($string_limits as $field => $limit) {
+			if (isset($obj[$field]) && $obj[$field] !== null && $obj[$field] !== '' && $obj[$field] !== 'NULL') {
+				if (!is_string($obj[$field]) || strlen($obj[$field]) > $limit) {
+					$invalid[] = $field;
+				}
+			}
+		}
+
+		if (isset($obj['cat_url']) && $obj['cat_url'] !== null && $obj['cat_url'] !== '' && $obj['cat_url'] !== 'NULL') {
+			if (!is_string($obj['cat_url']) || $this->sanitize_cat_url($obj['cat_url']) === false) {
+				$invalid[] = 'cat_url';
+			}
+		}
+
+		return $invalid;
 	}
 
 	/*

--- a/application/libraries/api_v2/Radio_resource.php
+++ b/application/libraries/api_v2/Radio_resource.php
@@ -73,6 +73,13 @@ class Radio_resource extends Api_v2_resource {
 			throw new Api_v2_exception('validation_error', 'Missing required field(s): radio', 400, ['missing' => ['radio']]);
 		}
 
+		// Shared shape validation with the legacy v1 endpoint (Cat::update()
+		// column limits). Casts numeric fields to int in place.
+		$invalid = $this->CI->cat->validate_radio_payload($body);
+		if (!empty($invalid)) {
+			throw new Api_v2_exception('validation_error', 'Invalid field(s): ' . implode(', ', $invalid), 400, ['invalid' => $invalid]);
+		}
+
 		// Clubmode: a member token (owner != creator) logs under the creator as
 		// operator, mirroring Api::radio(). Otherwise operator == owner.
 		$operator = ($this->auth['user_id'] != $this->auth['created_by'])

--- a/application/models/Cat.php
+++ b/application/models/Cat.php
@@ -25,7 +25,53 @@
 			return self::MODE_OVERRIDES[strtoupper($mode)] ?? $mode;
 		}
 
-		function update($result, $user_id, $operator) {
+		/**
+	 * Validate a radio status payload (v1 Api::radio() and API v2 share this).
+	 *
+	 * Absent / null / '' / 'NULL' values are tolerated (legacy compatibility);
+	 * present values must match the cat table column shapes. Numeric fields
+	 * that pass are cast to int in place.
+	 *
+	 * @param array $result Decoded payload, modified by reference.
+	 * @return array List of invalid field names (empty = valid).
+	 */
+	function validate_radio_payload(&$result) {
+		$invalid = [];
+
+		if (!isset($result['radio']) || !is_string($result['radio']) || trim($result['radio']) == '' || strlen($result['radio']) > 250) {
+			$invalid[] = 'radio';
+		}
+
+		$numeric_fields = ['frequency', 'frequency_rx', 'uplink_freq', 'downlink_freq', 'power'];
+		foreach ($numeric_fields as $field) {
+			if (isset($result[$field]) && $result[$field] !== null && $result[$field] !== '' && $result[$field] !== 'NULL') {
+				if (!is_numeric($result[$field]) || (int) $result[$field] != $result[$field]) {
+					$invalid[] = $field;
+				} else {
+					$result[$field] = (int) $result[$field];
+				}
+			}
+		}
+
+		$string_limits = ['mode' => 10, 'mode_rx' => 10, 'uplink_mode' => 10, 'downlink_mode' => 10, 'prop_mode' => 10, 'sat_name' => 255];
+		foreach ($string_limits as $field => $limit) {
+			if (isset($result[$field]) && $result[$field] !== null && $result[$field] !== '' && $result[$field] !== 'NULL') {
+				if (!is_string($result[$field]) || strlen($result[$field]) > $limit) {
+					$invalid[] = $field;
+				}
+			}
+		}
+
+		if (isset($result['cat_url']) && $result['cat_url'] !== null && $result['cat_url'] !== '' && $result['cat_url'] !== 'NULL') {
+			if (!is_string($result['cat_url']) || !filter_var($result['cat_url'], FILTER_VALIDATE_URL) || !preg_match('/^https?:\/\//', $result['cat_url'])) {
+				$invalid[] = 'cat_url';
+			}
+		}
+
+		return $invalid;
+	}
+
+	function update($result, $user_id, $operator) {
 			$timestamp = gmdate("Y-m-d H:i:s");
 
 			if (isset($result['prop_mode'])) {


### PR DESCRIPTION
~~Legacy~~ API throws a 500 if a 3rd-party posts broken values, like: a trx mode longer than 10 characters, etc.
furthermore the api-url wasn't sanitized properly. this one fixes it.

testing:

curl against radio-api and play with values