### PR TITLE
Check QRG vs. Band

### DIFF
--- a/assets/js/cat.js
+++ b/assets/js/cat.js
@@ -1034,7 +1034,7 @@ $(document).ready(function() {
                     $frequency.trigger('change'); // Trigger for other event handlers
                     const newBand = frequencyToBand(d);
                     // Auto-update band based on frequency
-                    if ($band.val() != newBand) {
+                    if (newBand && $band.val() != newBand) {
                         $band.val(newBand).trigger('change'); // Trigger band change
                         // Update callsign status when band changes via CAT
                         if ($('#callsign').val().length >= 3) {
@@ -1048,8 +1048,9 @@ $(document).ready(function() {
             cat2UI($frequency,data.frequency,false,true,function(d){
                 $frequency.trigger('change');
                 // Auto-update band based on frequency
-                if ($band.val() != frequencyToBand(d)) {
-                    $band.val(frequencyToBand(d)).trigger('change');
+                var nb = frequencyToBand(d);
+                if (nb && $band.val() != nb) {
+                    $band.val(nb).trigger('change');
                     // Update callsign status when band changes via CAT
                     if ($('#callsign').val().length >= 3) {
                         $('#callsign').blur();

--- a/assets/js/dxwaterfall.js
+++ b/assets/js/dxwaterfall.js
@@ -6267,6 +6267,11 @@ function setFrequency(frequencyInKHz, fromWaterfall) {
     // The change event will trigger set_qrg() which updates freq_calculated display
     $('#frequency').val(frequencyInKHz * 1000);
 
+    var wfBand = frequencyToBand(frequencyInKHz * 1000);
+    if (wfBand && $('#band').val() != wfBand) {
+        $('#band').val(wfBand).trigger('change');
+    }
+
     // Trigger change event to update calculated fields and unit display
     // Skip trigger when called from waterfall to prevent recursive updates
     // Exception: If no radio is selected, update display even when called from waterfall

--- a/assets/js/sections/qrg_handler.js
+++ b/assets/js/sections/qrg_handler.js
@@ -148,7 +148,7 @@ async function set_new_qrg() {
 
 	$('#frequency').val(qrg_hz);
 	$('#freq_calculated').val(parsed_qrg);
-	if (new_band) { $('#band').val(new_band); }
+	if (new_band) { $('#band').val(new_band).trigger('change'); }
 
 	// Clear the manual update flag
 	window.user_updating_frequency = false;

--- a/assets/js/sections/qrg_handler.js
+++ b/assets/js/sections/qrg_handler.js
@@ -97,7 +97,7 @@ async function set_new_qrg() {
 		return;
 	}
 
-	let unit = $('#qrg_unit').html();
+	let unit = window.__qrg_unit_focus || $('#qrg_unit').html();
 
 	// check if the input contains a unit and parse the qrg
 	if (/^\d+(\.\d+)?\s*(hz|h)$/i.test(new_qrg)) {
@@ -148,7 +148,7 @@ async function set_new_qrg() {
 
 	$('#frequency').val(qrg_hz);
 	$('#freq_calculated').val(parsed_qrg);
-	$('#band').val(new_band);
+	if (new_band) { $('#band').val(new_band); }
 
 	// Clear the manual update flag
 	window.user_updating_frequency = false;
@@ -164,5 +164,9 @@ $('#frequency').on('change', function () {
 
 $('#freq_calculated').on('input', function () {
 	$(this).val($(this).val().replace(',', '.'));
+});
+
+$('#freq_calculated').on('focusin', function () {
+	window.__qrg_unit_focus = $('#qrg_unit').html();
 });
 

--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -1018,7 +1018,8 @@ if (qso_manual == 0) {
 			setTimeout(() => {
 				if (ev.data.frequency != null) {
 					$('#frequency').val(ev.data.frequency).trigger("change");
-					$("#band").val(frequencyToBand(ev.data.frequency));
+					var bmBand = frequencyToBand(ev.data.frequency);
+					if (bmBand) $("#band").val(bmBand).trigger('change');
 				}
 				if (ev.data.frequency_rx != "") {
 					$('#frequency_rx').val(ev.data.frequency_rx);
@@ -2745,7 +2746,7 @@ $('.mode').on('change', function () {
 /* Calculate Frequency */
 /* on band change */
 $('#band').on('change', function () {
-	if ($('#radio').val() == 0) {
+	if (frequencyToBand($('#frequency').val()) != $(this).val()) {
 		$.get(base_url + 'index.php/qso/band_to_freq/' + $(this).val() + '/' + $('.mode').val(), function (result) {
 			$('#frequency').val(result).trigger("change");
 


### PR DESCRIPTION
Bug: QSO form frequency/band desync on save

- QSOs were saved with COL_FREQ inconsistent with COL_BAND (e.g. band 13cm with a 10m frequency, or frequency off by ×1000). Root cause: five async writers.

Fix:
- assets/js/dxwaterfall.js — setFrequency() now sets the band select alongside the frequency (derived via frequencyToBand), instead of leaving the previous band in place. Out-of-range frequencies keep the current band.
- assets/js/sections/qso.js — band-change handler now fetches the band default frequency whenever the current frequency falls outside the newly selected band
- assets/js/sections/qrg_handler.js — set_new_qrg() parses bare numbers using the unit label captured at input focus, closing the race where a CAT/bandmap update flipped the unit label between typing and parsing (source of ×1000 frequency errors). Also guards against a null derived band.
- assets/js/cat.js — CAT band auto-update guards against null derived band, so out-of-band CAT frequencies no longer clear the band selection.

Frontend only, no backend/API changes. Contest engine untouched (already treats QRG as authoritative).

Testing
- Spot click on other band without CAT; 
- band flip with selected/stale CAT; 
- bandmap handoff
- kHz-style QRG entry during active CAT polling
- out-of-range frequencies (manual + CAT)
- live CAT band switching (no regressions/loops).