### PR TITLE
Make static map deal with no grid locations

### DIFF
--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -190,11 +190,11 @@ class Qra {
 	 */
 
 	function getCenterLatLng($coordinates) {
-		$x = $y = $z = 0;
-		$n = count($coordinates);
+		$x = $y = $z = $n = 0;
 		foreach ($coordinates as $point)
 		{
 			if (isset($point[0]) && isset($point[1])) {
+				$n++;
 				$lt = $point[0] * pi() / 180;
 				$lg = $point[1] * pi() / 180;
 				$x += cos($lt) * cos($lg);

--- a/application/libraries/Qra.php
+++ b/application/libraries/Qra.php
@@ -194,11 +194,13 @@ class Qra {
 		$n = count($coordinates);
 		foreach ($coordinates as $point)
 		{
-			$lt = $point[0] * pi() / 180;
-			$lg = $point[1] * pi() / 180;
-			$x += cos($lt) * cos($lg);
-			$y += cos($lt) * sin($lg);
-			$z += sin($lt);
+			if (isset($point[0]) && isset($point[1])) {
+				$lt = $point[0] * pi() / 180;
+				$lg = $point[1] * pi() / 180;
+				$x += cos($lt) * cos($lg);
+				$y += cos($lt) * sin($lg);
+				$z += sin($lt);
+			}
 		}
 		$x /= $n;
 		$y /= $n;


### PR DESCRIPTION
Static map fails to render if logbook contains locations without grid:

```
DEBUG - 2026-08-27 10:55:57 --> Cached static map image file does not exist. Creating a new one...
INFO - 2026-08-27 10:55:57 --> Model "Modes" initialized
INFO - 2026-08-27 10:55:57 --> Model "Logbook_model" initialized
ERROR - 2026-08-27 10:55:57 --> Severity: Warning --> Trying to access array offset on false /var/www/wavelog/application/libraries/Qra.php 197
ERROR - 2026-08-27 10:55:57 --> Severity: Warning --> Trying to access array offset on false /var/www/wavelog/application/libraries/Qra.php 198
```
