### PR TITLE
[DCL] Fix upload QSO carry-over across station profiles

### DIFF
--- a/application/controllers/Dcl.php
+++ b/application/controllers/Dcl.php
@@ -105,13 +105,12 @@ class Dcl extends CI_Controller {
 			$sync_user_id=null;
 		}
 
-		// Array of QSO IDs being Uploaded
-
-		$qso_id_array = array();
-
 		if ($station_profiles->num_rows() >= 1) {
 
 			foreach ($station_profiles->result() as $station_profile) {
+
+				// Array of QSO IDs being Uploaded
+				$qso_id_array = array();
 
 				// Get Certificate Data
 				$data['station_profile'] = $station_profile;
@@ -197,7 +196,6 @@ class Dcl extends CI_Controller {
 						$this->Logbook_model->mark_dcl_sent($qso_number);
 					}
 				}
-				$qso_id_array=[];
 			}
 		} else {
 			echo __("No Station Profiles found to upload to DCL");


### PR DESCRIPTION
$qso_id_array was declared once outside the station loop, so IDs collected for one station remained in the array when that station's upload failed (HTTP != 200 or curl error) and were carried over into the next station iteration. If that next station then succeeded, mark_dcl_sent() was called for all accumulated IDs, flagging QSOs as COL_DCL_QSL_SENT = 'Y' even though they were never imported on the receiver side.

Because get_dcl_qsos_to_upload() filters out QSOs already marked 'Y', affected QSOs were permanently locked out of future uploads.

Move the declaration inside the loop so the array is per-station and carry-over between profiles is structurally impossible. Drop the now redundant reset at the end of the loop.