### PR TITLE
Add qrz.com link to hams.at listing

### DIFF
--- a/application/controllers/Hamsat.php
+++ b/application/controllers/Hamsat.php
@@ -151,6 +151,7 @@ class Hamsat extends CI_Controller {
 				$decoded_json->data[$i]->sat_export_name = $decoded_json->data[$i]->satellite->name;
 			}
 			$decoded_json->data[$i]->my_gridsquare = $my_gridsquare;
+			$decoded_json->data[$i]->last_lotw_upload = $this->logbook_model->check_last_lotw($decoded_json->data[$i]->callsign);
 
 		}
 

--- a/application/views/hamsat/index.php
+++ b/application/views/hamsat/index.php
@@ -14,6 +14,7 @@
     <script type="text/javascript">
        var workable_preset = <?php echo $user_hamsat_workable_only; ?>;
        var feed_key_set = <?php echo strlen($user_hamsat_key); ?>;
+       var lang_qrz_lookup = "<?= __("Lookup on QRZ.com"); ?>";
     </script>
     <?php if ($user_hamsat_key != '') { ?>
     <span id="workable_hint">

--- a/application/views/hamsat/index.php
+++ b/application/views/hamsat/index.php
@@ -15,6 +15,7 @@
        var workable_preset = <?php echo $user_hamsat_workable_only; ?>;
        var feed_key_set = <?php echo strlen($user_hamsat_key); ?>;
        var lang_qrz_lookup = "<?= __("Lookup on QRZ.com"); ?>";
+       var lang_last_lotw_upload = "<?= __("LoTW User. Days since last upload: "); ?>";
     </script>
     <?php if ($user_hamsat_key != '') { ?>
     <span id="workable_hint">

--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -123,13 +123,13 @@ function loadActivationsTable(rows, show_workable_only) {
 		}
 
 		var data = [];
-		data.push(activation.aos_at_date);
-		data.push(activation.aos_to_los);
+		data.push(escapeHtml(activation.aos_at_date));
+		data.push(escapeHtml(activation.aos_to_los));
 		var callstring = '';
 		if (activation.callsign_wkd == 1) {;
-			callstring = "<span class=\"text-success callsign\">"+activation.callsign+"</span>";
+			callstring = "<span class=\"text-success callsign\">"+escapeHtml(activation.callsign)+"</span>";
 		} else {
-			callstring = "<span class=\"callsign\">"+activation.callsign+"</span>";
+			callstring = "<span class=\"callsign\">"+escapeHtml(activation.callsign)+"</span>";
 		}
 		var lotw_hint = "";
 		if (activation.last_lotw_upload != null) {
@@ -140,11 +140,11 @@ function loadActivationsTable(rows, show_workable_only) {
 			} else if (activation.last_lotw_upload > 7) {
 				lotw_hint = "lotw_info_yellow";
 			}
-			callstring = callstring + " <a href=\"https://lotw.arrl.org/lotwuser/act?act="+activation.callsign+"\" target=\"_blank\"><small id=\"lotw_info\" class=\"badge bg-success "+lotw_hint+"\" data-bs-toggle=\"tooltip\" title=\""+lang_last_lotw_upload+" "+activation.last_lotw_upload+"\">L</small></a>";
+			callstring = callstring + " <a href=\"https://lotw.arrl.org/lotwuser/act?act="+escapeHtml(activation.callsign)+"\" target=\"_blank\"><small id=\"lotw_info\" class=\"badge bg-success "+lotw_hint+"\" data-bs-toggle=\"tooltip\" title=\""+lang_last_lotw_upload+" "+activation.last_lotw_upload+"\">L</small></a>";
 		}
-		callstring = callstring + " <a target=\"_blank\" href=\"https://www.qrz.com/db/"+activation.callsign+"\"><img width=\"16\" height=\"16\" src=\""+base_url+"images/icons/qrz.png\" alt=\""+lang_qrz_lookup+"\"></a>";
+		callstring = callstring + " <a target=\"_blank\" href=\"https://www.qrz.com/db/"+escapeHtml(activation.callsign)+"\"><img width=\"16\" height=\"16\" src=\""+base_url+"images/icons/qrz.png\" alt=\""+lang_qrz_lookup+"\"></a>";
 		data.push(callstring);
-		data.push(activation.comment);
+		data.push(escapeHtml(activation.comment));
 		if (activation.satellite.name != activation.sat_export_name) {
 			sat = activation.sat_export_name;
 		} else {
@@ -158,23 +158,23 @@ function loadActivationsTable(rows, show_workable_only) {
 			} else if (activation.mhz_direction == "down") {
 				dir = '&darr;';
 			}
-			data.push("<span data-bs-toggle=\"tooltip\" data-bs-original-title=\""+freq+" MHz "+dir+"\">"+sat+"</span>");
+			data.push("<span data-bs-toggle=\"tooltip\" data-bs-original-title=\""+escapeHtml(freq)+" MHz "+dir+"\">"+escapeHtml(sat)+"</span>");
 		} else {
-			data.push(sat);
+			data.push(escapeHtml(sat));
 		}
-		data.push("<span title=\""+activation.mode+"\" class=\"badge "+activation.mode_class+"\">"+activation.mode+"</span>");
+		data.push("<span title=\""+escapeHtml(activation.mode)+"\" class=\"badge "+activation.mode_class+"\">"+escapeHtml(activation.mode)+"</span>");
 		grids = [];
 		for (var j=0; j < activation.grids_wkd.length; j++) {
 			if (!grids.some(str => str.includes(activation.grids[j].substring(0, 4)))) {
 				switch (activation.grids_wkd[j]) {
 					case 1:
-						grids.push("<a href=\"javascript:displayContacts('"+activation.grids[j].substring(0, 4)+"','SAT','All','All','All','VUCC','');\"><span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-warning\">"+activation.grids[j].substring(0, 4)+"</span></a>")
+						grids.push("<a href=\"javascript:displayContacts('"+escapeHtml(activation.grids[j].substring(0, 4))+"','SAT','All','All','All','VUCC','');\"><span data-bs-toggle=\"tooltip\" title=\"Worked\" class=\"badge bg-warning\">"+escapeHtml(activation.grids[j].substring(0, 4))+"</span></a>")
 						break;
 					case 2:
-						grids.push("<a href=\"javascript:displayContacts('"+activation.grids[j].substring(0, 4)+"','SAT','All','All','All','VUCC','');\"><span data-bs-toggle=\"tooltip\" title=\"Confirmed\" class=\"badge bg-success\">"+activation.grids[j].substring(0, 4)+"</span></a>")
+						grids.push("<a href=\"javascript:displayContacts('"+escapeHtml(activation.grids[j].substring(0, 4))+"','SAT','All','All','All','VUCC','');\"><span data-bs-toggle=\"tooltip\" title=\"Confirmed\" class=\"badge bg-success\">"+escapeHtml(activation.grids[j].substring(0, 4))+"</span></a>")
 						break;
 					default:
-						grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+activation.grids[j].substring(0, 4)+"</span>")
+						grids.push("<span data-bs-toggle=\"tooltip\" title=\"Not Worked\" class=\"badge bg-danger\">"+escapeHtml(activation.grids[j].substring(0, 4))+"</span>")
 						break;
 				}
 			}

--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -125,11 +125,14 @@ function loadActivationsTable(rows, show_workable_only) {
 		var data = [];
 		data.push(activation.aos_at_date);
 		data.push(activation.aos_to_los);
+		var callstring = '';
 		if (activation.callsign_wkd == 1) {;
-			data.push("<span class=\"text-success callsign\">"+activation.callsign+"</span>");
+			callstring = "<span class=\"text-success callsign\">"+activation.callsign+"</span>";
 		} else {
-			data.push('<span class="callsign">'+activation.callsign+'</span>');
+			callstring = "<span class=\"callsign\">"+activation.callsign+"</span>";
 		}
+		callstring = callstring + " <a target=\"_blank\" href=\"https://www.qrz.com/db/"+activation.callsign+"\"><img width=\"16\" height=\"16\" src=\""+base_url+"images/icons/qrz.png\" alt=\""+lang_qrz_lookup+"\"></a>";
+		data.push(callstring);
 		data.push(activation.comment);
 		if (activation.satellite.name != activation.sat_export_name) {
 			sat = activation.sat_export_name;

--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -131,6 +131,17 @@ function loadActivationsTable(rows, show_workable_only) {
 		} else {
 			callstring = "<span class=\"callsign\">"+activation.callsign+"</span>";
 		}
+		var lotw_hint = "";
+		if (activation.last_lotw_upload != null) {
+			if (activation.last_lotw_upload > 365) {
+				lotw_hint = "lotw_info_red";
+			} else if (activation.last_lotw_upload > 30) {
+				lotw_hint = "lotw_info_orange";
+			} else if (activation.last_lotw_upload > 7) {
+				lotw_hint = "lotw_info_yellow";
+			}
+			callstring = callstring + " <a href=\"https://lotw.arrl.org/lotwuser/act?act="+activation.callsign+"\" target=\"_blank\"><small id=\"lotw_info\" class=\"badge bg-success "+lotw_hint+"\" data-bs-toggle=\"tooltip\" title=\""+lang_last_lotw_upload+" "+activation.last_lotw_upload+"\">L</small></a>";
+		}
 		callstring = callstring + " <a target=\"_blank\" href=\"https://www.qrz.com/db/"+activation.callsign+"\"><img width=\"16\" height=\"16\" src=\""+base_url+"images/icons/qrz.png\" alt=\""+lang_qrz_lookup+"\"></a>";
 		data.push(callstring);
 		data.push(activation.comment);


### PR DESCRIPTION
Adds a link to qrz.com to quickly lookup grid activators:

<img width="1005" height="220" alt="image" src="https://github.com/user-attachments/assets/8625726f-df97-4029-addd-08d13f6a9ae2" />
