### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-02 14:14+0000\n"
-"PO-Revision-Date: 2026-09-01 12:38+0000\n"
-"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
+"PO-Revision-Date: 2026-09-02 14:33+0000\n"
+"Last-Translator: Jörg Dorgeist <wavelog@dj7nt.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -271,7 +271,7 @@ msgstr "Kumulierte Statistiken"
 #: application/views/achievements/index.php:74
 #: application/views/interface_assets/header.php:192
 msgid "Achievements"
-msgstr ""
+msgstr "Erfolge"
 
 #: application/controllers/Activated_gridmap.php:12
 #: application/views/activated_gridmap/index.php:6
@@ -4604,16 +4604,16 @@ msgstr "Statistiken abfragen"
 #, php-format
 msgid "%s day"
 msgid_plural "%s days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s Tag"
+msgstr[1] "%s Tage"
 
 #: application/models/Achievements_model.php:175
 msgid "Longest streak"
-msgstr ""
+msgstr "Längste Serie"
 
 #: application/models/Achievements_model.php:176
 msgid "Current streak"
-msgstr ""
+msgstr "Aktuelle Serie"
 
 #: application/models/Achievements_model.php:177
 #: application/models/Achievements_model.php:199
@@ -4624,120 +4624,120 @@ msgstr "Ziel"
 
 #: application/models/Achievements_model.php:180
 msgid "Reached on"
-msgstr ""
+msgstr "Erreicht am"
 
 #: application/models/Achievements_model.php:184
 #, php-format
 msgid "%d Day Streak"
-msgstr ""
+msgstr "%d Tage-Serie"
 
 #: application/models/Achievements_model.php:188
 #, php-format
 msgid "%s / %s day"
 msgid_plural "%s / %s days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s / %s Tag"
+msgstr[1] "%s / %s Tagen"
 
 #: application/models/Achievements_model.php:198
 msgid "QSOs in log"
-msgstr ""
+msgstr "QSOs im Log"
 
 #: application/models/Achievements_model.php:199
 #: application/models/Achievements_model.php:206
 #, php-format
 msgid "%s QSO"
 msgid_plural "%s QSOs"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s QSO"
+msgstr[1] "%s QSOs"
 
 #: application/models/Achievements_model.php:202
 msgid "Unlocked on"
-msgstr ""
+msgstr "Erreicht am"
 
 #: application/models/Achievements_model.php:210
 #, php-format
 msgid "%s / %s QSO"
 msgid_plural "%s / %s QSOs"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s / %s QSO"
+msgstr[1] "%s / %s QSOs"
 
 #: application/models/Achievements_model.php:240
 msgid "QSOs in classic digimodes"
-msgstr ""
+msgstr "QSOS in klassischen Digimodes"
 
 #: application/models/Achievements_model.php:242
 #: application/models/Achievements_model.php:359
 #: application/models/Achievements_model.php:392
 msgid "First QSO on"
-msgstr ""
+msgstr "Erstes QSO am"
 
 #: application/models/Achievements_model.php:245
 msgid "Top classic mode"
-msgstr ""
+msgstr "Häufigster klassischer Mode"
 
 #: application/models/Achievements_model.php:248
 msgid "First CW QSO"
-msgstr ""
+msgstr "Erstes CW QSO"
 
 #: application/models/Achievements_model.php:250
 msgid "First SSB QSO"
-msgstr ""
+msgstr "Erstes SSB QSO"
 
 #: application/models/Achievements_model.php:252
 msgid "First FT8 QSO"
-msgstr ""
+msgstr "Erstes FT8 QSO"
 
 #: application/models/Achievements_model.php:254
 msgid "First Classic Digimode QSO"
-msgstr ""
+msgstr "Ersters QSO in klassischem Digimode"
 
 #: application/models/Achievements_model.php:255
 msgid "Triple Threat"
-msgstr ""
+msgstr "Alle drei"
 
 #: application/models/Achievements_model.php:256
 #, php-format
 msgid "%s / 3 mode"
 msgid_plural "%s / 3 modes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s / 3 Mode"
+msgstr[1] "%s / 3 Modes"
 
 #: application/models/Achievements_model.php:258
 msgid "Worked modes"
-msgstr ""
+msgstr "Gearbeitete Modes"
 
 #: application/models/Achievements_model.php:259
 msgid "Missing modes"
-msgstr ""
+msgstr "Fehlende Modes"
 
 #: application/models/Achievements_model.php:275
 msgid "First LoTW Confirmation"
-msgstr ""
+msgstr "Erste LoTW Bestätigung"
 
 #: application/models/Achievements_model.php:276
 msgid "Confirmed on"
-msgstr ""
+msgstr "Bestätigt am"
 
 #: application/models/Achievements_model.php:294
 msgid "CW and SSB QSOs"
-msgstr ""
+msgstr "CW und SSB QSOs"
 
 #: application/models/Achievements_model.php:295
 msgid "FT8 and FT4 QSOs"
-msgstr ""
+msgstr "FT8 und FT4 QSOs"
 
 #: application/models/Achievements_model.php:296
 msgid "Current ratio"
-msgstr ""
+msgstr "Aktuelles Verhältnis"
 
 #: application/models/Achievements_model.php:297
 msgid "Needed ratio"
-msgstr ""
+msgstr "Benötigtes Verhältnis"
 
 #: application/models/Achievements_model.php:302
 #, php-format
 msgid "Total: %s QSOs"
-msgstr ""
+msgstr "Gesamt: %s QSOs"
 
 #: application/models/Achievements_model.php:306
 #: application/views/awards/counties/index.php:195
@@ -4758,59 +4758,59 @@ msgstr "Gearbeitet"
 
 #: application/models/Achievements_model.php:309
 msgid "Classic digimodes"
-msgstr ""
+msgstr "Klassische Digimodes"
 
 #: application/models/Achievements_model.php:313
 #, php-format
 msgid "HF: %s/%s"
-msgstr ""
+msgstr "KW: %s/%s"
 
 #: application/models/Achievements_model.php:314
 #, php-format
 msgid "WARC: %s/%s"
-msgstr ""
+msgstr "WARC: %s/%s"
 
 #: application/models/Achievements_model.php:315
 #, php-format
 msgid "SAT: %s"
-msgstr ""
+msgstr "SAT: %s"
 
 #: application/models/Achievements_model.php:317
 #, php-format
 msgid "First confirmation: %s"
-msgstr ""
+msgstr "Erste Bestätigung: %s"
 
 #: application/models/Achievements_model.php:317
 msgid "No LoTW confirmation yet"
-msgstr ""
+msgstr "Noch keine LoTW-Bestätigung"
 
 #: application/models/Achievements_model.php:319
 msgid "CW and SSB versus FT8 and FT4"
-msgstr ""
+msgstr "CW u. SSB zu FT8 u. FT4"
 
 #: application/models/Achievements_model.php:322
 msgid "Streak"
-msgstr ""
+msgstr "Serie"
 
 #: application/models/Achievements_model.php:323
 msgid "Volume"
-msgstr ""
+msgstr "Anzahl QSOs"
 
 #: application/models/Achievements_model.php:327
 msgid "Classic Mode Ratio"
-msgstr ""
+msgstr "Verhältnis klassische Modes"
 
 #: application/models/Achievements_model.php:356
 msgid "QSOs in this mode"
-msgstr ""
+msgstr "QSOs in diesem Mode"
 
 #: application/models/Achievements_model.php:374
 msgid "Bands worked"
-msgstr ""
+msgstr "Gearbeitete Bänder"
 
 #: application/models/Achievements_model.php:375
 msgid "Missing bands"
-msgstr ""
+msgstr "Fehlende Bänder"
 
 #: application/models/Achievements_model.php:376
 msgid "Range"
@@ -4818,36 +4818,36 @@ msgstr ""
 
 #: application/models/Achievements_model.php:379
 msgid "Completed on"
-msgstr ""
+msgstr "Vollständig am"
 
 #: application/models/Achievements_model.php:382
 #, php-format
 msgid "%s / %s band"
 msgid_plural "%s / %s bands"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s / %s Band"
+msgstr[1] "%s / %s Bändern"
 
 #: application/models/Achievements_model.php:390
 msgid "SAT QSOs"
-msgstr ""
+msgstr "SAT QSOs"
 
 #: application/models/Achievements_model.php:395
 msgid "Different satellites"
-msgstr ""
+msgstr "Unterschiedliche Satelliten"
 
 #: application/models/Achievements_model.php:401
 #, php-format
 msgid "Longest streak: %s day"
 msgid_plural "Longest streak: %s days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Längste Serie: %s Tag"
+msgstr[1] "Längste Serie: %s Tage"
 
 #: application/models/Achievements_model.php:403
 #, php-format
 msgid "Current streak: %s day"
 msgid_plural "Current streak: %s days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Aktuelle Serie: %s Tag"
+msgstr[1] "Aktuelle Serie: %s Tage"
 
 #: application/models/Achievements_model.php:410
 #: application/views/visitor/mini.php:214
@@ -4857,7 +4857,7 @@ msgstr "Noch keine QSOs"
 #: application/models/Achievements_model.php:413
 #: application/models/Achievements_model.php:415
 msgid "classic"
-msgstr ""
+msgstr "Klassisch"
 
 #: application/models/Api_v2_model.php:105
 msgid " (min. 2.1.0)"
@@ -5569,6 +5569,8 @@ msgid ""
 "No station locations are linked to your active logbook. Trophies need at "
 "least one linked station location."
 msgstr ""
+"Du hast keinen Stationsstandort zu Deinem Logbuch hinzugefügt. Um Erfolge "
+"anzuzeigen, verlinke mindestens einen Standort."
 
 #: application/views/achievements/index.php:76
 msgid "QSO filter"
@@ -5576,15 +5578,15 @@ msgstr ""
 
 #: application/views/achievements/index.php:77
 msgid "All QSOs"
-msgstr ""
+msgstr "Alle QSOs"
 
 #: application/views/achievements/index.php:78
 msgid "Confirmed only"
-msgstr ""
+msgstr "Nur Bestätigte"
 
 #: application/views/achievements/index.php:78
 msgid "Count only QSOs confirmed by LoTW or paper card"
-msgstr ""
+msgstr "Zähle nur QSOs die entweder per QSL-Karte oder LoTW bestätigt wurden"
 
 #: application/views/achievements/index.php:81
 #, php-format

--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -28,7 +28,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-02 14:14+0000\n"
 "PO-Revision-Date: 2026-09-02 14:33+0000\n"
-"Last-Translator: Jörg Dorgeist <wavelog@dj7nt.de>\n"
+"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -4814,7 +4814,7 @@ msgstr "Fehlende Bänder"
 
 #: application/models/Achievements_model.php:376
 msgid "Range"
-msgstr ""
+msgstr "Bereich"
 
 #: application/models/Achievements_model.php:379
 msgid "Completed on"
@@ -5574,7 +5574,7 @@ msgstr ""
 
 #: application/views/achievements/index.php:76
 msgid "QSO filter"
-msgstr ""
+msgstr "QSO-Filter"
 
 #: application/views/achievements/index.php:77
 msgid "All QSOs"
@@ -5591,21 +5591,21 @@ msgstr "Zähle nur QSOs die entweder per QSL-Karte oder LoTW bestätigt wurden"
 #: application/views/achievements/index.php:81
 #, php-format
 msgid "You have unlocked %s of %s trophies."
-msgstr ""
+msgstr "Du hast %s von %s Trophäen freigeschaltet."
 
 #: application/views/achievements/index.php:83
 #, php-format
 msgid "Cached data as of %s"
-msgstr ""
+msgstr "Zwischengespeicherte Daten vom %s"
 
 #: application/views/achievements/index.php:124
 #: application/views/achievements/index.php:189
 msgid "Unlocked"
-msgstr ""
+msgstr "Freigeschaltet"
 
 #: application/views/achievements/index.php:143
 msgid "Trophy"
-msgstr ""
+msgstr "Trophäe"
 
 #: application/views/achievements/index.php:144
 #: application/views/activationplanner/index.php:30
@@ -5633,7 +5633,7 @@ msgstr "Schließen"
 
 #: application/views/achievements/index.php:189
 msgid "Locked"
-msgstr ""
+msgstr "Gesperrt"
 
 #: application/views/activated_gridmap/index.php:10
 #: application/views/interface_assets/header.php:168

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-01 16:22+0000\n"
-"PO-Revision-Date: 2026-08-31 23:18+0000\n"
+"PO-Revision-Date: 2026-09-02 14:14+0000\n"
 "Last-Translator: \"Xu, Zefan (BI1GHZ)\" <ceba_robot@outlook.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
@@ -4695,7 +4695,7 @@ msgstr "利用できない無線局"
 
 #: application/models/Logbook_model.php:993
 msgid "Realtime upload disabled"
-msgstr ""
+msgstr "リアルタイムアップロードが無効になっています"
 
 #: application/models/Logbook_model.php:1451
 msgid "Station ID not allowed"
@@ -15912,7 +15912,7 @@ msgstr "%s による %s とのQSOがログブックに追加されました。"
 #: application/views/interface_assets/footer.php:85
 #, php-format
 msgid "Realtime upload failed: %s"
-msgstr ""
+msgstr "リアルタイムアップロードに失敗しました: %s"
 
 #: application/views/interface_assets/footer.php:86
 msgid "QSO Added to Backlog"

--- a/application/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/application/locale/tr_TR/LC_MESSAGES/messages.po
@@ -14,8 +14,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-01 16:22+0000\n"
-"PO-Revision-Date: 2026-08-27 10:19+0000\n"
-"Last-Translator: metint <metin@tekkalmaz.net>\n"
+"PO-Revision-Date: 2026-09-02 14:14+0000\n"
+"Last-Translator: \"Erkin Mercan (TA4AQG-SP9AQG)\" <ekomeko066@gmail.com>\n"
 "Language-Team: Turkish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/tr/>\n"
 "Language: tr_TR\n"
@@ -838,31 +838,31 @@ msgstr "WAIP"
 
 #: application/controllers/Awards.php:2572
 msgid "England"
-msgstr ""
+msgstr "İngiltere"
 
 #: application/controllers/Awards.php:2573
 msgid "Isle of Man"
-msgstr ""
+msgstr "Man Adası"
 
 #: application/controllers/Awards.php:2574
 msgid "Northern Ireland"
-msgstr ""
+msgstr "Kuzey İrlanda"
 
 #: application/controllers/Awards.php:2575
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 #: application/controllers/Awards.php:2576
 msgid "Scotland"
-msgstr ""
+msgstr "İskoçya"
 
 #: application/controllers/Awards.php:2577
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 #: application/controllers/Awards.php:2578
 msgid "Wales"
-msgstr ""
+msgstr "Galler"
 
 #: application/controllers/Awards.php:2794
 #: application/views/awards/wac/index.php:7
@@ -4703,7 +4703,7 @@ msgstr "İstasyona erişilemiyor"
 
 #: application/models/Logbook_model.php:993
 msgid "Realtime upload disabled"
-msgstr ""
+msgstr "Gerçek zamanlı yükleme devre dışı"
 
 #: application/models/Logbook_model.php:1451
 msgid "Station ID not allowed"
@@ -9291,28 +9291,28 @@ msgstr ""
 
 #: application/views/awards/wab/index.php:19
 msgid "Total squares"
-msgstr ""
+msgstr "Toplam kare sayısı"
 
 #: application/views/awards/wab/index.php:21
 msgid "Squares by DXCC"
-msgstr ""
+msgstr "DXCC'ye göre kareler"
 
 #: application/views/awards/wab/index.php:22
 #: application/views/awards/wab/index.php:44
 msgid "Go to square"
-msgstr ""
+msgstr "Kareye git"
 
 #: application/views/awards/wab/index.php:23
 msgid "WAB square not found"
-msgstr ""
+msgstr "WAB karesi bulunamadı"
 
 #: application/views/awards/wab/index.php:34
 msgid "View a map of worked / confirmed WAB squares"
-msgstr ""
+msgstr "Çalışılan / onaylanan WAB karelerinin haritasını görüntüle"
 
 #: application/views/awards/wab/index.php:43
 msgid "WAB square"
-msgstr ""
+msgstr "WAB Karesi"
 
 #: application/views/awards/wab/index.php:171
 msgid "List"
@@ -9388,7 +9388,7 @@ msgstr "Hayır"
 
 #: application/views/awards/wab/list.php:37
 msgid "Q = QSL card, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
-msgstr ""
+msgstr "Q = QSL kart, L = LoTW, E = eQSL, Z = QRZ.com, C = Clublog"
 
 #: application/views/awards/wac/index.php:8
 msgid ""
@@ -14331,7 +14331,7 @@ msgstr "Grid karesini ayarlamak için çağrı defteri sorgusu kullan"
 
 #: application/views/dbtools/index.php:126
 msgid "Lookup"
-msgstr ""
+msgstr "Sorgula"
 
 #: application/views/dbtools/index.php:134
 msgid "Check IOTA against DXCC"
@@ -14344,35 +14344,35 @@ msgstr "IOTA'yı DXCC'ye göre kontrol etmek için Wavelog'u kullan"
 #: application/views/dbtools/missinggridlist.php:12
 #, php-format
 msgid "%s QSO(s) selected"
-msgstr ""
+msgstr "%s QSO seçildi"
 
 #: application/views/dbtools/missinggridlist.php:13
 #, php-format
 msgid "%s QSO(s) remaining"
-msgstr ""
+msgstr "%s QSO kaldı"
 
 #: application/views/dbtools/missinggridlist.php:14
 #, php-format
 msgid "Updated: %s"
-msgstr ""
+msgstr "Güncellendi: %s"
 
 #: application/views/dbtools/missinggridlist.php:15
 #, php-format
 msgid "Not found: %s"
-msgstr ""
+msgstr "Bulunamadı: %s"
 
 #: application/views/dbtools/missinggridlist.php:16
 #, php-format
 msgid "Errors: %s"
-msgstr ""
+msgstr "Hata: %s"
 
 #: application/views/dbtools/missinggridlist.php:17
 msgid "Retrieving callbook data..."
-msgstr ""
+msgstr "Çağrı kitabı verileri alınıyor..."
 
 #: application/views/dbtools/missinggridlist.php:18
 msgid "Not found in callbook"
-msgstr ""
+msgstr "Çağrı kitabında bulunamadı"
 
 #: application/views/dbtools/missinggridlist.php:19
 #: application/views/logbookadvanced/index.php:39
@@ -14382,24 +14382,26 @@ msgstr "Atlandı"
 #: application/views/dbtools/missinggridlist.php:21
 #, php-format
 msgid "Lookup finished: %s gridsquare(s) set, %s not found, %s error(s)."
-msgstr ""
+msgstr "Sorgulama tamamlandı: %s grid karesi ayarlandı, %s bulunamadı, %s hata."
 
 #: application/views/dbtools/missinggridlist.php:22
 msgid "Lookup cancelled."
-msgstr ""
+msgstr "Sorgulama iptal edildi."
 
 #: application/views/dbtools/missinggridlist.php:32
 msgid "Only unconfirmed QSOs"
-msgstr ""
+msgstr "Yalnızca onaylanmamış QSO'lar"
 
 #: application/views/dbtools/missinggridlist.php:36
 #, php-format
 msgid "Found %s QSO(s) with missing gridsquare."
-msgstr ""
+msgstr "Grid karesi eksik %s QSO bulundu."
 
 #: application/views/dbtools/missinggridlist.php:37
 msgid "Uncheck the QSOs you want to skip, then start the lookup."
 msgstr ""
+"Atlamak istediğiniz QSO'ların işaretini kaldırın, ardından sorgulamayı "
+"başlatın."
 
 #: application/views/dbtools/missinggridlist.php:50
 #: application/views/view_log/partial/log_ajax.php:129
@@ -15717,7 +15719,7 @@ msgstr "Uydu Rover'ları"
 
 #: application/views/hamsat/index.php:18
 msgid "LoTW User. Days since last upload: "
-msgstr ""
+msgstr "LoTW Kullanıcısı. Son yüklemeden bu yana geçen gün: "
 
 #: application/views/hamsat/index.php:29
 #, php-format
@@ -15973,7 +15975,7 @@ msgstr "%s ile %s arasındaki QSO kayıt defterine eklendi."
 #: application/views/interface_assets/footer.php:85
 #, php-format
 msgid "Realtime upload failed: %s"
-msgstr ""
+msgstr "Gerçek zamanlı yükleme başarısız: %s"
 
 #: application/views/interface_assets/footer.php:86
 msgid "QSO Added to Backlog"
@@ -23056,7 +23058,7 @@ msgstr ""
 
 #: application/views/user/edit.php:459
 msgid "Prefill fields from callbook while logging"
-msgstr ""
+msgstr "QSO kaydı sırasında alanları çağrı kitabından otomatik doldur"
 
 #: application/views/user/edit.php:460
 msgid ""
@@ -23064,18 +23066,21 @@ msgid ""
 "when entering a callsign. DXCC lookup, the previous QSOs table and the "
 "callbook profile panel are always shown."
 msgstr ""
+"Çağrı işareti girildiğinde QSO alanlarını (ad, QTH, lokator vb.) hangi "
+"kaynakların dolduracağını belirler. DXCC sorgulaması, önceki QSO'lar tablosu "
+"ve çağrı kitabı profil paneli her zaman görüntülenir."
 
 #: application/views/user/edit.php:463
 msgid "Callbook and previous QSOs (default)"
-msgstr ""
+msgstr "Çağrı kitabı ve önceki QSO'lar (varsayılan)"
 
 #: application/views/user/edit.php:467
 msgid "Only previous QSOs"
-msgstr ""
+msgstr "Yalnızca önceki QSO'lar"
 
 #: application/views/user/edit.php:471
 msgid "No prefill"
-msgstr ""
+msgstr "Otomatik doldurma yok"
 
 #: application/views/user/edit.php:483
 msgid ""

--- a/application/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/application/locale/zh_CN/LC_MESSAGES/messages.po
@@ -38,10 +38,10 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-01 16:22+0000\n"
-"PO-Revision-Date: 2026-08-31 23:18+0000\n"
+"PO-Revision-Date: 2026-09-02 14:14+0000\n"
 "Last-Translator: \"Xu, Zefan (BI1GHZ)\" <ceba_robot@outlook.com>\n"
-"Language-Team: Chinese (Simplified Han script) <https://translate.wavelog."
-"org/projects/wavelog/main-translation/zh_Hans/>\n"
+"Language-Team: Chinese (Simplified Han script) <https://"
+"translate.wavelog.org/projects/wavelog/main-translation/zh_Hans/>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -4647,7 +4647,7 @@ msgstr "台站不可用"
 
 #: application/models/Logbook_model.php:993
 msgid "Realtime upload disabled"
-msgstr ""
+msgstr "实时上传已禁用"
 
 #: application/models/Logbook_model.php:1451
 msgid "Station ID not allowed"
@@ -15532,7 +15532,7 @@ msgstr "已将的由%s进行与%s的 QSO 添加到日志簿。"
 #: application/views/interface_assets/footer.php:85
 #, php-format
 msgid "Realtime upload failed: %s"
-msgstr ""
+msgstr "实时上传失败：%s"
 
 #: application/views/interface_assets/footer.php:86
 msgid "QSO Added to Backlog"


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)