### PR TITLE
Clear Contest Form on QSY

### DIFF
--- a/application/views/contesting/logger/index.php
+++ b/application/views/contesting/logger/index.php
@@ -138,6 +138,14 @@
                         </select>
                     </div>
                 </div>
+                <div class="list-group-item bg-dark text-white border-secondary">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <span title="<?= __("Clears the callsign field when the frequency changes by more than 500 Hz"); ?>"><?= __("Clear Call on QSY"); ?></span>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="clearCallOnQsyToggle">
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/assets/js/sections/contesting/contest_engine/components/qso-form.js
+++ b/assets/js/sections/contesting/contest_engine/components/qso-form.js
@@ -58,6 +58,7 @@ class QsoFormComponent {
 		this.loadExistingQSOs();
 		this.applyRstDefaults();
 		this._setupBandmapListener();
+		this._setupQsyClear();
 	}
 
 	// Show the current operator as a badge in this window's header (club stations only).
@@ -101,6 +102,26 @@ class QsoFormComponent {
 		bcWin.onmessage = (ev) => {
 			if (ev.data === 'ping') bcWin.postMessage('pong');
 		};
+	}
+
+	_setupQsyClear() {
+		this.clearCallOnQsy = localStorage.getItem('clearCallOnQsy') === '1';
+
+		const toggle = document.getElementById('clearCallOnQsyToggle');
+		if (toggle) {
+			toggle.checked = this.clearCallOnQsy;
+			toggle.addEventListener('change', () => {
+				this.clearCallOnQsy = toggle.checked;
+				localStorage.setItem('clearCallOnQsy', toggle.checked ? '1' : '0');
+			});
+		}
+
+		window.addEventListener('contest:qsy', () => {
+			if (!this.clearCallOnQsy) return;
+			const callsignInput = this.container.querySelector('#qso-callsign');
+			if (!callsignInput || !callsignInput.value.trim()) return;
+			this.clearForm(false);
+		});
 	}
 
 	defaultRst() {

--- a/assets/js/sections/contesting/contest_engine/components/radio.js
+++ b/assets/js/sections/contesting/contest_engine/components/radio.js
@@ -25,6 +25,7 @@ class RadioComponent {
 		this._wsReconnectAttempts = 0;
 		this._wsHasTriedFallback = false;
 		this._radioWsTransport = null;
+		this._lastFreq = null;
 
 		// Cache DOM elements
 		this.qrgUnitElement = document.getElementById('qrg_unit');
@@ -255,8 +256,17 @@ class RadioComponent {
 		}
 
 		this.frequency.value = freq;
+		this.checkQsy(parseInt(freq, 10));
 		this.set_qrg();
 		this.updateBandButtons(this.selectedBand, false);
+	}
+
+	checkQsy(hz) {
+		if (!Number.isFinite(hz)) return;
+		if (this._lastFreq !== null && Math.abs(hz - this._lastFreq) > 500) {
+			window.dispatchEvent(new CustomEvent('contest:qsy', { detail: { from: this._lastFreq, to: hz } }));
+		}
+		this._lastFreq = hz;
 	}
 
 	/**
@@ -440,6 +450,7 @@ class RadioComponent {
 
 			if (freqHz) {
 				this.frequency.value = freqHz;
+				this.checkQsy(Math.round(freqHz));
 				await this.set_qrg();
 				return;
 			}
@@ -458,6 +469,7 @@ class RadioComponent {
 			if (result) {
 				const freqHz = parseInt(result);
 				this.frequency.value = freqHz;
+				this.checkQsy(freqHz);
 				await this.set_qrg();
 			}
 		} catch (error) {
@@ -588,6 +600,7 @@ class RadioComponent {
 		localStorage.setItem('qrgunit_' + new_band, unit);
 
 		this.frequency.value = qrg_hz;
+		this.checkQsy(Math.round(qrg_hz));
 		this.freqCalculated.value = parsed_qrg;
 		this.selectedBand = new_band;
 


### PR DESCRIPTION
This one adds a "comfort-feature" to the contest-engine.
Many Contestloggers have this feature: Clear form on QSY.

e.g.: you're in contest, hear a Station you want to work. Enter Call, see it's already worked or there's pileup.
So you turn VFO. Once turned more than 500Hz the form is cleared (like pressing ESC).

Default disabled. Setting via Contest-Engine in settings. persisted locally.

<img width="507" height="246" alt="image" src="https://github.com/user-attachments/assets/f773dc16-b240-429b-8d1f-031245b00841" />
