### PR TITLE
use volume size ratio for free space checks

### DIFF
--- a/application/libraries/Upload_guard.php
+++ b/application/libraries/Upload_guard.php
@@ -9,23 +9,25 @@
  */
 class Upload_guard {
 
-    /** Minimum free space (bytes) that must remain after a write: 1 GB. */
-    const DEFAULT_BUFFER = 1073741824; // 1 * 1024 * 1024 * 1024
+    /** Share of the volume size that must remain free after a write: 10%. */
+    const DEFAULT_RESERVE_RATIO = 0.1;
 
     /**
      * Returns true only if $path is on a volume that, after writing
-     * $incoming_bytes, would still have at least $buffer bytes free.
+     * $incoming_bytes, would still have at least $reserve_ratio of its total
+     * size free. Relative to the volume size so small volumes stay usable.
      *
      * @param string $path           Target directory the file will be written to
-     * @param int    $incoming_bytes  Size of the file about to be written
-     * @param int    $buffer          Free-space buffer to preserve (default 4 GB)
+     * @param int    $incoming_bytes Size of the file about to be written
+     * @param float  $reserve_ratio  Share of the volume to keep free (default 10%)
      */
-    public function has_free_space($path, $incoming_bytes, $buffer = self::DEFAULT_BUFFER) {
+    public function has_free_space($path, $incoming_bytes, $reserve_ratio = self::DEFAULT_RESERVE_RATIO) {
         $free = @disk_free_space($path);
-        if ($free === false) {
+        $total = @disk_total_space($path);
+        if ($free === false || $total === false || $total <= 0) {
             return false; // can't determine free space -> fail safe
         }
-        return ($free - (int) $incoming_bytes) >= $buffer;
+        return ($free - (int) $incoming_bytes) >= ($total * $reserve_ratio);
     }
 
     /**


### PR DESCRIPTION
when using quotas on storage volumes (mounted zfs, kubernetes pvc, and so on) setting 1Gb quota on userdata does not work as the check requires 1 Gb on free storage. It would be better to use a relative check and check for at least 10% free storage of the whole disk capacity.