### PR TITLE
Parallelize QRZ-Upload (concurrency = 5)

### DIFF
--- a/application/controllers/Qrz.php
+++ b/application/controllers/Qrz.php
@@ -116,7 +116,7 @@ class Qrz extends CI_Controller {
 
 	/*
 	 * Function gets all QSOs from given station_id, that are not previously uploaded to qrz.
-	 * Adif is build for each qso, and then uploaded, one at a time
+	 * Adif is build for each qso, and then uploaded in parallel (curl_multi, sliding window)
 	 */
 	function mass_upload_qsos($station_id, $qrz_api_key, $trusted = false) {
 		$i = 0;
@@ -128,58 +128,122 @@ class Qrz extends CI_Controller {
 		}
 
 		if ($data['qsos']) {
+			$queue = array();
 			foreach ($data['qsos']->result() as $qso) {
-				$adif = $this->adifhelper->getAdifLine($qso);
+				$queue[] = array(
+					'pk'      => $qso->COL_PRIMARY_KEY,
+					'adif'    => $this->adifhelper->getAdifLine($qso),
+					'replace' => ($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == 'M'),
+					'qso'     => $qso,
+				);
+			}
+			$queue_count = count($queue);
 
-				if ($qso->COL_QRZCOM_QSO_UPLOAD_STATUS == 'M') {
-					$result = $this->logbook_model->push_qso_to_qrz($qrz_api_key, $adif, true);
-				} else {
-					$result = $this->logbook_model->push_qso_to_qrz($qrz_api_key, $adif);
+			$max_parallel = 5;
+			$useragent = 'Wavelog/'.$this->optionslib->get_option('version');
+
+			$mh = curl_multi_init();
+			$active_handles = array();
+			$queue_index = 0;
+			$station_aborted = false;
+
+			while ($queue_index < $queue_count && count($active_handles) < $max_parallel) {
+				$entry = $queue[$queue_index];
+				$ch = $this->qrz_upload_handle($qrz_api_key, $entry['adif'], $entry['replace'], $useragent);
+				curl_multi_add_handle($mh, $ch);
+				$active_handles[(int)$ch] = array_merge($entry, array('ch' => $ch));
+				$queue_index++;
+			}
+
+			$result = array('status' => 'OK');
+
+			while (count($active_handles) > 0) {
+				curl_multi_exec($mh, $running);
+
+				while ($info = curl_multi_info_read($mh)) {
+					$ch = $info['handle'];
+					$entry = $active_handles[(int)$ch];
+					unset($active_handles[(int)$ch]);
+					curl_multi_remove_handle($mh, $ch);
+
+					$qso = $entry['qso'];
+					$content = curl_multi_getcontent($ch);
+					$errno = curl_errno($ch);
+
+					if ($content) {
+						if (stristr($content, 'RESULT=OK') || stristr($content, 'RESULT=REPLACE')) {
+							$result['status'] = 'OK';
+						} else {
+							$result['status'] = 'error';
+							$result['message'] = $content;
+						}
+					} elseif ($errno) {
+						$result['status'] = 'error';
+						$result['message'] = 'Curl error: ' . $errno;
+					} else {
+						$result['status'] = 'error';
+						$result['message'] = 'Empty response from QRZ.com';
+					}
+
+					if ( ($result['status'] == 'OK') || ( ($result['status'] == 'error') && ( ($result['message'] == 'STATUS=FAIL&RESULT=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED=') || ($result['message'] == 'STATUS=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED='))) ){
+						$this->markqso($qso->COL_PRIMARY_KEY);
+						$i++;
+						$result['status'] = 'OK';
+					} elseif ( ($result['status']=='error') && (str_contains($result['message'],'add_qso: outside date range')) ) {
+						log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
+						$this->markqso($qso->COL_PRIMARY_KEY,'I');
+						$result['status'] = 'Error';
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					} elseif ( ($result['status']=='error') && (str_contains($result['message'],'wrong station_callsign')) ) {
+						log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
+						$this->markqso($qso->COL_PRIMARY_KEY,'I');
+						$result['status'] = 'Error';
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					} elseif ( ($result['status']=='error') && (str_contains($result['message'],'DXCC could not be determined')) ) {
+						log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
+						$this->markqso($qso->COL_PRIMARY_KEY,'I');
+						$result['status'] = 'Error';
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					} elseif ( ($result['status']=='error') && (str_contains($result['message'],'cannot determine band from')) ) {
+						log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
+						$this->markqso($qso->COL_PRIMARY_KEY,'I');
+						$result['status'] = 'Error';
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					} elseif ( ($result['status']=='error') && (str_contains($result['message'],'required field missing mode')) ) {
+						log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
+						$this->markqso($qso->COL_PRIMARY_KEY,'I');
+						$result['status'] = 'Error';
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+					} elseif ( ($result['status']=='error') && (substr($result['message'],0,11)  == 'STATUS=AUTH')) {
+						log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+						$result['status'] = 'Error';
+            				$sql = 'update station_profile set qrzrealtime = -1 where station_id = ?';
+            				$this->db->query($sql,$station_id);
+						$station_aborted = true; /* If key is invalid, immediate stop syncing for more QSOs of this station */
+					} else {
+						log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
+						log_message('error', 'QRZ upload failed with the following message: ' .$result['message']);
+						$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
+						$result['status'] = 'Error';
+					}
+
+					if (!$station_aborted && $queue_index < $queue_count) {
+						$entry = $queue[$queue_index];
+						$new_ch = $this->qrz_upload_handle($qrz_api_key, $entry['adif'], $entry['replace'], $useragent);
+						curl_multi_add_handle($mh, $new_ch);
+						$active_handles[(int)$new_ch] = array_merge($entry, array('ch' => $new_ch));
+						$queue_index++;
+					}
 				}
 
-				if ( ($result['status'] == 'OK') || ( ($result['status'] == 'error') && ( ($result['message'] == 'STATUS=FAIL&RESULT=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED=') || ($result['message'] == 'STATUS=FAIL&REASON=Unable to add QSO to database: duplicate&EXTENDED='))) ){
-					$this->markqso($qso->COL_PRIMARY_KEY);
-					$i++;
-					$result['status'] = 'OK';
-				} elseif ( ($result['status']=='error') && (str_contains($result['message'],'add_qso: outside date range')) ) {
-					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
-					$this->markqso($qso->COL_PRIMARY_KEY,'I');
-					$result['status'] = 'Error';
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-				} elseif ( ($result['status']=='error') && (str_contains($result['message'],'wrong station_callsign')) ) {
-					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
-					$this->markqso($qso->COL_PRIMARY_KEY,'I');
-					$result['status'] = 'Error';
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-				} elseif ( ($result['status']=='error') && (str_contains($result['message'],'DXCC could not be determined')) ) {
-					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
-					$this->markqso($qso->COL_PRIMARY_KEY,'I');
-					$result['status'] = 'Error';
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-				} elseif ( ($result['status']=='error') && (str_contains($result['message'],'cannot determine band from')) ) {
-					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
-					$this->markqso($qso->COL_PRIMARY_KEY,'I');
-					$result['status'] = 'Error';
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-				} elseif ( ($result['status']=='error') && (str_contains($result['message'],'required field missing mode')) ) {
-					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
-					$this->markqso($qso->COL_PRIMARY_KEY,'I');
-					$result['status'] = 'Error';
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-				} elseif ( ($result['status']=='error') && (substr($result['message'],0,11)  == 'STATUS=AUTH')) {
-					log_message('error', 'QRZ upload failed for qso for Station_ID '.$station_id.' //  Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON . ' // Message: '.$result['message']);
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-					$result['status'] = 'Error';
-        				$sql = 'update station_profile set qrzrealtime = -1 where station_id = ?';
-        				$this->db->query($sql,$station_id);
-					break; /* If key is invalid, immediate stop syncing for more QSOs of this station */
-				} else {
-					log_message('error', 'QRZ upload failed for qso: Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON);
-					log_message('error', 'QRZ upload failed with the following message: ' .$result['message']);
-					$errormessages[] = $result['message'] . ' Call: ' . $qso->COL_CALL . ' Band: ' . $qso->COL_BAND . ' Mode: ' . $qso->COL_MODE . ' Time: ' . $qso->COL_TIME_ON;
-					$result['status'] = 'Error';
+				if (count($active_handles) > 0) {
+					curl_multi_select($mh, 1.0);
 				}
 			}
+
+			curl_multi_close($mh);
+
 			if ($i == 0) {
 			    $result['status']='OK';
 		    }
@@ -192,6 +256,27 @@ class Qrz extends CI_Controller {
 			$result['errormessages'] = $errormessages;
 			return $result;
 		}
+	}
+
+	private function qrz_upload_handle($qrz_api_key, $adif, $replaceoption, $useragent) {
+		$post_data['KEY'] = $qrz_api_key;
+		$post_data['ACTION'] = 'INSERT';
+		$post_data['ADIF'] = $adif;
+
+		if ($replaceoption) {
+			$post_data['OPTION'] = 'REPLACE';
+		}
+
+		$ch = curl_init('https://logbook.qrz.com/api');
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $post_data);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+		curl_setopt($ch, CURLOPT_HEADER, 0);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+		curl_setopt($ch, CURLOPT_USERAGENT, $useragent);
+		return $ch;
 	}
 
 	/*


### PR DESCRIPTION
Besides the fact, that QRZ is only a callbook and has bugs handling SAT-QSOs, etc., there's another major gap in their interface:

User can set valid ranges (From / Till) in qrz itself. But when a client tries to upload a QSO which is out of that range, QRZ answers with `add_qso: outside date range`.

There's absolutely no way to check (via API) whats the valid range for a given Call.
A client needs to push QSO by QSO, to see if it's accepted or not.
The error itself (`add_qso: outside date range`) is already handled in WL. The QSO gets a mark "invalid" for QRZ-Upload.

But: If a user uploads - e.g. 100k QSOs - WL needs to iterate through that 100k QSOs.

The PR here addresses that. Parallelizing requests to QRZ, to milden it a bit. Without the PR it'd take multiple sync-cycles to process those QSOs. Side-Effect: All other stations/users have to wait till the broken QSOs are processed.

PS: Parallelizing is already implemented (and working) for about 1y with LoTW in the same way.