### PR TITLE
[Search] add one-click option to search for all QSOs with specific DXCC

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -1017,12 +1017,28 @@ function findlotwunconfirmed(){
     });
 }
 
-function searchButtonPress() {
+function searchButtonPress(searchDxcc) {
     if (event) { event.preventDefault(); }
     if ($('#callsign').val()) {
 		$('#btn-lba').removeAttr('hidden');
         let fixedcall = $('#callsign').val().trim();
         $('#partial_view').load("logbook/search_result/" + fixedcall, function() {
+            $('[data-bs-toggle="tooltip"]').tooltip();
+            $('.table-responsive .dropdown-toggle').off('mouseenter').on('mouseenter', function() {
+                showQsoActionsMenu($(this).closest('.dropdown'));
+            });
+        });
+    } else if (searchDxcc) {
+        $('#partial_view').load("<?php echo site_url('search/search_result'); ?>", {
+            search: JSON.stringify({
+                condition: "AND",
+                rules: [{
+                    field: "COL_DXCC",
+                    operator: "equal",
+                    value: searchDxcc
+                }]
+            })
+        }, function() {
             $('[data-bs-toggle="tooltip"]').tooltip();
             $('.table-responsive .dropdown-toggle').off('mouseenter').on('mouseenter', function() {
                 showQsoActionsMenu($(this).closest('.dropdown'));
@@ -1035,6 +1051,9 @@ $(document).ready(function(){
     <?php if($this->input->post('callsign') != "") { ?>
         $('#callsign').val('<?php echo $this->input->post('callsign'); ?>');
         searchButtonPress();
+    <?php } ?>
+    <?php if($this->input->post('dxcc') !== null && is_numeric($this->input->post('dxcc'))) { ?>
+        searchButtonPress(<?php echo (int) $this->input->post('dxcc'); ?>);
     <?php } ?>
 
 $($('#callsign')).on('keypress',function(e) {

--- a/application/views/view_log/qso.php
+++ b/application/views/view_log/qso.php
@@ -278,7 +278,13 @@
                         <td><?php if ($row->adif == '0') {
                                      echo $row->name;
                                   } else {
-                                     echo ucwords(strtolower(($row->name)), "- (/"); if ($dxccFlag != null) { echo " ".$dxccFlag; } if ($row->end != null) { echo ' <span class="badge text-bg-danger">'.__("Deleted DXCC").'</span>'; }
+                                     echo ucwords(strtolower(($row->name)), "- (/");
+                                     if ($dxccFlag != null) {
+                                         echo '<form method="POST" action="'.site_url('search').'" style="display: inline;">';
+                                         echo '<input type="hidden" name="dxcc" value="'.(int) $row->COL_DXCC.'">';
+                                         echo '<button type="submit" class="btn btn-link text-decoration-none p-0 align-baseline" title="'.html_escape(__("Show all QSOs with this DXCC")).'">'.$dxccFlag.'</button></form>';
+                                     }
+                                     if ($row->end != null) { echo ' <span class="badge text-bg-danger">'.__("Deleted DXCC").'</span>'; }
                                   } ?></td>
                     </tr>
                     <?php } ?>


### PR DESCRIPTION
This one is a PR that is mostly a quality-of-life change that would improve my personal workflow. But maybe it's useful for others too. Feel free to say no if a feature like this is not wanted.

I relatively often find myself in the qso view wanting to know "what other QSOs have I had with this DXCC?" to check for used modes and confirmation status. Of course I can go into LBA and use the filters there.

This one makes the DXCC Flag clickable, using the same mechanism that the "More QSOs" button presents for searching for more QSOs with only that specific callsign.

At the moment only the DXCC flag is clickable, I decided against a dedicated "more from this DXCC"-Button for the first draft.