### PR TITLE
Use ham friendly SAT name instead of TLE object name

### DIFF
--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -283,7 +283,7 @@ class Satellite extends CI_Controller {
 			$date = $this->security->xss_clean($this->input->post('date'));
 			$mintime = $this->security->xss_clean($this->input->post('mintime'));
 			$minelevation = $this->security->xss_clean($this->input->post('minelevation'));
-			$data = $this->calcPasses($tles, $yourgrid, $date, $mintime,$minelevation);
+			$data = $this->calcPasses($tles, $yourgrid, $date, $mintime, $minelevation);
 
 			$this->load->view('satellite/passtable', $data);
 		}

--- a/application/libraries/Satpredict.php
+++ b/application/libraries/Satpredict.php
@@ -16,13 +16,14 @@ class Satpredict {
 	public function build_tle($sat_tle) {
 		$raw = isset($sat_tle->tle) ? trim($sat_tle->tle) : '';
 
-		if (Predict_TLE::isOmmJson($raw)) {
-			return Predict_TLE::fromOmmJson($raw);
-		}
-
 		$name = (isset($sat_tle->satellite) && $sat_tle->satellite)
 			? $sat_tle->satellite
 			: (isset($sat_tle->displayname) ? $sat_tle->displayname : '');
+
+		if (Predict_TLE::isOmmJson($raw)) {
+			return Predict_TLE::fromOmmJson($raw, $name);
+		}
+
 		$temp = preg_split('/\n/', $sat_tle->tle);
 		return new Predict_TLE($name, $temp[0], $temp[1]);
 	}

--- a/src/predict/Predict/TLE.php
+++ b/src/predict/Predict/TLE.php
@@ -137,7 +137,7 @@ class Predict_TLE
      * Accepts single object, list, or JSON string.
      * @throws Predict_Exception on invalid JSON or missing mean elements
      */
-    public static function fromOmmJson($omm)
+    public static function fromOmmJson($omm, $name = null)
     {
         if (is_string($omm)) {
             $decoded = json_decode(trim($omm), true);
@@ -163,7 +163,8 @@ class Predict_TLE
 
         $t = new Predict_TLE();
 
-        $name          = isset($omm['OBJECT_NAME']) ? $omm['OBJECT_NAME'] : '';
+        //$name          = isset($omm['OBJECT_NAME']) ? $omm['OBJECT_NAME'] : '';
+        //Do not use object name of TLEs but prefer ham frienly name given as parameter
         $t->header     = $name;
         $t->sat_name   = $name;
         $t->catnr      = isset($omm['NORAD_CAT_ID']) ? (int) $omm['NORAD_CAT_ID'] : 0;


### PR DESCRIPTION
This fixes a regression from https://github.com/wavelog/wavelog/pull/3358. Sats which have OMM TLE format were using their object name for display instead of the ham-friendly and commonly used names. Also the link to the tpx info data was broken.
Screenshot:

<img width="1745" height="988" alt="image" src="https://github.com/user-attachments/assets/11f2631a-b432-40b1-893b-32f8739f781c" />

The example shows AO-10 as "PHASE" and RS-15 as "RADIO". Fix is to hand the ham-friendly name to Predict's TLE construction and use that as name rather than the object name. Same behaviour was implemented for TLE in two line format back in https://github.com/wavelog/wavelog/pull/2828.