### PR TITLE
Translations update from Wavelog Translations

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/messages.po
+++ b/application/locale/de_DE/LC_MESSAGES/messages.po
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-08 19:08+0000\n"
-"PO-Revision-Date: 2026-09-08 12:19+0000\n"
-"Last-Translator: Florian Wolters <wavelog@df2et.de>\n"
+"PO-Revision-Date: 2026-09-09 11:39+0000\n"
+"Last-Translator: Jörg Dorgeist <wavelog@dj7nt.de>\n"
 "Language-Team: German <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/de/>\n"
 "Language: de_DE\n"
@@ -14266,7 +14266,7 @@ msgstr "Index des solaren Flusses"
 
 #: application/views/dashboard/solar_data.php:58
 msgid "Sunspot Number"
-msgstr "Nummer des Sonnenfleckenzyklus"
+msgstr "Anzahl der Sonnenflecken"
 
 #: application/views/dashboard/solar_data.php:62
 msgid "K-index: Planetary geomagnetic activity (0-9)"

--- a/application/locale/it_IT/LC_MESSAGES/messages.po
+++ b/application/locale/it_IT/LC_MESSAGES/messages.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-09 11:39+0000\n"
-"PO-Revision-Date: 2026-09-07 13:57+0000\n"
+"PO-Revision-Date: 2026-09-09 15:48+0000\n"
 "Last-Translator: iv3cvn <ricentis@gmail.com>\n"
 "Language-Team: Italian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/it/>\n"
@@ -23244,7 +23244,7 @@ msgstr "Solo nuovo nell'anno selezionato"
 #: application/views/timeline/index.php:392
 #: application/views/timeline/index.php:427
 msgid "Confirmation Date"
-msgstr ""
+msgstr "Data di conferma"
 
 #: application/views/timeplotter/index.php:2
 msgid "contacts were plotted"
@@ -24565,7 +24565,7 @@ msgstr "Elevazione dell'antenna"
 
 #: application/views/view_log/qso.php:285
 msgid "Show all QSOs with this DXCC"
-msgstr ""
+msgstr "Mostra tutti i QSO con questo DXCC"
 
 #: application/views/view_log/qso.php:445
 msgid "QSL Card has been sent via the bureau"

--- a/application/locale/ja/LC_MESSAGES/messages.po
+++ b/application/locale/ja/LC_MESSAGES/messages.po
@@ -13,8 +13,8 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-08 12:12+0000\n"
-"PO-Revision-Date: 2026-09-08 12:13+0000\n"
-"Last-Translator: \"Xu, Zefan (BI1GHZ)\" <ceba_robot@outlook.com>\n"
+"PO-Revision-Date: 2026-09-08 13:05+0000\n"
+"Last-Translator: \"S.NAKAO(JG3HLX)\" <hlx.nakao@gmail.com>\n"
 "Language-Team: Japanese <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ja/>\n"
 "Language: ja\n"
@@ -22981,7 +22981,7 @@ msgstr "選択した年のみの新着"
 #: application/views/timeline/index.php:394
 #: application/views/timeline/index.php:429
 msgid "Confirmation Date"
-msgstr ""
+msgstr "確認日"
 
 #: application/views/timeplotter/index.php:2
 msgid "contacts were plotted"

--- a/application/locale/ru_RU/LC_MESSAGES/messages.po
+++ b/application/locale/ru_RU/LC_MESSAGES/messages.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-08 19:08+0000\n"
-"PO-Revision-Date: 2026-08-31 23:18+0000\n"
+"PO-Revision-Date: 2026-09-09 11:39+0000\n"
 "Last-Translator: Michael Skolsky <r1blh@yandex.ru>\n"
 "Language-Team: Russian <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/ru/>\n"
@@ -258,7 +258,7 @@ msgstr "Накопленная статистика"
 #: application/views/achievements/index.php:76
 #: application/views/interface_assets/header.php:192
 msgid "Achievements"
-msgstr ""
+msgstr "Достижения"
 
 #: application/controllers/Activated_gridmap.php:12
 #: application/views/activated_gridmap/index.php:6
@@ -4583,17 +4583,17 @@ msgstr "Просмотр статистики"
 #, php-format
 msgid "%s day"
 msgid_plural "%s days"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s день"
+msgstr[1] "%s дня"
+msgstr[2] "%s дней"
 
 #: application/models/Achievements_model.php:172
 msgid "Longest streak"
-msgstr ""
+msgstr "Самая длинная серия"
 
 #: application/models/Achievements_model.php:173
 msgid "Current streak"
-msgstr ""
+msgstr "Текущая серия"
 
 #: application/models/Achievements_model.php:174
 #: application/models/Achievements_model.php:196
@@ -4604,124 +4604,124 @@ msgstr "Цель"
 
 #: application/models/Achievements_model.php:177
 msgid "Reached on"
-msgstr ""
+msgstr "Достигнуто"
 
 #: application/models/Achievements_model.php:181
 #, php-format
 msgid "%d Day Streak"
-msgstr ""
+msgstr "%d день серии"
 
 #: application/models/Achievements_model.php:185
 #, php-format
 msgid "%s / %s day"
 msgid_plural "%s / %s days"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s день из %s"
+msgstr[1] "%s дня из %s"
+msgstr[2] "%s дней из %s"
 
 #: application/models/Achievements_model.php:195
 msgid "QSOs in log"
-msgstr ""
+msgstr "QSO в журнале"
 
 #: application/models/Achievements_model.php:196
 #: application/models/Achievements_model.php:203
 #, php-format
 msgid "%s QSO"
 msgid_plural "%s QSOs"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s QSO"
+msgstr[1] "%s QSO"
+msgstr[2] "%s QSO"
 
 #: application/models/Achievements_model.php:199
 msgid "Unlocked on"
-msgstr ""
+msgstr "Открыто"
 
 #: application/models/Achievements_model.php:207
 #, php-format
 msgid "%s / %s QSO"
 msgid_plural "%s / %s QSOs"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s QSO из %s"
+msgstr[1] "%s QSO из %s"
+msgstr[2] "%s QSO из %s"
 
 #: application/models/Achievements_model.php:237
 msgid "QSOs in classic digimodes"
-msgstr ""
+msgstr "QSO в классических цифровых видах модуляции"
 
 #: application/models/Achievements_model.php:239
 #: application/models/Achievements_model.php:356
 #: application/models/Achievements_model.php:389
 msgid "First QSO on"
-msgstr ""
+msgstr "Первое QSO"
 
 #: application/models/Achievements_model.php:242
 msgid "Top classic mode"
-msgstr ""
+msgstr "Наиболее часто используемый классический вид модуляции"
 
 #: application/models/Achievements_model.php:245
 msgid "First CW QSO"
-msgstr ""
+msgstr "Первое CW QSO"
 
 #: application/models/Achievements_model.php:247
 msgid "First SSB QSO"
-msgstr ""
+msgstr "Первое SSB QSO"
 
 #: application/models/Achievements_model.php:249
 msgid "First FT8 QSO"
-msgstr ""
+msgstr "Первое FT8 QSO"
 
 #: application/models/Achievements_model.php:251
 msgid "First Classic Digimode QSO"
-msgstr ""
+msgstr "Первое QSO в классических цифровых видах модуляции"
 
 #: application/models/Achievements_model.php:252
 msgid "Triple Threat"
-msgstr ""
+msgstr "Тройной удар"
 
 #: application/models/Achievements_model.php:253
 #, php-format
 msgid "%s / 3 mode"
 msgid_plural "%s / 3 modes"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s вид модуляции из 3"
+msgstr[1] "%s вида модуляции из 3"
+msgstr[2] "%s видов модуляции из 3"
 
 #: application/models/Achievements_model.php:255
 msgid "Worked modes"
-msgstr ""
+msgstr "Используемые виды модуляции"
 
 #: application/models/Achievements_model.php:256
 msgid "Missing modes"
-msgstr ""
+msgstr "Пропущенные виды модуляции"
 
 #: application/models/Achievements_model.php:272
 msgid "First LoTW Confirmation"
-msgstr ""
+msgstr "Первое подтверждение в LoTW"
 
 #: application/models/Achievements_model.php:273
 msgid "Confirmed on"
-msgstr ""
+msgstr "Подтверждено"
 
 #: application/models/Achievements_model.php:291
 msgid "CW and SSB QSOs"
-msgstr ""
+msgstr "CW и SSB QSO"
 
 #: application/models/Achievements_model.php:292
 msgid "FT8 and FT4 QSOs"
-msgstr ""
+msgstr "FT8 и FT4 QSO"
 
 #: application/models/Achievements_model.php:293
 msgid "Current ratio"
-msgstr ""
+msgstr "Текущее сооотношение"
 
 #: application/models/Achievements_model.php:294
 msgid "Needed ratio"
-msgstr ""
+msgstr "Необходимое соотношение"
 
 #: application/models/Achievements_model.php:299
 #, php-format
 msgid "Total: %s QSOs"
-msgstr ""
+msgstr "Всего: %s QSO"
 
 #: application/models/Achievements_model.php:303
 #: application/views/awards/counties/index.php:195
@@ -4742,99 +4742,99 @@ msgstr "Сработано"
 
 #: application/models/Achievements_model.php:306
 msgid "Classic digimodes"
-msgstr ""
+msgstr "Классические цифровые виды модуляции"
 
 #: application/models/Achievements_model.php:310
 #, php-format
 msgid "HF: %s/%s"
-msgstr ""
+msgstr "КВ: %s из %s"
 
 #: application/models/Achievements_model.php:311
 #, php-format
 msgid "WARC: %s/%s"
-msgstr ""
+msgstr "WARC: %s/ из %s"
 
 #: application/models/Achievements_model.php:312
 #, php-format
 msgid "SAT: %s"
-msgstr ""
+msgstr "SAT: %s"
 
 #: application/models/Achievements_model.php:314
 #, php-format
 msgid "First confirmation: %s"
-msgstr ""
+msgstr "Первое подтверждение: %s"
 
 #: application/models/Achievements_model.php:314
 msgid "No LoTW confirmation yet"
-msgstr ""
+msgstr "Пока нет подтверждений в LoTW"
 
 #: application/models/Achievements_model.php:316
 msgid "CW and SSB versus FT8 and FT4"
-msgstr ""
+msgstr "CW и SSB против FT8 и FT4"
 
 #: application/models/Achievements_model.php:319
 msgid "Streak"
-msgstr ""
+msgstr "Серия"
 
 #: application/models/Achievements_model.php:320
 msgid "Volume"
-msgstr ""
+msgstr "Количество"
 
 #: application/models/Achievements_model.php:324
 msgid "Classic Mode Ratio"
-msgstr ""
+msgstr "Рейтинг классических видов модуляции"
 
 #: application/models/Achievements_model.php:353
 msgid "QSOs in this mode"
-msgstr ""
+msgstr "QSOs в этом виде модуляции"
 
 #: application/models/Achievements_model.php:371
 msgid "Bands worked"
-msgstr ""
+msgstr "Сработано диапазонов"
 
 #: application/models/Achievements_model.php:372
 msgid "Missing bands"
-msgstr ""
+msgstr "Не хватает диапазонов"
 
 #: application/models/Achievements_model.php:373
 msgid "Range"
-msgstr ""
+msgstr "Список"
 
 #: application/models/Achievements_model.php:376
 msgid "Completed on"
-msgstr ""
+msgstr "Завершено"
 
 #: application/models/Achievements_model.php:379
 #, php-format
 msgid "%s / %s band"
 msgid_plural "%s / %s bands"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s диапазон из %s"
+msgstr[1] "%s диапазона из %s"
+msgstr[2] "%s диапазонов из %s"
 
 #: application/models/Achievements_model.php:387
 msgid "SAT QSOs"
-msgstr ""
+msgstr "SAT QSO"
 
 #: application/models/Achievements_model.php:392
 msgid "Different satellites"
-msgstr ""
+msgstr "Различных спутников"
 
 #: application/models/Achievements_model.php:398
 #, php-format
 msgid "Longest streak: %s day"
 msgid_plural "Longest streak: %s days"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Самая длинная серия: %s день"
+msgstr[1] "Самая длинная серия: %s дня"
+msgstr[2] "Самая длинная серия: %s дней"
 
 #: application/models/Achievements_model.php:400
 #, php-format
 msgid "Current streak: %s day"
 msgid_plural "Current streak: %s days"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Текущая серия: %s день"
+msgstr[1] "Текущая серия: %s дня"
+msgstr[2] "Текущая серия: %s дней"
 
 #: application/models/Achievements_model.php:407
 #: application/views/visitor/mini.php:214
@@ -4844,7 +4844,7 @@ msgstr "Пока нет QSO"
 #: application/models/Achievements_model.php:410
 #: application/models/Achievements_model.php:412
 msgid "classic"
-msgstr ""
+msgstr "классика"
 
 #: application/models/Api_v2_model.php:105
 msgid " (min. 2.1.0)"
@@ -5006,7 +5006,7 @@ msgstr "Станция недоступна"
 
 #: application/models/Logbook_model.php:994
 msgid "Realtime upload disabled"
-msgstr ""
+msgstr "Загрузка в реальном времени отключена"
 
 #: application/models/Logbook_model.php:1452
 msgid "Station ID not allowed"
@@ -5553,41 +5553,44 @@ msgid ""
 "No station locations are linked to your active logbook. Trophies need at "
 "least one linked station location."
 msgstr ""
+"К вашему активному журналу не привязан ни один профиль QTH. Для подсчёта "
+"достижений нужен хотя бы один привязанный профиль QTH."
 
 #: application/views/achievements/index.php:78
 msgid "QSO filter"
-msgstr ""
+msgstr "Фильтр QSO"
 
 #: application/views/achievements/index.php:79
 msgid "All QSOs"
-msgstr ""
+msgstr "Все QSO"
 
 #: application/views/achievements/index.php:80
 msgid "Confirmed only"
-msgstr ""
+msgstr "Подтверждённые QSO"
 
 #: application/views/achievements/index.php:80
 msgid "Count only QSOs confirmed by LoTW or paper card"
 msgstr ""
+"Считать только QSO, подтверждённые через LoTW или бумажной QSL-карточкой"
 
 #: application/views/achievements/index.php:83
 #, php-format
 msgid "You have unlocked %s of %s trophies."
-msgstr ""
+msgstr "Вы разблокировали %s из %s достижений."
 
 #: application/views/achievements/index.php:85
 #, php-format
 msgid "Cached data as of %s"
-msgstr ""
+msgstr "Данные кэшированы на %s"
 
 #: application/views/achievements/index.php:126
 #: application/views/achievements/index.php:191
 msgid "Unlocked"
-msgstr ""
+msgstr "Разблокированно"
 
 #: application/views/achievements/index.php:145
 msgid "Trophy"
-msgstr ""
+msgstr "Достижение"
 
 #: application/views/achievements/index.php:146
 #: application/views/activationplanner/index.php:30
@@ -5615,7 +5618,7 @@ msgstr "Закрыть"
 
 #: application/views/achievements/index.php:191
 msgid "Locked"
-msgstr ""
+msgstr "Заблокированно"
 
 #: application/views/activated_gridmap/index.php:10
 #: application/views/interface_assets/header.php:168
@@ -12344,7 +12347,7 @@ msgstr "Синхронизировано"
 
 #: application/views/contesting/logger/components/qso-form.php:36
 msgid "QSO could not be saved:"
-msgstr ""
+msgstr "QSO не может быть сохранено:"
 
 #: application/views/contesting/logger/components/qso-form.php:37
 msgid "Delete this QSO?"
@@ -16381,7 +16384,7 @@ msgstr "QSO с %s от %s было добавлено в журнал."
 #: application/views/interface_assets/footer.php:85
 #, php-format
 msgid "Realtime upload failed: %s"
-msgstr ""
+msgstr "Ошибка при загрузке в реальном времени: %s"
 
 #: application/views/interface_assets/footer.php:86
 msgid "QSO Added to Backlog"
@@ -23236,7 +23239,7 @@ msgstr "Только новые в выбранном году"
 #: application/views/timeline/index.php:392
 #: application/views/timeline/index.php:427
 msgid "Confirmation Date"
-msgstr ""
+msgstr "Дата подтверждения"
 
 #: application/views/timeplotter/index.php:2
 msgid "contacts were plotted"
@@ -24545,7 +24548,7 @@ msgstr "Возвышение антенны"
 
 #: application/views/view_log/qso.php:285
 msgid "Show all QSOs with this DXCC"
-msgstr ""
+msgstr "Показать все QSO с этим DXCC"
 
 #: application/views/view_log/qso.php:445
 msgid "QSL Card has been sent via the bureau"

--- a/application/locale/tr_TR/LC_MESSAGES/messages.po
+++ b/application/locale/tr_TR/LC_MESSAGES/messages.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: translations@wavelog.org\n"
 "POT-Creation-Date: 2026-09-08 19:08+0000\n"
-"PO-Revision-Date: 2026-09-08 12:13+0000\n"
+"PO-Revision-Date: 2026-09-09 11:39+0000\n"
 "Last-Translator: metint <metin@tekkalmaz.net>\n"
 "Language-Team: Turkish <https://translate.wavelog.org/projects/wavelog/main-"
 "translation/tr/>\n"
@@ -23109,7 +23109,7 @@ msgstr "Yalnızca seçilen yıldaki yeniler"
 #: application/views/timeline/index.php:392
 #: application/views/timeline/index.php:427
 msgid "Confirmation Date"
-msgstr ""
+msgstr "Onay Tarihi"
 
 #: application/views/timeplotter/index.php:2
 msgid "contacts were plotted"


### PR DESCRIPTION
Translations update from [Wavelog Translations](https://translate.wavelog.org) for [Wavelog/Main Translation](https://translate.wavelog.org/projects/wavelog/main-translation/).



Current translation status:

[![Übersetzungsstatus](https://translate.wavelog.org/widget/wavelog/multi-auto.svg)](https://translate.wavelog.org/engage/wavelog/)