### PR TITLE
Imp- Export for labels from labeldesigner

### DIFF
--- a/application/controllers/Labeldesigner.php
+++ b/application/controllers/Labeldesigner.php
@@ -166,6 +166,84 @@ class Labeldesigner extends CI_Controller {
         }
     }
 
+    // Download a template as a versioned JSON file (geometry snapshot + layout)
+    public function export_template($id) {
+        $envelope = $this->Labeldesigner_model->export_envelope((int)$id);
+        if (!$envelope) {
+            show_404();
+            return;
+        }
+
+        // A template whose label type was deleted carries no geometry; the
+        // import side needs one, so refuse rather than ship a half envelope.
+        if (!is_array($envelope['label_type'] ?? null)) {
+            show_error(__("The label type of this template no longer exists. Please select another one before exporting."));
+            return;
+        }
+
+        $json = json_encode($envelope, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        session_write_close();
+
+        $name = preg_replace('/[^A-Za-z0-9_-]/', '_', $envelope['name'] ?? '');
+        if ($name === '') {
+            $name = 'tpl_' . (int)$id;
+        }
+
+        header('Content-Type: application/json; charset=utf-8');
+        header('Content-Disposition: attachment; filename="label_template_' . $name . '_' . date('Ymd-Hi') . '.json"');
+        if (!ini_get('zlib.output_compression')) {
+            header('Content-Length: ' . strlen($json));
+        }
+        echo $json;
+        exit;
+    }
+
+    // AJAX: POST a template JSON file (same caps as save_template)
+    public function import_template() {
+        $raw = $this->input->raw_input_stream;
+
+        if (strlen($raw) > 256 * 1024) {
+            return $this->_json_error('Payload too large', 413);
+        }
+
+        $payload = json_decode($raw, true);
+
+        if (!is_array($payload)
+            || ($payload['wavelog_label_template'] ?? 0) !== 1
+            || !is_array($payload['label_type'] ?? null)
+            || !is_array($payload['layout'] ?? null)
+        ) {
+            return $this->_json_error('Invalid payload');
+        }
+
+        $els = $payload['layout']['elements'] ?? null;
+        if ($els !== null && (!is_array($els) || count($els) > 200)) {
+            return $this->_json_error('Too many layout elements');
+        }
+
+        try {
+            $out = $this->Labeldesigner_model->import_template(
+                $payload['label_type'],
+                empty($payload['paper_type']) ? null : $payload['paper_type'],
+                $payload['layout'],
+                is_string($payload['name'] ?? null) ? $payload['name'] : ''
+            );
+        } catch (Throwable $e) {
+            log_message('error', 'LABELDESIGNER import failed: ' . $e->getMessage());
+            return $this->_json_error('Import failed', 500);
+        }
+
+        $this->output
+            ->set_content_type('application/json')
+            ->set_output(json_encode([
+                'ok'         => true,
+                'id'         => $out['template_id'],
+                'name'       => $out['name'],
+                'label_type' => $out['label_type'],
+            ]));
+    }
+
     private function _json_error($msg, $code = 400) {
         $this->output
             ->set_status_header($code)

--- a/application/models/Labeldesigner_model.php
+++ b/application/models/Labeldesigner_model.php
@@ -85,9 +85,225 @@ class Labeldesigner_model extends CI_Model {
     }
 
     function delete_template($id) {
-        $uid = $this->session->userdata('user_id');
-        $this->db->query("DELETE FROM label_templates WHERE id = ? AND user_id = ?", [$id, $uid]);
-        return true;
+	$uid = $this->session->userdata('user_id');
+	$this->db->query("DELETE FROM label_templates WHERE id = ? AND user_id = ?", [$id, $uid]);
+	return true;
+    }
+
+    // --- Import / export -----------------------------------------------
+    // The exchanged file is a versioned envelope: template name, a geometry
+    // snapshot of the label type (plus its paper type, if any) and the layout
+    // JSON. Row ids are user/install-specific, so only geometry travels.
+
+    public function export_envelope($id) {
+	$tpl = $this->get_template($id);
+	if (!$tpl) {
+	    return null;
+	}
+
+	$label = $this->get_label_with_paper($tpl['label_type_id']);
+
+	$label_type = null;
+	$paper_type = null;
+	if ($label) {
+	    $label_type = [
+		'label_name' => (string)$label->label_name,
+		'metric'     => (string)$label->metric,
+		'marginleft' => (float)$label->marginleft,
+		'margintop'  => (float)$label->margintop,
+		'nx'         => (float)$label->nx,
+		'ny'         => (float)$label->ny,
+		'spacex'     => (float)$label->spacex,
+		'spacey'     => (float)$label->spacey,
+		'width'      => (float)$label->width,
+		'height'     => (float)$label->height,
+		'font_size'  => (int)$label->font_size,
+		'qsos'       => (int)$label->qsos,
+	    ];
+
+	    if (!empty($label->paper_id)) {
+		$paper = $this->db->query(
+		    "SELECT paper_name, metric, width, height, orientation
+		     FROM paper_types WHERE paper_id = ? AND user_id = ?",
+		    [(int)$label->paper_id, $this->session->userdata('user_id')]
+		)->row_array();
+		if ($paper) {
+		    $paper_type = [
+			'paper_name'  => (string)$paper['paper_name'],
+			'metric'      => (string)$paper['metric'],
+			'width'       => (float)$paper['width'],
+			'height'      => (float)$paper['height'],
+			'orientation' => (string)$paper['orientation'],
+		    ];
+		}
+	    }
+	}
+
+	return [
+	    'wavelog_label_template' => 1,
+	    'name'       => (string)$tpl['name'],
+	    'label_type' => $label_type,
+	    'paper_type' => $paper_type,
+	    'layout'     => json_decode($tpl['layout_json'], true),
+	];
+    }
+
+    // $name arrives raw from the client; cleaned here so all sanitizing for
+    // the import path lives in one place.
+    public function import_template(array $label_type, $paper_type, array $layout, $name) {
+	$uid = $this->session->userdata('user_id');
+
+	$name = $this->_clean_name($name, 100);
+	if ($name === '') {
+	    $name = __('Imported');
+	}
+
+	$paper_id = is_array($paper_type)
+	    ? $this->_find_or_create_paper_type($paper_type, $uid)
+	    : 0;
+
+	$lt = $this->_find_or_create_label_type($label_type, $paper_id, $uid);
+
+	$tpl_id = $this->save_template(0, $name, $lt['id'], json_encode($layout, JSON_UNESCAPED_SLASHES));
+
+	return [
+	    'template_id' => $tpl_id,
+	    'name'        => $name,
+	    'label_type'  => $lt['meta'],
+	];
+    }
+
+    // paper_types identity is (user_id, paper_name) — there's a unique index.
+    // An import matching an existing name reuses that row, else a new one is
+    // created with the geometry from the file.
+    private function _find_or_create_paper_type(array $pt, $uid) {
+	$name = $this->_clean_name($pt['paper_name'] ?? '', 191);
+	if ($name === '') {
+	    $name = __('Imported paper');
+	}
+	$metric      = self::_metric_or_default($pt['metric'] ?? '');
+	$width       = $this->_clamp_num($pt['width'] ?? 210);
+	$height      = $this->_clamp_num($pt['height'] ?? 297);
+	$orientation = in_array($pt['orientation'] ?? '', ['P', 'L'], true) ? $pt['orientation'] : 'P';
+
+	$row = $this->db->query(
+	    "SELECT paper_id FROM paper_types WHERE user_id = ? AND paper_name = ?",
+	    [$uid, $name]
+	)->row_array();
+	if ($row) {
+	    return (int)$row['paper_id'];
+	}
+
+	$this->db->insert('paper_types', [
+	    'user_id'     => $uid,
+	    'paper_name'  => $name,
+	    'metric'      => $metric,
+	    'width'       => $width,
+	    'height'      => $height,
+	    'orientation' => $orientation,
+	    'last_modified' => date('Y-m-d H:i:s'),
+	]);
+	return (int)$this->db->insert_id();
+    }
+
+    // label_types has no unique key on name; its identity for import purposes
+    // is the geometry (incl. paper). A template whose geometry matches an
+    // existing type reuses that row — the name is cosmetic and stays as-is.
+    // On creation, a colliding name gets a " (n)" suffix like copy_template.
+    private function _find_or_create_label_type(array $lt, $paper_id, $uid) {
+	$metric = self::_metric_or_default($lt['metric'] ?? '');
+	$geo = [
+	    'marginleft' => $this->_clamp_num($lt['marginleft'] ?? 0),
+	    'margintop'  => $this->_clamp_num($lt['margintop'] ?? 0),
+	    'nx'         => $this->_clamp_num($lt['nx'] ?? 3, 1, 100),
+	    'ny'         => $this->_clamp_num($lt['ny'] ?? 8, 1, 100),
+	    'spacex'     => $this->_clamp_num($lt['spacex'] ?? 0),
+	    'spacey'     => $this->_clamp_num($lt['spacey'] ?? 0),
+	    'width'      => $this->_clamp_num($lt['width'] ?? 66.675),
+	    'height'     => $this->_clamp_num($lt['height'] ?? 25.4),
+	];
+	$font_size = (int)$this->_clamp_num($lt['font_size'] ?? 8, 1, 100);
+	$qsos      = (int)$this->_clamp_num($lt['qsos'] ?? 1, 1, 100);
+
+	$row = $this->db->query(
+	    "SELECT id, label_name FROM label_types
+	     WHERE user_id = ? AND metric = ? AND marginleft = ? AND margintop = ?
+	       AND nx = ? AND ny = ? AND spacex = ? AND spacey = ?
+	       AND width = ? AND height = ? AND paper_type_id = ?",
+	    [$uid, $metric, $geo['marginleft'], $geo['margintop'], $geo['nx'], $geo['ny'],
+	     $geo['spacex'], $geo['spacey'], $geo['width'], $geo['height'], $paper_id]
+	)->row_array();
+
+	$lt_name = null;
+	if ($row) {
+	    $id       = (int)$row['id'];
+	    $lt_name  = (string)$row['label_name'];
+	} else {
+	    $base = $this->_clean_name($lt['label_name'] ?? '', 250);
+	    if ($base === '') {
+		$base = __('Imported label type');
+	    }
+	    $lt_name = $base;
+	    $i = 0;
+	    while ($this->db->query(
+		"SELECT 1 FROM label_types WHERE user_id = ? AND label_name = ?",
+		[$uid, $lt_name]
+	    )->row_array()) {
+		$i++;
+		$lt_name = mb_substr($base, 0, 250 - strlen(" ($i)")) . " ($i)";
+	    }
+
+	    $this->db->insert('label_types', [
+		'user_id'     => $uid,
+		'label_name'  => $lt_name,
+		'metric'      => $metric,
+		'marginleft'  => $geo['marginleft'],
+		'margintop'   => $geo['margintop'],
+		'nx'          => $geo['nx'],
+		'ny'          => $geo['ny'],
+		'spacex'      => $geo['spacex'],
+		'spacey'      => $geo['spacey'],
+		'width'       => $geo['width'],
+		'height'      => $geo['height'],
+		'font_size'   => $font_size,
+		'qsos'        => $qsos,
+		'paper_type_id' => $paper_id,
+		'last_modified' => date('Y-m-d H:i:s'),
+	    ]);
+	    $id = (int)$this->db->insert_id();
+	}
+
+	// Meta for the frontend dropdown/canvas (same shape as LABEL_TYPES in
+	// the designer view).
+	$w_in = ($metric == 'in') ? $geo['width'] : $geo['width'] / 25.4;
+	$h_in = ($metric == 'in') ? $geo['height'] : $geo['height'] / 25.4;
+	$meta = [
+	    'id'        => $id,
+	    'w_in'      => round($w_in, 4),
+	    'h_in'      => round($h_in, 4),
+	    'nx'        => (int)$geo['nx'],
+	    'ny'        => (int)$geo['ny'],
+	    'name'      => $lt_name,
+	    'has_paper' => $paper_id > 0,
+	];
+
+	return ['id' => $id, 'meta' => $meta];
+    }
+
+    private static function _metric_or_default($m) {
+	return in_array($m, ['mm', 'in'], true) ? $m : 'mm';
+    }
+
+    // decimal(6,3) columns — clamp into range and round to column precision
+    // (a value like 66.6751 would be stored as 66.675 and never match the
+    // find-or-create geometry SELECT again).
+    private function _clamp_num($v, $min = 0, $max = 999.999) {
+	return round(max($min, min($max, (float)$v)), 3);
+    }
+
+    private function _clean_name($s, $max) {
+	$s = preg_replace('/[\x00-\x1F\x7F]/u', '', strip_tags((string)$s));
+	return mb_substr(trim($s), 0, $max);
     }
 
     // Fetch a label type together with its paper type geometry (aliases

--- a/application/views/labeldesigner/designer.php
+++ b/application/views/labeldesigner/designer.php
@@ -106,10 +106,10 @@ foreach (($labels ?? []) as $l) {
 						<button id="btnDelete" class="btn btn-sm btn-outline-danger text-nowrap" title="<?= __("Delete Template"); ?>">
 							<i class="fas fa-trash"></i>
 						</button>
-						<button id="btnExport" class="btn btn-sm btn-outline-secondary text-nowrap" title="<?= __("Export Template"); ?>">
+						<button id="btnExport" class="btn btn-sm btn-outline-primary text-nowrap" title="<?= __("Export Template"); ?>">
 							<i class="fas fa-file-export"></i>
 						</button>
-						<button id="btnImport" class="btn btn-sm btn-outline-secondary text-nowrap" title="<?= __("Import Template"); ?>">
+						<button id="btnImport" class="btn btn-sm btn-outline-primary text-nowrap" title="<?= __("Import Template"); ?>">
 							<i class="fas fa-file-import"></i>
 						</button>
 						<input type="file" id="importFile" accept=".json,application/json" hidden>

--- a/application/views/labeldesigner/designer.php
+++ b/application/views/labeldesigner/designer.php
@@ -67,6 +67,12 @@ foreach (($labels ?? []) as $l) {
 		discardChanges: <?= json_encode(__("Discard changes")); ?>,
 		keepEditing: <?= json_encode(__("Keep editing")); ?>,
 		leavePage: <?= json_encode(__("Leave page")); ?>,
+		importFailed: <?= json_encode(__("Import failed")); ?>,
+		exportFailed: <?= json_encode(__("Export failed")); ?>,
+		importSuccess: <?= json_encode(__("Template imported.")); ?>,
+		selectTemplateToExport: <?= json_encode(__("Please select a template to export.")); ?>,
+		fileTooLarge: <?= json_encode(__("File is too large.")); ?>,
+		noPaperAssigned: <?= json_encode(__("No paper assigned")); ?>,
 	};
 
 	// Label type geometry: id → {w_in, h_in, nx, ny, name, has_paper}
@@ -100,6 +106,13 @@ foreach (($labels ?? []) as $l) {
 						<button id="btnDelete" class="btn btn-sm btn-outline-danger text-nowrap" title="<?= __("Delete Template"); ?>">
 							<i class="fas fa-trash"></i>
 						</button>
+						<button id="btnExport" class="btn btn-sm btn-outline-secondary text-nowrap" title="<?= __("Export Template"); ?>">
+							<i class="fas fa-file-export"></i>
+						</button>
+						<button id="btnImport" class="btn btn-sm btn-outline-secondary text-nowrap" title="<?= __("Import Template"); ?>">
+							<i class="fas fa-file-import"></i>
+						</button>
+						<input type="file" id="importFile" accept=".json,application/json" hidden>
 					</div>
 				</div>
 

--- a/assets/js/sections/labels_designer.js
+++ b/assets/js/sections/labels_designer.js
@@ -1659,6 +1659,83 @@
 		showToast(LANG.success, LANG.copySuccess, 'bg-success text-white', 4000);
 	});
 
+	document.getElementById('btnExport').addEventListener('click', async () => {
+		const id = parseInt(tplSelect.value || '0', 10);
+		if (!id) { showToast(LANG.error, LANG.selectTemplateToExport, 'bg-danger text-white', 5000); return; }
+
+		// Fetch as a blob so server-side errors surface as a toast instead of
+		// navigating the browser to an error page.
+		const r = await fetch(base_url + 'index.php/labeldesigner/export_template/' + id);
+		if (!r.ok) { showToast(LANG.error, LANG.exportFailed, 'bg-danger text-white', 5000); return; }
+
+		const blob = await r.blob();
+		const cd = r.headers.get('Content-Disposition') || '';
+		const m = cd.match(/filename="([^"]+)"/);
+		const a = Object.assign(document.createElement('a'), {
+			href: URL.createObjectURL(blob),
+			download: m ? m[1] : 'label_template.json',
+		});
+		a.click();
+		// Safari starts the download asynchronously — revoking immediately can abort it.
+		setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+	});
+
+	document.getElementById('btnImport').addEventListener('click', () => {
+		document.getElementById('importFile').click();
+	});
+
+	document.getElementById('importFile').addEventListener('change', async () => {
+		const input = document.getElementById('importFile');
+		const f = input.files && input.files[0];
+		input.value = ''; // allow re-selecting the same file later
+		if (!f) return;
+
+		if (f.size > 256 * 1024) {
+			showToast(LANG.error, LANG.fileTooLarge, 'bg-danger text-white', 5000);
+			return;
+		}
+
+		let out;
+		try {
+			const r = await fetch(base_url + 'index.php/labeldesigner/import_template', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: await f.text(),
+			});
+			out = await r.json();
+		} catch (_) {
+			showToast(LANG.error, LANG.importFailed, 'bg-danger text-white', 5000);
+			return;
+		}
+		if (!out.ok) { showToast(LANG.error, out.error || LANG.importFailed, 'bg-danger text-white', 5000); return; }
+
+		// Register the (possibly new) label type so loadTemplate() can select it.
+		const lt = out.label_type;
+		if (lt && !labelTypeSelect.querySelector('option[value="' + String(lt.id) + '"]')) {
+			const o = document.createElement('option');
+			o.value = lt.id;
+			o.textContent = lt.name + (lt.has_paper ? '' : ' — ' + LANG.noPaperAssigned);
+			labelTypeSelect.appendChild(o);
+			LABEL_TYPES[lt.id] = {
+				w_in: lt.w_in, h_in: lt.h_in, nx: lt.nx, ny: lt.ny,
+				name: lt.name, has_paper: lt.has_paper,
+			};
+		}
+
+		const opt = document.createElement('option');
+		opt.value = out.id;
+		opt.textContent = out.name || LANG.untitled;
+		tplSelect.appendChild(opt);
+
+		// Same behaviour as Copy: switch to the imported template unless the
+		// canvas holds unsaved work.
+		if (!hasUnsavedChanges()) {
+			tplSelect.value = out.id;
+			await applyTemplateSelection(out.id);
+		}
+		showToast(LANG.success, LANG.importSuccess, 'bg-success text-white', 4000);
+	});
+
 	// ===================================================================
 	//  Init
 	// ===================================================================


### PR DESCRIPTION
This one adds (hopefully bulletproof) export and import for custom created labels from the label-designer to share designs.

Export contains:
- paperdefinition
- labeldefinition
- Design

Import checks:
- if valid file
- if a similar paperdefinition already exists (takes them / otherwise creates)
- various checks
