### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-01 10:50+0000\n"
-"PO-Revision-Date: 2026-08-28 10:36+0000\n"
+"PO-Revision-Date: 2026-09-01 11:03+0000\n"
 "Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
@@ -4755,7 +4755,7 @@ msgstr "Station nicht verfügbar"
 
 #: application/models/Logbook_model.php:993
 msgid "Realtime upload disabled"
-msgstr ""
+msgstr "Echtzeit-Upload deaktiviert"
 
 #: application/models/Logbook_model.php:1451
 msgid "Station ID not allowed"
@@ -16097,7 +16097,7 @@ msgstr "QSO mit %s von %s wurde dem Logbuch hinzugefügt."
 #: application/views/interface_assets/footer.php:85
 #, php-format
 msgid "Realtime upload failed: %s"
-msgstr ""
+msgstr "Echtzeit-Upload fehlgeschlagen: %s"
 
 #: application/views/interface_assets/footer.php:86
 msgid "QSO Added to Backlog"


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)