### PR TITLE
Trim QRZ-Key always. no matter what...

### DIFF
--- a/application/models/Stationsetup_model.php
+++ b/application/models/Stationsetup_model.php
@@ -300,7 +300,7 @@ class Stationsetup_model extends CI_Model {
 				'station_pota'          => ((isset($loc['station_pota']) && $loc['station_pota'] != "") ? xss_clean($loc['station_pota']) : null),
 				'state'                 => ((isset($loc['state']) && $loc['state'] != "") ? xss_clean($loc['state']) : null),
 				'station_cnty'          => ((isset($loc['station_cnty']) && $loc['station_cnty'] != "") ? xss_clean($loc['station_cnty']) : null),
-				'qrzapikey'             => ((isset($loc['qrzapikey']) && $loc['qrzapikey'] != "") ? xss_clean($loc['qrzapikey']) : null),
+				'qrzapikey'             => ((isset($loc['qrzapikey']) && $loc['qrzapikey'] != "") ? trim(xss_clean($loc['qrzapikey'])) : null),
 				'qrzrealtime'           => ((isset($loc['qrzrealtime']) && $loc['qrzrealtime'] != "") ? xss_clean($loc['qrzrealtime']) : 0),
 				'oqrs'                  => ((isset($loc['oqrs']) && $loc['oqrs'] != "") ? xss_clean($loc['oqrs']) : 0),
 				'oqrs_text'             => ((isset($loc['oqrs_text']) && $loc['oqrs_text'] != "") ? xss_clean($loc['oqrs_text']) : null),

--- a/application/views/station_profile/create.php
+++ b/application/views/station_profile/create.php
@@ -299,7 +299,7 @@ if ($dxcc_list->result() > 0) {
 					<div class="mb-3">
 						<label for="qrzApiKey">QRZ.com Logbook API Key</label>
 						<div class="input-group">
-							<input type="text" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(isset($qrzapikey)) { echo htmlspecialchars((string)$qrzapikey); } ?>">
+							<input type="text" class="form-control" name="qrzapikey" pattern="^\s*([A-F0-9]{4}-){3}[A-F0-9]{4}\s*$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(isset($qrzapikey)) { echo htmlspecialchars((string)$qrzapikey); } ?>">
 							<button class="btn btn-secondary" type="button" id="qrz_apitest_btn"><?= __("Test API-Key"); ?></button>
 						</div>
 						<div class="alert mt-3" style="display: none;" id="qrz_apitest_msg"></div>

--- a/application/views/station_profile/edit.php
+++ b/application/views/station_profile/edit.php
@@ -321,7 +321,7 @@ if ($dxcc_list->result() > 0) {
 					<div class="mb-3">
 						<label for="qrzApiKey">QRZ.com Logbook API Key</label> <!-- This does not need Multilanguage Support -->
 						<div class="input-group">
-							<input type="password" class="form-control" name="qrzapikey" pattern="^([A-F0-9]{4}-){3}[A-F0-9]{4}$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(set_value('qrzapikey') != "") { echo set_value('qrzapikey'); } else { echo $my_station_profile->qrzapikey; } ?>">
+							<input type="password" class="form-control" name="qrzapikey" pattern="^\s*([A-F0-9]{4}-){3}[A-F0-9]{4}\s*$" id="qrzApiKey" aria-describedby="qrzApiKeyHelp" value="<?php if(set_value('qrzapikey') != "") { echo set_value('qrzapikey'); } else { echo $my_station_profile->qrzapikey; } ?>">
 							<span class="input-group-btn"><button class="btn btn-default btn-pwd-showhide" type="button"><i class="fa fa-eye-slash"></i></button></span>
 							<button class="btn btn-secondary" type="button" id="qrz_apitest_btn">Test API-Key</button>
 						</div>


### PR DESCRIPTION
QRZ shows key with leading and trailing whitespace (even when copied).
This one trims the key (more than before)