### PR TITLE
[LotW] fix LotW cert status check when ARRL is not reachable

### DIFF
--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1313,8 +1313,13 @@ class Lotw extends CI_Controller {
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 			$result = curl_exec($ch);
-			if(curl_errno($ch)){
-				log_message('error', 'Error fetch LoTW CRL results: '.curl_strerror(curl_errno($ch)));
+			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+			if (curl_errno($ch) || $http_code !== 200) {
+				log_message(
+					'error',
+					'Error fetching LoTW CRL: HTTP '.$http_code.' / '.curl_error($ch)
+				);
 				return 99;
 			}
 			$xml = new SimpleXMLElement($result);

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1306,27 +1306,46 @@ class Lotw extends CI_Controller {
 	}
 
 	function lotw_cert_status ($serial) {
+		
+	//skip if no serial
 		if (($serial ?? '') != '' && is_numeric($serial)) {
+			
+			//define API call
 			$url = 'https://lotw.arrl.org/lotw/crl?serial='.$serial;
 			$ch = curl_init();
 			curl_setopt($ch, CURLOPT_URL, $url);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+			
+			//execute API call and check for HTTP errors
 			$result = curl_exec($ch);
 			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-			if (curl_errno($ch) || $http_code !== 200) {
-				log_message(
-					'error',
-					'Error fetching LoTW CRL: HTTP '.$http_code.' / '.curl_error($ch)
-				);
+			// Check for cURL errors or non-2xx HTTP response
+			if (curl_errno($ch) || $http_code < 200 || $http_code >= 300) {
+				log_message('error', 'Error fetching LoTW CRL: HTTP '.$http_code.' / '.curl_error($ch));
 				return 99;
 			}
-			$xml = new SimpleXMLElement($result);
+
+			//check if result is empty or not a string
+			if (!is_string($result) || trim($result) === '') {
+				log_message('error', 'LoTW CRL returned an empty response.');
+				return 98;
+			}
+
+			//try parsing the result
+			try {
+				$xml = new SimpleXMLElement($result);
+			} catch (Exception $e) {
+				log_message('error', 'Error parsing LoTW CRL result: '.$e->getMessage());
+				return 98;
+			}
 			if (!isset($xml->Status)) {
 				log_message('error', 'Error parsing LoTW CRL result: '.$result);
 				return 98;
 			}
+
+			//react to status inside xml
 			switch ((string)$xml->Status) {
 			case 'Superceded':
 				return 1;

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1332,7 +1332,7 @@ class Lotw extends CI_Controller {
 		//check if result is empty or not a string
 		if (!is_string($result) || trim($result) === '') {
 			log_message('error', 'LoTW CRL returned an empty response.');
-			return 98;
+			return 99;
 		}
 
 		//try parsing the result

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1307,56 +1307,56 @@ class Lotw extends CI_Controller {
 
 	function lotw_cert_status ($serial) {
 		
-	//skip if no serial
-		if (($serial ?? '') != '' && is_numeric($serial)) {
-			
-			//define API call
-			$url = 'https://lotw.arrl.org/lotw/crl?serial='.$serial;
-			$ch = curl_init();
-			curl_setopt($ch, CURLOPT_URL, $url);
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
-			
-			//execute API call and check for HTTP errors
-			$result = curl_exec($ch);
-			$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-			// Check for cURL errors or non-2xx HTTP response
-			if (curl_errno($ch) || $http_code < 200 || $http_code >= 300) {
-				log_message('error', 'Error fetching LoTW CRL: HTTP '.$http_code.' / '.curl_error($ch));
-				return 99;
-			}
-
-			//check if result is empty or not a string
-			if (!is_string($result) || trim($result) === '') {
-				log_message('error', 'LoTW CRL returned an empty response.');
-				return 98;
-			}
-
-			//try parsing the result
-			try {
-				$xml = new SimpleXMLElement($result);
-			} catch (Exception $e) {
-				log_message('error', 'Error parsing LoTW CRL result: '.$e->getMessage());
-				return 98;
-			}
-			if (!isset($xml->Status)) {
-				log_message('error', 'Error parsing LoTW CRL result: '.$result);
-				return 98;
-			}
-
-			//react to status inside xml
-			switch ((string)$xml->Status) {
-			case 'Superceded':
-				return 1;
-			case 'Unrevoked':
-				return 0;
-			default:
-				log_message('error', 'Unknown LotW CRL status: '.(string)$xml->Status);
-				return 97;
-			}
+		//skip if no serial
+		if (($serial ?? '') == '' || !is_numeric($serial)) {
+			return 99;
 		}
-		return 99;
+		
+		//define API call
+		$url = 'https://lotw.arrl.org/lotw/crl?serial='.$serial;
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+		
+		//execute API call and check for HTTP errors
+		$result = curl_exec($ch);
+		$http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+		// Check for cURL errors or non-2xx HTTP response
+		if (curl_errno($ch) || $http_code < 200 || $http_code >= 300) {
+			log_message('error', 'Error fetching LoTW CRL: HTTP '.$http_code.' / '.curl_error($ch));
+			return 99;
+		}
+
+		//check if result is empty or not a string
+		if (!is_string($result) || trim($result) === '') {
+			log_message('error', 'LoTW CRL returned an empty response.');
+			return 98;
+		}
+
+		//try parsing the result
+		try {
+			$xml = new SimpleXMLElement($result);
+		} catch (Exception $e) {
+			log_message('error', 'Error parsing LoTW CRL result: '.$e->getMessage());
+			return 98;
+		}
+		if (!isset($xml->Status)) {
+			log_message('error', 'Error parsing LoTW CRL result: '.$result);
+			return 98;
+		}
+
+		//react to status inside xml
+		switch ((string)$xml->Status) {
+		case 'Superceded':
+			return 1;
+		case 'Unrevoked':
+			return 0;
+		default:
+			log_message('error', 'Unknown LotW CRL status: '.(string)$xml->Status);
+			return 97;
+		}
 	}
 
 } // end class

--- a/application/controllers/Lotw.php
+++ b/application/controllers/Lotw.php
@@ -1340,11 +1340,11 @@ class Lotw extends CI_Controller {
 			$xml = new SimpleXMLElement($result);
 		} catch (Exception $e) {
 			log_message('error', 'Error parsing LoTW CRL result: '.$e->getMessage());
-			return 98;
+			return 99;
 		}
 		if (!isset($xml->Status)) {
 			log_message('error', 'Error parsing LoTW CRL result: '.$result);
-			return 98;
+			return 99;
 		}
 
 		//react to status inside xml


### PR DESCRIPTION
When a user has LotW certificates with serial numbers and at the same time ARRL is down (like at the moment, where it responds with HTTP 500 after a lot of waiting), the LotW certificate status check crashes wavelog when the user opens the LotW dashboard page.

This happens because the lotw_cert_status function never checks the HTTP status code and tries parsing the non-xml response.

This PR fixes that so (after a lot of waiting until HTTP 500 arrives), the dashboard opens again without crashing.

It might be worth a second PR to move this function to just right before the upload/download instead of checking during the opening of the page, potentially locking wavelog for that user for minutes at a time (wait time till failure multiplies with certificate count)