### PR TITLE
[Upload image] Check image based on content

### DIFF
--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -84,12 +84,8 @@ class Qsl extends CI_Controller {
 
         $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
-        // Align the filename's extension with the file's real content: JPEGs
-        // named .png are common and fail the upload library's ext-vs-mime cross-check.
-        $real_ext = $this->upload_guard->real_image_ext($_FILES['qslcardfront']['tmp_name']);
-        if ($real_ext !== null) {
-            $_FILES['qslcardfront']['name'] = 'qslcard.' . $real_ext;
-        }
+        // Align the filename's extension with the file's real content (JPEGs named .png etc.)
+        $this->upload_guard->normalize_image_ext('qslcardfront');
         $array = explode(".", $_FILES['qslcardfront']['name']);
         $ext = end($array);
         $config['file_name'] = $qsoid . '_' . time() . '_' . bin2hex(random_bytes(8)) . '.' . $ext;
@@ -138,12 +134,8 @@ class Qsl extends CI_Controller {
 
         $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
-        // Align the filename's extension with the file's real content: JPEGs
-        // named .png are common and fail the upload library's ext-vs-mime cross-check.
-        $real_ext = $this->upload_guard->real_image_ext($_FILES['qslcardback']['tmp_name']);
-        if ($real_ext !== null) {
-            $_FILES['qslcardback']['name'] = 'qslcard.' . $real_ext;
-        }
+        // Align the filename's extension with the file's real content (JPEGs named .png etc.)
+        $this->upload_guard->normalize_image_ext('qslcardback');
         $array = explode(".", $_FILES['qslcardback']['name']);
         $ext = end($array);
         $config['file_name'] = $qsoid . '_' . time() . '_' . bin2hex(random_bytes(8)) . '.' . $ext;

--- a/application/controllers/Qsl.php
+++ b/application/controllers/Qsl.php
@@ -84,6 +84,12 @@ class Qsl extends CI_Controller {
 
         $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
+        // Align the filename's extension with the file's real content: JPEGs
+        // named .png are common and fail the upload library's ext-vs-mime cross-check.
+        $real_ext = $this->upload_guard->real_image_ext($_FILES['qslcardfront']['tmp_name']);
+        if ($real_ext !== null) {
+            $_FILES['qslcardfront']['name'] = 'qslcard.' . $real_ext;
+        }
         $array = explode(".", $_FILES['qslcardfront']['name']);
         $ext = end($array);
         $config['file_name'] = $qsoid . '_' . time() . '_' . bin2hex(random_bytes(8)) . '.' . $ext;
@@ -132,6 +138,12 @@ class Qsl extends CI_Controller {
 
         $config['upload_path']          = $this->paths->getUserdataPath('qsl_card', 'p');
         $config['allowed_types']        = 'jpg|gif|png|jpeg|JPG|PNG';
+        // Align the filename's extension with the file's real content: JPEGs
+        // named .png are common and fail the upload library's ext-vs-mime cross-check.
+        $real_ext = $this->upload_guard->real_image_ext($_FILES['qslcardback']['tmp_name']);
+        if ($real_ext !== null) {
+            $_FILES['qslcardback']['name'] = 'qslcard.' . $real_ext;
+        }
         $array = explode(".", $_FILES['qslcardback']['name']);
         $ext = end($array);
         $config['file_name'] = $qsoid . '_' . time() . '_' . bin2hex(random_bytes(8)) . '.' . $ext;

--- a/application/controllers/Qslpostcard.php
+++ b/application/controllers/Qslpostcard.php
@@ -53,12 +53,8 @@ class Qslpostcard extends CI_Controller {
 
         $this->load->library('upload_guard');
 
-        // Align the filename's extension with the file's real content: JPEGs
-        // named .png are common and fail the upload library's ext-vs-mime cross-check.
-        $real_ext = $this->upload_guard->real_image_ext($_FILES['preview_image']['tmp_name']);
-        if ($real_ext !== null) {
-            $_FILES['preview_image']['name'] = 'preview.' . $real_ext;
-        }
+        // Align the filename's extension with the file's real content (JPEGs named .png etc.)
+        $this->upload_guard->normalize_image_ext('preview_image');
 
         if (!$this->upload_guard->has_free_space($config['upload_path'], $_FILES['preview_image']['size'])) {
             $this->output

--- a/application/controllers/Qslpostcard.php
+++ b/application/controllers/Qslpostcard.php
@@ -53,6 +53,13 @@ class Qslpostcard extends CI_Controller {
 
         $this->load->library('upload_guard');
 
+        // Align the filename's extension with the file's real content: JPEGs
+        // named .png are common and fail the upload library's ext-vs-mime cross-check.
+        $real_ext = $this->upload_guard->real_image_ext($_FILES['preview_image']['tmp_name']);
+        if ($real_ext !== null) {
+            $_FILES['preview_image']['name'] = 'preview.' . $real_ext;
+        }
+
         if (!$this->upload_guard->has_free_space($config['upload_path'], $_FILES['preview_image']['size'])) {
             $this->output
                 ->set_content_type('application/json')

--- a/application/libraries/Upload_guard.php
+++ b/application/libraries/Upload_guard.php
@@ -42,4 +42,26 @@ class Upload_guard {
         }
         return in_array($info[2], array(IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_GIF), true);
     }
+
+    /**
+     * Returns the extension implied by the file's actual content ('jpg',
+     * 'png', 'gif'), or null if it is not a raster image we accept. Used to
+     * normalize client filenames whose extension doesn't match the real
+     * payload (e.g. a JPEG named .png), which the Upload library's
+     * ext-vs-mime cross-check would otherwise reject.
+     *
+     * @param string $tmp_name $_FILES[<field>]['tmp_name']
+     */
+    public function real_image_ext($tmp_name) {
+        $info = @getimagesize($tmp_name);
+        if ($info === false) {
+            return null;
+        }
+        switch ($info[2]) {
+            case IMAGETYPE_JPEG: return 'jpg';
+            case IMAGETYPE_PNG:  return 'png';
+            case IMAGETYPE_GIF:  return 'gif';
+            default:             return null;
+        }
+    }
 }

--- a/application/libraries/Upload_guard.php
+++ b/application/libraries/Upload_guard.php
@@ -64,4 +64,24 @@ class Upload_guard {
             default:             return null;
         }
     }
+
+    /**
+     * Aligns the extension of an uploaded image's client filename with the
+     * file's actual content (e.g. a JPEG named .png becomes *.jpg), in place
+     * in $_FILES. The Upload library's ext-vs-mime cross-check would
+     * otherwise reject such files, and the honest extension ensures the
+     * stored file is served with the correct Content-Type. Non-images are
+     * left untouched, so the existing rejection paths apply unchanged.
+     *
+     * @param string $field Key in the $_FILES array
+     */
+    public function normalize_image_ext($field) {
+        if (empty($_FILES[$field]['tmp_name'])) {
+            return;
+        }
+        $ext = $this->real_image_ext($_FILES[$field]['tmp_name']);
+        if ($ext !== null) {
+            $_FILES[$field]['name'] = 'image.' . $ext;
+        }
+    }
 }


### PR DESCRIPTION
## Fix QSL card upload failing for JPEGs named .png

### Problem

Valid QSL card images are rejected with *"The filetype you are attempting to upload is not allowed"* — typically a JPEG carrying a `.png` extension, which is very common with scanned cards, email attachments and card-printing services. Both formats are in `allowed_types`, so the error message misleads users: the type isn't forbidden, the file just fails a technicality.

### Cause

CodeIgniter's `is_allowed_filetype()` checks that the content agrees with the **extension of the client-supplied filename**: it sniffs the real MIME type (`image/jpeg`) and looks it up in the mimes map **for the declared extension** (`'png' => ['image/png', 'image/x-png']`) → mismatch → rejected. It never asks whether the content is one of the allowed types.

### Fix

New helper `Upload_guard::real_image_ext()` sniffs the upload's temp file (`getimagesize()`) and returns the extension the *content* implies. Before validation, the three upload paths (`uploadQslCardFront`, `uploadQslCardBack`, `Qslpostcard::upload_preview`) align the filename's extension with the real format — so the check passes and the card is stored under an honest extension, which also fixes the wrong-`Content-Type` serving that a JPEG stored as `.png` would cause.

### Why this is safe

Nothing is relaxed: a non-image renamed to `.png` is still rejected by the library's `finfo` check and the post-upload magic-byte check, and the on-disk filename remains server-generated in all three paths. Only which extension the server appends changes — now the truthful one. No changes to `system/` files or the global `config/mimes.php`.