### PR TITLE
po/mo updates for USA-CA scoring strings (#3782)

### DIFF
--- a/application/locale/bg_BG/LC_MESSAGES/messages.po
+++ b/application/locale/bg_BG/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2024-11-01 08:53+0000\n"
 "Last-Translator: Plamen Panteleev <lz1ppl@abv.bg>\n"
 "Language-Team: Bulgarian <https://translate.wavelog.org/projects/wavelog/"
@@ -258,8 +258,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Активиране на картата с QTH локатори"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -324,7 +324,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -511,17 +511,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -778,39 +778,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -822,74 +822,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5162,7 +5162,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5872,10 +5872,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7422,8 +7422,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7669,8 +7669,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7702,7 +7706,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15925,6 +15929,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/bs/LC_MESSAGES/messages.po
+++ b/application/locale/bs/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2024-11-16 17:03+0000\n"
 "Last-Translator: Samir <DL4DCO@users.noreply.translate.wavelog.org>\n"
 "Language-Team: Bosnian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -260,8 +260,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -326,7 +326,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -513,17 +513,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -780,39 +780,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -824,74 +824,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5891,10 +5891,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7443,8 +7443,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7617,7 +7617,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7690,8 +7690,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7723,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15956,6 +15960,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/cnr/LC_MESSAGES/messages.po
+++ b/application/locale/cnr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2024-11-19 01:22+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: Montenegrin <https://translate.wavelog.org/projects/wavelog/"
@@ -260,8 +260,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -326,7 +326,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -513,17 +513,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -780,39 +780,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -824,74 +824,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5891,10 +5891,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7443,8 +7443,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7617,7 +7617,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7690,8 +7690,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7723,7 +7727,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15951,6 +15955,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/cs_CZ/LC_MESSAGES/messages.po
+++ b/application/locale/cs_CZ/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-07-29 08:13+0000\n"
 "Last-Translator: Dariusz Koryto <dariusz@koryto.eu>\n"
 "Language-Team: Czech <https://translate.wavelog.org/projects/wavelog/main-"
@@ -263,8 +263,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa aktivovaných lokátorů"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -329,7 +329,7 @@ msgid "Zones"
 msgstr "Zóny"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU zóny"
@@ -516,17 +516,17 @@ msgstr "Diplomy"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplomy - %s"
@@ -783,39 +783,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "US Okresy"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Zobrazení logu - Counties"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplomy - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Pracováno lokátorů"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Lokátory potvrzené LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Lokátory potvrzené papírovým QSL"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Celkem pracováno lokátorů"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -827,74 +827,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplomy- SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 na 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "Ocenění \"Polska\""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Diplomy - AMSAT Rover"
 
@@ -5270,7 +5270,7 @@ msgstr "Rozdíl"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5980,10 +5980,10 @@ msgstr "Minimální počet"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7611,8 +7611,8 @@ msgstr "Stáhnout CSV"
 msgid "County"
 msgstr "Okres"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7796,8 +7796,8 @@ msgstr "Navázané okresy"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "z %s známých okresů"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7869,8 +7869,12 @@ msgstr "Postup navázaných"
 msgid "Confirmed Progress"
 msgstr "Postup potvrzených"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7902,7 +7906,7 @@ msgstr "Postup potvrzených"
 msgid "Total"
 msgstr "Celkem"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -9916,9 +9920,9 @@ msgid ""
 "Macao/152, Taiwan/386, Pratas Isl./505 or Scarborough Reef/506) and valid "
 "State (ADIF: DXCC and STATE)"
 msgstr ""
-"Pole použitá pro tento odznak: DXCC (musí být jeden z Čína/318, "
-"HongKong/321, Macao/152, Taiwan/386, Pratas Isl./505 nebo Scarborough "
-"Reef/506) a platný State (ADIF: DXCC a STATE)"
+"Pole použitá pro tento odznak: DXCC (musí být jeden z Čína/318, HongKong/"
+"321, Macao/152, Taiwan/386, Pratas Isl./505 nebo Scarborough Reef/506) a "
+"platný State (ADIF: DXCC a STATE)"
 
 #: application/views/awards/wapc/index.php:55
 msgid "Show WAPC Map"
@@ -16614,6 +16618,10 @@ msgstr ""
 msgid "Needed counties for state:"
 msgstr ""
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "Přejít na obsah"
@@ -19656,8 +19664,9 @@ msgstr "Motiv"
 #: application/views/options/appearance.php:24
 msgid "Global Theme Choice, this is used when users arent logged in."
 msgstr ""
-"Globální volba motivu, která se používá, když uživatelé nejsou přihlášeni."
-"Globální volba motivu, která se používá, když uživatelé nejsou přihlášeni."
+"Globální volba motivu, která se používá, když uživatelé nejsou "
+"přihlášeni.Globální volba motivu, která se používá, když uživatelé nejsou "
+"přihlášeni."
 
 #: application/views/options/appearance.php:28
 msgid "Logbook Map"
@@ -19783,8 +19792,8 @@ msgstr "Emailová adresa"
 msgid ""
 "The email address from which the emails are sent, e.g. 'wavelog@example.com'"
 msgstr ""
-"E-mailová adresa, ze které jsou e-maily odesílány, např. 'wavelog@example."
-"com'"
+"E-mailová adresa, ze které jsou e-maily odesílány, např. "
+"'wavelog@example.com'"
 
 #: application/views/options/email.php:46
 msgid "SMTP Host"
@@ -23221,8 +23230,8 @@ msgid ""
 "Show profile picture of QSO partner from qrz.com/hamqth.com profile in the "
 "log QSO section."
 msgstr ""
-"Zobrazit profilový obrázek partnera z QSO záznamu z profilu qrz.com/hamqth."
-"com v sekci protokolu QSO."
+"Zobrazit profilový obrázek partnera z QSO záznamu z profilu qrz.com/"
+"hamqth.com v sekci protokolu QSO."
 
 #: application/views/user/edit.php:484
 msgid ""
@@ -24567,6 +24576,10 @@ msgstr ""
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr ""
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "z %s známých okresů"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -26,7 +26,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-09-02 14:33+0000\n"
 "Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
@@ -280,8 +280,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Karte der aktivierten Locator"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -346,7 +346,7 @@ msgid "Zones"
 msgstr "Zonen"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU-Zonen"
@@ -535,17 +535,17 @@ msgstr "Diplome"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplome – %s"
@@ -802,39 +802,39 @@ msgstr "IOTA (Islands On The Air)"
 msgid "US Counties"
 msgstr "US Counties"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Log Ansicht – Counties"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplome - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Gearbeitete Locator"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Auf LoTW bestätigte Locator"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Per Papier QSL bestätigte Locator"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Summe gearbeiteter Locator"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -846,74 +846,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplome - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "England"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Nordirland"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Schottland"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Wales"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Diplom"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Diplome - AMSAT Rover"
 
@@ -3298,8 +3298,8 @@ msgid ""
 "Please compare your current config.php with the latest config.sample.php and "
 "update accordingly."
 msgstr ""
-"Bitte vergleiche deine aktuelle config.php mit der neuesten config.sample."
-"php und aktualisiere sie entsprechend."
+"Bitte vergleiche deine aktuelle config.php mit der neuesten "
+"config.sample.php und aktualisiere sie entsprechend."
 
 #: application/controllers/Qslpostcard.php:34
 #: application/views/interface_assets/header.php:574
@@ -5328,7 +5328,7 @@ msgstr "Differenz"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6044,10 +6044,10 @@ msgstr "Minimale Anzahl"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7723,8 +7723,8 @@ msgstr "CSV herunterladen"
 msgid "County"
 msgstr "County"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "Nicht in der USA-CA County-Liste"
 
@@ -7909,8 +7909,8 @@ msgstr "Gearbeitete Bezirke"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "von %s bekannten Bezirken"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7982,8 +7982,12 @@ msgstr "Forschritt gearbeitet"
 msgid "Confirmed Progress"
 msgstr "Fortschritt Bestätigt"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -8015,7 +8019,7 @@ msgstr "Fortschritt Bestätigt"
 msgid "Total"
 msgstr "Gesamt"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15992,8 +15996,8 @@ msgstr ""
 #: application/views/eqsl/export.php:37
 msgid "Clicking 'Upload QSOs' will send QSO information to eQSL.cc."
 msgstr ""
-"Wenn du auf 'QSOs hochladen' klickst, sendest du QSO-Informationen an eQSL."
-"cc."
+"Wenn du auf 'QSOs hochladen' klickst, sendest du QSO-Informationen an "
+"eQSL.cc."
 
 #: application/views/eqsl/export.php:46
 msgid "The following QSOs were sent to eQSL."
@@ -16848,6 +16852,10 @@ msgstr "Counties im Bundesstaat:"
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
 msgstr "Benötigte Counties für Bundesstaat:"
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
 
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
@@ -20052,8 +20060,8 @@ msgstr "E-Mail Adresse"
 msgid ""
 "The email address from which the emails are sent, e.g. 'wavelog@example.com'"
 msgstr ""
-"Die E-Mail Adresse von der die Mails versendet werden, z.B. 'wavelog@example."
-"com'"
+"Die E-Mail Adresse von der die Mails versendet werden, z.B. "
+"'wavelog@example.com'"
 
 #: application/views/options/email.php:46
 msgid "SMTP Host"
@@ -22138,8 +22146,8 @@ msgid ""
 msgstr ""
 "Um zu beginnen, stelle sicher, dass du die Felder auf der linken Seite "
 "bereits mit Datum, Stationsrufzeichen/-standort und Rufzeichen des Operators "
-"ausgefüllt hast. Die wichtigsten Daten umfassen das Band (oder QRG in MHz, z."
-"B. %s), Mode und Zeit. Nach der Zeit gibst du das erste QSO an, was im "
+"ausgefüllt hast. Die wichtigsten Daten umfassen das Band (oder QRG in MHz, "
+"z.B. %s), Mode und Zeit. Nach der Zeit gibst du das erste QSO an, was im "
 "wesentlichen das Rufzeichen ist."
 
 #: application/views/simplefle/syntax_help.php:23
@@ -23194,9 +23202,9 @@ msgid ""
 "Create a new folder in 'assets/css/' and upload a 'bootstrap.min.css' file "
 "which contains basic styling rules. We use the themes from %s"
 msgstr ""
-"Erstelle einen neuen Ordner in 'assets/css/' und lade eine 'bootstrap.min."
-"css' Datei hoch, welche die grundlegende Styling-Regeln enthält. Wir "
-"verwenden die Themes von %s"
+"Erstelle einen neuen Ordner in 'assets/css/' und lade eine "
+"'bootstrap.min.css' Datei hoch, welche die grundlegende Styling-Regeln "
+"enthält. Wir verwenden die Themes von %s"
 
 #: application/views/themes/index.php:50
 msgid "2. Step"
@@ -24933,6 +24941,10 @@ msgstr "Clublog Logsuche"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "LoTW Nutzer. Letzter Upload vom "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "von %s bekannten Bezirken"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/el_GR/LC_MESSAGES/messages.po
+++ b/application/locale/el_GR/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2025-12-30 19:49+0000\n"
 "Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
 "Language-Team: Greek <https://translate.wavelog.org/projects/wavelog/main-"
@@ -260,8 +260,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -326,7 +326,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -513,17 +513,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -780,39 +780,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -824,74 +824,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5166,7 +5166,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5876,10 +5876,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7426,8 +7426,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7600,7 +7600,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7673,8 +7673,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7706,7 +7710,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15929,6 +15933,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/es_ES/LC_MESSAGES/messages.po
+++ b/application/locale/es_ES/LC_MESSAGES/messages.po
@@ -16,7 +16,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-27 17:14+0000\n"
 "Last-Translator: David Quental <ct1drb72@gmail.com>\n"
 "Language-Team: Spanish <https://translate.wavelog.org/projects/wavelog/main-"
@@ -269,8 +269,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa de Cuadrículas Activado"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -335,7 +335,7 @@ msgid "Zones"
 msgstr "Zonas"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "Zonas ITU"
@@ -524,17 +524,17 @@ msgstr "Diplomas"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplomas - %s"
@@ -791,39 +791,39 @@ msgstr "IOTA (Islas en el Aire)"
 msgid "US Counties"
 msgstr "Condados de EEUU"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Vista de registro - Condados"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplomas - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Cuadrículas trabajadas"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Cuadrículas confirmadas en LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Cuadrículas confirmadas por QSL físicas"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Total de Cuadrículas trabajadas"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Diploma Memorial Fred Fish (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -835,74 +835,74 @@ msgstr "Diploma Memorial Fred Fish (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplomas - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 en 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "Premio \"Polska\""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Premios - AMSAT Rover"
 
@@ -5318,7 +5318,7 @@ msgstr "Diferencia"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6031,10 +6031,10 @@ msgstr "Cuenta Mínima"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7698,8 +7698,8 @@ msgstr "Descargar CSV"
 msgid "County"
 msgstr "Condado"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "No está en la lista de condados de EE.UU.-CA"
 
@@ -7885,8 +7885,8 @@ msgstr "Condados Trabajados"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "de %s condados conocidos"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7958,8 +7958,12 @@ msgstr "Progreso trabajado"
 msgid "Confirmed Progress"
 msgstr "Progreso confirmado"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7991,7 +7995,7 @@ msgstr "Progreso confirmado"
 msgid "Total"
 msgstr "Total"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -10051,9 +10055,9 @@ msgid ""
 "Macao/152, Taiwan/386, Pratas Isl./505 or Scarborough Reef/506) and valid "
 "State (ADIF: DXCC and STATE)"
 msgstr ""
-"Campos tomados para este Premio: DXCC (Debe ser uno de China/318, "
-"HongKong/321, Macao/152, Taiwán/386, Islas Pratas/505 o Arrecife "
-"Scarborough/506) y Estado válido (ADIF: DXCC y STATE)"
+"Campos tomados para este Premio: DXCC (Debe ser uno de China/318, HongKong/"
+"321, Macao/152, Taiwán/386, Islas Pratas/505 o Arrecife Scarborough/506) y "
+"Estado válido (ADIF: DXCC y STATE)"
 
 #: application/views/awards/wapc/index.php:55
 msgid "Show WAPC Map"
@@ -10118,8 +10122,8 @@ msgid ""
 "and STATE (Must contain a valid U.S. state abbreviation!)"
 msgstr ""
 "Campos tomados para este premio: DXCC (Debe ser uno de EE.UU., Alaska o "
-"Hawái) y ESTADO (¡Debe contener una abreviatura válida de un estado de EE."
-"UU.!)"
+"Hawái) y ESTADO (¡Debe contener una abreviatura válida de un estado de "
+"EE.UU.!)"
 
 #: application/views/awards/was/index.php:55
 msgid "Show WAS Map"
@@ -15200,8 +15204,8 @@ msgid ""
 "Go to your application/config Folder and compare config.sample.php with your "
 "config.php"
 msgstr ""
-"Ve a tu carpeta application/config y compara config.sample.php con tu config."
-"php"
+"Ve a tu carpeta application/config y compara config.sample.php con tu "
+"config.php"
 
 #: application/views/debug/index.php:250
 #, php-format
@@ -16857,6 +16861,10 @@ msgstr "Condados en el estado:"
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
 msgstr "Condados necesarios para el estado:"
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
 
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
@@ -23217,8 +23225,9 @@ msgid ""
 "Create a new folder in 'assets/css/' and upload a 'bootstrap.min.css' file "
 "which contains basic styling rules. We use the themes from %s"
 msgstr ""
-"Crea una nueva carpeta en 'assets/css/' y sube un archivo 'bootstrap.min."
-"css' que contenga reglas de estilo básicas. Usamos los temas de %s"
+"Crea una nueva carpeta en 'assets/css/' y sube un archivo "
+"'bootstrap.min.css' que contenga reglas de estilo básicas. Usamos los temas "
+"de %s"
 
 #: application/views/themes/index.php:50
 msgid "2. Step"
@@ -23267,8 +23276,8 @@ msgid ""
 "filenames for the logos %swithout%s the file extension '.png'"
 msgstr ""
 "Haz clic aquí en 'Agregar un tema' y escribe los datos necesarios. Escribe "
-"los nombres de archivo para los logotipos %ssin%s la extensión de archivo '."
-"png'"
+"los nombres de archivo para los logotipos %ssin%s la extensión de archivo "
+"'.png'"
 
 #: application/views/themes/index.php:83
 msgid "Foldername"
@@ -24961,6 +24970,10 @@ msgstr "Búsqueda de registros en Clublog"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "Usuario de LoTW. La última carga fue "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "de %s condados conocidos"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/et/LC_MESSAGES/messages.po
+++ b/application/locale/et/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2025-02-11 12:33+0000\n"
 "Last-Translator: tviitkar <tambet@viitkar.ee>\n"
 "Language-Team: Estonian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -258,8 +258,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Aktiveeritud ruutkaart"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -324,7 +324,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU tsoonid"
@@ -511,17 +511,17 @@ msgstr "Auhinnad"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Auhinnad - %s"
@@ -778,39 +778,39 @@ msgstr "IOTA"
 msgid "US Counties"
 msgstr "Ameerika Ühendriikide maakonnad"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Logivaade - Maakonnad"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Auhinnad - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Töötatud ruutvõrgud"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "LoTW keskkonnas kinnitatud ruutvõrgud"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Paberkandjal kinnitatud ruutvõrgud"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -822,74 +822,74 @@ msgstr ""
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5164,7 +5164,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5874,10 +5874,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7424,8 +7424,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7598,7 +7598,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7671,8 +7671,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7704,7 +7708,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15930,6 +15934,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/fi_FI/LC_MESSAGES/messages.po
+++ b/application/locale/fi_FI/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-09-01 12:38+0000\n"
 "Last-Translator: Miko Savolainen <oh3cyt@oh3cyt.com>\n"
 "Language-Team: Finnish <https://translate.wavelog.org/projects/wavelog/main-"
@@ -263,8 +263,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Lokaattorikartan aktivointi"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -329,7 +329,7 @@ msgid "Zones"
 msgstr "Vyöhykkeet (zonet)"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU-vyöhykkeet"
@@ -518,17 +518,17 @@ msgstr "Awardit"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Awardit - %s"
@@ -785,39 +785,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "Yhdysvaltojen piirikunnat"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Lokinäkymä - Yhdysvaltojen piirikunnat"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Awardit - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Workitut lokaattorit"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "LOTW:ssa vahvistetut lokaattorit"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Paperi-QSL:llä vahvistetut lokaattorit"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Kaikki workitut lokaattorit"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -829,74 +829,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Awardit - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "Englanti"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Mansaari"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Pohjois-Irlanti"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Skotlanti"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Wales"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Awardi"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Awardi - AMSAT Rover"
 
@@ -5265,7 +5265,7 @@ msgstr "Ero"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5975,10 +5975,10 @@ msgstr "Minimimäärä"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7608,8 +7608,8 @@ msgstr "Lataa CSV"
 msgid "County"
 msgstr "Kunta"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7795,7 +7795,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7868,8 +7868,12 @@ msgstr "Työskennellyt (Worked) edistyminen"
 msgid "Confirmed Progress"
 msgstr "Vahvistusten (confirmed) edistyminen"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7901,7 +7905,7 @@ msgstr "Vahvistusten (confirmed) edistyminen"
 msgid "Total"
 msgstr "Yhteensä"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -9451,8 +9455,8 @@ msgstr ""
 "on oma yhdistyksensä, joka määrittelee kyseisen yhdistyksen SOTA-huiput. "
 "Jokaisesta huipusta saa aktivaattoreille ja hunttereille pisteitä, jotka "
 "liittyvät huipun korkeuteen. Erilaisista pistemääristä saa todistuksia, "
-"jotka johtavat arvostettuihin 'Mountain Goat' ja 'Shack Sloth' -"
-"palkintoihin. Aktivaattoreiden ja hunttereiden kunniataulukkoa ylläpidetään "
+"jotka johtavat arvostettuihin 'Mountain Goat' ja 'Shack Sloth' "
+"-palkintoihin. Aktivaattoreiden ja hunttereiden kunniataulukkoa ylläpidetään "
 "SOTAn online-tietokannassa."
 
 #: application/views/awards/sota/index.php:28
@@ -14387,8 +14391,8 @@ msgid ""
 "Results depends on the correct DXCC, and it will only be checked against "
 "current DXCC. False positive results may occur."
 msgstr ""
-"Tulokset riippuvat oikeasta DXCC:stä, ja ne tarkistetaan vain nykyistä DXCC:"
-"tä vastaan. Virheellisiä positiivisia tuloksia voi esiintyä."
+"Tulokset riippuvat oikeasta DXCC:stä, ja ne tarkistetaan vain nykyistä "
+"DXCC:tä vastaan. Virheellisiä positiivisia tuloksia voi esiintyä."
 
 #: application/views/dbtools/checkresult.php:381
 msgid "QSO DXCC"
@@ -16298,8 +16302,8 @@ msgstr "Lokaattorin muotoilu"
 msgid ""
 "Enter multiple (4-digit) grids separated with commas. For example: IO77,IO78"
 msgstr ""
-"Syötä useita (4-numeroisia) ruutuja pilkulla erotettuna. Esimerkiksi: IO77,"
-"IO78"
+"Syötä useita (4-numeroisia) ruutuja pilkulla erotettuna. Esimerkiksi: "
+"IO77,IO78"
 
 #: application/views/interface_assets/footer.php:121
 msgid "live"
@@ -16381,8 +16385,8 @@ msgstr "Sijainti haetaan DXCC-koordinaateista (ei lokaattoria annettu)"
 msgid ""
 "Location could not be determined as gridsquare is empty and DXCC is -NONE-"
 msgstr ""
-"Sijaintia ei voitu määrittää, koska lokaattoriruutu on tyhjä ja DXCC on -"
-"NONE-"
+"Sijaintia ei voitu määrittää, koska lokaattoriruutu on tyhjä ja DXCC on "
+"-NONE-"
 
 #: application/views/interface_assets/footer.php:142
 msgid "Error saving operator callsign. Please try again."
@@ -16598,6 +16602,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97
@@ -23800,8 +23808,8 @@ msgid ""
 "events to handle multiple operators. A clubstation is basically a normal "
 "user account with some special features and some restrictions."
 msgstr ""
-"Kerhoasemat Wavelogissa ovat ainutlaatuinen tapa kerhoille ja erikoiskutsu -"
-"tapahtumille hallita useita operaattoreita. Kerhoasema on periaatteessa "
+"Kerhoasemat Wavelogissa ovat ainutlaatuinen tapa kerhoille ja erikoiskutsu "
+"-tapahtumille hallita useita operaattoreita. Kerhoasema on periaatteessa "
 "tavallinen käyttäjätili, jossa on joitakin erityistoimintoja ja rajoituksia."
 
 #: application/views/user/index.php:143

--- a/application/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/application/locale/fr_FR/LC_MESSAGES/messages.po
@@ -19,7 +19,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-07-13 09:35+0000\n"
 "Last-Translator: Telectroboy <telectroboy@hotmail.com>\n"
 "Language-Team: French <https://translate.wavelog.org/projects/wavelog/main-"
@@ -273,8 +273,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Carte des Locator activés"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -339,7 +339,7 @@ msgid "Zones"
 msgstr "Zones"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "Zones ITU"
@@ -526,17 +526,17 @@ msgstr "Trophées"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Trophées - %s"
@@ -793,39 +793,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "Comtés US"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Vue du journal - Comtés"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Trophées - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Locators contactés"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Locators confirmés par LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Locators confirmés par Carte QSL papier"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Nombre total de carrés de la grille travaillés"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -837,74 +837,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Trophées - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 sur 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "Prix « Polska »"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Prix - AMSAT Rover"
 
@@ -3287,8 +3287,8 @@ msgid ""
 "Please compare your current config.php with the latest config.sample.php and "
 "update accordingly."
 msgstr ""
-"Veuillez comparer votre fichier config.php actuel avec le fichier config."
-"sample.php le plus récent et le mettre à jour en conséquence."
+"Veuillez comparer votre fichier config.php actuel avec le fichier "
+"config.sample.php le plus récent et le mettre à jour en conséquence."
 
 #: application/controllers/Qslpostcard.php:34
 #: application/views/interface_assets/header.php:574
@@ -4265,8 +4265,8 @@ msgid ""
 "encryption_key in your config.php file first!"
 msgstr ""
 "Vous ne pouvez actuellement pas usurper l'identité d'un autre utilisateur. "
-"Veuillez d'abord changer la clé de chiffrement dans votre fichier config."
-"php !"
+"Veuillez d'abord changer la clé de chiffrement dans votre fichier "
+"config.php !"
 
 #: application/controllers/User.php:1830
 msgid "Invalid Hash"
@@ -5314,7 +5314,7 @@ msgstr "Différence"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6024,10 +6024,10 @@ msgstr "Nbre d'activation minimum"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7645,8 +7645,8 @@ msgid ""
 "the screenshots to your application email."
 msgstr ""
 "Pour ajouter des captures d'écran de confirmation LoTW, cliquez sur "
-"l'indicatif d'appel dans le tableau des activations ci-dessus. Cliquez sur « "
-"Soumettre » sur la page LoTW et effectuez une capture d'écran. Joignez les "
+"l'indicatif d'appel dans le tableau des activations ci-dessus. Cliquez sur "
+"« Soumettre » sur la page LoTW et effectuez une capture d'écran. Joignez les "
 "captures d'écran à votre courriel de candidature."
 
 #: application/views/awards/amsat_rover/index.php:279
@@ -7682,8 +7682,8 @@ msgstr "Télécharger le fichier CSV"
 msgid "County"
 msgstr "Comté"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7868,7 +7868,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7941,8 +7941,12 @@ msgstr "Avancement des travaux"
 msgid "Confirmed Progress"
 msgstr "Progrès confirmés"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7974,7 +7978,7 @@ msgstr "Progrès confirmés"
 msgid "Total"
 msgstr "Total"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15942,8 +15946,8 @@ msgstr ""
 #: application/views/eqsl/export.php:37
 msgid "Clicking 'Upload QSOs' will send QSO information to eQSL.cc."
 msgstr ""
-"Cliquer sur 'Téléverser les QSOs' enverra les informations de QSO vers eQSL."
-"cc."
+"Cliquer sur 'Téléverser les QSOs' enverra les informations de QSO vers "
+"eQSL.cc."
 
 #: application/views/eqsl/export.php:46
 msgid "The following QSOs were sent to eQSL."
@@ -16790,6 +16794,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97
@@ -19984,8 +19992,8 @@ msgid ""
 "The hostname of the mail server, e.g. 'mail.example.com' (without 'ssl://' "
 "or 'tls://')"
 msgstr ""
-"Le nom d'hôte du serveur de messagerie, par exemple « mail.example."
-"com » (sans « ssl:// » ou « tls:// »)"
+"Le nom d'hôte du serveur de messagerie, par exemple « mail.example.com » "
+"(sans « ssl:// » ou « tls:// »)"
 
 #: application/views/options/email.php:54
 msgid "SMTP Port"
@@ -24934,9 +24942,9 @@ msgstr ""
 #~ msgstr ""
 #~ "Pour commencer, assurez-vous d'avoir rempli le formulaire sur la gauche "
 #~ "avec la date, l'indicatif de la station et l'indicatif de l'opérateur. "
-#~ "Les données principales incluent la bande (ou QRG en MHz, par exemple « "
-#~ "7.145 »), le mode et l'heure. Après l'heure, indiquez le premier QSO, qui "
-#~ "correspond essentiellement à l'indicatif."
+#~ "Les données principales incluent la bande (ou QRG en MHz, par exemple "
+#~ "« 7.145 »), le mode et l'heure. Après l'heure, indiquez le premier QSO, "
+#~ "qui correspond essentiellement à l'indicatif."
 
 #~ msgid ""
 #~ "If you don't provide any RST information, the syntax will use 59 (599 for "

--- a/application/locale/hr/LC_MESSAGES/messages.po
+++ b/application/locale/hr/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-12 05:07+0000\n"
 "Last-Translator: marin <wavelog@marin.fyi>\n"
 "Language-Team: Croatian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -262,8 +262,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa aktiviranih lokatora"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -328,7 +328,7 @@ msgid "Zones"
 msgstr "Zone"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU Zone"
@@ -515,17 +515,17 @@ msgstr "Nagrade"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Nagrade - %s"
@@ -782,39 +782,39 @@ msgstr "IOTA (Otoci u eteru)"
 msgid "US Counties"
 msgstr "SAD Okruzi"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Pregled loga - Okruzi"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplome - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Odrađenih lokatora"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Polja potvrđena preko LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Polja potvrđena QSL kartama"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Ukupno odrađenih lokatora"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -826,74 +826,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Nagrade - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Award"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Diplome - AMSAT Rover"
 
@@ -5189,7 +5189,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5899,10 +5899,10 @@ msgstr "Minimalan broj"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7451,8 +7451,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7625,7 +7625,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7698,8 +7698,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7731,7 +7735,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15959,6 +15963,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/hu/LC_MESSAGES/messages.po
+++ b/application/locale/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-03 12:17+0000\n"
 "Last-Translator: Mathias Regner <mabregner@gmail.com>\n"
 "Language-Team: Hungarian <https://translate.wavelog.org/projects/wavelog/"
@@ -259,8 +259,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Aktivált lokátorok térképe"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -325,7 +325,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU zónák"
@@ -512,17 +512,17 @@ msgstr "Díjak"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Díjak - %s"
@@ -779,39 +779,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "US Counties"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Napló nézet - Counties"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Díjak - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Dolgozott lokátorok"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "LoTW-n megerősített lokátorok"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Papír alapú QSL-lel megerősített lokátorok"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -823,74 +823,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Díjak - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5171,7 +5171,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5881,10 +5881,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7431,8 +7431,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7605,7 +7605,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7678,8 +7678,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7711,7 +7715,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15937,6 +15941,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/hy/LC_MESSAGES/messages.po
+++ b/application/locale/hy/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2025-08-23 15:21+0000\n"
 "Last-Translator: Matthias Jung <jungma@eit.uni-kl.de>\n"
 "Language-Team: Armenian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -259,8 +259,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Ակտիվացված քառակուսի քարտեզ"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -325,7 +325,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -512,17 +512,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -779,39 +779,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -823,74 +823,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5163,7 +5163,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5873,10 +5873,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7423,8 +7423,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7597,7 +7597,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7670,8 +7670,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7703,7 +7707,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15926,6 +15930,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/it_IT/LC_MESSAGES/messages.po
+++ b/application/locale/it_IT/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-29 04:04+0000\n"
 "Last-Translator: iv3cvn <ricentis@gmail.com>\n"
 "Language-Team: Italian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -264,8 +264,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mappa locatori attivati"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -330,7 +330,7 @@ msgid "Zones"
 msgstr "Zone"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "Zone ITU"
@@ -519,17 +519,17 @@ msgstr "Diplomi"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplomi - %s"
@@ -786,39 +786,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "Contee USA"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Visualizza log - Contee"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplomi - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Locatori collegati"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Locatori confermati via LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Locatori confermati via QSL cartacea"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Totale locatori collegati"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -830,74 +830,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplomi - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "Inghilterra"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Isola di Man"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Irlanda del nord"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Scozia"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Galles"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "Diploma \"Polska\""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Diplomi - AMSAT Rover"
 
@@ -3277,8 +3277,8 @@ msgid ""
 "Please compare your current config.php with the latest config.sample.php and "
 "update accordingly."
 msgstr ""
-"Per favore, confronta il tuo attuale config.php con l'ultimo config.sample."
-"php e aggiornalo di conseguenza."
+"Per favore, confronta il tuo attuale config.php con l'ultimo "
+"config.sample.php e aggiornalo di conseguenza."
 
 #: application/controllers/Qslpostcard.php:34
 #: application/views/interface_assets/header.php:574
@@ -5303,7 +5303,7 @@ msgstr "Differenza"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6016,10 +6016,10 @@ msgstr "Conteggio minimo"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7678,8 +7678,8 @@ msgstr "Scarica CSV"
 msgid "County"
 msgstr "Contea"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "Non nella lista delle contee USA-CA"
 
@@ -7863,8 +7863,8 @@ msgstr "Contee lavorate"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "di %s contee conosciute"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7936,8 +7936,12 @@ msgstr "Progresso lavorati"
 msgid "Confirmed Progress"
 msgstr "Progresso confermati"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7969,7 +7973,7 @@ msgstr "Progresso confermati"
 msgid "Total"
 msgstr "Totale"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -16807,6 +16811,10 @@ msgstr "Contee nello stato:"
 msgid "Needed counties for state:"
 msgstr "Contee necessarie per lo stato:"
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "Salta al contenuto"
@@ -23156,8 +23164,9 @@ msgid ""
 "Create a new folder in 'assets/css/' and upload a 'bootstrap.min.css' file "
 "which contains basic styling rules. We use the themes from %s"
 msgstr ""
-"Crea una nuova cartella in 'assets/css/' e carica un file 'bootstrap.min."
-"css' che contiene regole di stile di base. Utilizziamo i temi di %s"
+"Crea una nuova cartella in 'assets/css/' e carica un file "
+"'bootstrap.min.css' che contiene regole di stile di base. Utilizziamo i temi "
+"di %s"
 
 #: application/views/themes/index.php:50
 msgid "2. Step"
@@ -24894,6 +24903,10 @@ msgstr "Ricerca Log Clublog"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "Utente LoTW. L'ultimo caricamento è stato "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "di %s contee conosciute"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-09-02 14:14+0000\n"
 "Last-Translator: \"Xu, Zefan (BI1GHZ)\" <ceba_robot@outlook.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
@@ -264,8 +264,8 @@ msgid "Activated Gridsquare Map"
 msgstr "アクティブなグリッドロケーターマップ"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -330,7 +330,7 @@ msgid "Zones"
 msgstr "ゾーン"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITUゾーン"
@@ -519,17 +519,17 @@ msgstr "アワード"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "アワード - %s"
@@ -786,39 +786,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "米国・郡"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "ログ表示 - 郡"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "アワード - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "交信したグリッドスクエア"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "LoTWで確認されたグリッドスクエア"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "紙QSLで確認されたグリッドスクエア"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "交信したグリッドスクエア数"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial アワード (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -830,74 +830,74 @@ msgstr "Fred Fish Memorial アワード (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "アワード - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "イングランド"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "マン島"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "北アイルランド"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "ジャージー"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "スコットランド"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "ガーンジー"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "ウェールズ"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "全大陸交信賞 (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "「ポーランド」アワード"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "アワード - AMSAT Rover"
 
@@ -4165,8 +4165,8 @@ msgid ""
 "Station created successfully! Welcome to Wavelog! To complete your station "
 "setup, click %shere%s."
 msgstr ""
-"無線局が正常に作成されました！Wavelogへようこそ！無線局の設定を完了するに"
-"は、%shere%sをクリックしてください。"
+"無線局が正常に作成されました！Wavelogへようこそ！無線局の設定を完了するには、"
+"%shere%sをクリックしてください。"
 
 #: application/controllers/User.php:1548
 msgid "Station setup failed! Please set up your station manually."
@@ -5262,7 +5262,7 @@ msgstr "違い"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5976,10 +5976,10 @@ msgstr "最小数"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7625,8 +7625,8 @@ msgstr "CSVファイルをダウンロード"
 msgid "County"
 msgstr "郡"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "米国カリフォルニア州の郡リストには含まれていません"
 
@@ -7808,8 +7808,8 @@ msgstr "Worked Counties"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "of %s known counties"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7881,8 +7881,12 @@ msgstr "作業進捗状況"
 msgid "Confirmed Progress"
 msgstr "進捗状況を確認済み"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7914,7 +7918,7 @@ msgstr "進捗状況を確認済み"
 msgid "Total"
 msgstr "合計"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -16641,6 +16645,10 @@ msgstr "州内の郡："
 msgid "Needed counties for state:"
 msgstr "州に必要な郡数："
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "コンテンツへスキップ"
@@ -24602,6 +24610,10 @@ msgid "LoTW User. Last upload was "
 msgstr "LoTWユーザー。最後のアップロードは "
 
 #, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "of %s known counties"
+
+#, php-format
 #~ msgid ""
 #~ "Maptile cache could not be removed. Delete the folder manually. Path: %s"
 #~ msgstr ""
@@ -25494,9 +25506,9 @@ msgstr "LoTWユーザー。最後のアップロードは "
 #~ "processed. %s Please make sure you export the LoTW certificate from tqsl "
 #~ "application without password! %s"
 #~ msgstr ""
-#~ "ファイル %s 内の証明書にはパスワードが含まれており、処理できませ"
-#~ "ん。%stqsl アプリケーションから LoTW 証明書をエクスポートする際は、パス"
-#~ "ワードなしで実行してください！%s"
+#~ "ファイル %s 内の証明書にはパスワードが含まれており、処理できません。"
+#~ "%stqsl アプリケーションから LoTW 証明書をエクスポートする際は、パスワード"
+#~ "なしで実行してください！%s"
 
 #~ msgid "Column"
 #~ msgstr "カラム"
@@ -25827,8 +25839,8 @@ msgstr "LoTWユーザー。最後のアップロードは "
 #~ "Your active Station Location isn't linked to your Logbook. Click %shere%s "
 #~ "to do it."
 #~ msgstr ""
-#~ "現在のステーション位置がログブックとリンクされていません。リンクするに"
-#~ "は、%shere%s をクリックしてください。"
+#~ "現在のステーション位置がログブックとリンクされていません。リンクするには、"
+#~ "%shere%s をクリックしてください。"
 
 #, php-format
 #~ msgctxt "Dashboard Warning"

--- a/application/locale/lt/LC_MESSAGES/messages.po
+++ b/application/locale/lt/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2024-11-19 01:22+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: Lithuanian <https://translate.wavelog.org/projects/wavelog/"
@@ -260,8 +260,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -326,7 +326,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -513,17 +513,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -780,39 +780,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -824,74 +824,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5177,7 +5177,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5887,10 +5887,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7439,8 +7439,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7613,7 +7613,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7686,8 +7686,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7719,7 +7723,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15944,6 +15948,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/lv/LC_MESSAGES/messages.po
+++ b/application/locale/lv/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2024-11-19 01:22+0000\n"
 "Last-Translator: Fabian Berg <fabian.berg@hb9hil.org>\n"
 "Language-Team: Latvian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -259,8 +259,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -325,7 +325,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -512,17 +512,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -779,39 +779,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -823,74 +823,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5176,7 +5176,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5886,10 +5886,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7438,8 +7438,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7612,7 +7612,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7685,8 +7685,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7718,7 +7722,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15943,6 +15947,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/application/locale/nl_NL/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-28 20:04+0000\n"
 "Last-Translator: Alexander <alexander@pa8s.nl>\n"
 "Language-Team: Dutch <https://translate.wavelog.org/projects/wavelog/main-"
@@ -262,8 +262,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Kaart met geactiveerde Locator-vakken"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -328,7 +328,7 @@ msgid "Zones"
 msgstr "Zones"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU Zones"
@@ -517,17 +517,17 @@ msgstr "Awards"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Awards - %s"
@@ -784,39 +784,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "US Counties"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Logweergave - Counties"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Awards - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Gewerkte locatorvakken"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Door LoTW bevestigde locatorvakken"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Door papieren QSL bevestigde locatorvakken"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Totaal locator aantal vakken gewerkt"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -828,74 +828,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Awards - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "Engeland"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Noord-Ierland"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Schotland"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Wales"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 op 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Award"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Awards - AMSAT Rover"
 
@@ -5287,7 +5287,7 @@ msgstr "Verschil"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6001,10 +6001,10 @@ msgstr "Minimum aantal"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7664,8 +7664,8 @@ msgstr "Download CSV"
 msgid "County"
 msgstr "County"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "Niet in de USA-CA county lijst"
 
@@ -7848,8 +7848,8 @@ msgstr "Gewerkte counties"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "van %s bekende counties"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7921,8 +7921,12 @@ msgstr "Voortgang gewerkt"
 msgid "Confirmed Progress"
 msgstr "Voortgang bevestigd"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7954,7 +7958,7 @@ msgstr "Voortgang bevestigd"
 msgid "Total"
 msgstr "Totaal"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -16752,6 +16756,10 @@ msgstr "Counties in staat:"
 msgid "Needed counties for state:"
 msgstr "Benodigde counties voor de staat:"
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "Direct naar inhoud"
@@ -22136,8 +22144,8 @@ msgid ""
 "does not work on its own line). To deactivate, use %s:"
 msgstr ""
 "Ontvangen berichten moeten worden voorafgegaan door een punt %s, verzonden "
-"berichten met een komma %s. De laatste twee regels zijn gelijkwaardig - d.w."
-"z. spaties maken niet uit en de volgorde evenmin. Elk van de vier "
+"berichten met een komma %s. De laatste twee regels zijn gelijkwaardig - "
+"d.w.z. spaties maken niet uit en de volgorde evenmin. Elk van de vier "
 "bovenstaande regels toont een type uitwisseling (alleen serie, alleen tekst "
 "of beide); merk op dat de verzonden uitwisseling 'sticky' is: eenmaal "
 "ingesteld, wordt deze automatisch meegenomen in de volgende QSO's (wanneer "
@@ -24817,6 +24825,10 @@ msgstr "Clublog Log Zoekopdracht"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "LoTW-gebruiker. Laatste upload was "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "van %s bekende counties"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/pl_PL/LC_MESSAGES/messages.po
+++ b/application/locale/pl_PL/LC_MESSAGES/messages.po
@@ -17,7 +17,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-30 21:12+0000\n"
 "Last-Translator: Piotr S <sp9lop@pm.me>\n"
 "Language-Team: Polish <https://translate.wavelog.org/projects/wavelog/main-"
@@ -271,8 +271,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa aktywowanych lokatorów"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -337,7 +337,7 @@ msgid "Zones"
 msgstr "Strefy"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "Strefy ITU"
@@ -524,17 +524,17 @@ msgstr "Nagrody"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Nagrody - %s"
@@ -791,39 +791,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "Hrabstwa USA"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Przegląd dziennika - hrabstwa"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Nagrody - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Zaliczone lokatory"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Lokatory potwierdzone na LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Lokatory potwierdzone papierową kartą QSL"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Wszystkich zaliczonych lokatorów"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -835,74 +835,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Nagrody - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "Anglia"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Wyspa Man"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Północna Irlandia"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Szkocja"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Walia"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "Dyplom \"Polska\""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Nagrody - AMSAT Rover"
 
@@ -5302,7 +5302,7 @@ msgstr "Różnica"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6012,10 +6012,10 @@ msgstr "Minimalna liczba"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7653,8 +7653,8 @@ msgstr "Pobierz CSV"
 msgid "County"
 msgstr "Hrabstwo"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7840,8 +7840,8 @@ msgstr "Zaliczone hrabstwa"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "z %s znanych hrabstw"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7913,8 +7913,12 @@ msgstr "Postęp zaliczonych"
 msgid "Confirmed Progress"
 msgstr "Postęp potwierdzonych"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7946,7 +7950,7 @@ msgstr "Postęp potwierdzonych"
 msgid "Total"
 msgstr "Razem"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -9987,8 +9991,8 @@ msgid ""
 "State (ADIF: DXCC and STATE)"
 msgstr ""
 "Pola brane pod uwagę przy tej nagrodzie: DXCC (musi być jednym z: Chiny/318, "
-"Hongkong/321, Makau/152, Tajwan/386, Wyspa Pratas/505 lub Rafa "
-"Scarborough/506) oraz ważny stan (ADIF: DXCC i STATE)"
+"Hongkong/321, Makau/152, Tajwan/386, Wyspa Pratas/505 lub Rafa Scarborough/"
+"506) oraz ważny stan (ADIF: DXCC i STATE)"
 
 #: application/views/awards/wapc/index.php:55
 msgid "Show WAPC Map"
@@ -15094,8 +15098,8 @@ msgid ""
 "Go to your application/config Folder and compare config.sample.php with your "
 "config.php"
 msgstr ""
-"Należy przejść do folderu application/config i porównać plik config.sample."
-"php z plikiem config.php"
+"Należy przejść do folderu application/config i porównać plik "
+"config.sample.php z plikiem config.php"
 
 #: application/views/debug/index.php:250
 #, php-format
@@ -16723,6 +16727,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97
@@ -24752,6 +24760,10 @@ msgstr ""
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr ""
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "z %s znanych hrabstw"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/pt_PT/LC_MESSAGES/messages.po
+++ b/application/locale/pt_PT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-27 17:14+0000\n"
 "Last-Translator: David Quental <ct1drb72@gmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://translate.wavelog.org/projects/"
@@ -264,8 +264,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa Gridsquare activadas"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -330,7 +330,7 @@ msgid "Zones"
 msgstr "Zonas"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "Zonas ITU"
@@ -519,17 +519,17 @@ msgstr "Prémios"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Prémios - %s"
@@ -786,39 +786,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "Condados dos EUA"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Visualização do log - Condados"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplomas - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Gridsquares trabalhadas"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Gridsquares confirmadas no LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Gridsquares confirmadas via QSL em papel"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Total de Gridsquares trabalhadas"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -830,74 +830,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplomas - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 em 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "Diploma \"Polska\""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Prémios - AMSAT Rover"
 
@@ -3276,8 +3276,8 @@ msgid ""
 "Please compare your current config.php with the latest config.sample.php and "
 "update accordingly."
 msgstr ""
-"Por favor, compare o seu atual config.php com o mais recente config.sample."
-"php e atualize em conformidade."
+"Por favor, compare o seu atual config.php com o mais recente "
+"config.sample.php e atualize em conformidade."
 
 #: application/controllers/Qslpostcard.php:34
 #: application/views/interface_assets/header.php:574
@@ -5304,7 +5304,7 @@ msgstr "Diferença"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6018,10 +6018,10 @@ msgstr "Contagem mínima"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7680,8 +7680,8 @@ msgstr "Transferir CSV"
 msgid "County"
 msgstr "Condado"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "Não está na lista de condados dos EUA-CA"
 
@@ -7866,8 +7866,8 @@ msgstr "Condados Trabalhados"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "de %s condados conhecidos"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7939,8 +7939,12 @@ msgstr "Progresso Trabalhado"
 msgid "Confirmed Progress"
 msgstr "Progresso Confirmado"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7972,7 +7976,7 @@ msgstr "Progresso Confirmado"
 msgid "Total"
 msgstr "Total"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -10090,8 +10094,8 @@ msgid ""
 "and STATE (Must contain a valid U.S. state abbreviation!)"
 msgstr ""
 "Campos considerados para este diploma: DXCC (Deve ser um dos E.U.A., Alasca "
-"ou Havai) e ESTADO (Deve conter uma abreviatura válida de um estado dos E.U."
-"A.!)"
+"ou Havai) e ESTADO (Deve conter uma abreviatura válida de um estado dos "
+"E.U.A.!)"
 
 #: application/views/awards/was/index.php:55
 msgid "Show WAS Map"
@@ -16495,8 +16499,8 @@ msgstr "Formatação de quadrícula"
 msgid ""
 "Enter multiple (4-digit) grids separated with commas. For example: IO77,IO78"
 msgstr ""
-"Digite várias grelhas (4 dígitos) separadas por vírgulas. Por exemplo: IO77,"
-"IO78"
+"Digite várias grelhas (4 dígitos) separadas por vírgulas. Por exemplo: "
+"IO77,IO78"
 
 #: application/views/interface_assets/footer.php:121
 msgid "live"
@@ -16803,6 +16807,10 @@ msgstr "Municípios no estado:"
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
 msgstr "Concelhos necessários para o estado:"
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
 
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
@@ -20018,8 +20026,8 @@ msgid ""
 "The hostname of the mail server, e.g. 'mail.example.com' (without 'ssl://' "
 "or 'tls://')"
 msgstr ""
-"O nome do anfitrião do servidor de correio, por exemplo, “mail.example."
-"com” (sem 'ssl://' ou 'tls://')"
+"O nome do anfitrião do servidor de correio, por exemplo, “mail.example.com” "
+"(sem 'ssl://' ou 'tls://')"
 
 #: application/views/options/email.php:54
 msgid "SMTP Port"
@@ -23142,8 +23150,9 @@ msgid ""
 "Create a new folder in 'assets/css/' and upload a 'bootstrap.min.css' file "
 "which contains basic styling rules. We use the themes from %s"
 msgstr ""
-"Crie uma nova pasta em 'assets/css/' e carregue um ficheiro 'bootstrap.min."
-"css' que contém regras de estilo básicas. Utilizamos os temas de %s"
+"Crie uma nova pasta em 'assets/css/' e carregue um ficheiro "
+"'bootstrap.min.css' que contém regras de estilo básicas. Utilizamos os temas "
+"de %s"
 
 #: application/views/themes/index.php:50
 msgid "2. Step"
@@ -23508,8 +23517,8 @@ msgid ""
 "Show profile picture of QSO partner from qrz.com/hamqth.com profile in the "
 "log QSO section."
 msgstr ""
-"Mostrar a imagem de perfil do parceiro de contacto do perfil QRZ.com/HamQTH."
-"com na secção de registo de contacto."
+"Mostrar a imagem de perfil do parceiro de contacto do perfil QRZ.com/"
+"HamQTH.com na secção de registo de contacto."
 
 #: application/views/user/edit.php:484
 msgid ""
@@ -24874,6 +24883,10 @@ msgstr "Pesquisa de Logs do Clublog"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "Utilizador LoTW. O último carregamento foi "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "de %s condados conhecidos"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/ro/LC_MESSAGES/messages.po
+++ b/application/locale/ro/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -257,8 +257,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -323,7 +323,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -510,17 +510,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -777,39 +777,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -821,74 +821,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5173,7 +5173,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5883,10 +5883,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7435,8 +7435,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7609,7 +7609,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7682,8 +7682,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7715,7 +7719,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15938,6 +15942,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/application/locale/ru_RU/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-31 23:18+0000\n"
 "Last-Translator: Michael Skolsky <r1blh@yandex.ru>\n"
 "Language-Team: Russian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -267,8 +267,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Карта активированных квадратов QTH-локатора"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -333,7 +333,7 @@ msgid "Zones"
 msgstr "Зоны"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "Зоны ITU"
@@ -522,17 +522,17 @@ msgstr "Дипломы"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Дипломы — %s"
@@ -789,39 +789,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "US Counties"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Просмотр журнала — Округа"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Дипломы — "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Сработанные квадраты QTH-локатора"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Квадраты QTH-локатора, подтверждённые на LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Квадраты QTH-локатора, подтверждённые бумажными QSL"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Всего сработано квадратов QTH-локатора"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -833,74 +833,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Дипломы — SIG — "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "Англия"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Остров Мэн"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Северная Ирландия"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Джерси"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Шотландия"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Гернси"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Уэльс"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Award"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Дипломы — AMSAT Rover"
 
@@ -5312,7 +5312,7 @@ msgstr "Разница"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6028,10 +6028,10 @@ msgstr "Минимальное количество"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7693,8 +7693,8 @@ msgstr "Скачать CSV"
 msgid "County"
 msgstr "Район"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "Не в списке округов США-Калифорнии"
 
@@ -7877,8 +7877,8 @@ msgstr "Сработано округов"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "%s известных округов"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7950,8 +7950,12 @@ msgstr "Прогресс (сработано)"
 msgid "Confirmed Progress"
 msgstr "Прогресс (подтверждено)"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7983,7 +7987,7 @@ msgstr "Прогресс (подтверждено)"
 msgid "Total"
 msgstr "Всего"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -16828,6 +16832,10 @@ msgstr "Округи в штате:"
 msgid "Needed counties for state:"
 msgstr "Необходимые округи для штата:"
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "Перейти к содержимому"
@@ -23150,8 +23158,9 @@ msgid ""
 "Create a new folder in 'assets/css/' and upload a 'bootstrap.min.css' file "
 "which contains basic styling rules. We use the themes from %s"
 msgstr ""
-"Создайте новую папку в 'assets/css/' и загрузите в нее файл 'bootstrap.min."
-"css', который содержит основные правила стилизации. Мы используем темы из %s"
+"Создайте новую папку в 'assets/css/' и загрузите в нее файл "
+"'bootstrap.min.css', который содержит основные правила стилизации. Мы "
+"используем темы из %s"
 
 #: application/views/themes/index.php:50
 msgid "2. Step"
@@ -23512,8 +23521,8 @@ msgid ""
 "Show profile picture of QSO partner from qrz.com/hamqth.com profile in the "
 "log QSO section."
 msgstr ""
-"Показать изображение корреспондента по QSO из его профиля на qrz.com/hamqth."
-"com в разделе QSO журнала."
+"Показать изображение корреспондента по QSO из его профиля на qrz.com/"
+"hamqth.com в разделе QSO журнала."
 
 #: application/views/user/edit.php:484
 msgid ""
@@ -24871,6 +24880,10 @@ msgstr "Поиск лога на Clublog"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "Пользователь LoTW. Последняя загрузка была "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "%s известных округов"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/sk/LC_MESSAGES/messages.po
+++ b/application/locale/sk/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-03-20 07:25+0000\n"
 "Last-Translator: Viliam Petrik <tatralom@gmail.com>\n"
 "Language-Team: Slovak <https://translate.wavelog.org/projects/wavelog/main-"
@@ -261,8 +261,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa aktivovaných lokátorov"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -327,7 +327,7 @@ msgid "Zones"
 msgstr "Zóny"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU zóny"
@@ -514,17 +514,17 @@ msgstr "Diplomy"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplomy - %s"
@@ -781,39 +781,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "Okresy USA"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Zobrazenie denníka - okresy"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplomy "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Lokátory urobené"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Lokátory potvrdené cez LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Lokátory potvrdené papierovými QSL"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Celkový počet urobených lokátorov"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -825,74 +825,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplomy - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Award"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -1535,8 +1535,9 @@ msgid ""
 "It should run every minute (* * * * *)."
 msgstr ""
 "Posledné spustenie prebehlo pred viac ako %s sekundami.%sProsím,\n"
-"skontrolujte svoj hlavný cron! Mal by sa spúšťať každú minútu (* * * * *)."
-"Posledné spustenie sa uskutočnilo pred viac ako %s sekundami.%sSkontroluj\n"
+"skontrolujte svoj hlavný cron! Mal by sa spúšťať každú minútu (* * * * "
+"*).Posledné spustenie sa uskutočnilo pred viac ako %s sekundami."
+"%sSkontroluj\n"
 "svoj hlavný cron! Mal by bežať každú minútu (* * * * *).Posledné spustenie "
 "sa uskutočnilo pred viac ako %s sekundami.%sSkontroluj svoj\n"
 "hlavný cron! Mal by bežať každú minútu (* * * * *).Posledný spustenie sa "
@@ -2304,8 +2305,9 @@ msgstr "eQSL"
 #: application/controllers/Logbook.php:1031
 msgid "All callbook lookups failed or provided no results."
 msgstr ""
-"Všetky vyhľadávania v callbooku zlyhali alebo neposkytli žiadne výsledky."
-"Všetky vyhľadávania v callbooku zlyhali alebo neposkytli žiadne výsledky."
+"Všetky vyhľadávania v callbooku zlyhali alebo neposkytli žiadne "
+"výsledky.Všetky vyhľadávania v callbooku zlyhali alebo neposkytli žiadne "
+"výsledky."
 
 #: application/controllers/Logbook.php:1489
 #: application/controllers/Radio.php:56
@@ -2828,8 +2830,8 @@ msgid ""
 msgstr ""
 "Certifikát nájdený v súbore %s obsahuje heslo a nemôže byť spracovaný.\n"
 "%sProsím, uistite sa, že exportujete LoTW certifikát z aplikácie tqsl bez\n"
-"hesla!%s Ďalšie informácie nájdete na %sstránke LoTW FAQ%s vo Wavelog Wiki."
-"Certifikát nájdený v súbore %s obsahuje heslo a nemožno ho spracovať.\n"
+"hesla!%s Ďalšie informácie nájdete na %sstránke LoTW FAQ%s vo Wavelog "
+"Wiki.Certifikát nájdený v súbore %s obsahuje heslo a nemožno ho spracovať.\n"
 "%sProsím, uistite sa, že exportujete certifikát LoTW z aplikácie tqsl bez\n"
 "hesla!%s Pre ďalšie informácie navštívte %sstránku LoTW FAQ%s vo Wavelog\n"
 "Wiki.Certifikát nájdený v súbore %s obsahuje heslo a nemožno ho spracovať. "
@@ -4288,8 +4290,8 @@ msgid ""
 msgstr ""
 "Momentálne nemôžete zastupovať iného používateľa. Najskôr zmeňte\n"
 "encryption_key vo vašom súbore config.php!Momentálne nemôžete predstierať, "
-"že ste iný používateľ. Najprv zmeňte encryption_key vo svojom súbore config."
-"php!"
+"že ste iný používateľ. Najprv zmeňte encryption_key vo svojom súbore "
+"config.php!"
 
 #: application/controllers/User.php:1830
 msgid "Invalid Hash"
@@ -5002,8 +5004,9 @@ msgstr "HRDlog: Pre volaciu značku neboli nájdené žiadne QSOs na nahratie: "
 #: application/models/Hrdlog_model.php:31
 msgid "HRDlog: No station profiles with HRDlog Credentials found."
 msgstr ""
-"HRDlog: Nenašli sa žiadne profily staníc s HRDlog prihlasovacími údajmi."
-"HRDlog: Nenašli sa žiadne profily staníc s prihlasovacími údajmi HRDlog."
+"HRDlog: Nenašli sa žiadne profily staníc s HRDlog prihlasovacími "
+"údajmi.HRDlog: Nenašli sa žiadne profily staníc s prihlasovacími údajmi "
+"HRDlog."
 
 #: application/models/Jcc_model.php:209 application/models/Jcc_model.php:210
 #: application/views/awards/iota/index.php:222
@@ -5327,7 +5330,7 @@ msgstr "Rozdiel"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -6037,10 +6040,10 @@ msgstr "Minimálny počet"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7707,8 +7710,8 @@ msgstr ""
 msgid "County"
 msgstr "Okres"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7901,7 +7904,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7974,8 +7977,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -8007,7 +8014,7 @@ msgstr ""
 msgid "Total"
 msgstr "Celkovo"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -8478,8 +8485,8 @@ msgstr ""
 "viac ako 630 km od východu na západ a takmer 900 km od severu na juh. Asi 70 "
 "000 z 82 miliónov obyvateľov Nemecka sú licencovaní rádioamatéri, z ktorých "
 "viac ako 40 000 je členmi DARC. DOK je systém, ktorý poskytuje jednotlivým "
-"miestnym pobočkám identifikátor a znamená \"Deutscher Ortsverband "
-"Kenner\" (po slovensky: \"Identifikátor nemeckého miestneho združenia\")."
+"miestnym pobočkám identifikátor a znamená \"Deutscher Ortsverband Kenner\" "
+"(po slovensky: \"Identifikátor nemeckého miestneho združenia\")."
 
 #: application/views/awards/dok/index.php:15
 msgid ""
@@ -8789,9 +8796,9 @@ msgstr ""
 #: application/views/awards/dxcc/index.php:558
 msgid "No results found for your search criteria. Please try again."
 msgstr ""
-"Pre vaše vyhľadávacie kritériá sa nenašli žiadne výsledky. Skúste to znova."
-"Podľa vašich vyhľadávacích kritérií neboli nájdené žiadne výsledky. Skúste "
-"to prosím znovu."
+"Pre vaše vyhľadávacie kritériá sa nenašli žiadne výsledky. Skúste to "
+"znova.Podľa vašich vyhľadávacích kritérií neboli nájdené žiadne výsledky. "
+"Skúste to prosím znovu."
 
 #: application/views/awards/dxcc/progress.php:31
 msgid "No mode data available."
@@ -8810,9 +8817,9 @@ msgid ""
 msgstr ""
 "Pamätné vyznamenanie Fred Fish bolo vytvorené na počesť Freda Fisha, W5FF\n"
 "(SK), ktorý bol prvým rádioamatérom, ktorý nadviazal a potvrdil všetkých\n"
-"488 lokátorov Maidenhead v 48 susediacich štátoch USA na pásme 6 metrov."
-"Diplom Freda Fisha bola vytvorená na počesť Freda Fisha, W5FF (SK), ktorý "
-"bol prvým amatérom, ktorý odpracoval a potvrdil všetky 488 Maidenhead "
+"488 lokátorov Maidenhead v 48 susediacich štátoch USA na pásme 6 "
+"metrov.Diplom Freda Fisha bola vytvorená na počesť Freda Fisha, W5FF (SK), "
+"ktorý bol prvým amatérom, ktorý odpracoval a potvrdil všetky 488 Maidenhead "
 "lokátorových štvorcov v 48 susediacich štátoch USA na 6 metroch."
 
 #: application/views/awards/ffma/index.php:13
@@ -10220,12 +10227,12 @@ msgstr ""
 "Provinces (WAP) rádiovým amatérom, ktorí majú potvrdené spojenia so\n"
 "stanicami v každej z dvanástich provincií Holandska. Toto ocenenie\n"
 "povzbudzuje operátorov, aby nadviazali spojenia s rozmanitými stanicami v\n"
-"celej krajine, čím podporuje národnú dostupnosť aj prevádzkové zručnosti."
-"VRZA (Vereniging voor Radio Zend Amateurs) ponúka diplom Worked All "
-"Provinces (WAP) rádioamatérom, ktorí majú potvrdené spojenia so stanicami v "
-"každej z dvanástich provincií Holandska. Toto ocenenie povzbudzuje "
-"operátorov, aby spolupracovali s rôznorodým spektrom staníc v celej krajine, "
-"čím podporuje národné prepojenie a prevádzkovú zručnosť."
+"celej krajine, čím podporuje národnú dostupnosť aj prevádzkové "
+"zručnosti.VRZA (Vereniging voor Radio Zend Amateurs) ponúka diplom Worked "
+"All Provinces (WAP) rádioamatérom, ktorí majú potvrdené spojenia so "
+"stanicami v každej z dvanástich provincií Holandska. Toto ocenenie "
+"povzbudzuje operátorov, aby spolupracovali s rôznorodým spektrom staníc v "
+"celej krajine, čím podporuje národné prepojenie a prevádzkovú zručnosť."
 
 #: application/views/awards/wap/index.php:27
 #, php-format
@@ -10290,8 +10297,8 @@ msgstr ""
 "Použité polia pre toto ocenenie: DXCC (Musí byť jedno z Čína/318,\n"
 "Hongkong/321, Macao/152, Taiwan/386, Pratas Isl./505 alebo Scarborough\n"
 "Reef/506) a platný štát (ADIF: DXCC a STATE)Pre tento diplom sa používajú "
-"oblasti: DXCC (musí byť jedno z Čína/318, HongKong/321, Macao/152, "
-"Taiwan/386, Pratas Isl./505 alebo Scarborough"
+"oblasti: DXCC (musí byť jedno z Čína/318, HongKong/321, Macao/152, Taiwan/"
+"386, Pratas Isl./505 alebo Scarborough"
 
 #: application/views/awards/wapc/index.php:55
 msgid "Show WAPC Map"
@@ -11630,8 +11637,8 @@ msgstr "Výsledky aktualizácie contestového CBR"
 msgid ""
 "Your contest QSOs have been updated using the values of your Cabrillo file."
 msgstr ""
-"Vaše súťažné QSO boli aktualizované pomocou hodnôt z vášho Cabrillo súboru."
-"Tvoje contestové spojenia boli aktualizované pomocou hodnôt z tvojho "
+"Vaše súťažné QSO boli aktualizované pomocou hodnôt z vášho Cabrillo "
+"súboru.Tvoje contestové spojenia boli aktualizované pomocou hodnôt z tvojho "
 "Cabrillo súboru."
 
 #: application/views/cabrillo/cbr_success.php:19
@@ -14131,8 +14138,9 @@ msgid ""
 "You need to upgrade your PHP version. Minimum version is %s. Your version "
 "is: %s."
 msgstr ""
-"Musíte upgradovať verziu PHP. Minimálna verzia je %s. Vaša verzia je: %s."
-"Musíš si aktualizovať verziu PHP. Minimálna verzia je %s. Tvoja verzia je %s."
+"Musíte upgradovať verziu PHP. Minimálna verzia je %s. Vaša verzia je: "
+"%s.Musíš si aktualizovať verziu PHP. Minimálna verzia je %s. Tvoja verzia je "
+"%s."
 
 #: application/views/dashboard/index.php:120
 #, php-format
@@ -14648,8 +14656,9 @@ msgstr ""
 #: application/views/logbookadvanced/distancedialog.php:4
 msgid "Update will only set the distance for QSOs where the distance is empty."
 msgstr ""
-"Aktualizácia nastaví vzdialenosť iba pre QSO, kde je vzdialenosť prázdna."
-"Aktualizácia nastaví vzdialenosť iba pre QSO, kde je vzdialenosť prázdna."
+"Aktualizácia nastaví vzdialenosť iba pre QSO, kde je vzdialenosť "
+"prázdna.Aktualizácia nastaví vzdialenosť iba pre QSO, kde je vzdialenosť "
+"prázdna."
 
 #: application/views/dbtools/checkresult.php:49
 #: application/views/dbtools/checkresult.php:65
@@ -15422,8 +15431,8 @@ msgid ""
 "config.php"
 msgstr ""
 "Prejdite do priečinka application/config a porovnajte config.sample.php s\n"
-"vašim config.phpPrejdi do priečinka application/config a porovnaj config."
-"sample.php so svojím config.php"
+"vašim config.phpPrejdi do priečinka application/config a porovnaj "
+"config.sample.php so svojím config.php"
 
 #: application/views/debug/index.php:250
 #, php-format
@@ -16471,8 +16480,9 @@ msgstr "O kód možno požiadať na %s"
 #: application/views/webadif/export.php:34
 msgid "This might take a while as QSO uploads are processed sequentially."
 msgstr ""
-"Toto môže chvíľu trvať, pretože nahrávania QSO sa spracovávajú sekvenčne."
-"Môže to chvíľu trvať, pretože nahrávané spojenia sa spracúvajú postupne."
+"Toto môže chvíľu trvať, pretože nahrávania QSO sa spracovávajú "
+"sekvenčne.Môže to chvíľu trvať, pretože nahrávané spojenia sa spracúvajú "
+"postupne."
 
 #: application/views/hrdlog/export.php:60
 msgid ""
@@ -17119,6 +17129,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97
@@ -19777,9 +19791,9 @@ msgstr "Zobraziť meno"
 #: application/views/lotw_views/index.php:4
 msgid "Upload folder is not writable. Please contact your admin."
 msgstr ""
-"Priečinok na nahrávanie nie je zapisovateľný. Kontaktujte svojho správcu."
-"Priečinok na nahrávanie nie je zapisovateľný. Prosím, kontaktujte svojho "
-"správcu."
+"Priečinok na nahrávanie nie je zapisovateľný. Kontaktujte svojho "
+"správcu.Priečinok na nahrávanie nie je zapisovateľný. Prosím, kontaktujte "
+"svojho správcu."
 
 #: application/views/lotw_views/index.php:18
 msgid "LoTW Import"
@@ -20310,8 +20324,8 @@ msgid ""
 "or 'tls://')"
 msgstr ""
 "Názov hostiteľa poštového servera, napr. 'mail.example.com' (bez 'ssl://'\n"
-"alebo 'tls://')Názov hostiteľa poštového servera, napr. 'mail.example."
-"com' (bez 'ssl://'"
+"alebo 'tls://')Názov hostiteľa poštového servera, napr. 'mail.example.com' "
+"(bez 'ssl://'"
 
 #: application/views/options/email.php:54
 msgid "SMTP Port"
@@ -20495,8 +20509,8 @@ msgid ""
 msgstr ""
 "Informácie o verzii sa zobrazujú každému používateľovi. Používateľ má\n"
 "možnosť zatvoriť dialóg po prečítaní. Vyberte, či chcete zobraziť iba\n"
-"poznámky k vydaniu (získané z githubu), iba vlastný text alebo oboje."
-"Informácie o verzii sa zobrazujú každému používateľovi. Používateľ má "
+"poznámky k vydaniu (získané z githubu), iba vlastný text alebo "
+"oboje.Informácie o verzii sa zobrazujú každému používateľovi. Používateľ má "
 "možnosť zavrieť dialógové okno po jeho prečítaní. Vyberte si, či chcete "
 "zobraziť iba poznámky k vydaniu (získané z githubu), iba vlastný text alebo "
 "oboje."
@@ -21143,9 +21157,9 @@ msgid ""
 "No additional QSOs were found. That means they are probably already in the "
 "queue."
 msgstr ""
-"Nenašli sa žiadne ďalšie QSO. To znamená, že sú pravdepodobne už vo fronte."
-"Žiadne ďalšie spojenia sa nenašli. To znamená, že sú pravdepodobne už v "
-"poradovníku."
+"Nenašli sa žiadne ďalšie QSO. To znamená, že sú pravdepodobne už vo "
+"fronte.Žiadne ďalšie spojenia sa nenašli. To znamená, že sú pravdepodobne už "
+"v poradovníku."
 
 #: application/views/qso/award_tabs.php:2
 msgid "Showing summary for DXCC"
@@ -22025,9 +22039,9 @@ msgstr "Max elevácia"
 #: application/views/satellite/skedtable.php:89
 msgid "No overlapping passes found. Please check the input parameters."
 msgstr ""
-"Nenašli sa žiadne prekrývajúce sa prelety. Skontrolujte vstupné parametre."
-"Neboli nájdené žiadne prekrývajúce sa prelety. Skontrolujte prosím vstupné "
-"parametre."
+"Nenašli sa žiadne prekrývajúce sa prelety. Skontrolujte vstupné "
+"parametre.Neboli nájdené žiadne prekrývajúce sa prelety. Skontrolujte prosím "
+"vstupné parametre."
 
 #: application/views/satellite/tleinfo.php:6
 #, php-format
@@ -22095,9 +22109,9 @@ msgid ""
 "worked has uploaded to LoTW after your QSO date."
 msgstr ""
 "Vyhľadávanie zobrazuje QSO, ktoré nie sú potvrdené na LoTW, ale značka, s\n"
-"ktorou ste nadviazali spojenie, nahrala na LoTW až po dátume vášho QSO."
-"Vyhľadávanie zobrazuje spojenia, ktoré nie sú potvrdené na LoTW, ale volacia "
-"značka, s ktorou ste pracovali, nahrala na LoTW po dátume vášho QSO."
+"ktorou ste nadviazali spojenie, nahrala na LoTW až po dátume vášho "
+"QSO.Vyhľadávanie zobrazuje spojenia, ktoré nie sú potvrdené na LoTW, ale "
+"volacia značka, s ktorou ste pracovali, nahrala na LoTW po dátume vášho QSO."
 
 #: application/views/search/lotw_unconfirmed_result.php:10
 msgid "Last LoTW upload"
@@ -23459,8 +23473,9 @@ msgid ""
 msgstr ""
 "Vytvorte nový priečinok v 'assets/css/' a nahrajte súbor\n"
 "'bootstrap.min.css', ktorý obsahuje základné pravidlá štýlovania. Používame\n"
-"témy z %sVytvor nový priečinok v 'assets/css/' a nahraj súbor 'bootstrap.min."
-"css', ktorý obsahuje základné pravidlá štýlov. Používame témy z %s"
+"témy z %sVytvor nový priečinok v 'assets/css/' a nahraj súbor "
+"'bootstrap.min.css', ktorý obsahuje základné pravidlá štýlov. Používame témy "
+"z %s"
 
 #: application/views/themes/index.php:50
 msgid "2. Step"
@@ -24434,10 +24449,11 @@ msgid ""
 msgstr ""
 "Pomocou tlačidla na reset hesla môžete používateľovi odoslať e-mail\n"
 "obsahujúci odkaz na resetovanie hesla. Aby to fungovalo, uistite sa, že\n"
-"nastavenia e-mailu v globálnych možnostiach sú správne nakonfigurované."
-"Pomocou tlačidla na obnovenie hesla môžete používateľovi poslať e-mail, "
-"ktorý obsahuje odkaz na obnovenie hesla. Na dosiahnutie tohto zabezpečte, "
-"aby boli v globálnych možnostiach správne nastavené e-mailové nastavenia."
+"nastavenia e-mailu v globálnych možnostiach sú správne "
+"nakonfigurované.Pomocou tlačidla na obnovenie hesla môžete používateľovi "
+"poslať e-mail, ktorý obsahuje odkaz na obnovenie hesla. Na dosiahnutie tohto "
+"zabezpečte, aby boli v globálnych možnostiach správne nastavené e-mailové "
+"nastavenia."
 
 #: application/views/user/index.php:19
 msgid "Create user"
@@ -25377,13 +25393,14 @@ msgstr ""
 #~ "do ďalšieho QSO, ak obsahuje prijatú výmenu, alebo ak použijete jednu\n"
 #~ "čiarku ','. Pre automatické zvyšovanie odoslaného sériového čísla "
 #~ "použite\n"
-#~ "',++' a uveďte počiatočnú odoslanú výmenu. Pre deaktiváciu použite ',+0':"
-#~ "Prijatá výmena musí mať predponu s bodkou '.', odoslaná výmena s čiarkou "
-#~ "','. Posledné dva riadky sú ekvivalentné - teda na medzerách nezáleží, "
-#~ "ako ani na poradí. Výmena, ktorú ste poslali, bude automaticky zahrnutá v "
-#~ "nasledujúcom QSO, ak obsahuje prijatú výmenu, alebo ak použijete jednu "
-#~ "čiarku ','. Na automatické zvýšenie odoslanej série použite ',++' a dajte "
-#~ "počiatočnú odoslanú výmenu. Na deaktiváciu použite ',+0':"
+#~ "',++' a uveďte počiatočnú odoslanú výmenu. Pre deaktiváciu použite ',"
+#~ "+0':Prijatá výmena musí mať predponu s bodkou '.', odoslaná výmena s "
+#~ "čiarkou ','. Posledné dva riadky sú ekvivalentné - teda na medzerách "
+#~ "nezáleží, ako ani na poradí. Výmena, ktorú ste poslali, bude automaticky "
+#~ "zahrnutá v nasledujúcom QSO, ak obsahuje prijatú výmenu, alebo ak "
+#~ "použijete jednu čiarku ','. Na automatické zvýšenie odoslanej série "
+#~ "použite ',++' a dajte počiatočnú odoslanú výmenu. Na deaktiváciu použite "
+#~ "',+0':"
 
 #~ msgid ""
 #~ "Here, the first qso uses the set serial 1, and the second will use 2 as "
@@ -25401,9 +25418,9 @@ msgstr ""
 #~ msgstr ""
 #~ "Najprv sa vymaže všetok predchádzajúci výmenný údaj, potom sa nastaví "
 #~ "iba\n"
-#~ "sériové číslo. Inak by sa nastavil aj predchádzajúci výmenný údaj 'D23'."
-#~ "Najprv sa všetky predchádzajúce výmeny vymažú a potom sa nastaví iba "
-#~ "sériové číslo. Inak by bola nastavená aj predchádzajúca výmena 'D23'."
+#~ "sériové číslo. Inak by sa nastavil aj predchádzajúci výmenný údaj "
+#~ "'D23'.Najprv sa všetky predchádzajúce výmeny vymažú a potom sa nastaví "
+#~ "iba sériové číslo. Inak by bola nastavená aj predchádzajúca výmena 'D23'."
 
 #~ msgid "QSO on"
 #~ msgstr "QSO o"
@@ -25425,8 +25442,9 @@ msgstr ""
 
 #~ msgid "Private feed key empty. Please set the feed key in your profile."
 #~ msgstr ""
-#~ "Súkromný kľúč feedu je prázdny. Nastavte kľúč feedu vo svojom profile."
-#~ "Kľúč privátneho kanálu je prázdny. Nastav kľúč kanálu vo svojom profile."
+#~ "Súkromný kľúč feedu je prázdny. Nastavte kľúč feedu vo svojom "
+#~ "profile.Kľúč privátneho kanálu je prázdny. Nastav kľúč kanálu vo svojom "
+#~ "profile."
 
 #~ msgid "No upcoming activations found. Please check back later."
 #~ msgstr ""
@@ -25872,9 +25890,9 @@ msgstr ""
 #~ msgstr ""
 #~ "Časový graf sa používa na analýzu vášho denníka a zistenie, v akých "
 #~ "časoch\n"
-#~ "ste pracovali v určitých CQ zónach alebo DXCC krajinách na vybranom pásme."
-#~ "Timeplotter sa používa na analýzu vášho denníka, aby ste zistili, v akých "
-#~ "časoch ste pracovali v určitých CQ zónach alebo DXCC krajinách na "
+#~ "ste pracovali v určitých CQ zónach alebo DXCC krajinách na vybranom "
+#~ "pásme.Timeplotter sa používa na analýzu vášho denníka, aby ste zistili, v "
+#~ "akých časoch ste pracovali v určitých CQ zónach alebo DXCC krajinách na "
 #~ "vybranom pásme."
 
 #~ msgid ""

--- a/application/locale/sl/LC_MESSAGES/messages.po
+++ b/application/locale/sl/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-06-09 21:07+0000\n"
 "Last-Translator: Anton Tomanič <s57xz.toni@gmail.com>\n"
 "Language-Team: Slovenian <https://translate.wavelog.org/projects/wavelog/"
@@ -260,8 +260,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Zemljevid aktiviranih lokatorjev"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -326,7 +326,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU Zone"
@@ -513,17 +513,17 @@ msgstr "Diplome"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplome - %s"
@@ -780,39 +780,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "US Counties"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Pogled dnevnika - Counties"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplome - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "delani lokatorji"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Potrjena UL polja v LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "UL polja potrjena preko papirnatih QSL"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Skupno število delanih UL polj"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -824,74 +824,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplome - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Award"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Diplome - AMSAT Rover"
 
@@ -5285,7 +5285,7 @@ msgstr "Razlika"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5995,10 +5995,10 @@ msgstr "Najmanjše število"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7629,8 +7629,8 @@ msgstr "Prenesi CSV"
 msgid "County"
 msgstr "County"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7812,7 +7812,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7885,8 +7885,12 @@ msgstr "Napredek delane"
 msgid "Confirmed Progress"
 msgstr "Napredek potrjene"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7918,7 +7922,7 @@ msgstr "Napredek potrjene"
 msgid "Total"
 msgstr "Skupaj"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -9934,9 +9938,9 @@ msgid ""
 "Macao/152, Taiwan/386, Pratas Isl./505 or Scarborough Reef/506) and valid "
 "State (ADIF: DXCC and STATE)"
 msgstr ""
-"Polja, uporabljena za to diplomo: DXCC (Must be one of China/318, "
-"HongKong/321, Macao/152, Taiwan/386, Pratas Isl./505 or Scarborough "
-"Reef/506) and valid State (ADIF: DXCC and STATE)"
+"Polja, uporabljena za to diplomo: DXCC (Must be one of China/318, HongKong/"
+"321, Macao/152, Taiwan/386, Pratas Isl./505 or Scarborough Reef/506) and "
+"valid State (ADIF: DXCC and STATE)"
 
 #: application/views/awards/wapc/index.php:55
 msgid "Show WAPC Map"
@@ -16514,6 +16518,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/sq/LC_MESSAGES/messages.po
+++ b/application/locale/sq/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2024-08-17 10:49+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Albanian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -258,8 +258,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -324,7 +324,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -511,17 +511,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -778,39 +778,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -822,74 +822,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5162,7 +5162,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5872,10 +5872,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7422,8 +7422,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7596,7 +7596,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7669,8 +7669,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7702,7 +7706,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15925,6 +15929,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/sr/LC_MESSAGES/messages.po
+++ b/application/locale/sr/LC_MESSAGES/messages.po
@@ -9,7 +9,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-03-21 17:42+0000\n"
 "Last-Translator: Dariusz Koryto <dariusz@koryto.eu>\n"
 "Language-Team: Serbian <https://translate.wavelog.org/projects/wavelog/main-"
@@ -262,8 +262,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Mapa aktiviranih polja"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -328,7 +328,7 @@ msgid "Zones"
 msgstr "Zone"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU Zone"
@@ -515,17 +515,17 @@ msgstr "Diplome"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplome - %s"
@@ -782,39 +782,39 @@ msgstr "IOTA (Island On The Air - Ostrva u eteru)"
 msgid "US Counties"
 msgstr "US Okruzi"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Pregled loga - Okruzi"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplome - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Rađenih polja"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Polja potvrđenih preko LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Polja potvrđenih QSL kartama"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Укупно рађених поља"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -826,74 +826,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplome - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked all Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" награда"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -1017,8 +1017,9 @@ msgstr "Неважећи ID клуба!"
 #: application/controllers/Club.php:130 application/controllers/Club.php:221
 msgid "User could not be notified. Please check your email settings."
 msgstr ""
-"Корисник није могао бити обавештен. Молимо проверите ваша подешавања е-поште."
-"Корисник није могао бити обавештен. Молимо проверите ваша e-mailподешавања."
+"Корисник није могао бити обавештен. Молимо проверите ваша подешавања е-"
+"поште.Корисник није могао бити обавештен. Молимо проверите ваша e-"
+"mailподешавања."
 
 #: application/controllers/Club.php:134
 msgid "Club member permissions have been updated."
@@ -5229,7 +5230,7 @@ msgstr "Разлика"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5939,10 +5940,10 @@ msgstr "Минималан број"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7516,8 +7517,8 @@ msgstr ""
 msgid "County"
 msgstr "Округ"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7696,7 +7697,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7769,8 +7770,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7802,7 +7807,7 @@ msgstr ""
 msgid "Total"
 msgstr "Укупно"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -13513,8 +13518,9 @@ msgstr ""
 msgctxt "Dashboard Warning"
 msgid "You have no station linked to your logbook. Click %shere%s to do it."
 msgstr ""
-"Немате станицу повезану са вашим дневником. Кликните %sovde%s да то урадите."
-"Nemate stanicu povezanu sa vašim dnevnikom. Kliknite %sovde%s da touradite."
+"Немате станицу повезану са вашим дневником. Кликните %sovde%s да то "
+"урадите.Nemate stanicu povezanu sa vašim dnevnikom. Kliknite %sovde%s da "
+"touradite."
 
 #: application/views/dashboard/index.php:175
 #, php-format
@@ -14955,8 +14961,9 @@ msgstr[2] "Baza podataka sadrži%d QSOa bez staničnog profila (lokacije)"
 #: application/views/debug/index.php:835
 msgid "Please mark QSOs and reassign them to an existing station location:"
 msgstr ""
-"Молимо означите QSO-е и поново их доделите постојећој локацији станице:"
-"Molimo označite veze i ponovo ih dodelite postojećoj staničnojlokaciji:"
+"Молимо означите QSO-е и поново их доделите постојећој локацији "
+"станице:Molimo označite veze i ponovo ih dodelite postojećoj "
+"staničnojlokaciji:"
 
 #: application/views/debug/index.php:843
 msgctxt "Stationlocation"
@@ -15745,8 +15752,9 @@ msgstr "Boje"
 #: application/views/qso/edit_ajax.php:554
 msgid "Propagation mode is not supported by LoTW. LoTW QSL fields disabled."
 msgstr ""
-"Режим пропагације није подржан од стране LoTW-а. LoTW QSL поља онемогућена."
-"Vrsta propagacija nije podržana od strane LoTW. LoTW QSL polja suonemogućena."
+"Режим пропагације није подржан од стране LoTW-а. LoTW QSL поља "
+"онемогућена.Vrsta propagacija nije podržana od strane LoTW. LoTW QSL polja "
+"suonemogućena."
 
 #: application/views/interface_assets/footer.php:58
 msgid "No states for this DXCC available"
@@ -16294,6 +16302,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97
@@ -17242,8 +17254,9 @@ msgstr "Укупна висина једне етикете"
 #: application/views/labels/edit.php:110
 msgid "Font size used on the label don't go too big."
 msgstr ""
-"Величина фонта која се користи на етикети, немојте ићи превише велико."
-"Величина фонта која се користи на етикетама не би требало да будевелика."
+"Величина фонта која се користи на етикети, немојте ићи превише "
+"велико.Величина фонта која се користи на етикетама не би требало да "
+"будевелика."
 
 #: application/views/labels/create.php:111
 #: application/views/labels/edit.php:113
@@ -18988,9 +19001,9 @@ msgstr "Није синхронизовано"
 #: application/views/lotw_views/index.php:154
 msgid "You need to upload some LoTW p12 certificates to use this area."
 msgstr ""
-"Треба да отпремите неке LoTW p12 сертификате да бисте користили ово подручје."
-"Требало би да учитате неке LoTW p12 сертификате како бисте користилиове "
-"могућности."
+"Треба да отпремите неке LoTW p12 сертификате да бисте користили ово "
+"подручје.Требало би да учитате неке LoTW p12 сертификате како бисте "
+"користилиове могућности."
 
 #: application/views/lotw_views/index.php:173
 msgid "The next automatic sync with LoTW will happen at: "
@@ -22679,8 +22692,8 @@ msgstr "Format datuma"
 #: application/views/user/edit.php:268
 msgid "Select how you would like dates shown when logged into your account."
 msgstr ""
-"Изаберите како желите да се приказују датуми када сте пријављени у ваш налог."
-"Izaberite kako biste željeli da vam se prikazuju datumi kada ste usvom "
+"Изаберите како желите да се приказују датуми када сте пријављени у ваш "
+"налог.Izaberite kako biste željeli da vam se prikazuju datumi kada ste usvom "
 "nalogu."
 
 #: application/views/user/edit.php:272
@@ -22978,8 +22991,9 @@ msgstr "Изаберите број најновијих QSO-а за прика�
 #: application/views/user/edit.php:778
 msgid "Choose the number of latest QSOs to be displayed on dashboard."
 msgstr ""
-"Изаберите број најновијих QSO-а који ће бити приказани на контролној табли."
-"Изаберите број најновијих QSO-а који ће се приказивати на контролнојтабли."
+"Изаберите број најновијих QSO-а који ће бити приказани на контролној "
+"табли.Изаберите број најновијих QSO-а који ће се приказивати на "
+"контролнојтабли."
 
 #: application/views/user/edit.php:782
 msgid "Show Dashboard Map"
@@ -23690,9 +23704,9 @@ msgstr "Potvrdi lozinku"
 #: application/views/version_dialog/index.php:20
 msgid "No Version Dialog text set. Go to the Admin Menu and set one."
 msgstr ""
-"Није постављен текст дијалога верзије. Идите у Админ мени и поставите један."
-"Nije postavljen tekst za dijalog o verziji. Idite u administratorskimeni za "
-"postavljanje teksta."
+"Није постављен текст дијалога верзије. Идите у Админ мени и поставите "
+"један.Nije postavljen tekst za dijalog o verziji. Idite u "
+"administratorskimeni za postavljanje teksta."
 
 #: application/views/version_dialog/index.php:60
 msgid "Error at parsing JSON-Data or got empty result from github."
@@ -24227,14 +24241,15 @@ msgstr ""
 
 #~ msgid "Private feed key empty. Please set the feed key in your profile."
 #~ msgstr ""
-#~ "Лични кључ фида је празан. Молимо поставите кључ фида у вашем профилу."
-#~ "Lični ključ za snabdevanje je prazan. Molimo podesite ključ zasnabdevanje "
-#~ "u vašem profilu."
+#~ "Лични кључ фида је празан. Молимо поставите кључ фида у вашем "
+#~ "профилу.Lični ključ za snabdevanje je prazan. Molimo podesite ključ "
+#~ "zasnabdevanje u vašem profilu."
 
 #~ msgid "No upcoming activations found. Please check back later."
 #~ msgstr ""
-#~ "Нису пронађене предстојеће активности. Молимо проверите поново касније."
-#~ "Nisu pronađene predstojeće aktivacije. Molimo proverite ponovokasnije."
+#~ "Нису пронађене предстојеће активности. Молимо проверите поново "
+#~ "касније.Nisu pronađene predstojeće aktivacije. Molimo proverite "
+#~ "ponovokasnije."
 
 #~ msgctxt "Hamsat - Track Satellites"
 #~ msgid "Track"

--- a/application/locale/sv_SE/LC_MESSAGES/messages.po
+++ b/application/locale/sv_SE/LC_MESSAGES/messages.po
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-08-29 04:04+0000\n"
 "Last-Translator: \"Jorgen Dahl, NU1T\" <sm6srw@arrl.net>\n"
 "Language-Team: Swedish <https://translate.wavelog.org/projects/wavelog/main-"
@@ -262,8 +262,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Karta Aktiverade Lokatorrutor"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -328,7 +328,7 @@ msgid "Zones"
 msgstr "Zoner"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU-zoner"
@@ -516,17 +516,17 @@ msgstr "Diplom"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Diplom - %s"
@@ -783,39 +783,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "USA:s län"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Loggvy - Län"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Diplom - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Lokatorrutor kontaktade"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "Lokatorrutor bekräftade på LoTW"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Lokatorrutor bekräftade av pappers-QSL"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Totalt antal Lokatorrutor kontaktade"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -827,74 +827,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Diplom - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "England"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Isle of Man"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Nordirland"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "Skottland"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Wales"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Worked All Continents (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Diplom"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Diplom - AMSAT Rover"
 
@@ -5270,7 +5270,7 @@ msgstr "Skillnad"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5983,10 +5983,10 @@ msgstr "Minsta antal"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7634,8 +7634,8 @@ msgstr "Ladda ner CSV"
 msgid "County"
 msgstr "Län"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "Inte i USA-CA countylista"
 
@@ -7817,8 +7817,8 @@ msgstr "Kontaktade Counties"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "av %s kända counties"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7890,8 +7890,12 @@ msgstr "Kontaktade Framsteg"
 msgid "Confirmed Progress"
 msgstr "Bekräftade Framsteg"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7923,7 +7927,7 @@ msgstr "Bekräftade Framsteg"
 msgid "Total"
 msgstr "Totalt"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -9952,8 +9956,8 @@ msgid ""
 "State (ADIF: DXCC and STATE)"
 msgstr ""
 "Fält som använts för detta diplom: DXCC (måste vara ett av Kina/318, "
-"HongKong/321, Macao/152, Taiwan/386, Pratas Isl./505 eller Scarborough "
-"Reef/506) och giltig stat (ADIF: DXCC och STATE)"
+"HongKong/321, Macao/152, Taiwan/386, Pratas Isl./505 eller Scarborough Reef/"
+"506) och giltig stat (ADIF: DXCC och STATE)"
 
 #: application/views/awards/wapc/index.php:55
 msgid "Show WAPC Map"
@@ -16677,6 +16681,10 @@ msgstr "Counties i delstaten:"
 msgid "Needed counties for state:"
 msgstr "Nödvändiga counties för delstaten:"
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "Hoppa till innehåll"
@@ -17853,8 +17861,8 @@ msgid ""
 "We’ll keep the original value and add a more precise locator (e.g., JO90AB "
 "or JO90AB12) when a match is confident."
 msgstr ""
-"Vi behåller det ursprungliga värdet och lägger till en mer exakt lokator (t."
-"ex. JO90AB eller JO90AB12) när en matchning är säker."
+"Vi behåller det ursprungliga värdet och lägger till en mer exakt lokator "
+"(t.ex. JO90AB eller JO90AB12) när en matchning är säker."
 
 #: application/views/logbookadvanced/detachContest.php:6
 #, php-format
@@ -22995,8 +23003,8 @@ msgid ""
 "Only PNG files are allowed, and they should have a pixel ratio of 1:1 (e.g., "
 "1000px height and 1000px width)."
 msgstr ""
-"Endast PNG-filer är tillåtna, och de bör ha ett pixel-förhållande på 1:1 (t."
-"ex. 1000px höjd och 1000px bredd)."
+"Endast PNG-filer är tillåtna, och de bör ha ett pixel-förhållande på 1:1 "
+"(t.ex. 1000px höjd och 1000px bredd)."
 
 #: application/views/themes/index.php:64
 msgid "Place the two logo files in the folder 'assets/logo/'"
@@ -24675,6 +24683,10 @@ msgstr "Clublog Loggsökning"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "LoTW-användare. Senaste uppladdningen var "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "av %s kända counties"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/application/locale/tr_TR/LC_MESSAGES/messages.po
@@ -13,7 +13,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-09-02 14:14+0000\n"
 "Last-Translator: \"Erkin Mercan (TA4AQG-SP9AQG)\" <ekomeko066@gmail.com>\n"
 "Language-Team: Turkish <https://translate.wavelog.org/projects/wavelog/main-"
@@ -265,8 +265,8 @@ msgid "Activated Gridsquare Map"
 msgstr "Aktif Grid Kare Haritası"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -331,7 +331,7 @@ msgid "Zones"
 msgstr "Bölgeler"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU Bölgeleri"
@@ -519,17 +519,17 @@ msgstr "Ödüller"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "Ödüller - %s"
@@ -786,39 +786,39 @@ msgstr "IOTA (Island On The Air)"
 msgid "US Counties"
 msgstr "ABD Eyaletleri"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "Kayıt Görünümü - İlçeler"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "Ödüller - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "Çalışılan Grid Karesi"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "LoTW'de onaylanan Grid Karesi"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "Kağıt QSL ile onaylanan Grid Kareleri"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "Toplam çalışılan grid karesi"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "Fred Fish Memorial Award (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -830,74 +830,74 @@ msgstr "Fred Fish Memorial Award (FFMA)"
 msgid "SIG"
 msgstr "SIG (Special Interest Group)"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "Ödüller - SIG (Special Interest Group) - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "İngiltere"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "Man Adası"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "Kuzey İrlanda"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "Jersey"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "İskoçya"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "Guernsey"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "Galler"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "Tüm Kıtalarda Çalışıldı (WAC)"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "\"Polska\" Ödülü"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "Ödüller - AMSAT Rover"
 
@@ -5280,7 +5280,7 @@ msgstr "Fark"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5994,10 +5994,10 @@ msgstr "Minimum Sayı"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7655,8 +7655,8 @@ msgstr "CSV İndir"
 msgid "County"
 msgstr "İdari Bölge"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "USA-CA county listesinde değil"
 
@@ -7841,8 +7841,8 @@ msgstr "Çalışılan County'ler"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "%s bilinen county içinden"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7914,8 +7914,12 @@ msgstr "Çalışılan İlerlemesi"
 msgid "Confirmed Progress"
 msgstr "Onaylı İlerleme"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7947,7 +7951,7 @@ msgstr "Onaylı İlerleme"
 msgid "Total"
 msgstr "Toplam QSO"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -16717,6 +16721,10 @@ msgstr "Eyaletteki county'ler:"
 msgid "Needed counties for state:"
 msgstr "Eyalet için gereken county'ler:"
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "İçeriğe geç"
@@ -24737,6 +24745,10 @@ msgstr "Clublog Log Arama"
 #: src/QSLManager/QSO.php:921
 msgid "LoTW User. Last upload was "
 msgstr "LoTW Kullanıcısı. Son yükleme "
+
+#, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "%s bilinen county içinden"
 
 #, php-format
 #~ msgid ""

--- a/application/locale/uk/LC_MESSAGES/messages.po
+++ b/application/locale/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-03-17 23:37+0000\n"
 "Last-Translator: Dariusz Koryto <dariusz@koryto.eu>\n"
 "Language-Team: Ukrainian <https://translate.wavelog.org/projects/wavelog/"
@@ -260,8 +260,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -326,7 +326,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -513,17 +513,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -780,39 +780,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -824,74 +824,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5176,7 +5176,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5886,10 +5886,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7438,8 +7438,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7612,7 +7612,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7685,8 +7685,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7718,7 +7722,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15945,6 +15949,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97

--- a/application/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/application/locale/zh_CN/LC_MESSAGES/messages.po
@@ -37,11 +37,11 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: 2026-09-02 14:14+0000\n"
 "Last-Translator: \"Xu, Zefan (BI1GHZ)\" <ceba_robot@outlook.com>\n"
-"Language-Team: Chinese (Simplified Han script) <https://translate.wavelog."
-"org/projects/wavelog/main-translation/zh_Hans/>\n"
+"Language-Team: Chinese (Simplified Han script) <https://"
+"translate.wavelog.org/projects/wavelog/main-translation/zh_Hans/>\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -289,8 +289,8 @@ msgid "Activated Gridsquare Map"
 msgstr "已激活网格地图"
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -355,7 +355,7 @@ msgid "Zones"
 msgstr "分区"
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr "ITU 分区"
@@ -542,17 +542,17 @@ msgstr "奖项"
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr "奖项 - %s"
@@ -809,39 +809,39 @@ msgstr "IOTA (空中之岛)"
 msgid "US Counties"
 msgstr "美国县奖"
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr "日志视图 - 县(美国)"
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
 msgstr "奖项 - "
 
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
+#: application/controllers/Awards.php:1490
+#: application/controllers/Awards.php:1526
 msgid "Gridsquares worked"
 msgstr "已通联网格"
 
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
 msgid "Gridsquares confirmed on LoTW"
 msgstr "LoTW 已确认网格"
 
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
 msgid "Gridsquares confirmed by paper QSL"
 msgstr "通过纸质QSL已确认网格"
 
-#: application/controllers/Awards.php:1490
-#: application/controllers/Awards.php:1526
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr "已确认网格的总数"
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr "弗雷德·菲什纪念奖 (FFMA)"
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -853,74 +853,74 @@ msgstr "弗雷德·菲什纪念奖 (FFMA)"
 msgid "SIG"
 msgstr "SIG"
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr "奖项 - SIG - "
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr "WAP"
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr "WAIP"
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr "英格兰"
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr "马恩岛"
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr "北爱尔兰"
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr "泽西岛"
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr "苏格兰"
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr "根西"
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr "威尔士"
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr "通联世界大洲奖（WAC）"
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr "WAE"
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr "73 on 73"
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr "WPX"
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr "“波兰”奖项"
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr "奖状 - AMSAT 漫游者 (AMSAT Rover)"
 
@@ -5205,7 +5205,7 @@ msgstr "差异"
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5915,10 +5915,10 @@ msgstr "最低数量"
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7509,8 +7509,8 @@ msgstr "下载 CSV 文件"
 msgid "County"
 msgstr "县"
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr "不在美国加州的县列表中"
 
@@ -7690,8 +7690,8 @@ msgstr "通联的县"
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
-msgstr "共 %s 县"
+msgid "of %s counties"
+msgstr ""
 
 #: application/views/awards/counties/index.php:170
 msgid "Confirmed Counties"
@@ -7763,8 +7763,12 @@ msgstr "已完成通联"
 msgid "Confirmed Progress"
 msgstr "已确认通联"
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7796,7 +7800,7 @@ msgstr "已确认通联"
 msgid "Total"
 msgstr "总计"
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -9166,8 +9170,8 @@ msgid ""
 "any kind of 'Special Interest Group Award' for awards that are not "
 "implemented in Wavelog."
 msgstr ""
-"SIG 或特别兴趣小组类别（Special Interest Group Category）允许用户使用任意"
-"的“特别兴趣小组奖”来奖励未在当前 Wavelog 实现的奖。"
+"SIG 或特别兴趣小组类别（Special Interest Group Category）允许用户使用任意的"
+"“特别兴趣小组奖”来奖励未在当前 Wavelog 实现的奖。"
 
 #: application/views/awards/sig/index.php:8
 msgid ""
@@ -16255,6 +16259,10 @@ msgstr "州内的县："
 msgid "Needed counties for state:"
 msgstr "此州还需要的县："
 
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
+msgstr ""
+
 #: application/views/interface_assets/header.php:97
 msgid "Skip to content"
 msgstr "跳到内容"
@@ -22379,8 +22387,8 @@ msgid ""
 "Click here on 'Add a Theme' and type in the necessary data. Type in the "
 "filenames for the logos %swithout%s the file extension '.png'"
 msgstr ""
-"在这里添加主题，Logo 文件请输入 png 文件的文件名部分（ %s不带有%s 后缀 '."
-"png'）"
+"在这里添加主题，Logo 文件请输入 png 文件的文件名部分（ %s不带有%s 后缀 "
+"'.png'）"
 
 #: application/views/themes/index.php:83
 msgid "Foldername"
@@ -23972,6 +23980,10 @@ msgid "LoTW User. Last upload was "
 msgstr "LoTW 用户。最后上传于 "
 
 #, php-format
+#~ msgid "of %s known counties"
+#~ msgstr "共 %s 县"
+
+#, php-format
 #~ msgid ""
 #~ "Maptile cache could not be removed. Delete the folder manually. Path: %s"
 #~ msgstr "地图瓦片缓存文件无法删除，请手动删除： %s"
@@ -25540,8 +25552,8 @@ msgstr "LoTW 用户。最后上传于 "
 #~ "Click here on 'Add a Theme' and type in the necessary data. Type in the "
 #~ "filenames for the logos <b>without</b> the file extension '.png'"
 #~ msgstr ""
-#~ "在这里点击 '添加主题'，输入必要的信息，填写 Logo 的文件名（<b>不要带有 ."
-#~ "png 后缀名</b>）"
+#~ "在这里点击 '添加主题'，输入必要的信息，填写 Logo 的文件名（<b>不要带"
+#~ "有 .png 后缀名</b>）"
 
 #, php-format
 #~ msgid ""

--- a/assets/lang_src/messages.pot
+++ b/assets/lang_src/messages.pot
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
-"POT-Creation-Date: 2026-09-04 16:13+0000\n"
+"POT-Creation-Date: 2026-09-05 21:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -256,8 +256,8 @@ msgid "Activated Gridsquare Map"
 msgstr ""
 
 #: application/controllers/Activated_gridmap.php:33
-#: application/controllers/Awards.php:1486
-#: application/controllers/Awards.php:1522
+#: application/controllers/Awards.php:1489
+#: application/controllers/Awards.php:1525
 #: application/controllers/Gridmap.php:34
 #: application/controllers/Visitor.php:533
 #: application/views/activators/index.php:107
@@ -322,7 +322,7 @@ msgid "Zones"
 msgstr ""
 
 #: application/controllers/Activationplanner.php:33
-#: application/controllers/Awards.php:2664
+#: application/controllers/Awards.php:2667
 #: application/views/awards/itu/index.php:27
 msgid "ITU Zones"
 msgstr ""
@@ -509,17 +509,17 @@ msgstr ""
 #: application/controllers/Awards.php:1250
 #: application/controllers/Awards.php:1335
 #: application/controllers/Awards.php:1368
-#: application/controllers/Awards.php:1507
-#: application/controllers/Awards.php:1713
-#: application/controllers/Awards.php:1864
-#: application/controllers/Awards.php:1915
-#: application/controllers/Awards.php:2472
-#: application/controllers/Awards.php:2664
-#: application/controllers/Awards.php:2794
-#: application/controllers/Awards.php:2868
-#: application/controllers/Awards.php:2881
-#: application/controllers/Awards.php:2956
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:1510
+#: application/controllers/Awards.php:1716
+#: application/controllers/Awards.php:1867
+#: application/controllers/Awards.php:1918
+#: application/controllers/Awards.php:2475
+#: application/controllers/Awards.php:2667
+#: application/controllers/Awards.php:2797
+#: application/controllers/Awards.php:2871
+#: application/controllers/Awards.php:2884
+#: application/controllers/Awards.php:2959
+#: application/controllers/Awards.php:3101
 #, php-format
 msgid "Awards - %s"
 msgstr ""
@@ -776,39 +776,39 @@ msgstr ""
 msgid "US Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1452
+#: application/controllers/Awards.php:1455
 msgid "Log View - Counties"
 msgstr ""
 
-#: application/controllers/Awards.php:1468
+#: application/controllers/Awards.php:1471
 msgid "Awards - "
-msgstr ""
-
-#: application/controllers/Awards.php:1487
-#: application/controllers/Awards.php:1523
-msgid "Gridsquares worked"
-msgstr ""
-
-#: application/controllers/Awards.php:1488
-#: application/controllers/Awards.php:1524
-msgid "Gridsquares confirmed on LoTW"
-msgstr ""
-
-#: application/controllers/Awards.php:1489
-#: application/controllers/Awards.php:1525
-msgid "Gridsquares confirmed by paper QSL"
 msgstr ""
 
 #: application/controllers/Awards.php:1490
 #: application/controllers/Awards.php:1526
+msgid "Gridsquares worked"
+msgstr ""
+
+#: application/controllers/Awards.php:1491
+#: application/controllers/Awards.php:1527
+msgid "Gridsquares confirmed on LoTW"
+msgstr ""
+
+#: application/controllers/Awards.php:1492
+#: application/controllers/Awards.php:1528
+msgid "Gridsquares confirmed by paper QSL"
+msgstr ""
+
+#: application/controllers/Awards.php:1493
+#: application/controllers/Awards.php:1529
 msgid "Total Gridsquares worked"
 msgstr ""
 
-#: application/controllers/Awards.php:1507
+#: application/controllers/Awards.php:1510
 msgid "Fred Fish Memorial Award (FFMA)"
 msgstr ""
 
-#: application/controllers/Awards.php:1713
+#: application/controllers/Awards.php:1716
 #: application/views/interface_assets/header.php:206
 #: application/views/logbookadvanced/edit.php:256
 #: application/views/logbookadvanced/useroptions.php:250
@@ -820,74 +820,74 @@ msgstr ""
 msgid "SIG"
 msgstr ""
 
-#: application/controllers/Awards.php:1732
+#: application/controllers/Awards.php:1735
 msgid "Awards - SIG - "
 msgstr ""
 
-#: application/controllers/Awards.php:1864 application/views/bands/index.php:60
+#: application/controllers/Awards.php:1867 application/views/bands/index.php:60
 msgid "WAP"
 msgstr ""
 
-#: application/controllers/Awards.php:1915
+#: application/controllers/Awards.php:1918
 #: application/views/interface_assets/header.php:265
 msgid "WAIP"
 msgstr ""
 
-#: application/controllers/Awards.php:2572
+#: application/controllers/Awards.php:2575
 msgid "England"
 msgstr ""
 
-#: application/controllers/Awards.php:2573
+#: application/controllers/Awards.php:2576
 msgid "Isle of Man"
 msgstr ""
 
-#: application/controllers/Awards.php:2574
+#: application/controllers/Awards.php:2577
 msgid "Northern Ireland"
 msgstr ""
 
-#: application/controllers/Awards.php:2575
+#: application/controllers/Awards.php:2578
 msgid "Jersey"
 msgstr ""
 
-#: application/controllers/Awards.php:2576
+#: application/controllers/Awards.php:2579
 msgid "Scotland"
 msgstr ""
 
-#: application/controllers/Awards.php:2577
+#: application/controllers/Awards.php:2580
 msgid "Guernsey"
 msgstr ""
 
-#: application/controllers/Awards.php:2578
+#: application/controllers/Awards.php:2581
 msgid "Wales"
 msgstr ""
 
-#: application/controllers/Awards.php:2794
+#: application/controllers/Awards.php:2797
 #: application/views/awards/wac/index.php:7
 #: application/views/interface_assets/header.php:212
 msgid "Worked All Continents (WAC)"
 msgstr ""
 
-#: application/controllers/Awards.php:2868
+#: application/controllers/Awards.php:2871
 msgid "WAE"
 msgstr ""
 
-#: application/controllers/Awards.php:2881
+#: application/controllers/Awards.php:2884
 #: application/views/interface_assets/header.php:222
 msgid "73 on 73"
 msgstr ""
 
-#: application/controllers/Awards.php:2956
+#: application/controllers/Awards.php:2959
 #: application/views/awards/wpx/wpx_details.php:19
 msgid "WPX"
 msgstr ""
 
-#: application/controllers/Awards.php:3098
+#: application/controllers/Awards.php:3101
 #: application/views/awards/pl_polska/index.php:41
 #: application/views/interface_assets/header.php:287
 msgid "\"Polska\" Award"
 msgstr ""
 
-#: application/controllers/Awards.php:3142
+#: application/controllers/Awards.php:3145
 msgid "Awards - AMSAT Rover"
 msgstr ""
 
@@ -5160,7 +5160,7 @@ msgstr ""
 #: application/views/activated_gridmap/index.php:46
 #: application/views/activators/index.php:20
 #: application/views/adif/import.php:271
-#: application/views/awards/counties/index.php:255
+#: application/views/awards/counties/index.php:263
 #: application/views/awards/cq/index.php:157
 #: application/views/awards/dok/index.php:134
 #: application/views/awards/dxcc/index.php:190
@@ -5870,10 +5870,10 @@ msgstr ""
 
 #: application/views/activators/index.php:82
 #: application/views/awards/73on73/index.php:71
-#: application/views/awards/counties/counties_simple_ajax.php:21
-#: application/views/awards/counties/details_ajax.php:24
-#: application/views/awards/counties/index.php:240
-#: application/views/awards/counties/state_ajax.php:47
+#: application/views/awards/counties/counties_simple_ajax.php:32
+#: application/views/awards/counties/details_ajax.php:35
+#: application/views/awards/counties/index.php:248
+#: application/views/awards/counties/state_ajax.php:58
 #: application/views/awards/cq/index.php:283
 #: application/views/awards/dok/index.php:218
 #: application/views/awards/helvetia/index.php:218
@@ -7420,8 +7420,8 @@ msgstr ""
 msgid "County"
 msgstr ""
 
-#: application/views/awards/counties/details_ajax.php:14
-#: application/views/awards/counties/state_ajax.php:26
+#: application/views/awards/counties/details_ajax.php:25
+#: application/views/awards/counties/state_ajax.php:37
 msgid "Not in USA-CA county list"
 msgstr ""
 
@@ -7594,7 +7594,7 @@ msgstr ""
 
 #: application/views/awards/counties/index.php:165
 #, php-format
-msgid "of %s known counties"
+msgid "of %s counties"
 msgstr ""
 
 #: application/views/awards/counties/index.php:170
@@ -7667,8 +7667,12 @@ msgstr ""
 msgid "Confirmed Progress"
 msgstr ""
 
-#: application/views/awards/counties/index.php:228
-#: application/views/awards/counties/state_ajax.php:39
+#: application/views/awards/counties/index.php:201
+msgid "Unmatched"
+msgstr ""
+
+#: application/views/awards/counties/index.php:235
+#: application/views/awards/counties/state_ajax.php:50
 #: application/views/awards/dok/index.php:198
 #: application/views/awards/helvetia/index.php:197
 #: application/views/awards/iota/index.php:261
@@ -7700,7 +7704,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: application/views/awards/counties/index.php:254
+#: application/views/awards/counties/index.php:262
 #: application/views/awards/dok/index.php:123
 #: application/views/awards/helvetia/index.php:115
 #: application/views/awards/jcc/index.php:95
@@ -15923,6 +15927,10 @@ msgstr ""
 
 #: application/views/interface_assets/footer.php:2906
 msgid "Needed counties for state:"
+msgstr ""
+
+#: application/views/interface_assets/footer.php:2907
+msgid "Unmatched counties for state:"
 msgstr ""
 
 #: application/views/interface_assets/header.php:97


### PR DESCRIPTION
Regenerates \`assets/lang_src/messages.pot\` and merges it into every language's \`.po\` file via \`po_gen.sh\`, for the two new strings added in #3799 ("Unmatched", "Unmatched counties for state:"). Split out from #3799 per the project's convention of keeping translation regeneration separate from feature work.

No manual translation edits - existing translated strings are untouched, only the POT source and each PO's merged msgid list change. Compiled \`.mo\` files are intentionally not included, per \`po_gen.sh\`'s own note that these are generated on GitHub.

Depends on nothing merging first; #3799 can merge independently of this.