### PR TITLE
Option to make hams.at posts from SAT passes page

### DIFF
--- a/application/controllers/Satellite.php
+++ b/application/controllers/Satellite.php
@@ -284,6 +284,8 @@ class Satellite extends CI_Controller {
 			$mintime = $this->security->xss_clean($this->input->post('mintime'));
 			$minelevation = $this->security->xss_clean($this->input->post('minelevation'));
 			$data = $this->calcPasses($tles, $yourgrid, $date, $mintime, $minelevation);
+			$hkey_opt = $this->user_options_model->get_options('hamsat',array('option_name'=>'hamsat_key','option_key'=>'api'))->result();
+			$data['hamsat_key'] = $hkey_opt[0]->option_value ?? '';
 
 			$this->load->view('satellite/passtable', $data);
 		}
@@ -533,6 +535,32 @@ class Satellite extends CI_Controller {
 		$this->load->view('satellite/satinfo', $data);
 	}
 
+	public function prepHamsAtPosting() {
+		if ($this->session->userdata('user_date_format')) {
+			// If Logged in and session exists
+			$custom_date_format = $this->session->userdata('user_date_format');
+		} else {
+			// Get Default date format from /config/wavelog.php
+			$custom_date_format = $this->config->item('qso_date_format');
+		}
+		$data['custom_date_format'] = $custom_date_format;
+		$satname = $this->input->post('sat', true);
+		$data['aos'] = $this->input->post('aos', true);
+		$data['tca'] = $this->input->post('tca', true);
+		$data['los'] = $this->input->post('los', true);
+		$data['duration'] = $this->input->post('duration', true);
+		$this->load->model('satellite_model');
+		$data['satinfo'] = $this->satellite_model->get_satellite_information($satname);
+		$this->load->model('stations');
+		$active_station_id = $this->stations->find_active();
+		$data['homegrid'] = $this->stations->gridsquare_from_station($active_station_id);
+		$data['callsign'] = $this->stations->get_station_power($active_station_id)['station_callsign'];
+		$this->load->library('Qra');
+		[$data['lat'], $data['lon']] = $this->qra->qra2latlong($data['homegrid']);
+		$data['refs'] = $this->stations->get_station_refs($active_station_id);
+		$this->load->view('satellite/hamsatpost', $data);
+	}
+
 	public function editTleDialog() {
 		if($this->session->userdata('user_date_format')) {
 			// If Logged in and session exists
@@ -570,5 +598,59 @@ class Satellite extends CI_Controller {
 		$this->load->model('satellite_model');
 
 		$this->satellite_model->saveTle($id, $tle);
+	}
+
+	public function post_hams_at() {
+		$ci = & get_instance();
+		$tca = $this->input->post('tca', true);
+		$mode = $this->input->post('mode', true);
+		$catnr = $this->input->post('catnr', true);
+		$lat = (float)$this->input->post('lat', true);
+		$lon = (float)$this->input->post('lon', true);
+		$callsign = $this->input->post('callsign', true);
+		$comment = $this->input->post('comment', true);
+		$grid0 = $this->input->post('grid0', true);
+		$grid1 = $this->input->post('grid1', true);
+		$grid2 = $this->input->post('grid2', true);
+		$grid3 = $this->input->post('grid3', true);
+		$chat = $this->input->post('chat', true);
+		$mhz = $this->input->post('mhz', true);
+		$mhz_direction = $this->input->post('mhz_direction', true);
+		$data = array(
+			'mode' => $mode,
+			'comment' => $comment,
+			// Remove before push/merge!
+			'test' => true,
+			'satellite_number' => $catnr,
+			'callsign' => $callsign,
+			'chat_enabled' => $chat == 'true' ? true : false,
+			'grids' => [$grid0, $grid1, $grid2, $grid3],
+			'max_at' => $tca,
+			'mhz' => $mhz,
+			'mhz_direction' => $mhz_direction,
+			'observer_lat' => $lat,
+			'observer_lon' => $lon,
+		);
+		$jsondata = json_encode($data);
+		$hkey_opt=$this->user_options_model->get_options('hamsat',array('option_name'=>'hamsat_key','option_key'=>'api'))->result();
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_URL, 'https://hams.at/api/alerts');
+		curl_setopt($ch, CURLOPT_USERAGENT, 'Wavelog/'.$ci->optionslib->get_option('version'));
+		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Authorization: Bearer '.$hkey_opt[0]->option_value));
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS,$jsondata);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		$result = json_decode(curl_exec($ch), true);
+		$httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		if ($httpcode == 422) {
+			log_message('error', 'Error posting to hams.at: '.$result['errors'][0]);
+			$this->output->set_status_header(422);
+			print __("Generic error posting to hams.at. Please check the input values.");
+		} else if ($httpcode == 401) {
+			log_message('error', 'Error authenticating to hams.at: '.$result['errors'][0]);
+			$this->output->set_status_header(401);
+			print __("Error authenticating to hams.at. Please check API key.");
+		}
+
 	}
 }

--- a/application/models/Satellite_model.php
+++ b/application/models/Satellite_model.php
@@ -14,7 +14,7 @@ class Satellite_model extends CI_Model {
 
 	function get_satellite_information($satname = null) {
 		$bindings = [];
-		$sql = "select satellite.id, coalesce(nullif(satellite.name, ''), satellite.displayname) as satname, satellitemode.name as modename, satellite.displayname, satellite.orbit, satellite.lotw as lotw, tle.updated, satellitemode.uplink_mode, satellitemode.downlink_mode, FORMAT((satellitemode.uplink_freq / 1000000), 3) AS uplink_freq, FORMAT((satellitemode.downlink_freq / 1000000), 3) AS downlink_freq
+		$sql = "select satellite.id, coalesce(nullif(satellite.name, ''), satellite.displayname) as satname, satellitemode.name as modename, satellite.displayname, satellite.orbit, satellite.lotw as lotw, tle.updated, satellitemode.uplink_mode, satellitemode.downlink_mode, FORMAT((satellitemode.uplink_freq / 1000000), 3) AS uplink_freq, FORMAT((satellitemode.downlink_freq / 1000000), 3) AS downlink_freq, satellite.norad_id AS norad_id
 		from satellite
 		left outer join satellitemode on satellite.id = satellitemode.satelliteid
 		left outer join tle on satellite.id = tle.satelliteid ";

--- a/application/models/Stations.php
+++ b/application/models/Stations.php
@@ -656,6 +656,25 @@ class Stations extends CI_Model {
 		}
 		return false;
 	}
+
+	public function get_station_refs($stationid) {
+		$sql = "SELECT `station_iota`, `station_sota`, `station_sig`, `station_sig_info`, `station_wwff`, `station_pota` FROM `station_profile` WHERE station_id = ?;";
+		$query = $this->db->query($sql, $stationid);
+		$row = $query->row();
+		if($query->num_rows() >= 1) {
+			$row = $query->row(); // only one result expected
+			return [
+				'iota' => $row->station_iota,
+				'sota' => $row->station_sota,
+				'sig' => $row->station_sig,
+				'sig_info' => $row->station_sig_info,
+				'wwff' => $row->station_wwff,
+				'pota' => $row->station_pota,
+			];
+		} else {
+			return null;
+		}
+	}
 }
 
 ?>

--- a/application/views/interface_assets/footer.php
+++ b/application/views/interface_assets/footer.php
@@ -63,6 +63,7 @@
     var lang_general_word_please_wait = "<?= __("Please Wait ..."); ?>";
     var lang_general_states_deprecated = "<?= _pgettext("Word for country states that are deprecated but kept for legacy reasons.", "deprecated"); ?>";
     var lang_gen_hamradio_sat_info = "<?= __("Satellite Information"); ?>";
+    var lang_gen_hamradio_sat_hamsat_post = "<?= __("Prepare hams.at Activation Posting"); ?>";
 
     var lang_notes_error_loading = "<?= __("Error loading notes"); ?>";
     var lang_notes_sort = "<?= __("Sorting"); ?>";

--- a/application/views/satellite/hamsatpost.php
+++ b/application/views/satellite/hamsatpost.php
@@ -1,0 +1,143 @@
+<head>
+<?php
+$aos_time = date_create($aos);
+$tca_time = date_create($tca);
+$los_time = date_create($los);
+//echo "TEST: ".date_format($tca_time, 'Y-m-d\TH:i:sp');
+?>
+</head>
+<body class="container-fluidx">
+<div id="error-messages-hamsat-post"></div>
+<form name="hamsatpost" id="hamsatform">
+   <div class="container-fluid">
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="sat_name"><?= __("Satellite"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-4">
+            <span><?= $satinfo[0]->satname; ?></span>
+         </div>
+      </div>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="date"><?= __("Date"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-4">
+            <span><?= date_format($aos_time, $custom_date_format); ?></span>
+         </div>
+      </div>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="pass_time"><?= __("Pass Time"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-4">
+            <span><?= date_format($aos_time, 'H:i:s'); ?></span> - <span><?= date_format($los_time, 'H:i:s'); ?></span>
+         </div>
+      </div>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="mode"><?= __("Mode"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-2">
+            <?php
+               $sat_modes = array();
+               foreach ($satinfo as $sat) {
+                  $sat_modes[] = $sat->uplink_mode;
+               }
+            ?>
+            <select id ="mode" name="mode" tabindex="1" class="form-select" <?php echo (count($sat_modes) == 1 && ($sat_modes[0] == 'FM' || $sat_modes[0] == 'PKT')) ? 'disabled' : ''; ?>>
+            <?php if (in_array('FM', $sat_modes)) { ?>
+                  <option value="Data">FM</option>
+            <?php } ?>
+            <?php if (in_array('SSB', $sat_modes) || in_array('USB', $sat_modes) || in_array('LSB', $sat_modes)) { ?>
+                  <option value="SSB">SSB</option>
+                  <option value="CW">CW</option>
+            <?php } ?>
+            <?php if (in_array('PKT', $sat_modes) || in_array('SSB', $sat_modes) || in_array('USB', $sat_modes) || in_array('LSB', $sat_modes)) { ?>
+                  <option value="Data">Data</option>
+            <?php } ?>
+               </select>
+         </div>
+      </div>
+      <?php if ($satinfo[0]->uplink_mode != 'FM') { ?>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="callsign"><?= __("Frequency"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-2">
+            <input class="form-control" type="text" name="mhz" placeholder="<?= __("Optional"); ?>"/>
+            <small><?= __("Center"); ?>: <span id="tpx_center_freq"><?= $satinfo[0]->downlink_freq; ?></span></small>
+         </div>
+         <div class="mb-3 col-sm-2">
+            <input type="radio" value="up" name="mhz_direction" onClick="toggleRxTx('up')"> <?= __("Uplink"); ?>
+            <input type="radio" value="down" name="mhz_direction" checked onClick="toggleRxTx('down')"> <?= __("Downlink"); ?>
+         </div>
+      </div>
+      <?php } ?>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="callsign"><?= __("Callsign"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-4">
+            <input class="form-control uppercase" type="text" name="callsign" value="<?= $callsign; ?>" />
+         </div>
+      </div>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="homegrid"><?= __("Gridsquare(s)"); ?></label>
+         </div>
+            <?php
+               $grids = explode(',', $homegrid);
+            ?>
+         <div class="mb-3 col-sm-1">
+            <input class="form-control uppercase" type="text" name="grid0" value="<?= substr($grids[0] ?? '', 0, 4); ?>" />
+         </div>
+         <div class="mb-3 col-sm-1">
+            <input class="form-control uppercase" type="text" name="grid1" value="<?= substr($grids[1] ?? '', 0, 4); ?>" />
+         </div>
+         <div class="mb-3 col-sm-1">
+            <input class="form-control uppercase" type="text" name="grid2" value="<?= substr($grids[2] ?? '', 0, 4); ?>" />
+         </div>
+         <div class="mb-3 col-sm-1">
+            <input class="form-control uppercase" type="text" name="grid3" value="<?= substr($grids[3] ?? '', 0, 4); ?>" />
+         </div>
+      </div>
+      <?php
+         if ($refs) {
+            $reftxt = array();
+            $refs['iota'] && $reftxt[] = 'IOTA '.$refs['iota'];
+            $refs['sota'] && $reftxt[] = 'SOTA '.$refs['sota'];
+            ($refs['sig'] && $refs['sig_info']) && $reftxt[] = $refs['sig'].' '.$refs['sig_info'];
+            $refs['wwff'] && $reftxt[] = 'WWFF '.$refs['wwff'];
+            $refs['pota'] && $reftxt[] = 'POTA '.$refs['pota'];
+         }
+      ?>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="comment"><?= __("Comment"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-4">
+            <input class="form-control" type="text" name="comment" placeholder="<?= __("Optional") ;?>"value="<?= implode(', ', $reftxt); ?>" maxlength="50"/>
+            <small><?= __("Max 50 characters"); ?></small>
+         </div>
+      </div>
+      <div class="row">
+         <div class="mb-3 col-sm-2">
+            <label for="chat"><?= __("Realtime chat enabled"); ?></label>
+         </div>
+         <div class="mb-3 col-sm-4">
+            <input class="form-check-input" type="checkbox" name="chat" value="true" aria-describedby="chat_help"/>
+            <small id="chat_help" class="form-text text-muted">(<?= __("Chat is open until 1 day after the pass ends"); ?>)</small>
+         </div>
+      </div>
+   </div>
+<input type="hidden" name="tca" value="<?= date_format($tca_time, 'c'); ?>" />
+<input type="hidden" name="catnr" value="<?= $satinfo[0]->norad_id; ?>" />
+<input type="hidden" name="lat" value="<?= $lat; ?>" />
+<input type="hidden" name="lon" value="<?= $lon; ?>" />
+<input type="hidden" name="downlink_freq" id="downlink_freq" value="<?= $satinfo[0]->downlink_freq; ?>" />
+<input type="hidden" name="uplink_freq" id="uplink_freq" value="<?= $satinfo[0]->uplink_freq; ?>" />
+<button id="post" type="button" name="post" class="btn btn-primary" onclick="post_hamsat();"><i class="fas fa-arrow-up-right-from-square"></i> <?= __("Post");?></button>
+<form>
+
+</body>

--- a/application/views/satellite/passtable.php
+++ b/application/views/satellite/passtable.php
@@ -5,6 +5,7 @@ if (isset($filtered)) {
 				<tr id="toptable">
 					<th>' . __("Satellite") . ' <i class="fa-solid fa-satellite"></i></th>
 					<th>' . __("AOS Time") . '</th>
+					<th>' . __("TCA Time") . '</th>
 					<th>' . __("LOS Time") . '</th>
 					<th>' . __("Duration") . '</th>
 					<th style="white-space: nowrap">' . __("Path") . '</th>
@@ -30,6 +31,7 @@ if (isset($filtered)) {
 				echo '<tr>';
 				echo '<td>' . ($pass->satname != '' ? $pass->satname : $pass->displayname) . ' <i class="satelliteinfo fa fa-info-circle"></i></td>';
 				echo '<td>' . Predict_Time::daynum2readable($pass->aos, $zone, $format) . '<span style="margin-left: 10px; display: inline-block;"><a href="' . $ics.'" target="newics"><i class="fas fa-calendar-plus"></i></a><span></td>';
+				echo '<td>' . Predict_Time::daynum2readable($pass->tca, $zone, $format) . '</td>';
 				echo '<td>' . Predict_Time::daynum2readable($pass->los, $zone, $format) . '</td>';
 				echo '<td>' . returntimediff(Predict_Time::daynum2readable($pass->aos, $zone, $format), Predict_Time::daynum2readable($pass->los, $zone, $format), $format) . '</td>';
 				echo '<td><a href="flightpath/'.$pass->satname.'" target="_blank"><?xml version="1.0" encoding="UTF-8" standalone="no"?>

--- a/application/views/satellite/passtable.php
+++ b/application/views/satellite/passtable.php
@@ -29,11 +29,14 @@ if (isset($filtered)) {
 				$tca=sat2pol($max_el_az,$max_el,$scale);
 				$control = array(2 * $tca[0] - ($aos[0] + $los[0]) / 2, 2 * $tca[1] - ($aos[1] + $los[1]) / 2);	// Calc Controlpoints for Bezier-Curve
 				echo '<tr>';
-				echo '<td>' . ($pass->satname != '' ? $pass->satname : $pass->displayname) . ' <i class="satelliteinfo fa fa-info-circle"></i></td>';
-				echo '<td>' . Predict_Time::daynum2readable($pass->aos, $zone, $format) . '<span style="margin-left: 10px; display: inline-block;"><a href="' . $ics.'" target="newics"><i class="fas fa-calendar-plus"></i></a><span></td>';
-				echo '<td>' . Predict_Time::daynum2readable($pass->tca, $zone, $format) . '</td>';
-				echo '<td>' . Predict_Time::daynum2readable($pass->los, $zone, $format) . '</td>';
-				echo '<td>' . returntimediff(Predict_Time::daynum2readable($pass->aos, $zone, $format), Predict_Time::daynum2readable($pass->los, $zone, $format), $format) . '</td>';
+				echo '<td>' . ($pass->satname != '' ? $pass->satname : $pass->displayname) . ' <i class="satelliteinfo fa fa-info-circle"></i>';
+				if ($hamsat_key) {
+					echo ' <i class="hamsatposting fa fa-bullhorn"></i></td>';
+				}
+				echo '<td id="aos">' . Predict_Time::daynum2readable($pass->aos, $zone, $format) . '<span style="margin-left: 10px; display: inline-block;"><a href="' . $ics.'" target="newics"><i class="fas fa-calendar-plus"></i></a><span></td>';
+				echo '<td id="tca">' . Predict_Time::daynum2readable($pass->tca, $zone, $format) . '</td>';
+				echo '<td id="los">' . Predict_Time::daynum2readable($pass->los, $zone, $format) . '</td>';
+				echo '<td id="duration">' . returntimediff(Predict_Time::daynum2readable($pass->aos, $zone, $format), Predict_Time::daynum2readable($pass->los, $zone, $format), $format) . '</td>';
 				echo '<td><a href="flightpath/'.$pass->satname.'" target="_blank"><?xml version="1.0" encoding="UTF-8" standalone="no"?>
 					<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" baseProfile="full" width="'.($scale*2).'" height="'.($scale*2).'">
 					<circle cx="'.$scale.'" cy="'.$scale.'" r="'.($scale / 10 * 9).'" stroke="darkgrey" stroke-width="1" fill="none" />

--- a/assets/js/sections/common.js
+++ b/assets/js/sections/common.js
@@ -684,6 +684,25 @@ function qso_save() {
     });
 }
 
+function post_hamsat() {
+    let myform = $("#hamsatform")[0];
+    let fd = new FormData(myform);
+    $.ajax({
+        url: base_url + 'index.php/satellite/post_hams_at',
+        data: fd,
+        cache: false,
+        processData: false,
+        contentType: false,
+        type: 'POST',
+        success: function () {
+           $(".preparehamsat-dialog").modal('hide');
+        },
+        error: function(xhr, status, error) {
+           $("#error-messages-hamsat-post").html('<div class="alert alert-danger alert-dismissible fade show" role="alert">'+xhr.responseText+'<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>');
+        }
+    });
+}
+
 function selectize_usa_county(state_field, county_field) {
     $(county_field).selectize()[0].selectize.destroy();
     $(county_field).selectize({

--- a/assets/js/sections/hamsat.js
+++ b/assets/js/sections/hamsat.js
@@ -217,4 +217,6 @@ $(document).ready(function() {
 	hamsAtTimer = setInterval(function() {
 		loadHamsAt(obj);
 	}, 60000);
+
 });
+

--- a/assets/js/sections/hamsatpost.js
+++ b/assets/js/sections/hamsatpost.js
@@ -1,0 +1,1 @@
+console.log("TEST");

--- a/assets/js/sections/satpasses.js
+++ b/assets/js/sections/satpasses.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    loadPassSettingsList();
+	loadPassSettingsList();
 
 	$('#satlist').multiselect({
 		// template is needed for bs5 support
@@ -73,6 +73,9 @@ function loadPasses() {
 			$('.satelliteinfo').click(function (event) {
 				getSatelliteInfo(this);
 			});
+			$('.hamsatposting').click(function (event) {
+				prepHamsAtPosting(this);
+			});
 		},
 		error: function(e) {
 			modalloading=false;
@@ -106,6 +109,42 @@ function getSatelliteInfo(element) {
 
         }
     });
+}
+
+function prepHamsAtPosting(element) {
+	var satname = $(element).closest('td').contents().first().text().trim();
+	var aos = $(element).parent().parent().find('#aos').contents().text().trim();
+	var tca = $(element).parent().parent().find('#tca').contents().text().trim();
+	var los = $(element).parent().parent().find('#los').contents().text().trim();
+	var duration = $(element).parent().parent().find('#duration').contents().text().trim();
+	$.ajax({
+		url: base_url + 'index.php/satellite/prepHamsAtPosting',
+		type: 'post',
+		data: {
+			'sat': satname,
+			'aos': aos,
+			'tca': tca,
+			'los': los,
+			'duration': duration,
+		},
+		success: function (html) {
+			BootstrapDialog.show({
+				title: lang_gen_hamradio_sat_hamsat_post,
+				size: BootstrapDialog.SIZE_WIDE,
+				cssClass: 'preparehamsat-dialog bg-opacity-50',
+				nl2br: false,
+				message: html,
+				buttons: [{
+					label: lang_admin_close,
+					action: function (dialogItself) {
+						dialogItself.close();
+					}
+				}]
+			});
+		},
+		error: function(e) {
+		}
+	});
 }
 
 function loadSkedPasses() {
@@ -246,4 +285,13 @@ function loadPassSettingsList() {
             console.log(e);
         }
     });
+}
+
+function toggleRxTx(dir) {
+   console.log("toggleRxTx");
+   if (dir == 'up') {
+      $("#tpx_center_freq").html($("#uplink_freq").val());
+   } else if (dir == 'down') {
+      $("#tpx_center_freq").html($("#downlink_freq").val());
+   }
 }

--- a/src/predict/Predict.php
+++ b/src/predict/Predict.php
@@ -238,6 +238,7 @@ class Predict
                 $pass->maxel_az = 0.0;
                 $pass->vis      = '---';
                 $pass->satname  = $sat->nickname;
+                $pass->catnr    = $sat->catnr;
                 $pass->details  = array();
 
                 /* iterate over each time step */

--- a/src/predict/Predict/Pass.php
+++ b/src/predict/Predict/Pass.php
@@ -4,6 +4,7 @@
 class Predict_Pass
 {
     public $satname;  /*!< satellite name */
+    public $catnr;    /*!< Norad ID of satellite*/
     public $aos;      /*!< AOS time in "jul_utc" */
     public $tca;      /*!< TCA time in "jul_utc" */
     public $los;      /*!< LOS time in "jul_utc" */

--- a/src/predict/Predict/Sat.php
+++ b/src/predict/Predict/Sat.php
@@ -29,6 +29,7 @@ class Predict_Sat
     public $name     = null;
     public $nickname = null;
     public $website  = null;
+    public $catnr    = null;
 
     public $tle      = null;   /*!< Keplerian elements */
     public $flags    = 0;      /*!< Flags for algo ctrl */
@@ -72,6 +73,7 @@ class Predict_Sat
         $headerParts    = explode(' ', $tle->header);
         $this->name     = $headerParts[0];
         $this->nickname = $this->name;
+        $this->catnr    = $tle->catnr;
         $this->tle      = $tle;
         $this->pos      = new Predict_Vector();
         $this->vel      = new Predict_Vector();


### PR DESCRIPTION
This aims to add a new option to post activations to hams.at from sat passes list. Stuff todo:

- [x] Handle setting of frequencies for sats with multiple tpx'es (e.g. ISS)
- [x] Verify hams.at API key on storage
- [x] Better placement of buttons in popup modal
- [ ] ~~Fix vertical alignment of text and input boxes~~

And maybe more. Sneak peak:

<img width="1720" height="886" alt="Screenshot from 2026-09-11 21-08-04" src="https://github.com/user-attachments/assets/086600a2-125c-4bae-a808-172aab9bb16e" />
