### PR TITLE
Differentiate between HF/SAT and VHF+ QSOs

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -130,14 +130,7 @@ class Dashboard extends CI_Controller {
 		$stats = $this->logbook_model->dashboard_stats_batch($logbooks_locations_array);
 
 		// Country stats
-		$data['total_countries'] = $stats['Countries_Worked'];
-		$data['total_deleted_countries'] = $stats['Countries_Deleted_Worked'];
 		$data['unique_callsigns'] = $stats['Unique_Callsigns'];
-		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
-		$data['total_deleted_countries_confirmed_paper'] = $stats['Countries_Deleted_Worked_QSL'];
-		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];
-		$data['total_deleted_countries_confirmed_lotw'] = $stats['Countries_Deleted_Worked_LOTW'];
-		$confirmed = $stats['Countries_Worked_Confirmed'];
 
 		// QSL stats
 		$data['total_qsl_sent'] = $stats['QSL_Sent'];
@@ -218,7 +211,20 @@ class Dashboard extends CI_Controller {
 			$data['firstloginwizard'] = $this->load->view('user/modals/first_login_wizard', $viewdata, true);
 		}
 
-		$data['total_countries_needed'] = max(0, count($dxcc->result()) - $confirmed);
+		// DXCC breakdown sections: HF always, SAT/VHF+ only when such QSOs exist
+		$groups = $stats['DXCC_Groups'] ?? [];
+		$current_count = count($dxcc->result());
+		$zero_group = ['qsos' => 0, 'worked' => 0, 'deleted' => 0, 'qsl' => 0, 'deleted_qsl' => 0, 'lotw' => 0, 'deleted_lotw' => 0, 'confirmed' => 0];
+		$data['dxcc_sections'] = [];
+		foreach (['hf' => __("HF"), 'sat' => __("SAT"), 'vhf' => __("VHF+")] as $key => $label) {
+			$group = array_merge($zero_group, $groups[$key] ?? []);
+			if ($key != 'hf' && $group['qsos'] == 0) {
+				continue;
+			}
+			$group['label'] = $label;
+			$group['needed'] = max(0, $current_count - $group['confirmed']);
+			$data['dxcc_sections'][$key] = $group;
+		}
 
 		// Check user preferrence to show Solar Data on Dashboard and load data if yes
 		// Default to not show

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4399,6 +4399,39 @@ class Logbook_model extends CI_Model {
 
 			$query = $this->db->query($sql);
 
+			// HF / SAT / VHF+ DXCC split, based on propagation mode and frequency
+			$dxcc_groups = [];
+			$sql_groups = "SELECT
+				CASE WHEN t.COL_PROP_MODE = 'SAT' THEN 'sat'
+					WHEN COALESCE(t.COL_FREQ, 0) >= 50000000 THEN 'vhf'
+					ELSE 'hf' END as grp,
+				COUNT(*) as qsos,
+				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as worked,
+				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as deleted,
+				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as qsl,
+				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as deleted_qsl,
+				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as lotw,
+				COUNT(DISTINCT CASE WHEN t.COL_LOTW_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND d.end IS NOT NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as deleted_lotw,
+				COUNT(DISTINCT CASE WHEN (t.COL_QSL_RCVD = 'Y' OR t.COL_LOTW_QSL_RCVD = 'Y') AND t.COL_COUNTRY != 'Invalid' AND d.end IS NULL AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as confirmed
+				FROM " . $this->config->item('table_name') . " t
+				LEFT JOIN dxcc_entities d ON d.adif = t.col_dxcc
+				WHERE t.station_id IN (" . $location_list . ")
+				GROUP BY grp";
+
+			$query_groups = $this->db->query($sql_groups);
+			foreach ($query_groups->result() as $group_row) {
+				$dxcc_groups[$group_row->grp] = [
+					'qsos' => (int) $group_row->qsos,
+					'worked' => (int) $group_row->worked,
+					'deleted' => (int) $group_row->deleted,
+					'qsl' => (int) $group_row->qsl,
+					'deleted_qsl' => (int) $group_row->deleted_qsl,
+					'lotw' => (int) $group_row->lotw,
+					'deleted_lotw' => (int) $group_row->deleted_lotw,
+					'confirmed' => (int) $group_row->confirmed,
+				];
+			}
+
 			if ($query->num_rows() > 0) {
 				$row = $query->row();
 				return [
@@ -4412,6 +4445,8 @@ class Logbook_model extends CI_Model {
 					'Countries_Deleted_Worked_LOTW' => $row->Countries_Deleted_Worked_LOTW,
 					'Countries_Worked_Confirmed' => $row->Countries_Worked_Confirmed,
 					'Countries_Current' => $row->Countries_Current,
+					// HF / SAT / VHF+ split
+					'DXCC_Groups' => $dxcc_groups,
 					// QSL stats
 					'QSL_Sent' => $row->QSL_Sent,
 					'QSL_Received' => $row->QSL_Received,
@@ -4450,6 +4485,7 @@ class Logbook_model extends CI_Model {
 			'Countries_Deleted_Worked_LOTW' => 0,
 			'Countries_Worked_Confirmed' => 0,
 			'Countries_Current' => 0,
+			'DXCC_Groups' => [],
 			'QSL_Sent' => 0,
 			'QSL_Received' => 0,
 			'QSL_Requested' => 0,

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -485,21 +485,37 @@ function echo_table_header_col($name) {
 			</div>
 			<div class="card-body p-0">
 				<table class="table table-striped mb-0" aria-label="<?= __("DXCCs Breakdown"); ?>">
-					<tr>
-						<th scope="row" width="50%"><?= __("Worked"); ?></th>
-						<td width="50%"><?php echo $total_countries; ?> <?php echo (isset($total_deleted_countries) && $total_deleted_countries > 0) ? "<span title=\"". __("Deleted DXCCs") ."\" aria-label=\"i". __("Deleted DXCCs") .": ".$total_deleted_countries."\" data-bs-toggle=\"tooltip\">(".$total_deleted_countries.")</span>" : ''; ?></td>
-					</tr>
-					<tr>
-						<th scope="row" width="50%"><?= __("Confirmed"); ?></th>
-						<td width="50%">
-						<span title="<?= __("QSL Cards"); ?>" aria-label="<?= __("QSL Cards"); ?>: <?php echo $total_countries_confirmed_paper; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_paper; ?> <?php echo (isset($total_deleted_countries_confirmed_paper) && $total_deleted_countries_confirmed_paper > 0) ? "(".$total_deleted_countries_confirmed_paper.")" : ""; ?></span> /
-						<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $total_countries_confirmed_lotw; ?>" data-bs-toggle="tooltip"><?php echo $total_countries_confirmed_lotw; ?> <?php echo (isset($total_deleted_countries_confirmed_lotw) && $total_deleted_countries_confirmed_lotw > 0) ? "(".$total_deleted_countries_confirmed_lotw.")" : ""; ?></span>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row" width="50%"><?= __("Needed"); ?></th>
-						<td width="50%"><?php echo $total_countries_needed; ?></td>
-					</tr>
+					<thead>
+						<tr>
+							<th scope="col" width="25%"><span class="visually-hidden"><?= __("Status"); ?></span></th>
+							<?php foreach ($dxcc_sections as $section) { ?>
+							<th scope="col" width="25%"><?= $section['label']; ?></th>
+							<?php } ?>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<th scope="row"><?= __("Worked"); ?></th>
+							<?php foreach ($dxcc_sections as $section) { ?>
+							<td><?php echo $section['worked']; ?> <?php echo ($section['deleted'] > 0) ? "<span title=\"". __("Deleted DXCCs") ."\" aria-label=\"". __("Deleted DXCCs") .": ".$section['deleted']."\" data-bs-toggle=\"tooltip\">(".$section['deleted'].")</span>" : ''; ?></td>
+							<?php } ?>
+						</tr>
+						<tr>
+							<th scope="row"><?= __("Confirmed"); ?></th>
+							<?php foreach ($dxcc_sections as $section) { ?>
+							<td>
+								<span title="<?= __("QSL Cards"); ?>" aria-label="<?= __("QSL Cards"); ?>: <?php echo $section['qsl']; ?>" data-bs-toggle="tooltip"><?php echo $section['qsl']; ?> <?php echo ($section['deleted_qsl'] > 0) ? "(".$section['deleted_qsl'].")" : ""; ?></span> /
+								<span title="<?= __("LoTW"); ?>" aria-label="<?= __("LoTW"); ?>: <?php echo $section['lotw']; ?>" data-bs-toggle="tooltip"><?php echo $section['lotw']; ?> <?php echo ($section['deleted_lotw'] > 0) ? "(".$section['deleted_lotw'].")" : ""; ?></span>
+							</td>
+							<?php } ?>
+						</tr>
+						<tr>
+							<th scope="row"><?= __("Needed"); ?></th>
+							<?php foreach ($dxcc_sections as $section) { ?>
+							<td><?php echo $section['needed']; ?></td>
+							<?php } ?>
+						</tr>
+					</tbody>
 				</table>
 			</div>
 		</div>


### PR DESCRIPTION
DXCC-Award differentiates between HF, SAT and VHF+ QSOs,
so should we at Dashboard.

this PR adds SAT and VHF+ as extra-kpi's besided HF.

SAT and/or VHF+ are only shown if user has such QSOs.
