### PR TITLE
Fix wrong URL for tile cache

### DIFF
--- a/application/controllers/Tiles.php
+++ b/application/controllers/Tiles.php
@@ -69,7 +69,6 @@ class Tiles extends CI_Controller {
 		]);
 		$body = curl_exec($ch);
 		$status = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		curl_close($ch);
 
 		if ($body === false || $status !== 200 || strncmp($body, "\x89PNG", 4) !== 0) {
 			return null;

--- a/application/libraries/MaptileCache.php
+++ b/application/libraries/MaptileCache.php
@@ -71,7 +71,7 @@ class MaptileCache {
 		if ($url === null) {
 			[$upstream, $subdomains] = self::config();
 			$version = substr(hash('xxh128', $upstream . $subdomains), 0, 8);
-			$url = base_url('tiles/{z}/{x}/{y}.png?provider=' . $version);
+			$url = site_url('tiles/{z}/{x}/{y}.png?provider=' . $version);
 		}
 		return $url;
 	}


### PR DESCRIPTION
Map functions produce 404s on map tiles:

<img width="1081" height="569" alt="image" src="https://github.com/user-attachments/assets/3179435e-565a-484f-8ba5-76390a4da3d8" />

Reason: base_url does not include index.php. But if that is in use the tile URLs end up in 404.