### PR TITLE
always check if cache driver is loaded before loading

### DIFF
--- a/application/controllers/Amsatstatus.php
+++ b/application/controllers/Amsatstatus.php
@@ -9,7 +9,7 @@ class Amsatstatus extends CI_Controller {
 	}
 
 	public function index() {
-		$this->load->driver('cache', [
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter' => $this->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''

--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -1565,7 +1565,7 @@ class API extends CI_Controller {
 		}
 
 		// Load cache driver
-		$this->load->driver('cache', [
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter' => $this->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->config->item('cache_backup')	 ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''

--- a/application/controllers/Contesting.php
+++ b/application/controllers/Contesting.php
@@ -48,7 +48,7 @@ class Contesting extends CI_Controller {
 		$this->load->is_loaded('Worker') ?: $this->load->library('Worker');
 		$this->worker_available = $this->worker->is_enabled();
 
-		$this->load->driver('cache', [
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter'    => $this->config->item('cache_adapter')    ?? 'file',
 			'backup'     => $this->config->item('cache_backup')     ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''

--- a/application/controllers/Cron.php
+++ b/application/controllers/Cron.php
@@ -54,8 +54,8 @@ class cron extends CI_Controller {
 		// This is the main function, which handles all crons, runs them if enabled and writes the 'next run' timestamp to the database
 
 		// Rate limit: this function may only be triggered once every minute. To prevent attack vectors we lock the cron runner for 30 seconds after it's last run.
-		$this->load->driver('cache', [
-			'adapter' => $this->config->item('cache_adapter') ?? 'file', 
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
+			'adapter' => $this->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''
 		]);
@@ -356,7 +356,7 @@ class cron extends CI_Controller {
 
 		// Prevent manual and scheduled executions of the same cronjob from overlapping.
 		// Load cache driver for locking mechanism.
-		$this->load->driver('cache', [
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter' => $this->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''

--- a/application/controllers/Dxcluster.php
+++ b/application/controllers/Dxcluster.php
@@ -24,8 +24,8 @@ class Dxcluster extends CI_Controller {
 
 		// Only load cache driver if caching is enabled
 		if (($this->config->item('enable_dxcluster_file_cache_band') ?? false) || ($this->config->item('enable_dxcluster_file_cache_worked') ?? false)) {
-			$this->load->driver('cache', [
-				'adapter' => $this->config->item('cache_adapter') ?? 'file', 
+			$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
+				'adapter' => $this->config->item('cache_adapter') ?? 'file',
 				'backup' => $this->config->item('cache_backup') ?? 'file',
 				'key_prefix' => $this->config->item('cache_key_prefix') ?? ''
 			]);

--- a/application/controllers/Staticmap.php
+++ b/application/controllers/Staticmap.php
@@ -51,7 +51,7 @@ class Staticmap extends CI_Controller {
         // Contest: validate against the known contest adifnames (cached for 24h)
         $contest = strtoupper($this->input->get('contest', TRUE) ?? '');
         if ($contest != '') {
-            $this->load->driver('cache', [
+            $this->load->is_loaded('cache') ?: $this->load->driver('cache', [
                 'adapter' => $this->config->item('cache_adapter') ?? 'file',
                 'backup' => $this->config->item('cache_backup') ?? 'file',
                 'key_prefix' => $this->config->item('cache_key_prefix') ?? ''
@@ -223,7 +223,7 @@ class Staticmap extends CI_Controller {
                         $grids[] = $station_info['station_gridsquare'];
                     }
                 }
-                
+
                 $coordinates = [];
                 foreach ($grids as $grid) {
                     $coordinates[] = $this->qra->qra2latlong($grid);
@@ -236,11 +236,11 @@ class Staticmap extends CI_Controller {
                 }
 
                 $qsos = $this->visitor_model->get_qsos(
-                    $qsocount, 
-                    $logbooks_locations_array, 
-                    $band == 'nbf' ? '' : $band, 
-                    $continent == 'nC' ? '' : $continent, 
-                    $orbit == 'nOrb' ? '' : $orbit, 
+                    $qsocount,
+                    $logbooks_locations_array,
+                    $band == 'nbf' ? '' : $band,
+                    $continent == 'nC' ? '' : $continent,
+                    $orbit == 'nOrb' ? '' : $orbit,
                     $contest == 'nContest' ? '' : $contest,
                     $start_date == 'noStart' ? '' : $start_date,
                     $end_date == 'noEnd' ? '' : $end_date,

--- a/application/helpers/cronauth_helper.php
+++ b/application/helpers/cronauth_helper.php
@@ -17,7 +17,7 @@ if (!function_exists('cronauth_token')) {
 if (!function_exists('cronauth_mark_active')) {
 	function cronauth_mark_active() {
 		$CI = &get_instance();
-		$CI->load->driver('cache', [
+		$CI->load->is_loaded('cache') ?: $CI->load->driver('cache', [
 			'adapter' => $CI->config->item('cache_adapter') ?? 'file',
 			'backup' => $CI->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $CI->config->item('cache_key_prefix') ?? ''
@@ -35,7 +35,7 @@ if (!function_exists('cronauth_allowed')) {
 			return true;
 		}
 
-		$CI->load->driver('cache', [
+		$CI->load->is_loaded('cache') ?: $CI->load->driver('cache', [
 			'adapter' => $CI->config->item('cache_adapter') ?? 'file',
 			'backup' => $CI->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $CI->config->item('cache_key_prefix') ?? ''

--- a/application/libraries/DxclusterCache.php
+++ b/application/libraries/DxclusterCache.php
@@ -115,8 +115,8 @@ class DxclusterCache {
 	// =========================================================================
 
 	private function _delete_from_cache($cache_key) {
-		$this->CI->load->driver('cache', [
-			'adapter' => $this->CI->config->item('cache_adapter') ?? 'file', 
+		$this->CI->load->is_loaded('cache') ?: $this->CI->load->driver('cache', [
+			'adapter' => $this->CI->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->CI->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->CI->config->item('cache_key_prefix') ?? ''
 		]);

--- a/application/libraries/MaptileCache.php
+++ b/application/libraries/MaptileCache.php
@@ -30,7 +30,7 @@ class MaptileCache {
 		$cache_backup = $CI->config->item('cache_backup') ?? 'file';
 		// apcu has a default limit of 32MB which is too small for storing map tiles
 		// so we fall back to file. redis is also a good option if available.
-		$CI->load->driver('cache', [
+		$CI->load->is_loaded('cache') ?: $CI->load->driver('cache', [
 			'adapter' => $cache_adapter === 'apcu' ? 'file' : $cache_adapter,
 			'backup' => $cache_backup === 'apcu' ? 'file' : $cache_backup,
 			'key_prefix' => $CI->config->item('cache_key_prefix') ?? '',

--- a/application/libraries/Rate_limit.php
+++ b/application/libraries/Rate_limit.php
@@ -15,8 +15,8 @@ class Rate_limit {
 
     public function __construct() {
         $this->CI =& get_instance();
-        $this->CI->load->driver('cache', [
-			'adapter' => $this->CI->config->item('cache_adapter') ?? 'file', 
+        $this->CI->load->is_loaded('cache') ?: $this->CI->load->driver('cache', [
+			'adapter' => $this->CI->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->CI->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->CI->config->item('cache_key_prefix') ?? ''
 		]);

--- a/application/models/Calendar_model.php
+++ b/application/models/Calendar_model.php
@@ -11,7 +11,7 @@ class Calendar_model extends CI_Model {
 	function __construct() {
 		$this->today = date('Y-m-d');
 
-		$this->load->driver('cache', [
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter' => $this->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''

--- a/application/models/Counties.php
+++ b/application/models/Counties.php
@@ -4,7 +4,7 @@ class Counties extends CI_Model
 {
 
     function __construct() {
-        $this->load->driver('cache', [
+        $this->load->is_loaded('cache') ?: $this->load->driver('cache', [
             'adapter' => $this->config->item('cache_adapter') ?? 'file',
             'backup'  => $this->config->item('cache_backup')  ?? 'file',
             'key_prefix' => $this->config->item('cache_key_prefix') ?? ''

--- a/application/models/Debug_model.php
+++ b/application/models/Debug_model.php
@@ -238,8 +238,8 @@ class Debug_model extends CI_Model
         }
 
         // Load cache driver
-		$this->load->driver('cache', [
-			'adapter' => $cache_adapter, 
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
+			'adapter' => $cache_adapter,
 			'backup' => $cache_backup,
 			'key_prefix' => $cache_key_prefix
 		]);
@@ -251,7 +251,7 @@ class Debug_model extends CI_Model
         // Get cache details
         $cache_size = $this->get_cache_size();
         $cache_keys_count = $this->get_cache_keys_count();
-        
+
         $response['details']['size'] = $this->format_bytes($cache_size);
         $response['details']['size_bytes'] = $cache_size;
         $response['details']['keys_count'] = $cache_keys_count;
@@ -275,7 +275,7 @@ class Debug_model extends CI_Model
         $cache_backup = $this->config->item('cache_backup') ?? 'file';
         $cache_key_prefix = $this->config->item('cache_key_prefix') ?? '';
 
-		$this->load->driver('cache', [
+		$this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter' => $cache_adapter,
 			'backup' => $cache_backup,
 			'key_prefix' => $cache_key_prefix
@@ -295,20 +295,20 @@ class Debug_model extends CI_Model
             case 'file':
                 $cache_path = $this->config->item('cache_path') ?: 'application/cache';
                 $cache_path = realpath(APPPATH . '../') . '/' . $cache_path;
-                
+
                 if (!is_dir($cache_path)) {
                     return 0;
                 }
 
                 $size = 0;
                 $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($cache_path, RecursiveDirectoryIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
-                
+
                 foreach ($files as $file) {
                     if ($file->isFile() && !in_array($file->getFilename(), ['index.html', '.htaccess'])) {
                         $size += $file->getSize();
                     }
                 }
-                
+
                 return $size;
 
             case 'redis':
@@ -326,7 +326,7 @@ class Debug_model extends CI_Model
             case 'memcached':
                 if ($this->cache->is_supported('memcached')) {
                     $memcached_info = $this->cache->cache_info('memcached');
-                    
+
                     // Memcached returns array of servers, each with stats
                     if (is_array($memcached_info)) {
                         $total_bytes = 0;
@@ -340,12 +340,12 @@ class Debug_model extends CI_Model
                         }
                         return $total_bytes;
                     }
-                    
+
                     // Fallback for single server format
                     if (isset($memcached_info['bytes'])) {
                         return (int) $memcached_info['bytes'];
                     }
-                    
+
                     return 0;
                 }
                 return 0;
@@ -369,20 +369,20 @@ class Debug_model extends CI_Model
             case 'file':
                 $cache_path = $this->config->item('cache_path') ?: 'application/cache';
                 $cache_path = realpath(APPPATH . '../') . '/' . $cache_path;
-                
+
                 if (!is_dir($cache_path)) {
                     return 0;
                 }
 
                 $count = 0;
                 $files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($cache_path, RecursiveDirectoryIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
-                
+
                 foreach ($files as $file) {
                     if ($file->isFile() && !in_array($file->getFilename(), ['index.html', '.htaccess'])) {
                         $count++;
                     }
                 }
-                
+
                 return $count;
 
             case 'redis':
@@ -432,7 +432,7 @@ class Debug_model extends CI_Model
             default:
                 return 0;
         }
-        
+
     }
 
     function format_bytes($bytes, $precision = 2) {

--- a/application/models/Qslpostcard_model.php
+++ b/application/models/Qslpostcard_model.php
@@ -8,7 +8,7 @@ class Qslpostcard_model extends CI_Model {
     const MAX_BG_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
 
     function __construct() {
-        $this->load->driver('cache', [
+        $this->load->is_loaded('cache') ?: $this->load->driver('cache', [
 			'adapter' => $this->config->item('cache_adapter') ?? 'file',
 			'backup' => $this->config->item('cache_backup') ?? 'file',
 			'key_prefix' => $this->config->item('cache_key_prefix') ?? ''


### PR DESCRIPTION
Cron Manager firing every minute triggers many `Cache class already loaded. Second attempt ignored.` DEBUG messages in application log.

This PR checks if cache driver is already loaded before loading.

(Whitespace auto-edits courtesy of VSCode and .editorconfig)