### PR TITLE
Timeline conf

### DIFF
--- a/application/controllers/Timeline.php
+++ b/application/controllers/Timeline.php
@@ -98,6 +98,7 @@ class Timeline extends CI_Controller {
 		$data['user_default_band'] = $this->session->userdata('user_default_band');
 		$data['years'] = $this->Timeline_model->get_years();
 		$data['onlynew'] = $onlynew;
+		$data['confirm'] = ($qsl == '1' || $lotw == '1' || $eqsl == '1' || $clublog == '1' || $qrz == '1');
 		$data['selectedyear'] = $year;
 		$data['adif_propmodes'] = $this->config->item('adif_propmodes');
 

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -340,7 +340,7 @@ class Timeline_model extends CI_Model {
 		if ($clublog) { $cols[] = "nullif(col_clublog_qso_download_date, '0000-00-00')"; }
 		if ($qrz)     { $cols[] = "nullif(col_qrzcom_qso_download_date, '0000-00-00')"; }
 		if (!$cols)   { return null; }
-		return 'COALESCE(' . implode(', ', $cols) . ', col_time_on)';
+		return 'COALESCE(' . implode(', ', $cols) . ', DATE(col_time_on))';
 	}
 
 	function confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz) {

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -334,22 +334,22 @@ class Timeline_model extends CI_Model {
 
 	function confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) {
 		$cols = [];
-		if ($lotw)    { $cols[] = "nullif(col_lotw_qslrdate, '0000-00-00')"; }
-		if ($qsl)     { $cols[] = "nullif(col_qslrdate, '0000-00-00')"; }
-		if ($eqsl)    { $cols[] = "nullif(col_eqsl_qslrdate, '0000-00-00')"; }
-		if ($clublog) { $cols[] = "nullif(col_clublog_qso_download_date, '0000-00-00')"; }
-		if ($qrz)     { $cols[] = "nullif(col_qrzcom_qso_download_date, '0000-00-00')"; }
+		if ($lotw)    { $cols[] = "if(col_lotw_qslrdate > '0001-01-01', col_lotw_qslrdate, null)"; }
+		if ($qsl)     { $cols[] = "if(col_qslrdate > '0001-01-01', col_qslrdate, null)"; }
+		if ($eqsl)    { $cols[] = "if(col_eqsl_qslrdate > '0001-01-01', col_eqsl_qslrdate, null)"; }
+		if ($clublog) { $cols[] = "if(col_clublog_qso_download_date > '0001-01-01', col_clublog_qso_download_date, null)"; }
+		if ($qrz)     { $cols[] = "if(col_qrzcom_qso_download_date > '0001-01-01', col_qrzcom_qso_download_date, null)"; }
 		if (!$cols)   { return null; }
 		return 'COALESCE(' . implode(', ', $cols) . ', DATE(col_time_on))';
 	}
 
 	function confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz) {
 		$selects = '';
-		if ($lotw)    { $selects .= ", nullif(col_lotw_qslrdate, '0000-00-00') AS lotw_date"; }
-		if ($qsl)     { $selects .= ", nullif(col_qslrdate, '0000-00-00') AS qsl_date"; }
-		if ($eqsl)    { $selects .= ", nullif(col_eqsl_qslrdate, '0000-00-00') AS eqsl_date"; }
-		if ($clublog) { $selects .= ", nullif(col_clublog_qso_download_date, '0000-00-00') AS clublog_date"; }
-		if ($qrz)     { $selects .= ", nullif(col_qrzcom_qso_download_date, '0000-00-00') AS qrz_date"; }
+		if ($lotw)    { $selects .= ", if(col_lotw_qslrdate > '0001-01-01', col_lotw_qslrdate, null) AS lotw_date"; }
+		if ($qsl)     { $selects .= ", if(col_qslrdate > '0001-01-01', col_qslrdate, null) AS qsl_date"; }
+		if ($eqsl)    { $selects .= ", if(col_eqsl_qslrdate > '0001-01-01', col_eqsl_qslrdate, null) AS eqsl_date"; }
+		if ($clublog) { $selects .= ", if(col_clublog_qso_download_date > '0001-01-01', col_clublog_qso_download_date, null) AS clublog_date"; }
+		if ($qrz)     { $selects .= ", if(col_qrzcom_qso_download_date > '0001-01-01', col_qrzcom_qso_download_date, null) AS qrz_date"; }
 		return $selects;
 	}
 

--- a/application/models/Timeline_model.php
+++ b/application/models/Timeline_model.php
@@ -26,10 +26,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_timeline_dxcc($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, prefix, dxcc_entities.name as dxcc_name, end, adif, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", prefix, dxcc_entities.name as dxcc_name, end, adif, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY adif ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY adif ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			join dxcc_entities on thcv.col_dxcc = dxcc_entities.adif
 			where station_id in (" . $location_list . ") and col_dxcc > 0 ";
@@ -55,7 +57,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -69,7 +71,7 @@ class Timeline_model extends CI_Model {
 
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 		return $query->result();
@@ -77,10 +79,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_timeline_waja($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, col_state, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", col_state, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY COL_STATE ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY COL_STATE ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			where station_id in (" . $location_list . ")";
 
@@ -112,7 +116,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -123,7 +127,7 @@ class Timeline_model extends CI_Model {
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
 
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 
@@ -132,10 +136,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_timeline_was($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, col_state, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", col_state, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY COL_STATE ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY COL_STATE ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			where station_id in (" . $location_list . ")";
 
@@ -166,7 +172,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -177,7 +183,7 @@ class Timeline_model extends CI_Model {
 
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 
@@ -186,10 +192,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_timeline_iota($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, col_iota, name, prefix, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", col_iota, name, prefix, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY col_iota ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY col_iota ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			join iota on thcv.col_iota = iota.tag
 			where station_id in (" . $location_list . ")";
@@ -222,7 +230,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -231,7 +239,7 @@ class Timeline_model extends CI_Model {
 		$sql .= " and col_iota <> ''";
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 
@@ -240,10 +248,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_timeline_waz($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, col_cqz, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", col_cqz, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY col_cqz ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY col_cqz ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			where station_id in (" . $location_list . ")";
 
@@ -275,7 +285,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -284,7 +294,7 @@ class Timeline_model extends CI_Model {
 		$sql .= " and col_cqz <> ''";
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 
@@ -320,6 +330,40 @@ class Timeline_model extends CI_Model {
 			$sql.=' 1=0)';
 		}
 		return $sql;
+	}
+
+	function confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) {
+		$cols = [];
+		if ($lotw)    { $cols[] = "nullif(col_lotw_qslrdate, '0000-00-00')"; }
+		if ($qsl)     { $cols[] = "nullif(col_qslrdate, '0000-00-00')"; }
+		if ($eqsl)    { $cols[] = "nullif(col_eqsl_qslrdate, '0000-00-00')"; }
+		if ($clublog) { $cols[] = "nullif(col_clublog_qso_download_date, '0000-00-00')"; }
+		if ($qrz)     { $cols[] = "nullif(col_qrzcom_qso_download_date, '0000-00-00')"; }
+		if (!$cols)   { return null; }
+		return 'COALESCE(' . implode(', ', $cols) . ', col_time_on)';
+	}
+
+	function confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz) {
+		$selects = '';
+		if ($lotw)    { $selects .= ", nullif(col_lotw_qslrdate, '0000-00-00') AS lotw_date"; }
+		if ($qsl)     { $selects .= ", nullif(col_qslrdate, '0000-00-00') AS qsl_date"; }
+		if ($eqsl)    { $selects .= ", nullif(col_eqsl_qslrdate, '0000-00-00') AS eqsl_date"; }
+		if ($clublog) { $selects .= ", nullif(col_clublog_qso_download_date, '0000-00-00') AS clublog_date"; }
+		if ($qrz)     { $selects .= ", nullif(col_qrzcom_qso_download_date, '0000-00-00') AS qrz_date"; }
+		return $selects;
+	}
+
+	private function vucc_entry($grid, $gridsquare) {
+		$entry = array(
+			'gridsquare' => $gridsquare,
+			'date'       => $grid->date,
+			'sort_date'  => $grid->sort_date,
+			'sat_name'   => $grid->sat_name ?? '');
+		foreach (array('lotw', 'qsl', 'eqsl', 'clublog', 'qrz') as $m) {
+			$k = $m . '_date';
+			if (isset($grid->$k)) { $entry[$k] = $grid->$k; }
+		}
+		return $entry;
 	}
 
 	public function timeline_qso_details($querystring, $band, $propmode, $mode, $type){
@@ -391,10 +435,7 @@ class Timeline_model extends CI_Model {
 		$col_gridsquare = $this->get_gridsquare($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew);
 
 		foreach ($col_gridsquare as $grid) {
-			$timeline[] = array(
-				'gridsquare' => $grid->gridsquare,
-				'date'       => $grid->date,
-				'sat_name'   => $grid->sat_name ?? '');
+			$timeline[] = $this->vucc_entry($grid, $grid->gridsquare);
 		}
 
 		$col_vucc_grids = $this->get_vucc_grids($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew);
@@ -406,22 +447,18 @@ class Timeline_model extends CI_Model {
 				$index = array_search($grid_four, array_column($timeline, 'gridsquare'));
 				if ($index === false) {
 					// Doesn't exist, add new entry
-					$timeline[] = array(
-						'gridsquare' => $grid_four,
-						'date'       => $gridSplit->date,
-						'sat_name'   => $gridSplit->sat_name ?? ''
-					);
+					$timeline[] = $this->vucc_entry($gridSplit, $grid_four);
 				} else {
 					// Exists, check the date
-					if ($gridSplit->date < $timeline[$index]['date']) {
+					if ($gridSplit->sort_date < $timeline[$index]['sort_date']) {
 						// Update only if the new date is older
-						$timeline[$index]['date'] = $gridSplit->date;
+						$timeline[$index] = $this->vucc_entry($gridSplit, $grid_four);
 					}
 				}
 			}
 		}
 		usort($timeline, function($a, $b) {
-			return $b['date'] <=> $a['date'];
+			return $b['sort_date'] <=> $a['sort_date'];
 		});
 
 		return $timeline;
@@ -429,10 +466,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_gridsquare($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, upper(substring(COL_GRIDSQUARE, 1, 4)) AS gridsquare, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", upper(substring(COL_GRIDSQUARE, 1, 4)) AS gridsquare, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY upper(substring(COL_GRIDSQUARE, 1, 4)) ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY upper(substring(COL_GRIDSQUARE, 1, 4)) ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			WHERE station_id IN (" . $location_list . ")";
 
@@ -463,7 +502,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -472,7 +511,7 @@ class Timeline_model extends CI_Model {
 		$sql .= " AND COL_GRIDSQUARE <> ''";
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 
@@ -481,10 +520,12 @@ class Timeline_model extends CI_Model {
 
 	public function get_vucc_grids($band, $mode, $propmode, $location_list, $qsl, $lotw, $eqsl, $clublog, $year, $qrz, $onlynew) {
 		$binding = [];
+		$date_expr = $this->confirm_date_expr($qsl, $lotw, $eqsl, $clublog, $qrz) ?? 'COL_TIME_ON';
+		$date_selects = $this->confirm_date_selects($qsl, $lotw, $eqsl, $clublog, $qrz);
 		$sql = "SELECT * FROM (";
-		$sql .= "SELECT COL_TIME_ON AS date, upper(COL_VUCC_GRIDS) AS gridsquare, ";
+		$sql .= "SELECT COL_TIME_ON AS date, " . $date_expr . " AS sort_date" . $date_selects . ", upper(COL_VUCC_GRIDS) AS gridsquare, ";
 		$sql .= "COL_SAT_NAME AS sat_name, ";
-		$sql .= "ROW_NUMBER() OVER (PARTITION BY upper(COL_VUCC_GRIDS) ORDER BY COL_TIME_ON ASC) AS rn ";
+		$sql .= "ROW_NUMBER() OVER (PARTITION BY upper(COL_VUCC_GRIDS) ORDER BY " . $date_expr . " ASC, COL_TIME_ON ASC) AS rn ";
 		$sql .= "FROM ".$this->config->item('table_name'). " thcv
 			WHERE station_id IN (" . $location_list . ")";
 
@@ -515,7 +556,7 @@ class Timeline_model extends CI_Model {
 		}
 
 		if ($year != "All" && $onlynew == 0) {
-			$sql .= " and year(col_time_on) = ?";
+			$sql .= " and year(" . $date_expr . ") = ?";
 			$binding[] = $year;
 		}
 
@@ -524,7 +565,7 @@ class Timeline_model extends CI_Model {
 		$sql .= " AND COL_VUCC_GRIDS <> ''";
 		$sql .= ") ranked ";
 		$sql .= "WHERE rn = 1 ";
-		$sql .= "ORDER BY date DESC;";
+		$sql .= "ORDER BY sort_date DESC;";
 
 		$query = $this->db->query($sql, $binding);
 		return $query->result();

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2243,6 +2243,18 @@ $('#sats').change(function(){
                     url: getDataTablesLanguageUrl(),
                 },
                 dom: 'Bfrtip',
+                initComplete: function() {
+                    document.querySelectorAll('.timelinetable td[data-bs-toggle="tooltip"]').forEach(el => {
+                        new bootstrap.Tooltip(el, {
+                            container: 'body',
+                            html: true,
+                            placement: 'right',
+                            offset: [0, -150],
+                            customClass: 'tooltip-tl',
+                            delay: { show: 200, hide: 0 }
+                        });
+                    });
+                },
                 buttons: [
                     {
 						extend: 'csv',

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2244,14 +2244,16 @@ $('#sats').change(function(){
                 },
                 dom: 'Bfrtip',
                 initComplete: function() {
-                    document.querySelectorAll('.timelinetable td[data-bs-toggle="tooltip"]').forEach(el => {
+                    document.querySelectorAll('.timelinetable [data-bs-toggle="tooltip"]').forEach(el => {
                         new bootstrap.Tooltip(el, {
                             container: 'body',
                             html: true,
                             placement: 'right',
-                            offset: [0, -150],
+                            fallbackPlacements: ['right', 'top'],
+                            trigger: 'hover',
+                            offset: [0, 2],
                             customClass: 'tooltip-tl',
-                            delay: { show: 200, hide: 0 }
+                            delay: { show: 200, hide: 150 }
                         });
                     });
                 },

--- a/application/views/timeline/index.php
+++ b/application/views/timeline/index.php
@@ -192,9 +192,12 @@ function filter_timeline_array_vucc($timeline_array, $selectedyear, $onlynew, $c
     });
 }
 
+function timeline_confirm_order() {
+    return array('lotw', 'qsl', 'eqsl', 'clublog', 'qrz');
+}
+
 function timeline_primary_confirm($line, $assoc = false) {
-    $order = array('lotw', 'qsl', 'eqsl', 'clublog', 'qrz');
-    foreach ($order as $m) {
+    foreach (timeline_confirm_order() as $m) {
         $k = $m . '_date';
         $v = $assoc ? ($line[$k] ?? null) : ($line->$k ?? null);
         if ($v) { return array($m, $v); }
@@ -203,20 +206,23 @@ function timeline_primary_confirm($line, $assoc = false) {
 }
 
 function write_confirm_cell($line, $custom_date_format, $assoc = false) {
-    $primary = timeline_primary_confirm($line, $assoc);
+    $labels = array('lotw' => 'LoTW', 'qsl' => 'QSL', 'eqsl' => 'eQSL', 'clublog' => 'Club Log', 'qrz' => 'QRZ');
+    $primary = null;
+    $tips = array();
+    foreach (timeline_confirm_order() as $m) {
+        $k = $m . '_date';
+        $v = $assoc ? ($line[$k] ?? null) : ($line->$k ?? null);
+        if ($v) {
+            $tips[] = $labels[$m] . ': ' . html_escape(date($custom_date_format, strtotime($v)));
+            if ($primary === null) { $primary = $v; }
+        }
+    }
     if ($primary === null) {
         echo '<td>-</td>';
         return;
     }
-    $labels = array('lotw' => 'LoTW', 'qsl' => 'QSL', 'eqsl' => 'eQSL', 'clublog' => 'Club Log', 'qrz' => 'QRZ');
-    $tips = array();
-    foreach (array('lotw', 'qsl', 'eqsl', 'clublog', 'qrz') as $m) {
-        $k = $m . '_date';
-        $v = $assoc ? ($line[$k] ?? null) : ($line->$k ?? null);
-        if ($v) { $tips[] = $labels[$m] . ': ' . date($custom_date_format, strtotime($v)); }
-    }
-    $title = $tips ? ' data-bs-toggle="tooltip" title="' . implode('<br>', $tips) . '"' : '';
-    echo '<td' . $title . '>' . date($custom_date_format, strtotime($primary[1])) . '</td>';
+    $title = ' data-bs-toggle="tooltip" title="' . implode('<br>', $tips) . '"';
+    echo '<td><span' . $title . '>' . html_escape(date($custom_date_format, strtotime($primary))) . '</span></td>';
 }
 
 

--- a/application/views/timeline/index.php
+++ b/application/views/timeline/index.php
@@ -137,12 +137,12 @@
 
     if ($timeline_array) {
         switch ($this->input->post('award')) {
-            case 'dxcc': $result = write_dxcc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew); break;
-            case 'was':  $result = write_was_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew); break;
-            case 'iota': $result = write_iota_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew); break;
-            case 'waz':  $result = write_waz_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew); break;
-            case 'vucc':  $result = write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew); break;
-            case 'waja':  $result = write_waja_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew); break;
+            case 'dxcc': $result = write_dxcc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew, $confirm); break;
+            case 'was':  $result = write_was_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew, $confirm); break;
+            case 'iota': $result = write_iota_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew, $confirm); break;
+            case 'waz':  $result = write_waz_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew, $confirm); break;
+            case 'vucc':  $result = write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew, $confirm); break;
+            case 'waja':  $result = write_waja_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $this->input->post('award'), $selectedyear, $onlynew, $confirm); break;
         }
     }
     else {
@@ -156,39 +156,80 @@
 
 <?php
 
-function filter_timeline_array($timeline_array, $selectedyear, $onlynew) {
+function filter_timeline_array($timeline_array, $selectedyear, $onlynew, $confirm) {
     // Filter the timeline array
-    return array_filter($timeline_array, function($line) use ($selectedyear, $onlynew) {
+    return array_filter($timeline_array, function($line) use ($selectedyear, $onlynew, $confirm) {
         if ($onlynew == "1") {
-            $entry_year = date('Y', strtotime($line->date ?? '1970-01-01 00:00:00'));
+            if ($confirm) {
+                $primary = timeline_primary_confirm($line);
+                if ($primary === null) { return false; }
+                $check = $primary[1];
+            } else {
+                $check = $line->date ?? '1970-01-01 00:00:00';
+            }
+            $entry_year = date('Y', strtotime($check));
             return $entry_year == $selectedyear; // Include only rows matching the year
         }
         return true; // Include all rows if $onlynew is not 1
     });
 }
 
-function filter_timeline_array_vucc($timeline_array, $selectedyear, $onlynew) {
+function filter_timeline_array_vucc($timeline_array, $selectedyear, $onlynew, $confirm) {
     // Filter the timeline array
-    return array_filter($timeline_array, function($line) use ($selectedyear, $onlynew) {
+    return array_filter($timeline_array, function($line) use ($selectedyear, $onlynew, $confirm) {
         if ($onlynew == "1") {
-            $entry_year = date('Y', strtotime($line['date'] ?? '1970-01-01 00:00:00')); // Use array key 'date'
+            if ($confirm) {
+                $primary = timeline_primary_confirm($line, true);
+                if ($primary === null) { return false; }
+                $check = $primary[1];
+            } else {
+                $check = $line['date'] ?? '1970-01-01 00:00:00';
+            }
+            $entry_year = date('Y', strtotime($check)); // Use array key 'date'
             return $entry_year == $selectedyear; // Include only rows matching the year
         }
         return true; // Include all rows if $onlynew is not 1
     });
 }
 
+function timeline_primary_confirm($line, $assoc = false) {
+    $order = array('lotw', 'qsl', 'eqsl', 'clublog', 'qrz');
+    foreach ($order as $m) {
+        $k = $m . '_date';
+        $v = $assoc ? ($line[$k] ?? null) : ($line->$k ?? null);
+        if ($v) { return array($m, $v); }
+    }
+    return null;
+}
 
-function write_dxcc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew) {
+function write_confirm_cell($line, $custom_date_format, $assoc = false) {
+    $primary = timeline_primary_confirm($line, $assoc);
+    if ($primary === null) {
+        echo '<td>-</td>';
+        return;
+    }
+    $labels = array('lotw' => 'LoTW', 'qsl' => 'QSL', 'eqsl' => 'eQSL', 'clublog' => 'Club Log', 'qrz' => 'QRZ');
+    $tips = array();
+    foreach (array('lotw', 'qsl', 'eqsl', 'clublog', 'qrz') as $m) {
+        $k = $m . '_date';
+        $v = $assoc ? ($line[$k] ?? null) : ($line->$k ?? null);
+        if ($v) { $tips[] = $labels[$m] . ': ' . date($custom_date_format, strtotime($v)); }
+    }
+    $title = $tips ? ' data-bs-toggle="tooltip" title="' . implode('<br>', $tips) . '"' : '';
+    echo '<td' . $title . '>' . date($custom_date_format, strtotime($primary[1])) . '</td>';
+}
+
+
+function write_dxcc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew, $confirm) {
     // Apply filtering to the timeline array
-    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew);
+    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew, $confirm);
     $i = count($filtered_timeline); // General counter for all entries
 
     echo '<table style="width:100%" class="table table-sm timelinetable table-bordered table-hover table-striped table-condensed text-center">
               <thead>
                     <tr>
                         <td>#</td>
-                        <td>' . __("Date") . '</td>
+                        <td>' . __("Date") . '</td>' . ($confirm ? '<td>' . __("Confirmation Date") . '</td>' : '') . '
                         <td>' . __("Prefix") . '</td>
                         <td>' . __("Country") . '</td>';
     if ($propmode == 'SAT' || $propmode == 'All') {
@@ -205,8 +246,9 @@ function write_dxcc_timeline($timeline_array, $custom_date_format, $bandselect, 
         $date_as_timestamp = strtotime($line->date ?? '1970-01-01 00:00:00');
         echo '<tr>
                 <td>' . $i-- . '</td>
-                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
-                <td class="callsign">' . $line->prefix . '</td>
+                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>';
+        if ($confirm) { write_confirm_cell($line, $custom_date_format); }
+        echo '                <td class="callsign">' . $line->prefix . '</td>
                 <td>' . ucwords(strtolower($line->dxcc_name)) . '</td>';
         if ($propmode == 'SAT' || $propmode == 'All') {
             echo '<td>'.html_escape($line->sat_name).'</td>';
@@ -222,17 +264,17 @@ function write_dxcc_timeline($timeline_array, $custom_date_format, $bandselect, 
     echo '</tbody></table>';
 }
 
-function write_waja_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew) {
+function write_waja_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew, $confirm) {
     $CI = &get_instance();
     $CI->load->model("Waja");
     // Apply filtering to the timeline array
-    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew);
+    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew, $confirm);
     $i = count($filtered_timeline); // General counter for all entries
     echo '<table style="width:100%" class="table table-sm timelinetable table-bordered table-hover table-striped table-condensed text-center">
               <thead>
                     <tr>
                         <td>#</td>
-                        <td>'.__("Date").'</td>
+                        <td>'.__("Date").'</td>' . ($confirm ? '<td>'.__("Confirmation Date").'</td>' : '') . '
                         <td>'.__("Prefecture").'</td>';
     if ($propmode == 'SAT' || $propmode == 'All') {
         echo '          <td>'.__("Satellite").'</td>';
@@ -247,8 +289,9 @@ function write_waja_timeline($timeline_array, $custom_date_format, $bandselect, 
 
         echo '<tr>
                 <td>' . $i-- . '</td>
-                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
-                <td>' . html_escape($CI->Waja->jaPrefectures[$line->col_state]) . ' ('.html_escape($line->col_state).')</td>';
+                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>';
+        if ($confirm) { write_confirm_cell($line, $custom_date_format); }
+        echo '                <td>' . html_escape($CI->Waja->jaPrefectures[$line->col_state]) . ' ('.html_escape($line->col_state).')</td>';
         if ($propmode == 'SAT' || $propmode == 'All') {
             echo '<td>'.html_escape($line->sat_name).'</td>';
         }
@@ -258,15 +301,15 @@ function write_waja_timeline($timeline_array, $custom_date_format, $bandselect, 
     echo '</tfoot></table></div>';
 }
 
-function write_was_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew) {
+function write_was_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew, $confirm) {
     // Apply filtering to the timeline array
-    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew);
+    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew, $confirm);
     $i = count($filtered_timeline); // General counter for all entries
     echo '<table style="width:100%" class="table table-sm timelinetable table-bordered table-hover table-striped table-condensed text-center">
               <thead>
                     <tr>
                         <td>#</td>
-                        <td>' . __("Date") . '</td>
+                        <td>' . __("Date") . '</td>' . ($confirm ? '<td>' . __("Confirmation Date") . '</td>' : '') . '
                         <td>' . __("State") . '</td>';
     if ($propmode == 'SAT' || $propmode == 'All') {
         echo '          <td>'.__("Satellite").'</td>';
@@ -281,8 +324,9 @@ function write_was_timeline($timeline_array, $custom_date_format, $bandselect, $
 
         echo '<tr>
                 <td>' . $i-- . '</td>
-                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
-                <td>' . html_escape($line->col_state) . '</td>';
+                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>';
+        if ($confirm) { write_confirm_cell($line, $custom_date_format); }
+        echo '                <td>' . html_escape($line->col_state) . '</td>';
         if ($propmode == 'SAT' || $propmode == 'All') {
            echo '<td>' . html_escape($line->sat_name) . '</td>';
         }
@@ -294,15 +338,15 @@ function write_was_timeline($timeline_array, $custom_date_format, $bandselect, $
 
 
 
-function write_iota_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew) {
+function write_iota_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew, $confirm) {
     // Apply filtering to the timeline array
-    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew);
+    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew, $confirm);
     $i = count($filtered_timeline); // General counter for all entries
     echo '<table style="width:100%" class="table table-sm timelinetable table-bordered table-hover table-striped table-condensed text-center">
               <thead>
                     <tr>
                         <td>#</td>
-                        <td>'.__("Date").'</td>
+                        <td>'.__("Date").'</td>' . ($confirm ? '<td>'.__("Confirmation Date").'</td>' : '') . '
                         <td>'.__("IOTA").'</td>
                         <td>'.__("Name").'</td>
                         <td>'.__("Prefix").'</td>';
@@ -319,8 +363,9 @@ function write_iota_timeline($timeline_array, $custom_date_format, $bandselect, 
 
         echo '<tr>
                 <td>' . $i-- . '</td>
-                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
-                <td>' . html_escape($line->col_iota) . '</td>
+                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>';
+        if ($confirm) { write_confirm_cell($line, $custom_date_format); }
+        echo '                <td>' . html_escape($line->col_iota) . '</td>
                 <td>' . $line->name . '</td>
                 <td class="callsign">' . $line->prefix . '</td>';
         if ($propmode == 'SAT' || $propmode == 'All') {
@@ -332,15 +377,15 @@ function write_iota_timeline($timeline_array, $custom_date_format, $bandselect, 
     echo '</tfoot></table></div>';
 }
 
-function write_waz_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew) {
+function write_waz_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect, $propmode, $award, $selectedyear, $onlynew, $confirm) {
     // Apply filtering to the timeline array
-    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew);
+    $filtered_timeline = filter_timeline_array($timeline_array, $selectedyear, $onlynew, $confirm);
     $i = count($filtered_timeline); // General counter for all entries
     echo '<table style="width:100%" class="table table-sm timelinetable table-bordered table-hover table-striped table-condensed text-center">
               <thead>
                     <tr>
                         <td>#</td>
-                        <td>'.__("Date").'</td>
+                        <td>'.__("Date").'</td>' . ($confirm ? '<td>'.__("Confirmation Date").'</td>' : '') . '
                         <td>'.__("CQ Zone").'</td>';
     if ($propmode == 'SAT' || $propmode == 'All') {
         echo '          <td>'.__("Satellite").'</td>';
@@ -355,8 +400,9 @@ function write_waz_timeline($timeline_array, $custom_date_format, $bandselect, $
 
         echo '<tr>
                 <td>' . $i-- . '</td>
-                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
-                <td>' . $line->col_cqz . '</td>';
+                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>';
+        if ($confirm) { write_confirm_cell($line, $custom_date_format); }
+        echo '                <td>' . $line->col_cqz . '</td>';
         if ($propmode == 'SAT' || $propmode == 'All') {
            echo '<td>' . html_escape($line->sat_name) . '</td>';
         }
@@ -366,16 +412,15 @@ function write_waz_timeline($timeline_array, $custom_date_format, $bandselect, $
     echo '</tfoot></table></div>';
 }
 
-function write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect,  $propmode, $award, $selectedyear, $onlynew) {
+function write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, $modeselect,  $propmode, $award, $selectedyear, $onlynew, $confirm) {
     // Apply filtering to the timeline array
-    $filtered_timeline = filter_timeline_array_vucc($timeline_array, $selectedyear, $onlynew);
+    $filtered_timeline = filter_timeline_array_vucc($timeline_array, $selectedyear, $onlynew, $confirm);
     $i = count($filtered_timeline); // General counter for all entries
     echo '<table style="width:100%" class="table table-sm timelinetable table-bordered table-hover table-striped table-condensed text-center">
               <thead>
                     <tr>
                         <td>#</td>
-                        <td>'.__("Date").'</td>
-                        <td>'.__("Time").'</td>
+                        <td>'.__("Date").'</td>' . ($confirm ? '<td>'.__("Confirmation Date").'</td>' : '') . '
                         <td>'.__("Gridsquare").'</td>';
     if ($propmode == 'SAT' || $propmode == 'All') {
         echo '          <td>'.__("Satellite").'</td>';
@@ -390,9 +435,9 @@ function write_vucc_timeline($timeline_array, $custom_date_format, $bandselect, 
 
         echo '<tr>
                 <td>' . $i-- . '</td>
-                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>
-                <td>' . date('H:i', $date_as_timestamp) . '</td>
-                <td>' . html_escape($line['gridsquare']) . '</td>';
+                <td>' . date($custom_date_format, $date_as_timestamp) . '</td>';
+        if ($confirm) { write_confirm_cell($line, $custom_date_format, true); }
+        echo '                <td>' . html_escape($line['gridsquare']) . '</td>';
         if ($propmode == 'SAT' || $propmode == 'All') {
             echo '<td>'.html_escape($line['sat_name']).'</td>';
         }

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1667,7 +1667,7 @@ svg text.month { fill: #AAA; }
     z-index: 9999 !important;
 }
 
-.tooltip-tl { --bs-tooltip-bg: rgba(0, 0, 0, 0.75); }
+.tooltip-tl { --bs-tooltip-bg: rgba(0, 0, 0, 0.75); pointer-events: none; }
 
 .qso_icons {
 	user-select: none;

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1667,6 +1667,8 @@ svg text.month { fill: #AAA; }
     z-index: 9999 !important;
 }
 
+.tooltip-tl { --bs-tooltip-bg: rgba(0, 0, 0, 0.75); }
+
 .qso_icons {
 	user-select: none;
 }


### PR DESCRIPTION
Adding a different sorting and displaylogic to the Timeline-Analytics.
Once user choses a confirmation-method, the achievements are ordered by the oldest valid confirmation of the thing to reach (DXCC, VUCC, State, etc.)
Furthermore the confirmationdate is shown. if you hover over it (and select more than once cnf-method), the confirmation-dates of the other methods will also be shown as tooltip

<img width="2260" height="1680" alt="image" src="https://github.com/user-attachments/assets/2244ddbe-2c84-4c7f-bc07-854ac2a4df63" />
