### PR TITLE
Fix contest race

### DIFF
--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -1177,6 +1177,7 @@ class Contesting extends CI_Controller {
 				'commands_processed' => 0,
 				'data' => [
 					'saved_qsos' => [],
+					'failed_qsos' => [],
 					'needs_resync' => false,
 					'all_qsos' => null,
 					'changed_qsos' => []
@@ -1191,6 +1192,13 @@ class Contesting extends CI_Controller {
 						$response['commands_processed'] += $this->_processCommand($command, $session_info);
 					} catch (Exception $e) {
 						$response['errors'][] = $e->getMessage();
+
+						if (($command['type'] ?? '') === 'save_qso' && !empty($command['data']['tmp_id'])) {
+							$response['data']['failed_qsos'][] = [
+								'tmp_id' => $command['data']['tmp_id'],
+								'error' => $e->getMessage()
+							];
+						}
 					}
 				}
 			}
@@ -1241,6 +1249,26 @@ class Contesting extends CI_Controller {
 				$this->load->is_loaded('logbook_model') ?: $this->load->model('logbook_model');
 				$this->load->is_loaded('contesting_model') ?: $this->load->model('contesting_model');
 
+				$operator = strtoupper(trim($this->session->userdata('operator_callsign') ?: $this->session->userdata('user_callsign')));
+
+				$existing = $this->contesting_model->find_session_qso(
+					$session_info['contest_session_id'],
+					$session_info['station_id'],
+					$command['data']['callsign'],
+					trim(($command['data']['date'] ?? '') . ' ' . ($command['data']['time'] ?? '')),
+					$operator
+				);
+
+				if ($existing) {
+					$this->new_qsos[] = [
+						'tmp_id' => $command['data']['tmp_id'],
+						'server_id' => (int) $existing['qso_id'],
+						'last_modified_ms' => (int) $existing['last_modified_ms']
+					];
+
+					return 1;
+				}
+
 				// Prepare QSO data for saving
 				$qso_data = [
 					'manual' => 0, // work always as non-manual entry; TODO: Implement something like POST CONTEST LOGGING
@@ -1264,7 +1292,7 @@ class Contesting extends CI_Controller {
 					'continent' => $command['data']['continent'] ?? NULL,
 					'dxcc_id' => $command['data']['dxcc_id'] ?? NULL,
 					'cqz' => $command['data']['cqz'] ?? NULL,
-					'operator_callsign' => strtoupper(trim($this->session->userdata('operator_callsign') ?: $this->session->userdata('user_callsign'))),
+					'operator_callsign' => $operator,
 					'station_profile' => $session_info['station_id'],
 					'contestname' => $session_info['contest_adifname'],
 					'exchangetype' => $session_info['exchangetype'] ?? 'Exchange',

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -1297,7 +1297,7 @@ class Contesting extends CI_Controller {
 						log_message('debug', 'published sync_required for contest session ' . $session_info['contest_session_id']);
 					}
 				} else {
-					throw new Exception('Failed to save QSO');;
+					throw new Exception('Failed to save QSO');
 				}
 
 				// Store mapping of tmp_id to real ID for client response

--- a/application/models/Contesting_model.php
+++ b/application/models/Contesting_model.php
@@ -696,6 +696,39 @@ class Contesting_model extends CI_Model {
 	}
 
 	/**
+	 * Looks up a QSO already logged in this session under the same natural key so it's idempotent.
+	 *
+	 * @param int $contest_session_id
+	 * @param int $station_id
+	 * @param string $callsign
+	 * @param string $time_on Y-m-d H:i:s
+	 * @param string $operator
+	 * @return array|null ['qso_id' => int, 'last_modified_ms' => int]
+	 */
+	function find_session_qso($contest_session_id, $station_id, $callsign, $time_on, $operator) {
+		$sql = "SELECT cq.qso_id, UNIX_TIMESTAMP(lb.last_modified) * 1000 AS last_modified_ms
+				FROM " . $this->config->item('table_name') . " lb
+				JOIN contest_qsos cq ON cq.qso_id = lb.COL_PRIMARY_KEY
+				WHERE lb.station_id   = ?
+				  AND lb.COL_CALL     = ?
+				  AND lb.COL_TIME_ON  = ?
+				  AND lb.COL_OPERATOR = ?
+				  AND cq.contest_session_id = ?
+				LIMIT 1";
+
+		$bindings = [
+			(int) $station_id,
+			$callsign,
+			$time_on,
+			$operator,
+			(int) $contest_session_id
+		];
+
+		$row = $this->db->query($sql, $bindings)->row_array();
+		return $row ?: null;
+	}
+
+	/**
 	 * Retrieves the total QSO count for a contest session.
 	 *
 	 * @param int $contest_session_id The ID of the contest session.

--- a/application/views/contesting/logger/components/qso-form.php
+++ b/application/views/contesting/logger/components/qso-form.php
@@ -33,6 +33,7 @@ $config = [
 	let lang_status_synced = "<?= __("Synced") ?>";
 	let lang_status_error = "<?= __("Error") ?>";
 	let lang_status_unknown = "<?= __("Unknown") ?>";
+	let lang_qso_save_failed = "<?= __("QSO could not be saved:") ?>";
 	let lang_delete_qso_confirm = decodeHtml("<?= __("Delete this QSO?") ?>");
 	let lang_qso_save = "<?= __("Save") ?>";
 	let lang_qso_edit = "<?= __("Edit") ?>";

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -1270,12 +1270,6 @@ class QsoFormComponent {
 		console.debug(`QSO Form: QSO ${qso.id} state changed from ${oldState} to ${newState}`);
 	}
 
-	_escapeHtml(value) {
-		const div = document.createElement('div');
-		div.textContent = value ?? '';
-		return div.innerHTML;
-	}
-
 	getStatusIndicator(state, message = '') {
 		if (state === 'pending') {
 			return `<span title="${lang_status_new}" style="color: orange;">&#9679;</span>`;
@@ -1283,7 +1277,7 @@ class QsoFormComponent {
 			return `<span title="${lang_status_synced}" style="color: green;">&#9679;</span>`;
 		} else if (state === 'error') {
 			const title = message ? `${lang_status_error}: ${message}` : lang_status_error;
-			return `<span title="${this._escapeHtml(title)}" style="color: red;">&#9679;</span>`;
+			return `<span title="${escapeHtml(title)}" style="color: red;">&#9679;</span>`;
 		} else {
 			return `<span title="${lang_status_unknown}" style="color: gray;">&#9679;</span>`;
 		}
@@ -1558,7 +1552,7 @@ class QsoFormComponent {
 
 			this.windowmanager.showToast(
 				lang_error,
-				this._escapeHtml(`${lang_qso_save_failed} ${qso.callsign}: ${failed.error}`),
+				escapeHtml(`${lang_qso_save_failed} ${qso.callsign}: ${failed.error}`),
 				'bg-danger text-white',
 				8000
 			);

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -489,17 +489,19 @@ class QsoFormComponent {
 		});
 	}
 
-	_renderQsoDropdown(enabled = true) {
-		if (!enabled) {
+	_renderQsoDropdown(enabled = true, deleteOnly = false) {
+		if (!enabled && !deleteOnly) {
 			return `<span title="${lang_qso_not_own}" style="display:inline-flex;">` +
 				`<div class="btn btn-secondary py-0 px-1" style="font-size:1rem; width:1.8rem; height:1.8rem; display:inline-flex; align-items:center; justify-content:center; opacity:0.4; cursor:not-allowed; pointer-events:none;">&#9776;</div>` +
 				`</span>`;
 		}
+		// A rejected QSO has no server id, so it can only be deleted locally
+		const editItem = deleteOnly ? '' : `<a class="dropdown-item qso-action-edit" href="#"><i class="fas fa-edit me-1"></i>${lang_qso_edit}</a>
+				<div class="dropdown-divider"></div>`;
 		return `<div class="dropdown d-inline-block ms-1">
 			<div class="btn btn-secondary py-0 px-1" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="font-size:1rem; width:1.8rem; height:1.8rem; display:inline-flex; align-items:center; justify-content:center;">&#9776;</div>
 			<div class="dropdown-menu dropdown-menu-end">
-				<a class="dropdown-item qso-action-edit" href="#"><i class="fas fa-edit me-1"></i>${lang_qso_edit}</a>
-				<div class="dropdown-divider"></div>
+				${editItem}
 				<a class="dropdown-item text-danger qso-action-delete" href="#"><i class="fas fa-trash me-1"></i>${lang_qso_delete}</a>
 			</div>
 		</div>`;
@@ -791,12 +793,13 @@ class QsoFormComponent {
 
 		const qsoOperator = (qso.operator ?? '').toUpperCase();
 		const isEditable = !!qso.serverId && qsoOperator === this.currentOperator;
+		const isFailed = qso.state === 'error';
 		if (isEditable) row.style.cursor = 'pointer';
 
 		row.innerHTML = `
 			${this._buildDataCells(qso, false)}
-			<td class="text-nowrap text-end">${qso.serverId ? this._renderQsoDropdown(isEditable) : ''}</td>
-			<td class="text-nowrap text-center">${this.getStatusIndicator(qso.state)}</td>
+			<td class="text-nowrap text-end">${(qso.serverId || isFailed) ? this._renderQsoDropdown(isEditable, isFailed) : ''}</td>
+			<td class="text-nowrap text-center">${this.getStatusIndicator(qso.state, qso.error)}</td>
 		`;
 	}
 
@@ -1267,13 +1270,20 @@ class QsoFormComponent {
 		console.debug(`QSO Form: QSO ${qso.id} state changed from ${oldState} to ${newState}`);
 	}
 
-	getStatusIndicator(state) {
+	_escapeHtml(value) {
+		const div = document.createElement('div');
+		div.textContent = value ?? '';
+		return div.innerHTML;
+	}
+
+	getStatusIndicator(state, message = '') {
 		if (state === 'pending') {
 			return `<span title="${lang_status_new}" style="color: orange;">&#9679;</span>`;
 		} else if (state === 'synced') {
 			return `<span title="${lang_status_synced}" style="color: green;">&#9679;</span>`;
 		} else if (state === 'error') {
-			return `<span title="${lang_status_error}" style="color: red;">&#9679;</span>`;
+			const title = message ? `${lang_status_error}: ${message}` : lang_status_error;
+			return `<span title="${this._escapeHtml(title)}" style="color: red;">&#9679;</span>`;
 		} else {
 			return `<span title="${lang_status_unknown}" style="color: gray;">&#9679;</span>`;
 		}
@@ -1333,14 +1343,15 @@ class QsoFormComponent {
 
 		// Show pointer cursor once the QSO is editable (synced + own operator)
 		const isEditable = !!qso.serverId && (qso.operator ?? '').toUpperCase() === this.currentOperator;
+		const isFailed = qso.state === 'error';
 		existingRow.style.cursor = isEditable ? 'pointer' : '';
 
 		// Update dropdown and status indicator in their respective cells
 		const cells = existingRow.querySelectorAll('td');
 		const statusCell   = cells[cells.length - 1];
 		const dropdownCell = cells[cells.length - 2];
-		if (statusCell)   statusCell.innerHTML   = this.getStatusIndicator(qso.state);
-		if (dropdownCell) dropdownCell.innerHTML = qso.serverId ? this._renderQsoDropdown(isEditable) : '';
+		if (statusCell)   statusCell.innerHTML   = this.getStatusIndicator(qso.state, qso.error);
+		if (dropdownCell) dropdownCell.innerHTML = (qso.serverId || isFailed) ? this._renderQsoDropdown(isEditable, isFailed) : '';
 	}
 
 	clearTable() {
@@ -1504,6 +1515,10 @@ class QsoFormComponent {
 			}
 		}
 
+		if (responseData.failed_qsos && responseData.failed_qsos.length > 0) {
+			this.processFailedQsos(responseData.failed_qsos, dataStore);
+		}
+
 		if (responseData.saved_qsos && responseData.saved_qsos.length > 0) {
 			this.processSavedQsos(responseData.saved_qsos, dataStore);
 			console.debug(`QSO Form: ${responseData.saved_qsos.length} QSO(s) saved to server`);
@@ -1518,6 +1533,38 @@ class QsoFormComponent {
 			// Normal case: apply only the QSOs changed since our watermark.
 			this.applyDelta(responseData.changed_qsos, dataStore);
 		}
+	}
+
+	/**
+	 * Marks QSOs the server rejected as 'error'. buildQsoCommands() only sends
+	 * QSOs in state 'pending', so this is what stops an endless resend loop.
+	 */
+	processFailedQsos(failedQsos, dataStore) {
+		failedQsos.forEach(failed => {
+			const qso = dataStore.get(`qso.${failed.tmp_id}`);
+			if (!qso || qso.state === 'error') return;
+
+			const oldState = qso.state;
+			const updated = { ...qso, state: 'error', error: failed.error };
+
+			// setLocal: the server already answered, this must not trigger a new sync
+			dataStore.setLocal(`qso.${failed.tmp_id}`, updated);
+
+			dataStore.emit('qso_state_changed', {
+				qso: updated,
+				oldState,
+				newState: 'error'
+			});
+
+			this.windowmanager.showToast(
+				lang_error,
+				this._escapeHtml(`${lang_qso_save_failed} ${qso.callsign}: ${failed.error}`),
+				'bg-danger text-white',
+				8000
+			);
+
+			console.warn(`QSO Form: QSO ${failed.tmp_id} rejected by server: ${failed.error}`);
+		});
 	}
 
 	processSavedQsos(savedQsos, dataStore) {

--- a/assets/js/sections/contesting/contest_engine/components/radio.js
+++ b/assets/js/sections/contesting/contest_engine/components/radio.js
@@ -330,17 +330,6 @@ class RadioComponent {
 	}
 
 	/**
-	 * Escape HTML for safe rendering
-	 * @param {string} text
-	 * @returns {string}
-	 */
-	escapeHtml(text) {
-		const div = document.createElement('div');
-		div.textContent = text;
-		return div.innerHTML;
-	}
-
-	/**
 	 * Get current frequency in Hz
 	 * @returns {number|null}
 	 */

--- a/assets/js/sections/contesting/contest_engine/core/ajax-transport.js
+++ b/assets/js/sections/contesting/contest_engine/core/ajax-transport.js
@@ -10,7 +10,7 @@ export class AjaxTransport extends TransportAdapter {
 		this.endpoint = base_url + 'index.php/contesting/heartbeat';
 		this.retryCount = 0;
 		this.maxRetries = 3;
-		this.timeout = 4000;
+		this.timeout = 10000; // only meant to be an emergency exit
 	}
 
 	/**

--- a/assets/js/sections/contesting/contest_engine/core/sync-engine.js
+++ b/assets/js/sections/contesting/contest_engine/core/sync-engine.js
@@ -17,7 +17,7 @@ export class SyncEngine {
 		this.isPending = false; // Track if a sync request is currently in-flight
 		this.lastHeartbeatTime = 0; // Track when last request was sent
 		this.heartbeatStartTime = 0; // Track when heartbeat request started
-		this.heartbeatMaxDuration = 4000; // Maximum acceptable duration is 4 seconds (no parallel requests possible)
+		this.heartbeatMaxDuration = 3000; // Warning threshold only - must stay below the transport timeout
 		this._workerDriven  = false; // When true, heartbeat only fires on triggerNow(), not on a timer
 		this._pendingTrigger = false; // A triggerNow() arrived while a request was in-flight
 
@@ -154,7 +154,7 @@ export class SyncEngine {
 					.then(response => {
 						// Measure heartbeat duration
 						const duration = Date.now() - this.heartbeatStartTime;
-						if (duration > this.heartbeatMaxDuration && this.windowManager) {
+						if (response?.success && duration > this.heartbeatMaxDuration && this.windowManager) {
 							this.windowManager.showToast(
 								lang_heartbeat_warning,
 								lang_heartbeat_slow.replace('%1', duration).replace('%2', this.heartbeatMaxDuration),


### PR DESCRIPTION
on long running ajax requests with enabled worker it could happen that the ajax timeout was hit and a pending qso was sent over and over again while already stored in database. This leads to duplicates. This pr fixes this and makes sure a qso store action is idempotent.