### PR TITLE
Fix handling of no coordinates for DXCC none

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -22,7 +22,7 @@ $config['migration_enabled'] = TRUE;
 |
 */
 
-$config['migration_version'] = 297;
+$config['migration_version'] = 298;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Update.php
+++ b/application/controllers/Update.php
@@ -79,8 +79,8 @@ class Update extends CI_Controller {
 			'ituz' => 0,
 			'cqz' => 0,
 			'cont' => '',
-			'long' => 0,
-			'lat' => 0,
+			'long' => null,
+			'lat' => null,
 			'start' => null,
 			'end' => null,
 		];

--- a/application/migrations/298_dxcc_none_null_coordinates.php
+++ b/application/migrations/298_dxcc_none_null_coordinates.php
@@ -20,9 +20,9 @@ class Migration_dxcc_none_null_coordinates extends CI_Migration {
 
 	public function down()
 	{
+		$this->dbtry("UPDATE {$this->table_name} SET `long` = 0, `lat` = 0 WHERE {$this->table_name}.`adif` = 0;");
 		$this->dbtry("ALTER TABLE {$this->table_name} CHANGE `long` `long` FLOAT NOT NULL;");
 		$this->dbtry("ALTER TABLE {$this->table_name} CHANGE `lat` `lat` FLOAT NOT NULL;");
-		$this->dbtry("UPDATE {$this->table_name} SET `long` = 0, `lat` = 0 WHERE {$this->table_name}.`adif` = 0;");
 	}
 
 	function dbtry($what) {

--- a/application/migrations/298_dxcc_none_null_coordinates.php
+++ b/application/migrations/298_dxcc_none_null_coordinates.php
@@ -1,0 +1,35 @@
+<?php
+
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+/*
+ * Lat/lon of 0/0 are valid coordinates though not for a DXCC.
+ * So we allow null as value here to allow differentiation
+ */
+
+class Migration_dxcc_none_null_coordinates extends CI_Migration {
+
+	private $table_name = 'dxcc_entities';
+
+	public function up()
+	{
+		$this->dbtry("ALTER TABLE {$this->table_name} CHANGE `long` `long` FLOAT NULL;");
+		$this->dbtry("ALTER TABLE {$this->table_name} CHANGE `lat` `lat` FLOAT NULL;");
+		$this->dbtry("UPDATE {$this->table_name} SET `long` = NULL, `lat` = NULL WHERE {$this->table_name}.`adif` = 0;");
+	}
+
+	public function down()
+	{
+		$this->dbtry("ALTER TABLE {$this->table_name} CHANGE `long` `long` FLOAT NOT NULL;");
+		$this->dbtry("ALTER TABLE {$this->table_name} CHANGE `lat` `lat` FLOAT NOT NULL;");
+		$this->dbtry("UPDATE {$this->table_name} SET `long` = 0, `lat` = 0 WHERE {$this->table_name}.`adif` = 0;");
+	}
+
+	function dbtry($what) {
+		try {
+			$this->db->query($what);
+		} catch (Exception $e) {
+			log_message("error", "Mig 298: Error updating dxcc_entitites table: ".$e." // Executing: ".$this->db->last_query());
+		}
+	}
+}

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -6394,6 +6394,8 @@ class Logbook_model extends CI_Model {
 			} else {
 				if (isset($row->lat) && isset($row->long)) {
 					$stn_loc = array($row->lat, $row->long);
+				} else {
+					continue;
 				}
 			}
 			if (isset($xbearing)) {

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -853,8 +853,8 @@
 ?>
 
 <script>
-var lat = <?php echo $lat; ?>;
-var long = <?php echo $lng; ?>;
+var lat = <?php echo $lat ?? 'null'; ?>;
+var long = <?php echo $lng ?? 'null'; ?>;
 var callsign = <?php echo js_escape($row->COL_CALL); ?>;
 </script>
     <div hidden id ='dxcc'><?php echo html_escape($row->COL_DXCC); ?></div>

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -812,12 +812,12 @@
          if (isset($row->lat)) {
             $lat = $row->lat;
          } else {
-            $lat = 0;
+            $lat = null;
          }
          if (isset($row->long)) {
             $lng = $row->long;
          } else {
-            $lng = 0;
+            $lng = null;
          }
       }
    } else if ($row->COL_VUCC_GRIDS != null) {
@@ -829,25 +829,25 @@
          if(isset($row->lat)) {
             $lat = $row->lat;
          } else {
-            $lat = 0;
+            $lat = null;
          }
          if(isset($row->long)) {
             $lng = $row->long;
          } else {
-            $lng = 0;
+            $lng = null;
          }
       }
    } else {
       if(isset($row->lat)) {
          $lat = $row->lat;
       } else {
-         $lat = 0;
+         $lat = null;
       }
 
       if(isset($row->long)) {
          $lng = $row->long;
       } else {
-         $lng = 0;
+         $lng = null;
       }
    }
 ?>

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -215,7 +215,7 @@ function displayQso(id) {
                     var dxcc = $("#dxcc").text();
                     var callsign = $("#callsign").text();
                     var zoom = 5;
-                    if (dxcc == 0) {
+                    if (dxcc == 0 && lat == '' && lng == '') {
                         zoom = 1;
                     }
                     var mymap = L.map('mapqso').setView([lat,lng], zoom);
@@ -234,7 +234,7 @@ function displayQso(id) {
                         hideControlContainer: true
                     }).addTo(mymap);
 
-                    if (dxcc != 0) {
+                    if (lat != '' && lng != '') {
                         var redIcon = L.icon({
                             iconUrl: icon_dot_url,
                             iconSize:     [18, 18], // size of the icon


### PR DESCRIPTION
Since we derive mapping coordinates for QSOs without grid from its DXCC and -NONE- as DXCC had 0/0 as coordinates we have some issues mapping those QSOs:

Though we have a grid the map does not center on grid and does not show a marker (if DXCC is -NONE-)

<img width="1272" height="596" alt="image" src="https://github.com/user-attachments/assets/e9a8ad64-5f10-43cd-ac6f-86aad79d6ffc" />

So we change structure of dxcc_entitites to allow null for lat/long and set it to null for DXCC -NONE- with id 0. We show maps centered and markers if we have a grid or coordinates (and not null as for DXCC -NONE- without grid)