### PR TITLE
Fix Error at WAP when entries are logged with different case

### DIFF
--- a/application/models/Wap.php
+++ b/application/models/Wap.php
@@ -195,7 +195,7 @@ class wap extends CI_Model {
 	 */
 	function getwapWorked($location_list, $band, $postdata) {
 		$bindings=[];
-		$sql = "SELECT distinct col_state FROM " . $this->config->item('table_name') . " thcv
+		$sql = "SELECT distinct UPPER(col_state) as col_state FROM " . $this->config->item('table_name') . " thcv
 			where station_id in (" . $location_list . ")";
 
 		if ($postdata['mode'] != 'All') {
@@ -237,7 +237,7 @@ class wap extends CI_Model {
 	 */
 	function getwapConfirmed($location_list, $band, $postdata) {
 		$bindings=[];
-		$sql = "SELECT distinct col_state FROM " . $this->config->item('table_name') . " thcv
+		$sql = "SELECT distinct UPPER(col_state) as col_state FROM " . $this->config->item('table_name') . " thcv
 			where station_id in (" . $location_list . ")";
 
 		if ($postdata['mode'] != 'All') {
@@ -249,7 +249,6 @@ class wap extends CI_Model {
 		$sql .= $this->addStateToQuery();
 
 		$sql .= $this->genfunctions->addBandToQuery($band,$bindings);
-
 		$sql .= $this->genfunctions->addQslToQuery($postdata);
 
 		$query = $this->db->query($sql,$bindings);

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -203,7 +203,7 @@
                     <?php if($row->COL_STATE != null) { ?>
                     <tr>
                         <th scope="row"><?php echo $primary_subdivision ?>:</th>
-                        <td><?php if ($row->subdivision != '') { echo $row->subdivision.' ('.$row->COL_STATE.')'; } else { echo html_escape($row->COL_STATE); } ?></td>
+                        <td><?php if ($row->subdivision != '') { echo $row->subdivision.' ('.strtoupper($row->COL_STATE).')'; } else { echo html_escape(strtoupper($row->COL_STATE)); } ?></td>
                     </tr>
                     <?php } ?>
 


### PR DESCRIPTION
Small bug in WAP-Award.
it fails with errors/warnings if one logs the province in lowercase or mixed-case.

this PR mitigates it.

Error/Warning shown (example)

```
--> Severity: Warning --> Undefined array key "nb" /var/www/html/application/models/Wap.php 43
--> Severity: Warning --> Undefined array key "count" /var/www/html/application/models/Wap.php 43
--> Severity: Warning --> Undefined array key "Ut" /var/www/html/application/models/Wap.php 43
--> Severity: Warning --> Undefined array key "count" /var/www/html/application/models/Wap.php 43
```