### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/it_IT/LC_MESSAGES/messages.po
+++ b/application/locale/it_IT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-28 10:44+0000\n"
-"PO-Revision-Date: 2026-08-26 11:05+0000\n"
+"PO-Revision-Date: 2026-08-29 04:04+0000\n"
 "Last-Translator: iv3cvn <ricentis@gmail.com>\n"
 "Language-Team: Italian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/it/>\n"
@@ -838,31 +838,31 @@ msgstr "WAIP"
 
 #: application/controllers/Awards.php:2572
 msgid "England"
-msgstr ""
+msgstr "Inghilterra"
 
 #: application/controllers/Awards.php:2573
 msgid "Isle of Man"
-msgstr ""
+msgstr "Isola di Man"
 
 #: application/controllers/Awards.php:2574
 msgid "Northern Ireland"
-msgstr ""
+msgstr "Irlanda del nord"
 
 #: application/controllers/Awards.php:2575
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 #: application/controllers/Awards.php:2576
 msgid "Scotland"
-msgstr ""
+msgstr "Scozia"
 
 #: application/controllers/Awards.php:2577
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 #: application/controllers/Awards.php:2578
 msgid "Wales"
-msgstr ""
+msgstr "Galles"
 
 #: application/controllers/Awards.php:2794
 #: application/views/awards/wac/index.php:7
@@ -7502,7 +7502,7 @@ msgstr "Mostra la mappa delle contee"
 #: application/views/awards/was/index.php:63
 #: application/views/awards/wpx/index.php:25
 msgid "Press 'Apply' to update the table"
-msgstr ""
+msgstr "Premi 'Applica' per aggiornare la tabella"
 
 #: application/views/awards/counties/index.php:110
 #: application/views/awards/cq/index.php:142
@@ -7524,7 +7524,7 @@ msgstr ""
 #: application/views/awards/wpx/index.php:79
 #: application/views/awards/wwff/index.php:128
 msgid "Band & Mode"
-msgstr ""
+msgstr "Banda e modo"
 
 #: application/views/awards/counties/index.php:130
 #: application/views/awards/cq/index.php:178
@@ -7756,7 +7756,7 @@ msgstr "Mostra mappa zona CQ"
 #: application/views/awards/wae/index.php:55
 #: application/views/awards/wwff/index.php:56
 msgid "Date Range"
-msgstr ""
+msgstr "Intervallo di date"
 
 #: application/views/awards/cq/index.php:67
 #: application/views/awards/dxcc/index.php:61
@@ -9330,28 +9330,28 @@ msgstr ""
 
 #: application/views/awards/wab/index.php:19
 msgid "Total squares"
-msgstr ""
+msgstr "Quadratoni totali"
 
 #: application/views/awards/wab/index.php:21
 msgid "Squares by DXCC"
-msgstr ""
+msgstr "Quadratoni per DXCC"
 
 #: application/views/awards/wab/index.php:22
 #: application/views/awards/wab/index.php:44
 msgid "Go to square"
-msgstr ""
+msgstr "Vai al quadratone"
 
 #: application/views/awards/wab/index.php:23
 msgid "WAB square not found"
-msgstr ""
+msgstr "Locatore WAB non trovato"
 
 #: application/views/awards/wab/index.php:34
 msgid "View a map of worked / confirmed WAB squares"
-msgstr ""
+msgstr "Visualizza una mappa dei locatori WAB lavorati / confermati"
 
 #: application/views/awards/wab/index.php:43
 msgid "WAB square"
-msgstr ""
+msgstr "Locatore WAB"
 
 #: application/views/awards/wab/index.php:171
 msgid "List"
@@ -9427,7 +9427,7 @@ msgstr "No"
 
 #: application/views/awards/wab/list.php:37
 msgid "Q = QSL card, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
-msgstr ""
+msgstr "Q = QSL card, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
 
 #: application/views/awards/wac/index.php:8
 msgid ""
@@ -9869,7 +9869,7 @@ msgstr ""
 
 #: application/views/awards/wwff/index.php:52
 msgid "Press ''Apply'' to update the table"
-msgstr ""
+msgstr "Premi 'Applica' per aggiornare la tabella"
 
 #: application/views/azimuthal/index.php:16
 msgid ""
@@ -14407,7 +14407,7 @@ msgstr "Ricerca nel registro per impostare il locatore"
 
 #: application/views/dbtools/index.php:126
 msgid "Lookup"
-msgstr ""
+msgstr "Ricerca"
 
 #: application/views/dbtools/index.php:134
 msgid "Check IOTA against DXCC"
@@ -14420,35 +14420,35 @@ msgstr "Usa Wavelog per controllare IOTA contro DXCC"
 #: application/views/dbtools/missinggridlist.php:12
 #, php-format
 msgid "%s QSO(s) selected"
-msgstr ""
+msgstr "%s QSO selezionato/i"
 
 #: application/views/dbtools/missinggridlist.php:13
 #, php-format
 msgid "%s QSO(s) remaining"
-msgstr ""
+msgstr "%s QSO rimanente/i"
 
 #: application/views/dbtools/missinggridlist.php:14
 #, php-format
 msgid "Updated: %s"
-msgstr ""
+msgstr "Aggiornato: %s"
 
 #: application/views/dbtools/missinggridlist.php:15
 #, php-format
 msgid "Not found: %s"
-msgstr ""
+msgstr "Non trovato: %s"
 
 #: application/views/dbtools/missinggridlist.php:16
 #, php-format
 msgid "Errors: %s"
-msgstr ""
+msgstr "Errori: %s"
 
 #: application/views/dbtools/missinggridlist.php:17
 msgid "Retrieving callbook data..."
-msgstr ""
+msgstr "Recupero dei dati del callbook..."
 
 #: application/views/dbtools/missinggridlist.php:18
 msgid "Not found in callbook"
-msgstr ""
+msgstr "Non trovato nel callbook"
 
 #: application/views/dbtools/missinggridlist.php:19
 #: application/views/logbookadvanced/index.php:39
@@ -14458,24 +14458,24 @@ msgstr "Saltato"
 #: application/views/dbtools/missinggridlist.php:21
 #, php-format
 msgid "Lookup finished: %s gridsquare(s) set, %s not found, %s error(s)."
-msgstr ""
+msgstr "Ricerca completata: %s quadrati impostati, %s non trovati, %s errori."
 
 #: application/views/dbtools/missinggridlist.php:22
 msgid "Lookup cancelled."
-msgstr ""
+msgstr "Ricerca annullata."
 
 #: application/views/dbtools/missinggridlist.php:32
 msgid "Only unconfirmed QSOs"
-msgstr ""
+msgstr "Solo i QSOs non confermati"
 
 #: application/views/dbtools/missinggridlist.php:36
 #, php-format
 msgid "Found %s QSO(s) with missing gridsquare."
-msgstr ""
+msgstr "Trovati %s QSO con locatore mancante."
 
 #: application/views/dbtools/missinggridlist.php:37
 msgid "Uncheck the QSOs you want to skip, then start the lookup."
-msgstr ""
+msgstr "Deseleziona i QSO che vuoi saltare, poi avvia la ricerca."
 
 #: application/views/dbtools/missinggridlist.php:50
 #: application/views/view_log/partial/log_ajax.php:129
@@ -15800,7 +15800,7 @@ msgstr "Satellite Rovers"
 
 #: application/views/hamsat/index.php:18
 msgid "LoTW User. Days since last upload: "
-msgstr ""
+msgstr "Utente LoTW. Giorni dall'ultimo caricamento: "
 
 #: application/views/hamsat/index.php:29
 #, php-format
@@ -23206,7 +23206,7 @@ msgstr ""
 
 #: application/views/user/edit.php:459
 msgid "Prefill fields from callbook while logging"
-msgstr ""
+msgstr "Precompila i campi dal callbook durante la messa a log"
 
 #: application/views/user/edit.php:460
 msgid ""
@@ -23214,18 +23214,21 @@ msgid ""
 "when entering a callsign. DXCC lookup, the previous QSOs table and the "
 "callbook profile panel are always shown."
 msgstr ""
+"Controlla quali fonti riempiono i campi QSO (nome, QTH, locatore, ecc.) "
+"quando si inserisce un nominativo. La ricerca DXCC, la tabella dei QSO "
+"precedenti e il pannello profilo del callbook sono sempre visualizzati."
 
 #: application/views/user/edit.php:463
 msgid "Callbook and previous QSOs (default)"
-msgstr ""
+msgstr "Callbook e QSO precedenti (predefinito)"
 
 #: application/views/user/edit.php:467
 msgid "Only previous QSOs"
-msgstr ""
+msgstr "Solo QSO precedenti"
 
 #: application/views/user/edit.php:471
 msgid "No prefill"
-msgstr ""
+msgstr "Nessun riempimento automatico"
 
 #: application/views/user/edit.php:483
 msgid ""

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-28 10:44+0000\n"
-"PO-Revision-Date: 2026-08-28 10:27+0000\n"
+"PO-Revision-Date: 2026-08-29 04:04+0000\n"
 "Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -14347,7 +14347,7 @@ msgstr "未確認の交信のみ"
 #: application/views/dbtools/missinggridlist.php:36
 #, php-format
 msgid "Found %s QSO(s) with missing gridsquare."
-msgstr "グリッドスクエアが未入力のQSOが％s件見つかりました。"
+msgstr "グリッドスクエアが未入力のQSOが%s件見つかりました。"
 
 #: application/views/dbtools/missinggridlist.php:37
 msgid "Uncheck the QSOs you want to skip, then start the lookup."
@@ -15660,7 +15660,7 @@ msgstr "衛星探査機"
 
 #: application/views/hamsat/index.php:18
 msgid "LoTW User. Days since last upload: "
-msgstr ""
+msgstr "LoTWユーザー。最終アップロードからの日数： "
 
 #: application/views/hamsat/index.php:29
 #, php-format

--- a/application/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/application/locale/nl_NL/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-28 10:44+0000\n"
-"PO-Revision-Date: 2026-08-27 18:59+0000\n"
+"PO-Revision-Date: 2026-08-28 20:04+0000\n"
 "Last-Translator: Alexander <alexander@pa8s.nl>\n"
 "Language-Team: Dutch <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/nl/>\n"
@@ -836,31 +836,31 @@ msgstr "WAIP"
 
 #: application/controllers/Awards.php:2572
 msgid "England"
-msgstr ""
+msgstr "Engeland"
 
 #: application/controllers/Awards.php:2573
 msgid "Isle of Man"
-msgstr ""
+msgstr "Isle of Man"
 
 #: application/controllers/Awards.php:2574
 msgid "Northern Ireland"
-msgstr ""
+msgstr "Noord-Ierland"
 
 #: application/controllers/Awards.php:2575
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 #: application/controllers/Awards.php:2576
 msgid "Scotland"
-msgstr ""
+msgstr "Schotland"
 
 #: application/controllers/Awards.php:2577
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 #: application/controllers/Awards.php:2578
 msgid "Wales"
-msgstr ""
+msgstr "Wales"
 
 #: application/controllers/Awards.php:2794
 #: application/views/awards/wac/index.php:7
@@ -9410,7 +9410,7 @@ msgstr "Nee"
 
 #: application/views/awards/wab/list.php:37
 msgid "Q = QSL card, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
-msgstr ""
+msgstr "Q = QSL-kaart, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
 
 #: application/views/awards/wac/index.php:8
 msgid ""
@@ -14367,7 +14367,7 @@ msgstr "Gebruik callbook om locatorvak in te stellen"
 
 #: application/views/dbtools/index.php:126
 msgid "Lookup"
-msgstr ""
+msgstr "Opzoeken"
 
 #: application/views/dbtools/index.php:134
 msgid "Check IOTA against DXCC"
@@ -14380,35 +14380,35 @@ msgstr "Gebruik Wavelog om IOTA tegen DXCC te controleren"
 #: application/views/dbtools/missinggridlist.php:12
 #, php-format
 msgid "%s QSO(s) selected"
-msgstr ""
+msgstr "%s QSO('s) geselecteerd"
 
 #: application/views/dbtools/missinggridlist.php:13
 #, php-format
 msgid "%s QSO(s) remaining"
-msgstr ""
+msgstr "%s QSO('s) over"
 
 #: application/views/dbtools/missinggridlist.php:14
 #, php-format
 msgid "Updated: %s"
-msgstr ""
+msgstr "Bijgewerkt: %s"
 
 #: application/views/dbtools/missinggridlist.php:15
 #, php-format
 msgid "Not found: %s"
-msgstr ""
+msgstr "Niet gevonden: %s"
 
 #: application/views/dbtools/missinggridlist.php:16
 #, php-format
 msgid "Errors: %s"
-msgstr ""
+msgstr "Fouten: %s"
 
 #: application/views/dbtools/missinggridlist.php:17
 msgid "Retrieving callbook data..."
-msgstr ""
+msgstr "Callbookgegevens ophalen..."
 
 #: application/views/dbtools/missinggridlist.php:18
 msgid "Not found in callbook"
-msgstr ""
+msgstr "Niet gevonden in callbook"
 
 #: application/views/dbtools/missinggridlist.php:19
 #: application/views/logbookadvanced/index.php:39
@@ -14419,23 +14419,25 @@ msgstr "Overgeslagen"
 #, php-format
 msgid "Lookup finished: %s gridsquare(s) set, %s not found, %s error(s)."
 msgstr ""
+"Opzoeking voltooid: %s locatorvak(ken) ingesteld, %s niet gevonden, %s fout"
+"(en)."
 
 #: application/views/dbtools/missinggridlist.php:22
 msgid "Lookup cancelled."
-msgstr ""
+msgstr "Opzoeken geannuleerd."
 
 #: application/views/dbtools/missinggridlist.php:32
 msgid "Only unconfirmed QSOs"
-msgstr ""
+msgstr "Alleen onbevestigde QSO's"
 
 #: application/views/dbtools/missinggridlist.php:36
 #, php-format
 msgid "Found %s QSO(s) with missing gridsquare."
-msgstr ""
+msgstr "Gevonden %s QSO('s) met ontbrekend locatorvak."
 
 #: application/views/dbtools/missinggridlist.php:37
 msgid "Uncheck the QSOs you want to skip, then start the lookup."
-msgstr ""
+msgstr "Vink de QSO's uit die je wilt overslaan en start dan de opzoeking."
 
 #: application/views/dbtools/missinggridlist.php:50
 #: application/views/view_log/partial/log_ajax.php:129
@@ -15755,7 +15757,7 @@ msgstr "Satellietrovers"
 
 #: application/views/hamsat/index.php:18
 msgid "LoTW User. Days since last upload: "
-msgstr ""
+msgstr "LoTW-gebruiker. Dagen sinds laatste upload: "
 
 #: application/views/hamsat/index.php:29
 #, php-format

--- a/application/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/application/locale/sv_SE/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-08-28 10:44+0000\n"
-"PO-Revision-Date: 2026-08-26 21:25+0000\n"
+"PO-Revision-Date: 2026-08-29 04:04+0000\n"
 "Last-Translator: \"Jorgen Dahl, NU1T\" <sm6srw@arrl.net>\n"
 "Language-Team: Swedish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/sv/>\n"
@@ -835,31 +835,31 @@ msgstr "WAIP"
 
 #: application/controllers/Awards.php:2572
 msgid "England"
-msgstr ""
+msgstr "England"
 
 #: application/controllers/Awards.php:2573
 msgid "Isle of Man"
-msgstr ""
+msgstr "Isle of Man"
 
 #: application/controllers/Awards.php:2574
 msgid "Northern Ireland"
-msgstr ""
+msgstr "Nordirland"
 
 #: application/controllers/Awards.php:2575
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 #: application/controllers/Awards.php:2576
 msgid "Scotland"
-msgstr ""
+msgstr "Skottland"
 
 #: application/controllers/Awards.php:2577
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 #: application/controllers/Awards.php:2578
 msgid "Wales"
-msgstr ""
+msgstr "Wales"
 
 #: application/controllers/Awards.php:2794
 #: application/views/awards/wac/index.php:7
@@ -9264,28 +9264,28 @@ msgstr ""
 
 #: application/views/awards/wab/index.php:19
 msgid "Total squares"
-msgstr ""
+msgstr "Lokator Totalt"
 
 #: application/views/awards/wab/index.php:21
 msgid "Squares by DXCC"
-msgstr ""
+msgstr "Lokatorrutor per DXCC"
 
 #: application/views/awards/wab/index.php:22
 #: application/views/awards/wab/index.php:44
 msgid "Go to square"
-msgstr ""
+msgstr "Gå till ruta"
 
 #: application/views/awards/wab/index.php:23
 msgid "WAB square not found"
-msgstr ""
+msgstr "WAB-ruta hittades inte"
 
 #: application/views/awards/wab/index.php:34
 msgid "View a map of worked / confirmed WAB squares"
-msgstr ""
+msgstr "Visa en karta över aktiverade / bekräftade WAB-rutor"
 
 #: application/views/awards/wab/index.php:43
 msgid "WAB square"
-msgstr ""
+msgstr "WAB-ruta"
 
 #: application/views/awards/wab/index.php:171
 msgid "List"
@@ -9361,7 +9361,7 @@ msgstr "Nej"
 
 #: application/views/awards/wab/list.php:37
 msgid "Q = QSL card, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
-msgstr ""
+msgstr "Q = QSL-kort, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
 
 #: application/views/awards/wac/index.php:8
 msgid ""
@@ -14298,7 +14298,7 @@ msgstr "Använd callbook-sökning för att justera lokatorruta"
 
 #: application/views/dbtools/index.php:126
 msgid "Lookup"
-msgstr ""
+msgstr "Slå upp"
 
 #: application/views/dbtools/index.php:134
 msgid "Check IOTA against DXCC"
@@ -14311,35 +14311,35 @@ msgstr "Använd Wavelog för att kontrollera IOTA mot DXCC"
 #: application/views/dbtools/missinggridlist.php:12
 #, php-format
 msgid "%s QSO(s) selected"
-msgstr ""
+msgstr "%s QSOs valda"
 
 #: application/views/dbtools/missinggridlist.php:13
 #, php-format
 msgid "%s QSO(s) remaining"
-msgstr ""
+msgstr "%s QSOs kvar"
 
 #: application/views/dbtools/missinggridlist.php:14
 #, php-format
 msgid "Updated: %s"
-msgstr ""
+msgstr "Uppdaterad: %s"
 
 #: application/views/dbtools/missinggridlist.php:15
 #, php-format
 msgid "Not found: %s"
-msgstr ""
+msgstr "Inte hittad: %s"
 
 #: application/views/dbtools/missinggridlist.php:16
 #, php-format
 msgid "Errors: %s"
-msgstr ""
+msgstr "Fel: %s"
 
 #: application/views/dbtools/missinggridlist.php:17
 msgid "Retrieving callbook data..."
-msgstr ""
+msgstr "Hämtar callbook-data..."
 
 #: application/views/dbtools/missinggridlist.php:18
 msgid "Not found in callbook"
-msgstr ""
+msgstr "Hittades inte i callboken"
 
 #: application/views/dbtools/missinggridlist.php:19
 #: application/views/logbookadvanced/index.php:39
@@ -14350,23 +14350,24 @@ msgstr "Skippad"
 #, php-format
 msgid "Lookup finished: %s gridsquare(s) set, %s not found, %s error(s)."
 msgstr ""
+"Uppslagsprocessen avslutad: %s rutor inställda, %s hittades inte, %s fel."
 
 #: application/views/dbtools/missinggridlist.php:22
 msgid "Lookup cancelled."
-msgstr ""
+msgstr "Uppslag avbrutet."
 
 #: application/views/dbtools/missinggridlist.php:32
 msgid "Only unconfirmed QSOs"
-msgstr ""
+msgstr "Endast obekräftade QSOs"
 
 #: application/views/dbtools/missinggridlist.php:36
 #, php-format
 msgid "Found %s QSO(s) with missing gridsquare."
-msgstr ""
+msgstr "Hittade %s QSO(s) utan lokatorruta."
 
 #: application/views/dbtools/missinggridlist.php:37
 msgid "Uncheck the QSOs you want to skip, then start the lookup."
-msgstr ""
+msgstr "Avmarkera de QSOs du vill hoppa över, starta sedan uppslagningen."
 
 #: application/views/dbtools/missinggridlist.php:50
 #: application/views/view_log/partial/log_ajax.php:129
@@ -15679,7 +15680,7 @@ msgstr "Satellit-Rovers"
 
 #: application/views/hamsat/index.php:18
 msgid "LoTW User. Days since last upload: "
-msgstr ""
+msgstr "LoTW-användare. Dagar sedan senaste uppladdning: "
 
 #: application/views/hamsat/index.php:29
 #, php-format
@@ -23008,7 +23009,7 @@ msgstr ""
 
 #: application/views/user/edit.php:459
 msgid "Prefill fields from callbook while logging"
-msgstr ""
+msgstr "Fyll i fälten från callbook medan du loggar"
 
 #: application/views/user/edit.php:460
 msgid ""
@@ -23016,18 +23017,21 @@ msgid ""
 "when entering a callsign. DXCC lookup, the previous QSOs table and the "
 "callbook profile panel are always shown."
 msgstr ""
+"Kontrollerar vilka källor som fyller i QSO-fälten (namn, QTH, lokator, etc.) "
+"när ett anropssignal anges. DXCC-uppslagning, tabellen med tidigare QSOs och "
+"callbook-profilpanelen visas alltid."
 
 #: application/views/user/edit.php:463
 msgid "Callbook and previous QSOs (default)"
-msgstr ""
+msgstr "Callbook och tidigare QSOs (standard)"
 
 #: application/views/user/edit.php:467
 msgid "Only previous QSOs"
-msgstr ""
+msgstr "Endast tidigare QSOs"
 
 #: application/views/user/edit.php:471
 msgid "No prefill"
-msgstr ""
+msgstr "Ingen förifyllning"
 
 #: application/views/user/edit.php:483
 msgid ""


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)