### PR TITLE
Fix bad-path for LoTW-Uploads

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -211,14 +211,13 @@ class Lotw extends CI_Controller {
 			$sync_user_id=null;
 		}
 
-		// Array of QSO IDs being Uploaded
-
-		$qso_id_array = array();
-
 		// Build TQ8 Outputs
 		if ($station_profiles->num_rows() >= 1) {
 
 			foreach ($station_profiles->result() as $station_profile) {
+
+				// Array of QSO IDs being Uploaded
+				$qso_id_array = array();
 
 				// Get Certificate Data
 				$this->load->model('Lotw_model');


### PR DESCRIPTION
Bug:

1. Station A: QSOs 1-10 pushed into array. Upload fails (curl error / signing error) → continue. Array NOT cleared — IDs 1-10 stay                                                                                                           
2. Station B: QSOs 11-20 pushed. Array now 1-20. Upload succeeds → all 20 marked COL_LOTW_QSL_SENT='Y'                                         
3. But QSOs 1-10 never reached ARRL. Wavelog thinks sent