### PR TITLE
Make Callbooklookup during QSO configurable

### DIFF
--- a/application/controllers/Header_auth.php
+++ b/application/controllers/Header_auth.php
@@ -346,6 +346,7 @@ class Header_auth extends CI_Controller {
             $mapped['user_dxwaterfall_enable']                ?? '',
             $mapped['user_qso_show_map']                      ?? '',
             $mapped['last_lotw_upload_widget_enabled']        ?? '',
+            $mapped['user_callbook_prefill']                  ?? 'default',
             0,                                                   // clubstation
             $external_identifier,                                // external_account
         );

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -166,6 +166,17 @@ class Logbook extends CI_Controller {
 
 		// Consolidated callsign lookup - reduces queries from 11 to 2
 		$callsign_info = $this->logbook_model->get_callsign_all_info($callsign);
+
+		// Prefill mode (user setting): 'default' = callbook + previous QSOs, 'logbook' = previous QSOs only, 'none' = no prefill.
+		// Only applied for the live lookup while logging (?ctx=live); explicit lookups (edit modal etc.) stay unaffected.
+		$prefill_mode = 'default';
+		if ($this->input->get('ctx') === 'live') {
+			$prefill_mode = $this->user_options_model->get_options('qso', array('option_name' => 'callbook_prefill', 'option_key' => 'setting'))->row()->option_value ?? 'default';
+		}
+		$_callbook = $callbook;
+		if ($prefill_mode !== 'default') { $callbook = []; }
+		if ($prefill_mode === 'none') { $callsign_info = array_fill_keys(array_keys($callsign_info), ''); }
+
 		$return['callsign_name'] 		= $this->nval($callsign_info['name'], $callbook['name'] ?? '', $lookup_priority);
 		$return['callsign_qra'] 		= $this->nval($callsign_info['qra'], $callbook['gridsquare'] ?? '', $lookup_priority);
 		$return['callsign_geoloc'] 		= $callbook['geoloc'] ?? '';
@@ -180,6 +191,10 @@ class Logbook extends CI_Controller {
 		$return['callsign_cqz'] 	= $this->nval($callsign_info['cqz'], $callbook['cqz'] ?? '', $lookup_priority);
 		// call_darc_dok remains separate due to different query pattern (uses logbooks_relationships)
 		$return['callsign_darc_dok'] 		= $this->nval($this->logbook_model->call_darc_dok($callsign), $callbook['darc_dok'] ?? '', $lookup_priority);
+
+		// Restore original callbook data (used by profile panel below) 
+		$callbook = $_callbook;
+		if ($prefill_mode === 'none') { $return['callsign_darc_dok'] = ''; }
 		$return['workedBefore'] 		= $this->worked_grid_before($return['callsign_qra'], $band, $mode);
 		$return['confirmed'] 			= $this->confirmed_grid_before($return['callsign_qra'], $band, $mode);
 		$return['timesWorked'] 			= $this->logbook_model->times_worked($lookupcall);

--- a/application/controllers/User.php
+++ b/application/controllers/User.php
@@ -240,6 +240,7 @@ class User extends CI_Controller {
 				$data['user_default_confirmation'] = ($this->input->post('user_default_confirmation_qsl') !== null ? 'Q' : '').($this->input->post('user_default_confirmation_lotw') !== null ? 'L' : '').($this->input->post('user_default_confirmation_eqsl') !== null ? 'E' : '').($this->input->post('user_default_confirmation_qrz') !== null ? 'Z' : '').($this->input->post('user_default_confirmation_clublog') !== null ? 'C' : '').($this->input->post('user_default_confirmation_dcl') !== null ? 'D' : '');
 				$data['user_qso_end_times'] = $this->input->post('user_qso_end_times');
 				$data['user_qso_db_search_priority'] = $this->input->post('user_qso_db_search_priority') ?? 'Y';
+				$data['user_callbook_prefill'] = $this->input->post('user_callbook_prefill', true) ?? 'default';
 				$data['user_quicklog'] = $this->input->post('user_quicklog');
 				$data['user_quicklog_enter'] = $this->input->post('user_quicklog_enter');
 				$data['user_hamsat_key'] = $this->input->post('user_hamsat_key');
@@ -336,6 +337,7 @@ class User extends CI_Controller {
 				$this->input->post('user_dxwaterfall_enable') ?? 'N',
 				$this->input->post('user_qso_show_map') ?? 1,
 				$this->input->post('last_lotw_upload_widget_enabled'),
+				$this->input->post('user_callbook_prefill', true) ?? 'default',
 				$this->input->post('clubstation') == '1' ? true : false)
 			) {
 				// Check for errors
@@ -710,6 +712,9 @@ class User extends CI_Controller {
 			} else {
 				$data['user_previous_qsl_type'] = $q->user_previous_qsl_type;
 			}
+
+			$data['user_callbook_prefill'] = $this->input->post('user_callbook_prefill', true)
+				?? $this->user_options_model->get_options('qso', array('option_name' => 'callbook_prefill', 'option_key' => 'setting'), $this->uri->segment(3))->row()->option_value ?? 'default';
 
 			if($this->input->post('user_amsat_status_upload')) {
 				$data['user_amsat_status_upload'] = $this->input->post('user_amsat_status_upload', false);
@@ -1114,6 +1119,7 @@ class User extends CI_Controller {
 					$this->user_options_model->set_option('oqrs', 'oqrs_auto_matching', array('boolean'=>$this->input->post('oqrs_auto_matching', true)), $user_id);
 					$this->user_options_model->set_option('oqrs', 'oqrs_direct_auto_matching', array('boolean'=>$this->input->post('oqrs_direct_auto_matching', true)), $user_id);
 					$this->user_options_model->set_option('oqrs', 'oqrs_delivery_method', array('setting'=>$this->input->post('oqrs_delivery_method', true) ?? 'both'), $user_id);
+					$this->user_options_model->set_option('qso', 'callbook_prefill', array('setting' => in_array($p = $this->input->post('user_callbook_prefill', true), array('default', 'logbook', 'none'), true) ? $p : 'default'), $user_id);
 					$this->user_options_model->set_option('dashboard', 'show_dxpeditions', array('boolean'=>($this->input->post('user_dashboard_show_dxpeditions') == '1' ? '1' : '0')), $user_id);
 					$this->user_options_model->set_option('dashboard', 'show_contests', array('boolean'=>($this->input->post('user_dashboard_show_contests') == '1' ? '1' : '0')), $user_id);
 					$this->user_options_model->set_option('dashboard', 'show_kpi_stats', array('boolean'=>($this->input->post('user_dashboard_show_kpi_stats') == '1' ? '1' : '0')), $user_id);
@@ -1182,6 +1188,7 @@ class User extends CI_Controller {
 			$data['oqrs_direct_auto_matching'] = $this->input->post('oqrs_direct_auto_matching', true);
 			$data['oqrs_delivery_method'] = $this->input->post('oqrs_delivery_method', true);
 			$data['user_qso_db_search_priority'] = $this->input->post('user_qso_db_search_priority', true);
+			$data['user_callbook_prefill'] = $this->input->post('user_callbook_prefill', true) ?? 'default';
 			$data['last_lotw_upload_widget_enabled'] = $this->input->post('last_lotw_upload_widget_enabled', true);
 
 			$this->load->view('user/edit', $data);

--- a/application/models/User_model.php
+++ b/application/models/User_model.php
@@ -251,7 +251,7 @@ class User_Model extends CI_Model {
 		$user_winkey, $on_air_widget_enabled, $on_air_widget_display_last_seen, $on_air_widget_show_only_most_recent_radio, $on_air_widget_display_radio_name,
 		$qso_widget_display_qso_time, $dashboard_banner, $dashboard_solar, $global_oqrs_text, $oqrs_grouped_search,
 		$oqrs_grouped_search_show_station_name, $oqrs_auto_matching, $oqrs_direct_auto_matching,$user_dxwaterfall_enable, $user_qso_show_map,
-		$last_lotw_upload_widget_enabled, $clubstation = 0, $external_account = null) {
+		$last_lotw_upload_widget_enabled, $user_callbook_prefill = 'default', $clubstation = 0, $external_account = null) {
 		// Check that the user isn't already used
 		if(!$this->exists($username)) {
 			$data = array(
@@ -345,6 +345,7 @@ class User_Model extends CI_Model {
 				['qso_db_search_priority', 'enable',      'boolean',                       $user_qso_db_search_priority ?? 'Y'],
 				['dxwaterfall', 'enable',                 'boolean',                       $user_dxwaterfall_enable     ?? 'N'],
 				['widget',     'last_lotw_upload',        'enabled',                       $last_lotw_upload_widget_enabled            ?? 'false'],
+				['qso',        'callbook_prefill',        'setting',                       in_array($user_callbook_prefill, ['default', 'logbook', 'none'], true) ? $user_callbook_prefill : 'default'],
 			];
 
 			foreach ($user_options as [$type, $name, $key, $value]) {

--- a/application/views/user/edit.php
+++ b/application/views/user/edit.php
@@ -454,8 +454,26 @@
 											<small id="SelectDateFormatHelp" class="form-text text-muted"><?= __('When set to "Yes", callsign lookup will first use data from your previous QSOs before querying external services. Set to "No" to always use external lookup services instead.'); ?></small>
 										</div>
 									</div>
-									<hr />
-									<?php if(!isset($user_show_profile_image)) { $user_show_profile_image='0'; }?>
+								<?php if(!isset($user_callbook_prefill)) { $user_callbook_prefill='default'; }?>
+								<div class="mb-3">
+									<label class="d-block mb-1"><?= __("Prefill fields from callbook while logging"); ?></label>
+									<small class="form-text text-muted d-block mb-2"><?= __('Controls which sources populate the QSO fields (name, QTH, locator, etc.) when entering a callsign. DXCC lookup, the previous QSOs table and the callbook profile panel are always shown.'); ?></small>
+									<div class="form-check">
+										<input class="form-check-input" type="radio" name="user_callbook_prefill" id="callbook_prefill_default" value="default" <?php if ($user_callbook_prefill == 'default') { echo 'checked'; } ?>>
+										<label class="form-check-label" for="callbook_prefill_default"><?= __("Callbook and previous QSOs (default)"); ?></label>
+									</div>
+									<div class="form-check">
+										<input class="form-check-input" type="radio" name="user_callbook_prefill" id="callbook_prefill_logbook" value="logbook" <?php if ($user_callbook_prefill == 'logbook') { echo 'checked'; } ?>>
+										<label class="form-check-label" for="callbook_prefill_logbook"><?= __("Only previous QSOs"); ?></label>
+									</div>
+									<div class="form-check">
+										<input class="form-check-input" type="radio" name="user_callbook_prefill" id="callbook_prefill_none" value="none" <?php if ($user_callbook_prefill == 'none') { echo 'checked'; } ?>>
+										<label class="form-check-label" for="callbook_prefill_none"><?= __("No prefill"); ?></label>
+									</div>
+								</div>
+
+								<hr />
+								<?php if(!isset($user_show_profile_image)) { $user_show_profile_image='0'; }?>
 									<div class="d-flex align-items-start gap-2 mb-3">
 										<input type="hidden" name="user_show_profile_image" value="0">
 										<div class="form-check form-switch mt-1">

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1583,7 +1583,7 @@ $("#callsign").on("focusout", function () {
 		const stationProfile = $('#stationProfile').val();
 
 		find_callsign = find_callsign.replace(/\//g, "-");
-		const url = `${base_url}index.php/logbook/json/${find_callsign}/${json_band}/${json_mode}/${stationProfile}/${startDate}/${last_qsos_count}`;
+		const url = `${base_url}index.php/logbook/json/${find_callsign}/${json_band}/${json_mode}/${stationProfile}/${startDate}/${last_qsos_count}?ctx=live`;
 
 		// Replace / in a callsign with - to stop urls breaking
 		lookupCall = $.getJSON(url, async function (result) {


### PR DESCRIPTION
Adds Useroption to skip Callbook lookup.
At the moment every QSO(-Partner) is looked up and the results are prefilled. Sometimes one don't want that (and it seems to be to complicated for those OPs to simply overwrite the prefilled values). However, this adds:

<img width="464" height="567" alt="image" src="https://github.com/user-attachments/assets/1c837b39-3e05-49f9-833a-3a03ff9fbaec" />

Default is still as before. Rest should be self-explaining.
