### PR TITLE
Refactor passing QSO-IDs as json instead of single-vals

### DIFF
--- a/application/controllers/Qslpostcard.php
+++ b/application/controllers/Qslpostcard.php
@@ -279,7 +279,12 @@ class Qslpostcard extends CI_Controller {
     }
 
     public function printqueue_selected() {
+        // Accept the ids as a JSON string (one POST var, immune to
+        // max_input_vars) or as a classic selected_qsos[] array.
         $selected_ids = $this->input->post('selected_qsos');
+        if (is_string($selected_ids)) {
+            $selected_ids = xss_clean(json_decode($selected_ids, true));
+        }
 
         if (!is_array($selected_ids) || empty($selected_ids)) {
             show_error(__("No QSOs were selected"));
@@ -309,7 +314,12 @@ class Qslpostcard extends CI_Controller {
                 return;
             }
 
+            // Accept the ids as a JSON string (one POST var, immune to
+            // max_input_vars) or as a classic selected_ids[] array.
             $selected_ids = $this->input->post('selected_ids');
+            if (is_string($selected_ids)) {
+                $selected_ids = xss_clean(json_decode($selected_ids, true));
+            }
             if (!is_array($selected_ids) || empty($selected_ids)) {
                 show_error(__("No selected QSO IDs were provided"));
                 return;

--- a/application/views/qslpostcard/printqueue_selected.php
+++ b/application/views/qslpostcard/printqueue_selected.php
@@ -21,9 +21,7 @@
 					<?= __("Print options (QSOs per card, background image, address printing) are set per template in the QSL Postcard Designer."); ?>
 				</div>
 
-				<?php foreach ($selected_ids as $id): ?>
-					<input type="hidden" name="selected_ids[]" value="<?= (int)$id ?>">
-				<?php endforeach; ?>
+				<input type="hidden" name="selected_ids" value="<?= htmlentities(json_encode($selected_ids)) ?>">
 
 			<div class="btn-group" role="group">
 				<button type="button" id="btnPrintSelected" class="btn btn-success">

--- a/assets/js/sections/logbookadvanced.js
+++ b/assets/js/sections/logbookadvanced.js
@@ -2144,13 +2144,11 @@ $(document).ready(function () {
 						// PDF endpoint (qslpostcard/pdfselected) receives them. The
 						// form owns the action button: it picks the chosen template
 						// and POSTs the ids to render the PDF download.
-						var $ids = $('#qslcard_selected_ids');
-						if ($ids.length) {
-							$ids.empty();
-							$.each(id_list, function (i, id) {
-								$('<input>').attr({ type: 'hidden', name: 'selected_ids[]' }).val(id).appendTo($ids);
-							});
-						}
+					var $ids = $('#qslcard_selected_ids');
+					if ($ids.length) {
+						$ids.empty();
+						$('<input>').attr({ type: 'hidden', name: 'selected_ids' }).val(JSON.stringify(id_list)).appendTo($ids);
+					}
 						$('#btnPrintQslCard').off('click').on('click', function () {
 							var tplId = $('#qslcard_template_id').val();
 							if (!tplId) {

--- a/assets/js/sections/qslprint.js
+++ b/assets/js/sections/qslprint.js
@@ -616,9 +616,7 @@ function printSelectedQsos(printAll) {
 		let $container = $('#qslcard_selected_ids');
 		if (id_list.length) {
 			$container.empty();
-			$.each(id_list, function (i, id) {
-				$('<input>').attr({ type: 'hidden', name: 'selected_ids[]' }).val(id).appendTo($container);
-			});
+			$('<input>').attr({ type: 'hidden', name: 'selected_ids' }).val(JSON.stringify(id_list)).appendTo($container);
 		}
 		let tplId = $('#qslcard_template_id').val();
 		if (!tplId) {
@@ -640,9 +638,7 @@ function saveAndPrintSelectedQsos(printAll) {
 		let $container = $('#qslcard_selected_ids');
 		if (id_list.length) {
 			$container.empty();
-			$.each(id_list, function (i, id) {
-				$('<input>').attr({ type: 'hidden', name: 'selected_ids[]' }).val(id).appendTo($container);
-			});
+			$('<input>').attr({ type: 'hidden', name: 'selected_ids' }).val(JSON.stringify(id_list)).appendTo($container);
 		}
 		var tplId = $('#qslcard_template_id').val();
 		if (!tplId) {


### PR DESCRIPTION
At QSL Label-printing we pass the IDs of the QSOs as JSON-Array, which is safe.
at Postcard, we do it as old'n'busted HTML-ID's, which lead into problems. See #3730 

this one refactors Postcardprint to the same technology as labelprint works.

old:
<img width="426" height="172" alt="image" src="https://github.com/user-attachments/assets/a4b9ac90-6ed1-4bd5-9bd2-9c0321491039" />

new:
<img width="411" height="137" alt="image" src="https://github.com/user-attachments/assets/e7be257e-28dd-4df6-95fd-be7bc02b48c7" />

Testing:
- Print Cards from LBA
- Print Cards from QSL-Menu