### PR TITLE
[Timeline] Fixes tooltip css, and layout css

### DIFF
--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -2225,7 +2225,7 @@ $('#sats').change(function(){
     <?php if ($this->uri->segment(1) == "timeline") { ?>
         <script>
          $.fn.dataTable.ext.buttons.clear = {
-               className: 'buttons-clear',
+               className: 'buttons-clear btn-sm',
                action: function ( e, dt, node, config ) {
                   dt.search('');
                   dt.draw();
@@ -2260,7 +2260,7 @@ $('#sats').change(function(){
                 buttons: [
                     {
 						extend: 'csv',
-						className: 'mb-1 btn btn-primary', // Bootstrap classes
+						className: 'mb-1 btn btn-sm btn-primary', // Bootstrap classes
 							init: function(api, node, config) {
 								$(node).removeClass('dt-button').addClass('btn btn-primary'); // Ensure Bootstrap class applies
 						},

--- a/application/views/timeline/index.php
+++ b/application/views/timeline/index.php
@@ -8,117 +8,115 @@
 		<div class="card-body">
 
 			<form class="form" action="<?php echo site_url('timeline'); ?>" method="post" enctype="multipart/form-data">
-				<!-- Select Basic -->
-						<div class="mb-3 row">
-							<label class="col-md-1 control-label" for="band"><?= __("Band") ?></label>
-							<div class="col-md-3">
-								<select id="band" name="band" class="form-select">
-									<option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("All") ?></option>
-									<?php foreach($worked_bands as $band) {
-										echo '<option value="' . $band . '"';
-										if ($this->input->post('band') == $band) echo ' selected';
-										echo '>' . $band . '</option>'."\n";
-									} ?>
-								</select>
-							</div>
+				<div class="row g-3 align-items-center">
 
-							<label class="col-md-1 control-label" for="mode"><?= __("Mode") ?></label>
-							<div class="col-md-3">
-								<select id="mode" name="mode" class="form-select">
-									<option value="All" <?php if ($this->input->post('mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("All") ?></option>
-									<?php
-									foreach($modes->result() as $mode){
-										if ($mode->submode == null) {
-											echo '<option value="' . $mode->mode . '"';
-											if ($this->input->post('mode') == $mode->mode) echo ' selected';
-											echo '>' . $mode->mode . '</option>'."\n";
-										} else {
-											echo '<option value="' . $mode->submode . '"';
-											if ($this->input->post('mode') == $mode->submode) echo ' selected';
-											echo '>' . $mode->submode . '</option>'."\n";
-										}
-									}
-									?>
-								</select>
-							</div>
-						</div>
+					<!-- Band -->
+					<label class="col-12 col-sm-3 col-md-2 col-form-label" for="band"><?= __("Band") ?></label>
+					<div class="col-12 col-sm-9 col-md-4">
+						<select id="band" name="band" class="form-select">
+							<option value="All" <?php if ($this->input->post('band') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("All") ?></option>
+							<?php foreach($worked_bands as $band) {
+								echo '<option value="' . $band . '"';
+								if ($this->input->post('band') == $band) echo ' selected';
+								echo '>' . $band . '</option>'."\n";
+							} ?>
+						</select>
+					</div>
 
-				<div class="mb-3 row">
-					<label class="col-md-1 control-label" for="award"><?= __("Award") ?></label>
-						<div class="col-md-3">
-							<select id="award" name="award" class="form-select">
-								<option value="dxcc" <?php if ($this->input->post('award') == "dxcc") echo ' selected'; ?> ><?= __("DX Century Club (DXCC)"); ?></option>
-								<option value="was" <?php if ($this->input->post('award') == "was") echo ' selected'; ?> ><?= __("Worked All States (WAS)"); ?></option>
-								<option value="iota" <?php if ($this->input->post('award') == "iota") echo ' selected'; ?> ><?= __("Islands On The Air (IOTA)"); ?></option>
-								<option value="waz" <?php if ($this->input->post('award') == "waz") echo ' selected'; ?> ><?= __("Worked All Zones (WAZ)"); ?></option>
-								<option value="vucc" <?php if ($this->input->post('award') == "vucc") echo ' selected'; ?> ><?= __("VHF / UHF Century Club (VUCC)"); ?></option>
-								<option value="waja" <?php if ($this->input->post('award') == "waja") echo ' selected'; ?> ><?= __("Worked All Japan (WAJA)"); ?></option>
-							</select>
+					<!-- Mode -->
+					<label class="col-12 col-sm-3 col-md-2 col-form-label" for="mode"><?= __("Mode") ?></label>
+					<div class="col-12 col-sm-9 col-md-4">
+						<select id="mode" name="mode" class="form-select">
+							<option value="All" <?php if ($this->input->post('mode') == "All" || $this->input->method() !== 'post') echo ' selected'; ?> ><?= __("All") ?></option>
+							<?php
+							foreach($modes->result() as $mode){
+								if ($mode->submode == null) {
+									echo '<option value="' . $mode->mode . '"';
+									if ($this->input->post('mode') == $mode->mode) echo ' selected';
+									echo '>' . $mode->mode . '</option>'."\n";
+								} else {
+									echo '<option value="' . $mode->submode . '"';
+									if ($this->input->post('mode') == $mode->submode) echo ' selected';
+									echo '>' . $mode->submode . '</option>'."\n";
+								}
+							}
+							?>
+						</select>
+					</div>
+
+					<!-- Award -->
+					<label class="col-12 col-sm-3 col-md-2 col-form-label" for="award"><?= __("Award") ?></label>
+					<div class="col-12 col-sm-9 col-md-4">
+						<select id="award" name="award" class="form-select">
+							<option value="dxcc" <?php if ($this->input->post('award') == "dxcc") echo ' selected'; ?> ><?= __("DX Century Club (DXCC)"); ?></option>
+							<option value="was" <?php if ($this->input->post('award') == "was") echo ' selected'; ?> ><?= __("Worked All States (WAS)"); ?></option>
+							<option value="iota" <?php if ($this->input->post('award') == "iota") echo ' selected'; ?> ><?= __("Islands On The Air (IOTA)"); ?></option>
+							<option value="waz" <?php if ($this->input->post('award') == "waz") echo ' selected'; ?> ><?= __("Worked All Zones (WAZ)"); ?></option>
+							<option value="vucc" <?php if ($this->input->post('award') == "vucc") echo ' selected'; ?> ><?= __("VHF / UHF Century Club (VUCC)"); ?></option>
+							<option value="waja" <?php if ($this->input->post('award') == "waja") echo ' selected'; ?> ><?= __("Worked All Japan (WAJA)"); ?></option>
+						</select>
+					</div>
+
+					<!-- Confirmation -->
+					<label class="col-12 col-sm-3 col-md-2 col-form-label"><?= __("Confirmation") ?></label>
+					<div class="col-12 col-sm-9 col-md-4">
+						<div class="form-check form-check-inline">
+							<input class="form-check-input" type="checkbox" name="qsl" value="1" id="qsl" <?php if ($this->input->post('qsl'))  echo ' checked="checked"'; ?> >
+							<label class="form-check-label" for="qsl"><?= __("QSL") ?></label>
 						</div>
-						<div class="col-md-1 control-label"><?= __("Confirmation") ?></div>
-						<div class="col-md-4">
-							<div class="form-check-inline">
-								<input class="form-check-input" type="checkbox" name="qsl" value="1" id="qsl" <?php if ($this->input->post('qsl'))  echo ' checked="checked"'; ?> >
-								<label class="form-check-label" for="qsl"><?= __("QSL") ?></label>
-							</div>
-							<div class="form-check-inline">
-								<input class="form-check-input" type="checkbox" name="lotw" value="1" id="lotw" <?php if ($this->input->post('lotw')) echo ' checked="checked"'; ?> >
-								<label class="form-check-label" for="lotw"><?= __("LoTW") ?></label>
-							</div>
-							<div class="form-check-inline">
-								<input class="form-check-input" type="checkbox" name="eqsl" value="1" id="eqsl" <?php if ($this->input->post('eqsl')) echo ' checked="checked"'; ?> >
-								<label class="form-check-label" for="eqsl"><?= __("eQSL") ?></label>
-							</div>
-							<div class="form-check-inline">
-								<input class="form-check-input" type="checkbox" name="clublog" value="1" id="clublog" <?php if ($this->input->post('clublog')) echo ' checked="checked"'; ?> >
-								<label class="form-check-label" for="clublog"><?= __("Clublog") ?></label>
-							</div>
-							<div class="form-check-inline">
-								<input class="form-check-input" type="checkbox" name="qrz" value="1" id="qrz" <?php if ($this->input->post('qrz')) echo ' checked="checked"'; ?> >
-								<label class="form-check-label" for="qrz"><?= __("QRZ") ?></label>
-							</div>
+						<div class="form-check form-check-inline">
+							<input class="form-check-input" type="checkbox" name="lotw" value="1" id="lotw" <?php if ($this->input->post('lotw')) echo ' checked="checked"'; ?> >
+							<label class="form-check-label" for="lotw"><?= __("LoTW") ?></label>
+						</div>
+						<div class="form-check form-check-inline">
+							<input class="form-check-input" type="checkbox" name="eqsl" value="1" id="eqsl" <?php if ($this->input->post('eqsl')) echo ' checked="checked"'; ?> >
+							<label class="form-check-label" for="eqsl"><?= __("eQSL") ?></label>
+						</div>
+						<div class="form-check form-check-inline">
+							<input class="form-check-input" type="checkbox" name="clublog" value="1" id="clublog" <?php if ($this->input->post('clublog')) echo ' checked="checked"'; ?> >
+							<label class="form-check-label" for="clublog"><?= __("Clublog") ?></label>
+						</div>
+						<div class="form-check form-check-inline">
+							<input class="form-check-input" type="checkbox" name="qrz" value="1" id="qrz" <?php if ($this->input->post('qrz')) echo ' checked="checked"'; ?> >
+							<label class="form-check-label" for="qrz"><?= __("QRZ") ?></label>
 						</div>
 					</div>
 
-					<div class="mb-3 row">
-						<!-- Propagation Mode -->
-						<label class="col-md-1" for="propmode"><?= __("Propagation"); ?></label>
-						<div class="col-md-3">
-							<select class="form-select" name="propmode" id="propmode">
-								<option value="0"<?php if (($propmode ?? '') == '0') { echo 'selected="selected"'; } ?>><?= __("All"); ?></option>
-								<option value="NoSAT"<?php if (($propmode ?? '') == 'NoSAT') { echo 'selected="selected"'; } ?>><?= __("All but SAT"); ?></option>
-								<option value="None"<?php if (($propmode ?? '') == 'None') { echo ' selected="selected"'; } ?>><?= __("None/Empty"); ?></option>
-								<?php foreach ($adif_propmodes as $mode => $desc) {
-									echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
-								} ?>
-							</select>
-						</div>
+					<!-- Propagation -->
+					<label class="col-12 col-sm-3 col-md-2 col-form-label" for="propmode"><?= __("Propagation"); ?></label>
+					<div class="col-12 col-sm-9 col-md-4">
+						<select class="form-select" name="propmode" id="propmode">
+							<option value="0"<?php if (($propmode ?? '') == '0') { echo 'selected="selected"'; } ?>><?= __("All"); ?></option>
+							<option value="NoSAT"<?php if (($propmode ?? '') == 'NoSAT') { echo 'selected="selected"'; } ?>><?= __("All but SAT"); ?></option>
+							<option value="None"<?php if (($propmode ?? '') == 'None') { echo ' selected="selected"'; } ?>><?= __("None/Empty"); ?></option>
+							<?php foreach ($adif_propmodes as $mode => $desc) {
+								echo "<option value=\"$mode\" ".((($propmode ?? '') == "$mode") ? "selected=\"selected\"" : "").">".htmlspecialchars_decode($desc)."</option>\n";
+							} ?>
+						</select>
+					</div>
 
-						<!-- Year and Checkbox -->
-						<label class="col-md-1" for="year"><?= __("Year"); ?></label>
-						<div class="col-md-4">
-							<div class="d-inline-block">
-								<select class="form-select d-inline-block w-auto" id="year" name="year">
-									<option value='All'><?= __("All Years"); ?></option>
-									<?php foreach($years as $year): ?>
-										<option value="<?= $year ?>" <?= ($this->input->post('year') == $year) ? 'selected' : '' ?>><?= $year ?></option>
-									<?php endforeach; ?>
-								</select>
-							</div>
-							<div class="form-check d-inline-block ms-2">
+					<!-- Year -->
+					<label class="col-12 col-sm-3 col-md-2 col-form-label" for="year"><?= __("Year"); ?></label>
+					<div class="col-12 col-sm-9 col-md-4">
+						<div class="d-flex flex-wrap align-items-center gap-2">
+							<select class="form-select w-auto" id="year" name="year">
+								<option value='All'><?= __("All Years"); ?></option>
+								<?php foreach($years as $year): ?>
+									<option value="<?= $year ?>" <?= ($this->input->post('year') == $year) ? 'selected' : '' ?>><?= $year ?></option>
+								<?php endforeach; ?>
+							</select>
+							<div class="form-check">
 								<input class="form-check-input" type="checkbox" name="onlynew" value="1" id="onlynew" <?= $this->input->post('onlynew') ? 'checked' : '' ?>>
 								<label class="form-check-label" for="onlynew"><?= __("Only new in selected year") ?></label>
 							</div>
 						</div>
 					</div>
 
-
-					<div class="mb-3 row">
-						<label class="col-md-1 control-label" for="button1id"></label>
-						<div class="col-md-10">
-							<button id="button1id" type="submit" name="button1id" class="btn btn-primary"><?= __("Show") ?></button>
-						</div>
+					<!-- Submit -->
+					<div class="col-12 col-sm-9 col-md-10 offset-sm-3 offset-md-2">
+						<button id="button1id" type="submit" name="button1id" class="btn btn-sm btn-primary"><?= __("Show") ?></button>
 					</div>
+				</div>
 
 			</form>
 

--- a/assets/css/general.css
+++ b/assets/css/general.css
@@ -1667,7 +1667,7 @@ svg text.month { fill: #AAA; }
     z-index: 9999 !important;
 }
 
-.tooltip-tl { --bs-tooltip-bg: rgba(0, 0, 0, 0.75); pointer-events: none; }
+.tooltip-tl { --bs-tooltip-bg: rgba(0, 0, 0, 0.75); --bs-tooltip-color: #fff; pointer-events: none; }
 
 .qso_icons {
 	user-select: none;


### PR DESCRIPTION
The tooltip for confirmations was all blacked out in the dark themes (Cyborg, Darkly, Superhero).
I also noticed that the non-wide themes wrapped labels, even though we have space.
Labels also had the wrong classes.

The form layout now uses available space:
Before:
<img width="1353" height="481" alt="image" src="https://github.com/user-attachments/assets/21ebfdb5-cc79-46d7-be6f-dacc221b9d9a" />


After:
<img width="1313" height="438" alt="image" src="https://github.com/user-attachments/assets/27e51dd0-81df-45f7-af3e-83031a6e52ea" />
