### PR TITLE
Invalidate cache for yesterday/today static maps at midnight

### DIFF
--- a/application/controllers/Staticmap.php
+++ b/application/controllers/Staticmap.php
@@ -190,7 +190,7 @@ class Staticmap extends CI_Controller {
             }
         }
 
-        if ($this->staticmap_model->validate_cached_image($filepath, $cacheDir, $maxAge, $slug)) {
+        if ($this->staticmap_model->validate_cached_image($filepath, $cacheDir, $maxAge, $slug, $day)) {
             log_message('debug', 'Static map image found in cache: ' . $filename);
             header('Content-Type: image/png');
             readfile($filepath);

--- a/application/models/Staticmap_model.php
+++ b/application/models/Staticmap_model.php
@@ -720,7 +720,7 @@ class Staticmap_model extends CI_Model {
      * @return bool  True if the file is valid, false if not
      */
 
-    function validate_cached_image($file, $cacheDir, $maxAge, $slug) {
+    function validate_cached_image($file, $cacheDir, $maxAge, $slug, $day) {
 
         $realPath = realpath($file);
         $filename = basename($file);
@@ -770,6 +770,14 @@ class Staticmap_model extends CI_Model {
 
         if (time() - filemtime($file) > $maxAge) {
             log_message('debug', "Cached static map image has expired. Deleting old cache file...");
+            if (!unlink($file)) {
+                log_message('error', "Failed to delete invalid cached static map image file: " . $file);
+            }
+            return false;
+        }
+
+        if (($day != '') && (strtotime('today+00:00') > filemtime($file))) {
+            log_message('debug', "Cached static map image for today/yesterday has expired. Deleting old cache file...");
             if (!unlink($file)) {
                 log_message('error', "Failed to delete invalid cached static map image file: " . $file);
             }


### PR DESCRIPTION
Static maps are cached for up to 7 days as per code. For static maps rendered for today or yesterday this does not make sense as they would show the old state of the day before if no now QSOs are made. So the map is filled with QSOs of the day before rather than being empty. 

So we enhance the static map validate cache function handle todays and yesterdays map separately. Cached is now invalidated at midnight each day for these two maps.