### PR TITLE
Modulo Az when it comes to plotting by 360

### DIFF
--- a/assets/js/sections/antennastats.js
+++ b/assets/js/sections/antennastats.js
@@ -166,7 +166,7 @@ function plot_azimuth() {
 				dataQso.push(0);
 			}
 			$.each(tmp, function () {
-				dataQso[this.azimuth] = +this.qsos || 0; // JSON may deliver the counts as strings
+				dataQso[((this.azimuth % 360) + 360) % 360] += +this.qsos || 0; // JSON may deliver the counts as strings; wrap out-of-range bearings into 0-359
 			});
 
 			lastAzCounts = dataQso;


### PR DESCRIPTION
Bug:
When Useradif or Log provides Azimuth > 360, the Antenna-Analytics-Map stops rendering.
This fixes it by taking Az and normalizing it to a base of 0-360
