### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/it_IT/LC_MESSAGES/messages.po
+++ b/application/locale/it_IT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-23 16:43+0000\n"
-"PO-Revision-Date: 2026-08-22 10:16+0000\n"
+"PO-Revision-Date: 2026-08-24 22:42+0000\n"
 "Last-Translator: iv3cvn <ricentis@gmail.com>\n"
 "Language-Team: Italian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/it/>\n"
@@ -1533,7 +1533,7 @@ msgstr "Bacheca"
 
 #: application/controllers/Dashboard.php:219
 msgid "HF"
-msgstr ""
+msgstr "HF"
 
 #: application/controllers/Dashboard.php:219
 #: application/views/dashboard/index.php:684
@@ -1549,7 +1549,7 @@ msgstr "SAT"
 
 #: application/controllers/Dashboard.php:219
 msgid "VHF+"
-msgstr ""
+msgstr "VHF+"
 
 #: application/controllers/Dayswithqso.php:16
 #: application/views/dayswithqso/index.php:2
@@ -1902,7 +1902,7 @@ msgstr "Esporta KML"
 #: application/controllers/Labeldesigner.php:22
 #: application/views/labels/index.php:36
 msgid "Label Designer"
-msgstr ""
+msgstr "Designer di etichette"
 
 #: application/controllers/Labeldesigner.php:114
 #: application/controllers/Labels.php:213
@@ -16948,7 +16948,7 @@ msgstr "Opzioni del modello"
 
 #: application/views/labeldesigner/designer.php:258
 msgid "Number of QSOs per label"
-msgstr ""
+msgstr "Numero di QSO per etichetta"
 
 #: application/views/labeldesigner/designer.php:262
 #: application/views/qslpostcard/designer.php:213
@@ -17011,11 +17011,11 @@ msgstr "Y"
 
 #: application/views/labeldesigner/designer.php:326
 msgid "Rows"
-msgstr ""
+msgstr "Righe"
 
 #: application/views/labeldesigner/designer.php:330
 msgid "Columns"
-msgstr ""
+msgstr "Colonne"
 
 #: application/views/labeldesigner/designer.php:336
 #: application/views/labels/index.php:45 application/views/labels/index.php:80
@@ -17039,11 +17039,11 @@ msgstr "Orientamento"
 
 #: application/views/labeldesigner/designer.php:351
 msgid "Horizontal"
-msgstr ""
+msgstr "Orizzontale"
 
 #: application/views/labeldesigner/designer.php:352
 msgid "Vertical"
-msgstr ""
+msgstr "Verticale"
 
 #: application/views/labeldesigner/designer.php:356
 msgid "Length"
@@ -17392,7 +17392,7 @@ msgstr ""
 #: application/views/logbookadvanced/startatform.php:23
 #: application/views/qslprint/printlabel.php:23
 msgid "Standard"
-msgstr ""
+msgstr "Standard"
 
 #: application/views/labels/startatform.php:30
 #: application/views/logbookadvanced/startatform.php:29

--- a/application/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/application/locale/nl_NL/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-23 16:43+0000\n"
-"PO-Revision-Date: 2026-08-22 10:16+0000\n"
+"PO-Revision-Date: 2026-08-24 22:42+0000\n"
 "Last-Translator: Alexander <alexander@pa8s.nl>\n"
 "Language-Team: Dutch <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/nl/>\n"
@@ -1531,7 +1531,7 @@ msgstr "Dashboard"
 
 #: application/controllers/Dashboard.php:219
 msgid "HF"
-msgstr ""
+msgstr "HF"
 
 #: application/controllers/Dashboard.php:219
 #: application/views/dashboard/index.php:684
@@ -1547,7 +1547,7 @@ msgstr "SAT"
 
 #: application/controllers/Dashboard.php:219
 msgid "VHF+"
-msgstr ""
+msgstr "VHF+"
 
 #: application/controllers/Dayswithqso.php:16
 #: application/views/dayswithqso/index.php:2
@@ -1898,7 +1898,7 @@ msgstr "KML-export"
 #: application/controllers/Labeldesigner.php:22
 #: application/views/labels/index.php:36
 msgid "Label Designer"
-msgstr ""
+msgstr "Labelontwerper"
 
 #: application/controllers/Labeldesigner.php:114
 #: application/controllers/Labels.php:213
@@ -1918,11 +1918,11 @@ msgstr "Sjabloon JSON is ongeldig"
 
 #: application/controllers/Labeldesigner.php:125
 msgid "Template has no elements"
-msgstr ""
+msgstr "Sjabloon heeft geen elementen"
 
 #: application/controllers/Labeldesigner.php:131
 msgid "Label type not found"
-msgstr ""
+msgstr "Labeltype niet gevonden"
 
 #: application/controllers/Labeldesigner.php:136
 #: application/controllers/Labels.php:225
@@ -1943,13 +1943,15 @@ msgstr "PDF-bestand werd niet aangemaakt"
 
 #: application/controllers/Labeldesigner.php:165
 msgid "Label PDF failed: "
-msgstr ""
+msgstr "Label PDF mislukt: "
 
 #: application/controllers/Labeldesigner.php:180
 msgid ""
 "The label type of this template no longer exists. Please select another one "
 "before exporting."
 msgstr ""
+"Het labeltype van deze sjabloon bestaat niet meer. Selecteer een ander "
+"voordat u exporteert."
 
 #: application/controllers/Labels.php:39 application/views/labels/index.php:31
 msgid "QSL Card Labels"
@@ -4663,15 +4665,15 @@ msgstr "Verwijderd"
 
 #: application/models/Labeldesigner_model.php:158
 msgid "Imported"
-msgstr ""
+msgstr "Geïmporteerd"
 
 #: application/models/Labeldesigner_model.php:182
 msgid "Imported paper"
-msgstr ""
+msgstr "Geïmporteerd papier"
 
 #: application/models/Labeldesigner_model.php:244
 msgid "Imported label type"
-msgstr ""
+msgstr "Geïmporteerd labeltype"
 
 #: application/models/Logbook_model.php:357
 msgid "Station not accessible"
@@ -7261,7 +7263,7 @@ msgstr "County"
 #: application/views/awards/counties/details_ajax.php:14
 #: application/views/awards/counties/state_ajax.php:26
 msgid "Not in USA-CA county list"
-msgstr ""
+msgstr "Niet in de USA-CA county lijst"
 
 #: application/views/awards/counties/index.php:9
 msgid "Hover over a county"
@@ -16230,11 +16232,11 @@ msgstr "Bevestigde counties voor staat:"
 
 #: application/views/interface_assets/footer.php:2900
 msgid "Counties in state:"
-msgstr ""
+msgstr "Counties in staat:"
 
 #: application/views/interface_assets/footer.php:2901
 msgid "Needed counties for state:"
-msgstr ""
+msgstr "Benodigde counties voor de staat:"
 
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
@@ -16594,7 +16596,7 @@ msgstr "Eigen tekst"
 
 #: application/views/labeldesigner/designer.php:46
 msgid "Line"
-msgstr ""
+msgstr "Lijn"
 
 #: application/views/labeldesigner/designer.php:48
 #: application/views/qslpostcard/designer.php:35
@@ -16661,12 +16663,14 @@ msgstr "geselecteerd"
 
 #: application/views/labeldesigner/designer.php:62
 msgid "Please select a label type first."
-msgstr ""
+msgstr "Selecteer eerst een labeltype."
 
 #: application/views/labeldesigner/designer.php:63
 msgid ""
 "The label type of this template no longer exists. Please select another one."
 msgstr ""
+"Het labeltype van deze sjabloon bestaat niet meer. Selecteer alstublieft een "
+"andere."
 
 #: application/views/labeldesigner/designer.php:64
 #: application/views/qslpostcard/designer.php:49
@@ -16708,23 +16712,23 @@ msgstr "Pagina verlaten"
 
 #: application/views/labeldesigner/designer.php:70
 msgid "Import failed"
-msgstr ""
+msgstr "Importeren mislukt"
 
 #: application/views/labeldesigner/designer.php:71
 msgid "Export failed"
-msgstr ""
+msgstr "Exporteren mislukt"
 
 #: application/views/labeldesigner/designer.php:72
 msgid "Template imported."
-msgstr ""
+msgstr "Sjabloon geïmporteerd."
 
 #: application/views/labeldesigner/designer.php:73
 msgid "Please select a template to export."
-msgstr ""
+msgstr "Selecteer een sjabloon om te exporteren."
 
 #: application/views/labeldesigner/designer.php:74
 msgid "File is too large."
-msgstr ""
+msgstr "Bestand is te groot."
 
 #: application/views/labeldesigner/designer.php:75
 #: application/views/labeldesigner/designer.php:126
@@ -16768,23 +16772,23 @@ msgstr "Sjabloon verwijderen"
 
 #: application/views/labeldesigner/designer.php:109
 msgid "Export Template"
-msgstr ""
+msgstr "Exporteer sjabloon"
 
 #: application/views/labeldesigner/designer.php:112
 msgid "Import Template"
-msgstr ""
+msgstr "Importeer sjabloon"
 
 #: application/views/labeldesigner/designer.php:121
 msgid "Label type"
-msgstr ""
+msgstr "Labeltype"
 
 #: application/views/labeldesigner/designer.php:124
 msgid "(select label type)"
-msgstr ""
+msgstr "(selecteer labeltype)"
 
 #: application/views/labeldesigner/designer.php:130
 msgid "Generate sample PDF with your latest QSOs"
-msgstr ""
+msgstr "Genereer een voorbeeld-PDF met je laatste QSO's"
 
 #: application/views/labeldesigner/designer.php:131
 #: application/views/qslpostcard/designer.php:95
@@ -16849,28 +16853,32 @@ msgid ""
 "Horizontal rule — enable 'Repeats per QSO' to draw a separator under every "
 "QSO row"
 msgstr ""
+"Horizontale lijn — schakel 'Herhalingen per QSO' in om een scheidingslijn "
+"onder elke QSO-rij te tekenen"
 
 #: application/views/labeldesigner/designer.php:201
 msgid "Horizontal Line"
-msgstr ""
+msgstr "Horizontale lijn"
 
 #: application/views/labeldesigner/designer.php:203
 msgid "Vertical rule — place at column edges to build a table grid"
-msgstr ""
+msgstr "Verticale lijn — plaats aan de kolomranden om een tabelraster te maken"
 
 #: application/views/labeldesigner/designer.php:204
 msgid "Vertical Line"
-msgstr ""
+msgstr "Verticale lijn"
 
 #: application/views/labeldesigner/designer.php:208
 msgid ""
 "Table grid — drag the corner to resize, drag the column markers to adjust "
 "column widths"
 msgstr ""
+"Tabelraster — sleep de hoek om te schalen, sleep de kolommarkeringen om de "
+"kolombreedtes aan te passen"
 
 #: application/views/labeldesigner/designer.php:209
 msgid "Add Table"
-msgstr ""
+msgstr "Tabel toevoegen"
 
 #: application/views/labeldesigner/designer.php:224
 #: application/views/qslpostcard/designer.php:175
@@ -16879,11 +16887,11 @@ msgstr "Geen van de velden komen overeen met je zoekopdracht."
 
 #: application/views/labeldesigner/designer.php:232
 msgid "Label Canvas"
-msgstr ""
+msgstr "Label Canvas"
 
 #: application/views/labeldesigner/designer.php:233
 msgid "drag fields onto the label"
-msgstr ""
+msgstr "sleep velden op het etiket"
 
 #: application/views/labeldesigner/designer.php:254
 #: application/views/qslpostcard/designer.php:205
@@ -16892,7 +16900,7 @@ msgstr "Sjabloonopties"
 
 #: application/views/labeldesigner/designer.php:258
 msgid "Number of QSOs per label"
-msgstr ""
+msgstr "Aantal QSO's per label"
 
 #: application/views/labeldesigner/designer.php:262
 #: application/views/qslpostcard/designer.php:213
@@ -16904,14 +16912,16 @@ msgid ""
 "Draws a rule between the QSO rows automatically, like the classic label "
 "layout"
 msgstr ""
+"Trekt automatisch een lijn tussen de QSO-regels, zoals de klassieke "
+"labelindeling"
 
 #: application/views/labeldesigner/designer.php:267
 msgid "Separator lines between QSO rows"
-msgstr ""
+msgstr "Scheidingslijnen tussen QSO-rijen"
 
 #: application/views/labeldesigner/designer.php:270
 msgid "Separator thickness"
-msgstr ""
+msgstr "Dikte van de scheidingslijn"
 
 #: application/views/labeldesigner/designer.php:279
 #: application/views/qslpostcard/designer.php:230
@@ -16955,11 +16965,11 @@ msgstr "Y"
 
 #: application/views/labeldesigner/designer.php:326
 msgid "Rows"
-msgstr ""
+msgstr "Rijen"
 
 #: application/views/labeldesigner/designer.php:330
 msgid "Columns"
-msgstr ""
+msgstr "Kolommen"
 
 #: application/views/labeldesigner/designer.php:336
 #: application/views/labels/index.php:45 application/views/labels/index.php:80
@@ -16974,7 +16984,7 @@ msgstr "Hoogte"
 #: application/views/labeldesigner/designer.php:344
 #: application/views/labeldesigner/designer.php:360
 msgid "Thickness"
-msgstr ""
+msgstr "Dikte"
 
 #: application/views/labeldesigner/designer.php:349
 #: application/views/labels/index.php:48
@@ -16983,15 +16993,15 @@ msgstr "Oriëntatie"
 
 #: application/views/labeldesigner/designer.php:351
 msgid "Horizontal"
-msgstr ""
+msgstr "Horizontaal"
 
 #: application/views/labeldesigner/designer.php:352
 msgid "Vertical"
-msgstr ""
+msgstr "Verticaal"
 
 #: application/views/labeldesigner/designer.php:356
 msgid "Length"
-msgstr ""
+msgstr "Lengte"
 
 #: application/views/labeldesigner/designer.php:367
 #: application/views/qslpostcard/designer.php:275
@@ -17022,7 +17032,7 @@ msgstr "Breedte omhullen"
 
 #: application/views/labeldesigner/designer.php:399
 msgid "Print this field once per QSO if a label holds multiple QSOs"
-msgstr ""
+msgstr "Print dit veld één keer per QSO als een etiket meerdere QSO's bevat"
 
 #: application/views/labeldesigner/designer.php:400
 #: application/views/qslpostcard/designer.php:308
@@ -17326,13 +17336,13 @@ msgstr "Bekijk QSO's"
 #: application/views/logbookadvanced/startatform.php:20
 #: application/views/qslprint/printlabel.php:20
 msgid "Label layout"
-msgstr ""
+msgstr "Labelindeling"
 
 #: application/views/labels/startatform.php:24
 #: application/views/logbookadvanced/startatform.php:23
 #: application/views/qslprint/printlabel.php:23
 msgid "Standard"
-msgstr ""
+msgstr "Standaard"
 
 #: application/views/labels/startatform.php:30
 #: application/views/logbookadvanced/startatform.php:29
@@ -17340,6 +17350,8 @@ msgstr ""
 msgid ""
 "Designed label templates use their own layout and ignore the options below."
 msgstr ""
+"Ontworpen label sjablonen gebruiken hun eigen lay-out en negeren de "
+"onderstaande opties."
 
 #: application/views/labels/startatform.php:41
 #: application/views/logbookadvanced/startatform.php:40

--- a/application/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/application/locale/ru_RU/LC_MESSAGES/messages.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-23 16:43+0000\n"
-"PO-Revision-Date: 2026-08-22 10:16+0000\n"
+"PO-Revision-Date: 2026-08-24 22:42+0000\n"
 "Last-Translator: Michael Skolsky <r1blh@yandex.ru>\n"
 "Language-Team: Russian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ru/>\n"
@@ -1535,7 +1535,7 @@ msgstr "Панель управления"
 
 #: application/controllers/Dashboard.php:219
 msgid "HF"
-msgstr ""
+msgstr "КВ"
 
 #: application/controllers/Dashboard.php:219
 #: application/views/dashboard/index.php:684
@@ -1551,7 +1551,7 @@ msgstr "Спутники"
 
 #: application/controllers/Dashboard.php:219
 msgid "VHF+"
-msgstr ""
+msgstr "УКВ+"
 
 #: application/controllers/Dayswithqso.php:16
 #: application/views/dayswithqso/index.php:2
@@ -1906,7 +1906,7 @@ msgstr "Экспорт KML"
 #: application/controllers/Labeldesigner.php:22
 #: application/views/labels/index.php:36
 msgid "Label Designer"
-msgstr ""
+msgstr "Редактор наклеек"
 
 #: application/controllers/Labeldesigner.php:114
 #: application/controllers/Labels.php:213
@@ -1926,7 +1926,7 @@ msgstr "JSON шаблона некорректен"
 
 #: application/controllers/Labeldesigner.php:125
 msgid "Template has no elements"
-msgstr ""
+msgstr "Шаблон не содержит элементов"
 
 #: application/controllers/Labeldesigner.php:131
 msgid "Label type not found"

--- a/application/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/application/locale/sv_SE/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-23 16:43+0000\n"
-"PO-Revision-Date: 2026-08-20 07:48+0000\n"
+"PO-Revision-Date: 2026-08-24 22:42+0000\n"
 "Last-Translator: \"Jorgen Dahl, NU1T\" <sm6srw@arrl.net>\n"
 "Language-Team: Swedish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/sv/>\n"
@@ -1521,7 +1521,7 @@ msgstr "Instrumentpanel"
 
 #: application/controllers/Dashboard.php:219
 msgid "HF"
-msgstr ""
+msgstr "HF"
 
 #: application/controllers/Dashboard.php:219
 #: application/views/dashboard/index.php:684
@@ -1537,7 +1537,7 @@ msgstr "SAT"
 
 #: application/controllers/Dashboard.php:219
 msgid "VHF+"
-msgstr ""
+msgstr "VHF+"
 
 #: application/controllers/Dayswithqso.php:16
 #: application/views/dayswithqso/index.php:2

--- a/application/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/application/locale/tr_TR/LC_MESSAGES/messages.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-23 16:43+0000\n"
-"PO-Revision-Date: 2026-08-23 22:44+0000\n"
-"Last-Translator: \"Erkin Mercan (TA4AQG-SP9AQG)\" <ekomeko066@gmail.com>\n"
+"PO-Revision-Date: 2026-08-24 22:42+0000\n"
+"Last-Translator: metint <metin@tekkalmaz.net>\n"
 "Language-Team: Turkish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/tr/>\n"
 "Language: tr_TR\n"
@@ -15519,7 +15519,7 @@ msgstr "Profiliniz"
 
 #: application/views/hamsat/index.php:39
 msgid "Gridsquare(s)"
-msgstr "QTH grid kareleri"
+msgstr "Grid kareleri"
 
 #: application/views/hamsat/index.php:40
 msgid "Workable"
@@ -19883,7 +19883,7 @@ msgstr "Gönderim Yöntemi"
 
 #: application/views/oqrs/showrequests.php:100
 msgid "Check log"
-msgstr "QSO'yu Kontrol Et"
+msgstr "Kaydı kontrol et"
 
 #: application/views/oqrs/showrequests.php:101
 msgid "QSO Match"
@@ -20257,7 +20257,7 @@ msgstr "Grid karesi özeti gösteriliyor"
 
 #: application/views/qso/award_tabs.php:13
 msgid "State input needs to be filled to show a summary!"
-msgstr "Özet göstermek için QSO'larda eyalet alanının doldurulması gerekiyor!"
+msgstr "Özet göstermek için eyalet alanının doldurulması gerekiyor!"
 
 #: application/views/qso/award_tabs.php:14
 msgid "SOTA input needs to be filled to show a summary!"
@@ -20285,8 +20285,7 @@ msgstr "Özet göstermek için modun SAT olması gerekir!"
 
 #: application/views/qso/award_tabs.php:20
 msgid "Gridsquare input needs to be filled to show a summary!"
-msgstr ""
-"Özet göstermek için QSO'larda Grid Karesi alanının doldurulması gerekiyor!"
+msgstr "Özet göstermek için Grid Karesi alanının doldurulması gerekiyor!"
 
 #: application/views/qso/award_tabs.php:21
 msgid "Summary only shows for the first POTA entered."

--- a/install/includes/gettext/locale/tr_TR/LC_MESSAGES/installer.po
+++ b/install/includes/gettext/locale/tr_TR/LC_MESSAGES/installer.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-07-29 15:45+0000\n"
-"PO-Revision-Date: 2026-08-22 10:17+0000\n"
+"PO-Revision-Date: 2026-08-24 22:42+0000\n"
 "Last-Translator: metint <metin@tekkalmaz.net>\n"
 "Language-Team: Turkish <https://translate.wavelog.org/projects/wavelog/"
 "installer/tr/>\n"
@@ -398,7 +398,7 @@ msgstr "Şifre %s içeremez ve boş bırakılamaz"
 
 #: install/index.php:433 install/index.php:451
 msgid "Good to know:"
-msgstr "Bİlmenizde fayda var:"
+msgstr "Bilmenizde fayda var:"
 
 #: install/index.php:434
 msgid ""


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)